### PR TITLE
Fix unauthenticated routes to the hub

### DIFF
--- a/pkg/client/src/app/common/KeycloakProvider.tsx
+++ b/pkg/client/src/app/common/KeycloakProvider.tsx
@@ -3,7 +3,7 @@ import i18n from "@app/i18n";
 import keycloak from "@app/keycloak";
 import { Flex, FlexItem, Spinner } from "@patternfly/react-core";
 import { ReactKeycloakProvider } from "@react-keycloak/web";
-import React from "react";
+import React, { useEffect } from "react";
 
 interface IKeycloakProviderProps {
   children: React.ReactNode;
@@ -17,6 +17,45 @@ export const KeycloakProvider: React.FunctionComponent<
   // );
   // TODO: Implement a short circuit for overriding auth requirements
   //   const overrideAuth = process.env["AUTH_REQUIRED"];
+
+  const setCookie = (cName: string, cValue: string, expDays: number) => {
+    let date = new Date();
+    date.setTime(date.getTime() + expDays * 24 * 60 * 60 * 1000);
+    const expires = "expires=" + date.toUTCString();
+    document.cookie = `${cName} = ${cValue}; ${expires}; path=/`;
+  };
+
+  const getCookie = (token: string) => {
+    let cookieArr = document.cookie.split(";");
+    for (let i = 0; i < cookieArr.length; i++) {
+      let cookiePair = cookieArr[i].split("=");
+      if (token == cookiePair[0].trim()) {
+        return decodeURIComponent(cookiePair[1]);
+      }
+    }
+    return null;
+  };
+
+  const checkCookie = () => {
+    let token = getCookie("proxyToken");
+    if (token !== "" && token !== null) {
+    } else {
+      token = keycloak?.token || "";
+
+      if (token != "" && token != null) {
+        setCookie("proxyToken", token, 365);
+      }
+    }
+  };
+  const deleteCookie = (name: string) => {
+    document.cookie = `${name} =; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+  };
+  useEffect(() => {
+    deleteCookie("proxyToken");
+    return () => {
+      checkCookie();
+    };
+  }, [keycloak.token]);
 
   return (
     <>
@@ -48,6 +87,7 @@ export const KeycloakProvider: React.FunctionComponent<
             initInterceptors(() => {
               return new Promise<string>((resolve, reject) => {
                 if (keycloak.token) {
+                  checkCookie();
                   keycloak
                     .updateToken(5)
                     .then(() => {

--- a/pkg/client/src/app/pages/applications/components/application-list-expanded-area/application-list-expanded-area-analysis.tsx
+++ b/pkg/client/src/app/pages/applications/components/application-list-expanded-area/application-list-expanded-area-analysis.tsx
@@ -10,7 +10,6 @@ import {
   Tooltip,
 } from "@patternfly/react-core";
 import { Link } from "react-router-dom";
-import { stringify } from "yaml";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { Application, Task } from "@app/api/models";
@@ -93,7 +92,7 @@ export const ApplicationListExpandedAreaAnalysis: React.FC<
             <Tooltip content="Click to view Analysis report">
               <Button variant="link" isInline>
                 <Link
-                  to={`/hub/applications/${application.id}/bucket${task?.data?.output}/`}
+                  to={`/hub/applications/${application.id}/bucket${task?.data?.output}`}
                   target="_blank"
                 >
                   Report

--- a/pkg/server/index.js
+++ b/pkg/server/index.js
@@ -2,10 +2,13 @@ const express = require("express");
 const path = require("path");
 const app = express(),
   bodyParser = require("body-parser");
+const cookieParser = require("cookie-parser");
 
 const setupProxy = require("./setupProxy");
 
 const port = 8080;
+
+app.use(cookieParser());
 
 setupProxy(app);
 

--- a/pkg/server/package-lock.json
+++ b/pkg/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "cookie-parser": "^1.4.6",
         "express": "^4.17.2",
         "http-proxy-middleware": "^2.0.2"
       }
@@ -105,6 +106,26 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -753,6 +774,22 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/pkg/server/package.json
+++ b/pkg/server/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "express": "^4.17.2",
     "http-proxy-middleware": "^2.0.2"
   },

--- a/pkg/server/setupProxy.js
+++ b/pkg/server/setupProxy.js
@@ -28,6 +28,12 @@ module.exports = function (app) {
         "^/hub": "",
       },
       logLevel: process.env.DEBUG ? "debug" : "info",
+      onProxyReq: (proxyReq, req, res) => {
+        if (req.get("Authorization")) {
+        } else if (req.cookies.proxyToken) {
+          proxyReq.setHeader('Authorization', `Bearer ${req.cookies.proxyToken}`)
+        }
+      },
     })
   );
 };


### PR DESCRIPTION
- Adds cookie storage logic for auth token. Clears cookie and updates when the keycloak token is regenerated
- Adds token header to requests made directly against the hub for windup reports. Fixes 401 errors. 