### PR TITLE
ForkTsCheckerWebpackPlugin: tune memory

### DIFF
--- a/pkg/client/config/webpack.common.js
+++ b/pkg/client/config/webpack.common.js
@@ -159,7 +159,7 @@ module.exports = (env) => {
       ],
     },
     plugins: [
-      new ForkTsCheckerWebpackPlugin(),
+      new ForkTsCheckerWebpackPlugin({ typescript: { memoryLimit: 4096 } }),
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, "../public/index.html"),
         favicon: path.resolve(__dirname, "../public/favicon.ico"),


### PR DESCRIPTION
Give the plugin a big more memory to avoid crash after few reloads (stack overflow)