### PR TITLE
Fix AppTableActionButtons with optional props

### DIFF
--- a/pkg/client/src/app/pages/controls/tags/tags.tsx
+++ b/pkg/client/src/app/pages/controls/tags/tags.tsx
@@ -224,6 +224,7 @@ export const Tags: React.FC = () => {
           title: (
             <AppTableActionButtons
               isDeleteEnabled={!!item.tags?.length}
+              tooltipMessage="Cannot delete non empty tag type"
               onEdit={() => setRowToUpdate(item)}
               onDelete={() => deleteRow(item)}
             />

--- a/pkg/client/src/app/shared/components/app-table-action-buttons/app-table-action-buttons.tsx
+++ b/pkg/client/src/app/shared/components/app-table-action-buttons/app-table-action-buttons.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Flex, FlexItem, Tooltip } from "@patternfly/react-core";
+import { Button, Flex, FlexItem } from "@patternfly/react-core";
 import { RBAC, RBAC_TYPE, writeScopes } from "@app/rbac";
 import { ConditionalTooltip } from "../ConditionalTooltip";
 
 export interface AppTableActionButtonsProps {
-  isDeleteEnabled: boolean;
+  isDeleteEnabled?: boolean;
+  tooltipMessage?: string;
   onEdit: () => void;
   onDelete: () => void;
 }
 
 export const AppTableActionButtons: React.FC<AppTableActionButtonsProps> = ({
-  isDeleteEnabled,
+  isDeleteEnabled = false,
+  tooltipMessage = "",
   onEdit,
   onDelete,
 }) => {
@@ -28,7 +30,7 @@ export const AppTableActionButtons: React.FC<AppTableActionButtonsProps> = ({
         <FlexItem>
           <ConditionalTooltip
             isTooltipEnabled={isDeleteEnabled}
-            content="Cannot delete non empty tag type"
+            content={tooltipMessage}
           >
             <Button
               aria-label="delete"


### PR DESCRIPTION
https://github.com/konveyor/tackle2-ui/pull/94 introduced props which need to be optional as the component is commonly used.