### PR TITLE
Fix infinite wizard re-render

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -31,8 +31,8 @@ import "./wizard.css";
 
 interface IAnalysisWizard {
   applications: Application[];
-  identities: Identity[];
   onClose: () => void;
+  isOpen: boolean;
 }
 export interface IReadFile {
   fileName: string;
@@ -73,8 +73,8 @@ const defaultTaskData: TaskData = {
 
 export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
   applications,
-  identities,
   onClose,
+  isOpen,
 }: IAnalysisWizard) => {
   const title = "Application analysis";
   const dispatch = useDispatch();
@@ -150,15 +150,6 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
       excludedRulesTags: [""],
     },
   });
-
-  // TODO Assess if useful in future to keep or discard
-  const hasIdentity = (application: Application, kind: string) => {
-    return !!application.identities?.some((appIdentity) =>
-      identities?.find(
-        (identity) => appIdentity.id === identity.id && identity.kind === kind
-      )
-    );
-  };
 
   const areApplicationsBinaryEnabled = (): boolean =>
     applications.every(
@@ -356,21 +347,25 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
   };
 
   return (
-    <FormProvider {...methods}>
-      <Wizard
-        isOpen={true}
-        title="Application analysis"
-        description={applications.map((app) => app.name).join(", ")}
-        navAriaLabel={`${title} steps`}
-        mainAriaLabel={`${title} content`}
-        steps={steps}
-        onNext={onMove}
-        onBack={onMove}
-        onSave={handleSubmit(onSubmit)}
-        onClose={() => {
-          handleClose();
-        }}
-      />
-    </FormProvider>
+    <>
+      {isOpen && (
+        <FormProvider {...methods}>
+          <Wizard
+            isOpen={isOpen}
+            title="Application analysis"
+            description={applications.map((app) => app.name).join(", ")}
+            navAriaLabel={`${title} steps`}
+            mainAriaLabel={`${title} content`}
+            steps={steps}
+            onNext={onMove}
+            onBack={onMove}
+            onSave={handleSubmit(onSubmit)}
+            onClose={() => {
+              handleClose();
+            }}
+          />
+        </FormProvider>
+      )}
+    </>
   );
 };

--- a/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -52,8 +52,6 @@ import {
   FilterToolbar,
   FilterType,
 } from "@app/shared/components/FilterToolbar";
-import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { useSortState } from "@app/shared/hooks/useSortState";
 import { AnalysisWizard } from "../analysis-wizard/analysis-wizard";
 import { ApplicationIdentityForm } from "../components/application-identity-form/application-identity-form";
 import { useDeleteTaskMutation, useFetchTasks } from "@app/queries/tasks";
@@ -64,7 +62,6 @@ import {
   useDeleteApplicationMutation,
   useFetchApplications,
 } from "@app/queries/applications";
-import { useFetchIdentities } from "@app/queries/identities";
 import {
   ApplicationTableType,
   getApplicationsFilterValues,
@@ -103,7 +100,6 @@ export const ApplicationsTableAnalyze: React.FC = () => {
   } = getApplicationsFilterValues(applications, ApplicationTableType.Analysis);
 
   const { tasks } = useFetchTasks();
-  const { identities } = useFetchIdentities();
 
   const completedDeleteTask = () => {
     dispatch(alertActions.addInfo("Task", "Deleted"));
@@ -543,7 +539,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
       {isAnalyzeModalOpen && (
         <AnalysisWizard
           applications={selectedRows}
-          identities={identities}
+          isOpen={isAnalyzeModalOpen}
           onClose={() => {
             setAnalyzeModalOpen(false);
           }}


### PR DESCRIPTION
- When you load the app and click analyze on a previously run analysis item in the app analyze table, the app crashes due to an issue with the pf implementation of wizard modal. 
- Closes #107 