### PR TITLE
Wizard: Single app requires `taskgroups` to upload file

### DIFF
--- a/pkg/client/src/app/api/rest.tsx
+++ b/pkg/client/src/app/api/rest.tsx
@@ -532,18 +532,6 @@ export const deleteTask = (id: number): AxiosPromise => {
   return APIClient.delete(`${TASKS}/${id}`);
 };
 
-export const uploadFileTask = ({
-  id,
-  path,
-  file,
-}: {
-  id: number;
-  path: string;
-  file: any;
-}): AxiosPromise<Task> => {
-  return APIClient.post(`${TASKS}/${id}/bucket/${path}`, file, formHeaders);
-};
-
 export const createTaskgroup = (obj: Taskgroup): AxiosPromise<Task> => {
   return APIClient.post(`${TASKGROUPS}`, obj);
 };

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
@@ -11,12 +11,13 @@ import {
   MultipleFileUploadTitleText,
   MultipleFileUploadTitleTextSeparator,
 } from "@patternfly/react-core";
-
-import { useUploadFileMutation } from "@app/queries/tasks";
-import { IAnalysisWizardFormValues, IReadFile } from "../analysis-wizard";
 import { useFormContext } from "react-hook-form";
-import { alertActions } from "@app/store/alert";
 import { useDispatch } from "react-redux";
+
+import { IReadFile } from "../analysis-wizard";
+import { alertActions } from "@app/store/alert";
+import { useUploadFileTaskgroupMutation } from "@app/queries/taskgroups";
+
 interface IUploadBinary {
   taskId: number;
 }
