### PR TITLE
Adjust taskgroup deletion when changing mode

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -139,12 +139,15 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
 
   const { mutate: uploadFile } = useUploadFileMutation(() => {}, onUploadError);
 
+  const onDeleteTaskgroupSuccess = () => setInitTaskgroup(false);
+
   const onDeleteTaskgroupError = (error: Error | unknown) => {
     console.log("Taskgroup: delete failed: ", error);
     dispatch(alertActions.addDanger("Taskgroup: delete failed"));
   };
 
   const { mutate: deleteTaskgroup } = useDeleteTaskgroupMutation(
+    onDeleteTaskgroupSuccess,
     onDeleteTaskgroupError
   );
 
@@ -277,7 +280,7 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
   }, [mode]);
 
   React.useEffect(() => {
-    if (createdTaskgroup && createdTaskgroup.id)
+    if (isInitTaskgroup && createdTaskgroup && createdTaskgroup.id)
       deleteTaskgroup(createdTaskgroup.id);
 
     if (analyzeableApplications.length > 0) {

--- a/pkg/client/src/app/queries/taskgroups.ts
+++ b/pkg/client/src/app/queries/taskgroups.ts
@@ -54,11 +54,15 @@ export const useUploadFileTaskgroupMutation = (
 };
 
 export const useDeleteTaskgroupMutation = (
+  onSuccess: () => void,
   onError: (err: Error | unknown) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation(deleteTaskgroup, {
+    onSuccess: () => {
+      onSuccess();
+    },
     onError: (err) => {
       onError(err);
       queryClient.invalidateQueries("tasks");


### PR DESCRIPTION
This is a follow up for https://github.com/konveyor/tackle2-ui/pull/149
To make sure there is no existing taskgroup to delete when swapping between modes.