### PR TITLE
Tags/TagTypes: Workaround Foreign key constraint error

### DIFF
--- a/pkg/client/src/app/pages/controls/tags/tags.tsx
+++ b/pkg/client/src/app/pages/controls/tags/tags.tsx
@@ -171,7 +171,13 @@ export const Tags: React.FC = () => {
             },
             (error) => {
               dispatch(confirmDialogActions.closeDialog());
-              dispatch(alertActions.addDanger(getAxiosErrorMessage(error)));
+              if (
+                error.response?.status === 500 &&
+                error.response?.data.error === "FOREIGN KEY constraint failed"
+              )
+                dispatch(alertActions.addDanger("Cannot delete a used tag"));
+              else
+                dispatch(alertActions.addDanger(getAxiosErrorMessage(error)));
             }
           );
         },
@@ -226,6 +232,7 @@ export const Tags: React.FC = () => {
         {
           title: (
             <AppTableActionButtons
+              isDeleteEnabled={!!item.tags?.length}
               onEdit={() => setRowToUpdate(item)}
               onDelete={() => deleteRow(item)}
             />
@@ -291,7 +298,15 @@ export const Tags: React.FC = () => {
             },
             (error) => {
               dispatch(confirmDialogActions.closeDialog());
-              dispatch(alertActions.addDanger(getAxiosErrorMessage(error)));
+              if (
+                error.response?.status === 500 &&
+                error.response?.data.error === "FOREIGN KEY constraint failed"
+              )
+                dispatch(
+                  alertActions.addDanger("Cannot delete a non empty tag type")
+                );
+              else
+                dispatch(alertActions.addDanger(getAxiosErrorMessage(error)));
             }
           );
         },

--- a/pkg/client/src/app/shared/components/ConditionalTooltip.tsx
+++ b/pkg/client/src/app/shared/components/ConditionalTooltip.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Tooltip, TooltipProps } from "@patternfly/react-core";
+
+export interface IConditionalTooltipProps extends TooltipProps {
+  isTooltipEnabled: boolean;
+  children: React.ReactElement;
+}
+
+// TODO: lib-ui candidate
+export const ConditionalTooltip: React.FunctionComponent<
+  IConditionalTooltipProps
+> = ({ isTooltipEnabled, children, ...props }: IConditionalTooltipProps) =>
+  isTooltipEnabled ? <Tooltip {...props}>{children}</Tooltip> : children;

--- a/pkg/client/src/app/shared/components/app-table-action-buttons/app-table-action-buttons.tsx
+++ b/pkg/client/src/app/shared/components/app-table-action-buttons/app-table-action-buttons.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Flex, FlexItem } from "@patternfly/react-core";
+import { Button, Flex, FlexItem, Tooltip } from "@patternfly/react-core";
 import { RBAC, RBAC_TYPE, writeScopes } from "@app/rbac";
+import { ConditionalTooltip } from "../ConditionalTooltip";
 
 export interface AppTableActionButtonsProps {
+  isDeleteEnabled: boolean;
   onEdit: () => void;
   onDelete: () => void;
 }
 
 export const AppTableActionButtons: React.FC<AppTableActionButtonsProps> = ({
+  isDeleteEnabled,
   onEdit,
   onDelete,
 }) => {
@@ -23,9 +26,19 @@ export const AppTableActionButtons: React.FC<AppTableActionButtonsProps> = ({
           </Button>
         </FlexItem>
         <FlexItem>
-          <Button aria-label="delete" variant="link" onClick={onDelete}>
-            {t("actions.delete")}
-          </Button>
+          <ConditionalTooltip
+            isTooltipEnabled={isDeleteEnabled}
+            content="Cannot delete non empty tag type"
+          >
+            <Button
+              aria-label="delete"
+              variant="link"
+              onClick={onDelete}
+              isAriaDisabled={isDeleteEnabled}
+            >
+              {t("actions.delete")}
+            </Button>
+          </ConditionalTooltip>
         </FlexItem>
       </Flex>
     </RBAC>


### PR DESCRIPTION
- Disables the delete button for tag types when tags are attached to it.
- Display a user friendly error notification "Cannot delete a used tag" when trying to delete a tag that is used .

For the latter, a long term solution to disable delete tag button would require to fetch applications to determine if the tag to be deleted is used or not. This would require a bigger effort because Tackle 1 UI didn't have foreign key constraint enabled for tags and tag types and therefore wasn't designed to handle it.

https://issues.redhat.com/projects/TACKLE/issues/TACKLE-446