@@ -60,7 +61,7 @@ export const UploadBinary: React.FunctionComponent<IUploadBinary> = ({
     setFileUploadProgress(0);
   };
 
-  const { mutate: uploadFile } = useUploadFileMutation(
+  const { mutate: uploadFile } = useUploadFileTaskgroupMutation(
     completedUpload,
     failedUpload
   );

--- a/pkg/client/src/app/queries/applications.ts
+++ b/pkg/client/src/app/queries/applications.ts
@@ -15,17 +15,14 @@ export const useFetchApplications = (
   defaultIsFetching: boolean = false
 ): IFetchState => {
   const [applications, setApplications] = useState<Application[]>([]);
-  const { isLoading, error, refetch } = useQuery(
-    "applications",
-    () =>
-      getApplications()
-        .then(({ data }) => {
-          setApplications(data);
-        })
-        .catch((error) => {
-          console.log("error, ", error);
-        }),
-    { refetchInterval: 5000 }
+  const { isLoading, error, refetch } = useQuery("applications", () =>
+    getApplications()
+      .then(({ data }) => {
+        setApplications(data);
+      })
+      .catch((error) => {
+        console.log("error, ", error);
+      })
   );
   return {
     applications: applications,

--- a/pkg/client/src/app/queries/applications.ts
+++ b/pkg/client/src/app/queries/applications.ts
@@ -15,14 +15,17 @@ export const useFetchApplications = (
   defaultIsFetching: boolean = false
 ): IFetchState => {
   const [applications, setApplications] = useState<Application[]>([]);
-  const { isLoading, error, refetch } = useQuery("applications", () =>
-    getApplications()
-      .then(({ data }) => {
-        setApplications(data);
-      })
-      .catch((error) => {
-        console.log("error, ", error);
-      })
+  const { isLoading, error, refetch } = useQuery(
+    "applications",
+    () =>
+      getApplications()
+        .then(({ data }) => {
+          setApplications(data);
+        })
+        .catch((error) => {
+          console.log("error, ", error);
+        }),
+    { refetchInterval: 5000 }
   );
   return {
     applications: applications,

--- a/pkg/client/src/app/queries/taskgroups.ts
+++ b/pkg/client/src/app/queries/taskgroups.ts
@@ -4,9 +4,10 @@ import {
   createTaskgroup,
   deleteTaskgroup,
   submitTaskgroup,
+  uploadFileTaskgroup,
 } from "@app/api/rest";
 
-export interface IMutateState {
+export interface ITaskgroupMutateState {
   mutate: any;
   isLoading: boolean;
   error: any;
@@ -15,7 +16,7 @@ export interface IMutateState {
 export const useCreateTaskgroupMutation = (
   onSuccess: (res: any) => void,
   onError: (err: Error | unknown) => void
-): IMutateState => {
+): ITaskgroupMutateState => {
   const { isLoading, mutate, error } = useMutation(createTaskgroup, {
     onSuccess: (res) => {
       onSuccess(res);
@@ -34,7 +35,7 @@ export const useCreateTaskgroupMutation = (
 export const useSubmitTaskgroupMutation = (
   onSuccess: (res: any) => void,
   onError: (err: Error | unknown) => void
-): IMutateState => {
+): ITaskgroupMutateState => {
   const queryClient = useQueryClient();
 
   const { isLoading, mutate, error } = useMutation(submitTaskgroup, {
@@ -54,9 +55,28 @@ export const useSubmitTaskgroupMutation = (
   };
 };
 
+export const useUploadFileTaskgroupMutation = (
+  successCallback: (res: any) => void,
+  errorCallback: (err: Error | null) => void
+): ITaskgroupMutateState => {
+  const { isLoading, mutate, error } = useMutation(uploadFileTaskgroup, {
+    onSuccess: (res) => {
+      successCallback && successCallback(res);
+    },
+    onError: (err: Error) => {
+      errorCallback && errorCallback(error);
+    },
+  });
+  return {
+    mutate,
+    isLoading,
+    error,
+  };
+};
+
 export const useDeleteTaskgroupMutation = (
   onError: (err: Error | unknown) => void
-): IMutateState => {
+): ITaskgroupMutateState => {
   const queryClient = useQueryClient();
 
   const { isLoading, mutate, error } = useMutation(deleteTaskgroup, {

--- a/pkg/client/src/app/queries/tasks.ts
+++ b/pkg/client/src/app/queries/tasks.ts
@@ -2,9 +2,9 @@ import { useState } from "react";
 import { useMutation, useQuery } from "react-query";
 
 import { Task } from "@app/api/models";
-import { deleteTask, getTasks, uploadFileTask } from "@app/api/rest";
+import { deleteTask, getTasks } from "@app/api/rest";
 
-export interface IFetchState {
+export interface ITaskFetchState {
   tasks: Task[];
   isFetching: boolean;
   fetchError: any;
@@ -12,9 +12,9 @@ export interface IFetchState {
 
 export const useFetchTasks = (
   defaultIsFetching: boolean = false
-): IFetchState => {
+): ITaskFetchState => {
   const [tasks, setTasks] = useState<Array<Task>>([]);
-  const { isLoading, data, error } = useQuery("tasks", () =>
+  const { isLoading, error } = useQuery("tasks", () =>
     getTasks()
       .then(({ data }) => {
         let uniqLatestTasks: Task[] = [];
@@ -40,35 +40,16 @@ export const useFetchTasks = (
   };
 };
 
-export interface IMutateState {
+export interface ITaskMutateState {
   mutate: any;
   isLoading: boolean;
   error: any;
 }
 
-export const useUploadFileMutation = (
-  successCallback: (res: any) => void,
-  errorCallback: (err: Error | null) => void
-): IMutateState => {
-  const { isLoading, mutate, error } = useMutation(uploadFileTask, {
-    onSuccess: (res) => {
-      successCallback && successCallback(res);
-    },
-    onError: (err: Error) => {
-      errorCallback && errorCallback(error);
-    },
-  });
-  return {
-    mutate,
-    isLoading,
-    error,
-  };
-};
-
 export const useDeleteTaskMutation = (
   onSuccess: () => void,
   onError: (err: Error | null) => void
-): IMutateState => {
+): ITaskMutateState => {
   const { mutate, isLoading, error } = useMutation(deleteTask, {
     onSuccess: () => {
       onSuccess && onSuccess();


### PR DESCRIPTION
Fixes the binary file upload for single application analysis case.

Recent change using taskgroups API needs to upload file with `taskgroups` and not through `tasks` API. 