### PR TITLE
Dockerfile: Build without workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 # Builder image
 FROM registry.access.redhat.com/ubi8/nodejs-16 as builder
-COPY pkg/client/dist/ ./client/dist/
-COPY pkg/server ./server/
-COPY entrypoint.sh .
-RUN cd ./server && npm install
+USER 0
+COPY . .
+WORKDIR "/opt/app-root/src/pkg/client" 
+RUN npm install && npm run build
+WORKDIR "/opt/app-root/src/pkg/server" 
+RUN npm install
 
 # Runner image
 FROM registry.access.redhat.com/ubi8/nodejs-16-minimal
@@ -31,7 +33,8 @@ LABEL name="konveyor/tackle-ui" \
       io.openshift.min-cpu="100m" \
       io.openshift.min-memory="350Mi"
 
-COPY --from=builder /opt/app-root/src /opt/app-root/src
+COPY --from=builder /opt/app-root/src/pkg/client/dist /opt/app-root/src/pkg/client/dist
+COPY --from=builder /opt/app-root/src/pkg/server /opt/app-root/src/pkg/server
 COPY --from=builder /opt/app-root/src/entrypoint.sh /usr/bin/entrypoint.sh
 
 ENV DEBUG=1

--- a/pkg/client/package.json
+++ b/pkg/client/package.json
@@ -7,7 +7,7 @@
     "analyze": "source-map-explorer 'dist/static/js/*.js'",
     "build:dev": "GENERATE_SOURCEMAP=true $(npm bin)/webpack --config config/webpack.dev.js",
     "build:instrumentation": "CYPRESS_INSTRUMENT_PRODUCTION=true react-scripts -r @cypress/instrument-cra build",
-    "build": "NODE_ENV=production $(npm bin)/webpack --config config/webpack.prod.js",
+    "build": "NODE_ENV=production $(npm bin)/webpack --config ./config/webpack.prod.js",
     "extract": "i18next --config i18next-parser.config.js",
     "proxy:hub": "kubectl port-forward svc/tackle-hub-api -n tackle-operator 9002:8080",
     "proxy:keycloak": "kubectl port-forward svc/tackle-keycloak-sso -n tackle-operator 9001:8080",


### PR DESCRIPTION
This allows to build client and server directly from their respective directories.
This won't be necessary once npm workspace is in place (and supported by cachito)