### PR TITLE
Fix useTranslation bug resulting in a noop

### DIFF
--- a/pkg/client/src/app/i18n.ts
+++ b/pkg/client/src/app/i18n.ts
@@ -9,7 +9,9 @@ i18n
     lng: "en",
     fallbackLng: "en",
     debug: false,
-
+    react: {
+      useSuspense: false,
+    },
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
https://github.com/i18next/react-i18next/issues/796

Setting useSuspense to false is fixing some noop memory leaks within our app. the i18n lib has a few internal bugs that this change will sidestep for the time being. 