### PR TITLE
Wizard: SetTargets to remember selection

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -292,7 +292,7 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
     }
   };
 
-  const { mode, artifact, targets } = methods.getValues();
+  const { mode, artifact } = methods.getValues();
 
   const isModeValid = (): boolean => {
     if (mode.includes("Upload")) return !isMutating && artifact !== "";
@@ -394,7 +394,6 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
               <Button
                 variant="secondary"
                 onClick={() => getPreviousStep(activeStep, onBack)}
-                className={activeStep.name === "General" ? "pf-m-disabled" : ""}
                 isDisabled={activeStep.name === "Analysis mode"}
               >
                 Back

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/select-card.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/select-card.tsx
@@ -21,11 +21,16 @@ import "./select-card.css";
 
 export interface SelectCardProps {
   item: TransformationTargets;
-  onChange: (isNeweCard: boolean, value: string) => void;
+  cardSelected: boolean;
+  onChange: (isNewCard: boolean, value: string) => void;
 }
 
-export const SelectCard: React.FC<SelectCardProps> = ({ item, onChange }) => {
-  const [isCardSelected, setCardSelected] = React.useState(false);
+export const SelectCard: React.FC<SelectCardProps> = ({
+  item,
+  cardSelected,
+  onChange,
+}) => {
+  const [isCardSelected, setCardSelected] = React.useState(cardSelected);
   const [isSelectOpen, setSelectOpen] = React.useState(false);
   const [selectedRelease, setSelectedRelease] = React.useState(
     [...item.options.keys()][0]

--- a/pkg/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -134,6 +134,9 @@ export const SetTargets: React.FunctionComponent = () => {
               <GalleryItem key={index}>
                 <SelectCard
                   item={elem}
+                  cardSelected={[...elem.options.keys()].some((key) =>
+                    targets.includes(key)
+                  )}
                   onChange={(isNewCard: boolean, selectionValue: string) => {
                     handleOnCardChange(isNewCard, selectionValue, elem);
                   }}


### PR DESCRIPTION
Makes sure targets selected are properly active when going back and forth between wizard steps.