### PR TITLE
Add progressive wizard logic & initial create task query

### DIFF
--- a/pkg/client/src/app/api/models.tsx
+++ b/pkg/client/src/app/api/models.tsx
@@ -334,8 +334,8 @@ export interface Task {
 }
 export interface TaskData {
   application: number;
-  path: string;
-  mode: {
+  path?: string;
+  mode?: {
     binary: boolean;
     withDeps: boolean;
     artifact?: {
@@ -343,9 +343,9 @@ export interface TaskData {
       path: string;
     };
   };
-  targets: string[];
-  sources: string[];
-  scope: {
+  targets?: string[];
+  sources?: string[];
+  scope?: {
     withKnown: boolean;
     packages: {
       included: string[];

--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard-container.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard-container.tsx
@@ -1,0 +1,353 @@
+import * as React from "react";
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+import {
+  FieldValues,
+  FormProvider,
+  useForm,
+  useFormContext,
+} from "react-hook-form";
+import { useDispatch } from "react-redux";
+import {
+  Button,
+  SelectProvider,
+  Wizard,
+  WizardContextConsumer,
+  WizardFooter,
+  WizardStepFunctionType,
+} from "@patternfly/react-core";
+
+import { Application, Task, TaskData } from "@app/api/models";
+import { SetMode } from "./set-mode";
+import { SetTargets } from "./set-targets";
+import { SetScope } from "./set-scope";
+import { SetOptions } from "./set-options";
+import { Review } from "./review";
+import { createTask } from "@app/api/rest";
+import { alertActions } from "@app/store/alert";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+import { CustomRules } from "./custom-rules";
+import { IReadFile } from "./components/add-custom-rules";
+
+import "./wizard.css";
+import { UploadBinary } from "./components/upload-binary";
+import { setTokenExpiryHandler } from "@konveyor/lib-ui";
+import { UploadBinaryStep } from "./upload-binary-step";
+import { useState } from "react";
+
+interface IAnalysisWizard {
+  applications: Application[];
+  onClose: () => void;
+}
+
+export interface IAnalysisWizardFormValues {
+  mode: string;
+  targets: string[];
+  sources: string[];
+  withKnown: string;
+  includedPackages: string[];
+  excludedPackages: string[];
+  customRulesFiles: any;
+  excludedRulesTags: string[];
+}
+
+const defaultTaskData: TaskData = {
+  application: 0,
+  path: "",
+  mode: {
+    binary: false,
+    withDeps: false,
+  },
+  targets: [],
+  sources: [],
+  scope: {
+    withKnown: false,
+    packages: {
+      included: [],
+      excluded: [],
+    },
+  },
+  rules: {
+    tags: {
+      excluded: [],
+    },
+  },
+};
+
+export const AnalysisWizardContainer: React.FunctionComponent<
+  IAnalysisWizard
+> = ({ applications, onClose }: IAnalysisWizard) => {
+  const { register, getValues, setValue, handleSubmit, watch, reset } =
+    useFormContext<IAnalysisWizardFormValues>();
+
+  const {
+    mode,
+    targets,
+    sources,
+    withKnown,
+    includedPackages,
+    excludedPackages,
+    customRulesFiles,
+    excludedRulesTags,
+  } = getValues();
+
+  const [stepIdReached, setStepIdReached] = useState(1);
+  const [showUploadBinaryStep, setShowUploadBinaryStep] = useState(false);
+  const [showSetTargetsStep, setShowSetTargetsStep] = useState(false);
+  const [showScopeStep, setShowScopeStep] = useState(false);
+  const [showAdvancedSteps, setShowAdvancedSteps] = useState(false);
+  const [showReviewStep, setShowReviewStep] = useState(false);
+
+  enum stepId {
+    AnalysisMode = 1,
+    UploadBinaryStep,
+    SetTargets,
+    Scope,
+    CustomRules,
+    Options,
+    Review,
+  }
+
+  const title = "Application analysis";
+  const dispatch = useDispatch();
+
+  const setTask = (application: Application, data: FieldValues): Task => {
+    return {
+      name: `${application.name}-windup-test`,
+      addon: "windup",
+      data: {
+        ...defaultTaskData,
+        application: application.id || 0,
+        path: "",
+        mode: {
+          binary: data.mode.includes("Binary") || data.mode.includes("binary"),
+          withDeps: data.mode.includes("dependencies"),
+        },
+        targets: data.targets,
+        sources: data.sources,
+        scope: {
+          withKnown: data.withKnown.includes("depsAll") ? true : false,
+          packages: {
+            included: data.includedPackages,
+            excluded: data.excludedPackages,
+          },
+        },
+        rules: {
+          tags: {
+            excluded: data.excludedRulesTags,
+          },
+        },
+      },
+    };
+  };
+
+  const onSubmit = (data: FieldValues) => {
+    if (data.targets.length < 1) {
+      console.log("Invalid form");
+      return;
+    }
+    const tasks = applications.map((app) => setTask(app, data));
+    const promises = Promise.all(tasks.map((task) => createTask(task)));
+    promises
+      .then((response) => {
+        dispatch(
+          alertActions.addSuccess(
+            `Task(s) ${response
+              .map((res) => res.data.name)
+              .join(", ")} were added`
+          )
+        );
+        onClose();
+      })
+      .catch((error) => {
+        dispatch(alertActions.addDanger(getAxiosErrorMessage(error)));
+      });
+  };
+
+  const onMove: WizardStepFunctionType = (
+    { id, name },
+    { prevId, prevName }
+  ) => {
+    if (id && stepIdReached < id) {
+      setStepIdReached(id as number);
+    }
+    if (prevId && id && prevId > 1 && id === 1) {
+      setShowAdvancedSteps(false);
+      setShowReviewStep(false);
+      setShowScopeStep(false);
+      setShowSetTargetsStep(false);
+      setShowUploadBinaryStep(false);
+    }
+  };
+
+  const uploadBinaryStep = {
+    id: stepId.UploadBinaryStep,
+    name: "Upload Binary",
+    component: <UploadBinaryStep></UploadBinaryStep>,
+    canJumpTo: stepIdReached >= stepId.UploadBinaryStep,
+  };
+
+  const setTargetsStep = {
+    id: stepId.SetTargets,
+    name: "Set targets",
+    component: <SetTargets />,
+  };
+  const scopeStep = {
+    id: stepId.Scope,
+    name: "Scope",
+    component: <SetScope />,
+  };
+  const advancedSteps = {
+    name: "Advanced",
+    steps: [
+      {
+        id: stepId.CustomRules,
+        name: "Custom rules",
+        component: <CustomRules />,
+      },
+      {
+        id: stepId.Options,
+        name: "Options",
+        component: <SetOptions />,
+      },
+    ],
+  };
+  const reviewStep = {
+    id: stepId.Review,
+    name: "Review",
+    component: <Review applications={applications} />,
+    nextButtonText: "Run",
+  };
+
+  const steps = [
+    {
+      name: "Configure analysis",
+      steps: [
+        {
+          id: stepId.AnalysisMode,
+          name: "Analysis mode",
+          component: (
+            <SetMode isSingleApp={applications.length === 1 ? true : false} />
+          ),
+          canJumpTo: stepIdReached >= stepId.AnalysisMode,
+        },
+        ...(showUploadBinaryStep ? [uploadBinaryStep] : []),
+        ...(showSetTargetsStep ? [setTargetsStep] : []),
+        ...(showScopeStep ? [scopeStep] : []),
+      ],
+    },
+    ...(showAdvancedSteps ? [advancedSteps] : []),
+    ...(showReviewStep ? [reviewStep] : []),
+  ];
+
+  console.log(watch());
+
+  const CustomFooter = (
+    <WizardFooter>
+      <WizardContextConsumer>
+        {({
+          activeStep,
+          goToStepByName,
+          goToStepById,
+          onNext,
+          onBack,
+          onClose,
+        }) => {
+          const isNextEnabled = () => {
+            switch (activeStep.id) {
+              case 1:
+                {
+                  if (mode) {
+                    return true;
+                  }
+                }
+                break;
+              default:
+                true;
+            }
+          };
+
+          return (
+            <>
+              <Button
+                variant="primary"
+                type="submit"
+                onClick={(event) => {
+                  getNextStep(activeStep, onNext);
+                }}
+                isDisabled={!isNextEnabled()}
+              >
+                {activeStep.name === "Results" ? "Finish" : "Next"}
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => getPreviousStep(activeStep, onBack)}
+                className={activeStep.name === "General" ? "pf-m-disabled" : ""}
+                isDisabled={activeStep.name === "Analysis mode"}
+              >
+                Back
+              </Button>
+              <Button variant="link" onClick={onClose}>
+                Cancel
+              </Button>
+            </>
+          );
+        }}
+      </WizardContextConsumer>
+    </WizardFooter>
+  );
+
+  const getNextStep = (activeStep: any, callback?: any) => {
+    if (activeStep.id === 1 && mode === "Upload a local binary") {
+      setShowUploadBinaryStep(true);
+      setShowSetTargetsStep(true);
+      setShowScopeStep(true);
+      setShowAdvancedSteps(true);
+      setShowReviewStep(true);
+      setTimeout(() => {
+        callback();
+      });
+    } else {
+      setShowSetTargetsStep(true);
+      setShowScopeStep(true);
+      setShowAdvancedSteps(true);
+      setShowReviewStep(true);
+      setTimeout(() => {
+        callback();
+      });
+    }
+  };
+
+  const getPreviousStep = (activeStep: any, callback: any) => {
+    setTimeout(() => {
+      callback();
+    });
+  };
+  const handleClose = () => {
+    onClose();
+    setStepIdReached(stepId.AnalysisMode);
+    setShowAdvancedSteps(false);
+    setShowReviewStep(false);
+    setShowScopeStep(false);
+    setShowSetTargetsStep(false);
+    setShowUploadBinaryStep(false);
+    reset();
+  };
+  return (
+    <Wizard
+      isOpen={true}
+      title="Application analysis"
+      description={applications.map((app) => app.name).join(", ")}
+      navAriaLabel={`${title} steps`}
+      mainAriaLabel={`${title} content`}
+      steps={steps}
+      footer={CustomFooter}
+      onNext={onMove}
+      onBack={onMove}
+      onSave={handleSubmit(onSubmit)}
+      onClose={() => {
+        handleClose();
+      }}
+    />
+  );
+};

--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -1,23 +1,11 @@
 import * as React from "react";
-import * as yup from "yup";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { FieldValues, FormProvider, useForm } from "react-hook-form";
-import { useDispatch } from "react-redux";
-import { Wizard } from "@patternfly/react-core";
-
+import { FormProvider, useForm } from "react-hook-form";
 import { Application, Task, TaskData } from "@app/api/models";
-import { SetMode } from "./set-mode";
-import { SetTargets } from "./set-targets";
-import { SetScope } from "./set-scope";
-import { SetOptions } from "./set-options";
-import { Review } from "./review";
-import { createTask } from "@app/api/rest";
-import { alertActions } from "@app/store/alert";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { CustomRules } from "./custom-rules";
-import { IReadFile } from "./components/add-custom-rules";
-
 import "./wizard.css";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import schema from "yup/lib/schema";
+import { AnalysisWizardContainer } from "./analysis-wizard-container";
 
 interface IAnalysisWizard {
   applications: Application[];
@@ -31,47 +19,20 @@ export interface IAnalysisWizardFormValues {
   withKnown: string;
   includedPackages: string[];
   excludedPackages: string[];
-  customRulesFiles: IReadFile[];
+  customRulesFiles: any;
   excludedRulesTags: string[];
 }
-
-const defaultTaskData: TaskData = {
-  application: 0,
-  path: "",
-  mode: {
-    binary: false,
-    withDeps: false,
-  },
-  targets: [],
-  sources: [],
-  scope: {
-    withKnown: false,
-    packages: {
-      included: [],
-      excluded: [],
-    },
-  },
-  rules: {
-    tags: {
-      excluded: [],
-    },
-  },
-};
 
 export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
   applications,
   onClose,
 }: IAnalysisWizard) => {
-  const title = "Application analysis";
-  const dispatch = useDispatch();
-
   const schema = yup
     .object({
       mode: yup.string().required(),
       target: yup.array().min(1, "Select one or more target"),
     })
     .required();
-
   const methods = useForm<IAnalysisWizardFormValues>({
     resolver: yupResolver(schema),
     defaultValues: {
@@ -85,114 +46,9 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
       excludedRulesTags: [""],
     },
   });
-
-  const setTask = (application: Application, data: FieldValues): Task => {
-    return {
-      name: `${application.name}-windup-test`,
-      addon: "windup",
-      data: {
-        ...defaultTaskData,
-        application: application.id || 0,
-        path: "",
-        mode: {
-          binary: data.mode.includes("Binary") || data.mode.includes("binary"),
-          withDeps: data.mode.includes("dependencies"),
-        },
-        targets: data.targets,
-        sources: data.sources,
-        scope: {
-          withKnown: data.withKnown.includes("depsAll") ? true : false,
-          packages: {
-            included: data.includedPackages,
-            excluded: data.excludedPackages,
-          },
-        },
-        rules: {
-          tags: {
-            excluded: data.excludedRulesTags,
-          },
-        },
-      },
-    };
-  };
-
-  const onSubmit = (data: FieldValues) => {
-    if (data.targets.length < 1) {
-      console.log("Invalid form");
-      return;
-    }
-    const tasks = applications.map((app) => setTask(app, data));
-    const promises = Promise.all(tasks.map((task) => createTask(task)));
-    promises
-      .then((response) => {
-        dispatch(
-          alertActions.addSuccess(
-            `Task(s) ${response
-              .map((res) => res.data.name)
-              .join(", ")} were added`
-          )
-        );
-        onClose();
-      })
-      .catch((error) => {
-        dispatch(alertActions.addDanger(getAxiosErrorMessage(error)));
-      });
-  };
-
-  const steps = [
-    {
-      name: "Configure analysis",
-      steps: [
-        {
-          name: "Analysis mode",
-          component: (
-            <SetMode isSingleApp={applications.length === 1 ? true : false} />
-          ),
-        },
-        {
-          name: "Set targets",
-          component: <SetTargets />,
-        },
-        {
-          name: "Scope",
-          component: <SetScope />,
-        },
-      ],
-    },
-    {
-      name: "Advanced",
-      steps: [
-        {
-          name: "Custom rules",
-          component: <CustomRules />,
-        },
-        {
-          name: "Options",
-          component: <SetOptions />,
-        },
-      ],
-    },
-    {
-      name: "Review",
-      component: <Review applications={applications} />,
-      nextButtonText: "Run",
-    },
-  ];
-
-  console.log(methods.watch());
-
   return (
     <FormProvider {...methods}>
-      <Wizard
-        isOpen={true}
-        title="Application analysis"
-        description={applications.map((app) => app.name).join(", ")}
-        navAriaLabel={`${title} steps`}
-        mainAriaLabel={`${title} content`}
-        steps={steps}
-        onSave={methods.handleSubmit(onSubmit)}
-        onClose={onClose}
-      />
+      <AnalysisWizardContainer applications={applications} onClose={onClose} />
     </FormProvider>
   );
 };

--- a/pkg/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
@@ -11,14 +11,26 @@ import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { SimpleSelect } from "@app/shared/components";
 import { UploadBinary } from "./components/upload-binary";
+import { IAnalysisWizardFormValues } from "./analysis-wizard";
 
 interface ISetMode {
   isSingleApp: boolean;
 }
 
 export const SetMode: React.FunctionComponent<ISetMode> = ({ isSingleApp }) => {
-  const { register, getValues, setValue } = useFormContext();
-  const mode: string = getValues("mode");
+  const { register, getValues, setValue } =
+    useFormContext<IAnalysisWizardFormValues>();
+
+  const {
+    mode,
+    targets,
+    sources,
+    withKnown,
+    includedPackages,
+    excludedPackages,
+    customRulesFiles,
+    excludedRulesTags,
+  } = getValues();
 
   const [isOpen, setIsOpen] = React.useState(false);
   const [isUpload, setIsUpload] = React.useState(false);
@@ -56,12 +68,12 @@ export const SetMode: React.FunctionComponent<ISetMode> = ({ isSingleApp }) => {
       </TextContent>
       <FormGroup label="Source for analysis" fieldId="sourceType">
         <SimpleSelect
-          {...register("mode")}
           variant={SelectVariant.single}
+          {...register("mode")}
           aria-label="Select user perspective"
           value={mode}
           onChange={(selection) => {
-            setValue("mode", selection);
+            setValue("mode", selection as string);
             if (selection === "Upload a local binary") setIsUpload(true);
             else setIsUpload(false);
             setIsOpen(!isOpen);
@@ -69,7 +81,7 @@ export const SetMode: React.FunctionComponent<ISetMode> = ({ isSingleApp }) => {
           options={options}
         />
       </FormGroup>
-      {isUpload && <UploadBinary />}
+      {/* {isUpload && <UploadBinary />} */}
     </>
   );
 };

--- a/pkg/client/src/app/pages/applications/analysis-wizard/upload-binary-step.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/upload-binary-step.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+import { UploadBinary } from "./components/upload-binary";
+
+export const UploadBinaryStep: React.FunctionComponent = () => {
+  return (
+    <>
+      <UploadBinary />
+    </>
+  );
+};

--- a/pkg/client/src/app/queries/tasks.ts
+++ b/pkg/client/src/app/queries/tasks.ts
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { AxiosError } from "axios";
+import { createAsyncAction, getType } from "typesafe-actions";
+import { createTask, getProxies, PROXIES, updateProxy } from "@app/api/rest";
+import { Proxy, Task } from "@app/api/models";
+import { useMutation, UseMutationResult, useQuery } from "react-query";
+import { ProxyFormValues } from "@app/pages/proxies/proxy-form";
+import { APIClient } from "@app/axios-config";
+
+export const {
+  request: fetchRequest,
+  success: fetchSuccess,
+  failure: fetchFailure,
+} = createAsyncAction(
+  "useFetchProxies/fetch/request",
+  "useFetchProxies/fetch/success",
+  "useFetchProxies/fetch/failure"
+)<void, any, AxiosError>();
+
+export interface IFetchState {
+  currentTask: any;
+  isFetching: boolean;
+  fetchError: any;
+}
+
+export const useFetchTask = (
+  defaultIsFetching: boolean = false,
+  taskID: any
+): IFetchState => {
+  const [task, setTask] = useState<Array<Task>>([]);
+  const { isLoading, isError, data, error } = useQuery("repoData", () =>
+    getProxies()
+      .then((res) => res)
+      .then(({ data }) => {
+        setTask(data);
+      })
+      .catch((error) => {
+        console.log("error, ", error);
+      })
+  );
+  return {
+    currentTask: task,
+    isFetching: isLoading,
+    fetchError: error,
+  };
+};
+
+export interface IMutateState {
+  mutate: any;
+  postResult: any;
+  isLoading: boolean;
+  error: any;
+}
+
+export const useCreateInitialTaskMutation = (onSuccess: any): IMutateState => {
+  const [postResult, setPostResult] = useState<any>(null);
+
+  const { isLoading, mutate, error } = useMutation(createTask, {
+    onSuccess: (res) => {
+      onSuccess();
+      setPostResult(res);
+    },
+    onError: (err) => {
+      setPostResult(err);
+    },
+  });
+  return {
+    mutate,
+    postResult,
+    isLoading,
+    error,
+  };
+};


### PR DESCRIPTION
- Add needed progressive wizard logic to enable hooking into navigation for event creation
- Dynamically show upload binary step since we need to break coupling between first step and binary upload. 
- Create initial task for single application flow with a query on nav past first step