### PR TITLE
Set ouptut, mode.artifact and rules path uploads

### DIFF
--- a/pkg/client/src/app/api/models.tsx
+++ b/pkg/client/src/app/api/models.tsx
@@ -336,13 +336,11 @@ export interface Task {
 
 export interface TaskData {
   path: string;
+  output: string;
   mode: {
     binary: boolean;
     withDeps: boolean;
-    artifact?: {
-      bucket: number;
-      path: string;
-    };
+    artifact: string;
   };
   targets: string[];
   sources: string[];
@@ -354,10 +352,7 @@ export interface TaskData {
     };
   };
   rules?: {
-    directory?: {
-      bucket: number;
-      path: string;
-    };
+    path: string;
     tags: {
       excluded: string[];
     };

--- a/pkg/client/src/app/api/rest.tsx
+++ b/pkg/client/src/app/api/rest.tsx
@@ -66,6 +66,7 @@ export const PROXIES = "/proxies";
 
 const halHeaders = { headers: { Accept: "application/hal+json" } };
 const jsonHeaders = { headers: { Accept: "application/json" } };
+const formHeaders = { headers: { Accept: "multipart/form-data" } };
 
 type Direction = "asc" | "desc";
 
@@ -541,6 +542,14 @@ export const updateTask = (obj: Task): AxiosPromise<Task> => {
 
 export const submitTask = (obj: Task): AxiosPromise<Task> => {
   return APIClient.put(`${TASKS}/${obj.id}/submit`, obj);
+};
+
+export const uploadFileTask = (
+  id: number,
+  path: string,
+  file: any
+): AxiosPromise<Task> => {
+  return APIClient.post(`${TASKS}/${id}/bucket/${path}`, file, formHeaders);
 };
 
 export const getProxies = (): AxiosPromise<Array<any>> => {

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
@@ -28,6 +28,7 @@ export interface IReadFile {
   data?: string;
   loadResult?: "danger" | "success";
   loadError?: DOMException;
+  file: File;
 }
 
 export const AddCustomRules: React.FunctionComponent = () => {
@@ -122,6 +123,7 @@ export const AddCustomRules: React.FunctionComponent = () => {
       data,
       fileName: file.name,
       loadResult: "success",
+      file: file,
     };
     const fileList = [...readFileData, newReadFile];
 

--- a/pkg/client/src/app/store/alert/actions.tsx
+++ b/pkg/client/src/app/store/alert/actions.tsx
@@ -1,6 +1,6 @@
 import { addNotification } from "@redhat-cloud-services/frontend-components-notifications/redux";
 
-type Variant = "danger" | "success";
+type Variant = "danger" | "success" | "info";
 
 export const addAlert = (
   variant: Variant,
@@ -12,6 +12,10 @@ export const addAlert = (
     title,
     description,
   });
+};
+
+export const addInfo = (title: string, description?: string) => {
+  return addAlert("info", title, description);
 };
 
 export const addSuccess = (title: string, description?: string) => {


### PR DESCRIPTION
Completely set up custom rules:
- Uploads custom rules files
- Makes rules optional for task.data

Adds generic rest request for file uploads to be used by both binary and custom rules

Harmonize notifications for Task creation (wizard initialization), custom rules uploads, task data set (update) and submission.