### PR TITLE
Update padding to display Report adoption correctly

### DIFF
--- a/pkg/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
+++ b/pkg/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
@@ -300,7 +300,7 @@ export const AdoptionCandidateGraph: React.FC = () => {
                 bottom: 100,
                 left: 75,
                 right: 50,
-                top: 50,
+                top: 60,
               };
 
               return (

--- a/pkg/client/src/app/pages/reports/components/adoption-candidate-graph/cartesian-square.tsx
+++ b/pkg/client/src/app/pages/reports/components/adoption-candidate-graph/cartesian-square.tsx
@@ -17,8 +17,8 @@ export const CartesianSquare: React.FC<ICartesianSquareProps> = ({
   const { t } = useTranslation();
 
   // Quadrants
-  const topY = ((padding?.top || 0) - 10).toString();
-  const bottomY = (height - (padding?.bottom || 0) + 20).toString();
+  const topY = ((padding?.top || 0) - 40).toString();
+  const bottomY = (height - (padding?.bottom || 0) + 50).toString();
   const leftX = (padding?.left || 0).toString();
   const rightX = width - (padding?.right || 0);
 


### PR DESCRIPTION
There was reported overlapping of application circle and adoption candidate chart description. Updating paddings to make title text readable.

Note, this is my first commit to the Tackle2 UI, I'm happy for every possible feedback. (the change might be naive, but looks to me to solving the reported issue). Sample screenshots attached in comments.

https://issues.redhat.com/browse/TACKLE-529