### PR TITLE
Bug: Collapse tagtype if no tags attached in table

### DIFF
--- a/pkg/client/src/app/pages/controls/tags/tags.tsx
+++ b/pkg/client/src/app/pages/controls/tags/tags.tsx
@@ -207,7 +207,7 @@ export const Tags: React.FC = () => {
 
   const rows: IRow[] = [];
   currentPageItems.forEach((item) => {
-    const isExpanded = isItemExpanded(item);
+    const isExpanded = isItemExpanded(item) && !!item?.tags?.length;
     rows.push({
       [ENTITY_FIELD]: item,
       isOpen: (item.tags || []).length > 0 ? isExpanded : undefined,


### PR DESCRIPTION
[Tags: Deleting attached "Tag name" from the "Tag Type" the expand shows the "Tag name" field](https://issues.redhat.com/browse/TACKLE-447)