### PR TITLE
Fix entrypoint server dir

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,5 +38,5 @@ fi
 #   # envsubst '${SSO_REALM} ${SSO_CLIENT_ID}' < ./build/keycloak.json.template > ./build/keycloak.json
 # fi
 
-cd server
+cd pkg/server
 exec node index.js


### PR DESCRIPTION
- Exec node call should be within pkg/server instead of server

@gildub Not sure if we should be using `exec npm run -s start` instead of `exec node index.js` to start the server there , is there any difference?