### PR TITLE
Repository url always required bug fix

### DIFF
--- a/pkg/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -200,9 +200,13 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
     const containsURL = (string) =>
       gitUrlRegex.test(string) || standardUrlRegex.test(string);
 
-    return schema.test("gitUrlTest", "Must be a valid URL.", (value) =>
-      containsURL(value)
-    );
+    return schema.test("gitUrlTest", "Must be a valid URL.", (value) => {
+      if (value) {
+        return containsURL(value);
+      } else {
+        return true;
+      }
+    });
   };
 
   const validationSchema = object().shape(


### PR DESCRIPTION
Allow repo url to be empty after latest validation changes