### PR TITLE
Loosen types on field values to fix ts error

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
@@ -6,7 +6,7 @@ import {
   SelectOption,
   SelectVariant,
 } from "@patternfly/react-core";
-import { useFormContext } from "react-hook-form";
+import { FieldValues, useFormContext } from "react-hook-form";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { SimpleSelect } from "@app/shared/components";
@@ -23,8 +23,7 @@ export const SetMode: React.FunctionComponent<ISetMode> = ({
   isSingleApp,
   createdTaskID,
 }) => {
-  const { register, getValues, setValue } =
-    useFormContext<IAnalysisWizardFormValues>();
+  const { register, getValues, setValue } = useFormContext();
 
   const { mode } = getValues();
 
@@ -69,7 +68,7 @@ export const SetMode: React.FunctionComponent<ISetMode> = ({
           aria-label="Select user perspective"
           value={mode}
           onChange={(selection) => {
-            setValue("mode", selection as string);
+            setValue("mode", selection);
             if (selection === "Upload a local binary") setIsUpload(true);
             else setIsUpload(false);
             setIsOpen(!isOpen);


### PR DESCRIPTION
Still need to find a fix for deep type checking against field values. This fixes the circular dep error that keeps popping up. https://github.com/react-hook-form/react-hook-form/discussions/7764