### PR TITLE
Single application analysis: no next unless artifact

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -314,7 +314,7 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
             (analyzeableApplications.length === 1 &&
               !isMutating &&
               artifact !== "") ||
-            (analyzeableApplications.length > 0 && !isMutating),
+            analyzeableApplications.length > 1,
           canJumpTo: stepIdReached >= stepId.AnalysisMode,
         },
         {


### PR DESCRIPTION
In the single application use case for analysis the wizard first step (set mode) next button cannot be enabled unless a binary file has been uploaded, so isMutating is false indicating there is no upload in progress and the `artifact` field is allocated.
This is taken care of the first part of the following condition, the OR part covers multiple applications use case, therefore the number of analyze able applications is greater than one.
```
  enableNext:
            (analyzeableApplications.length === 1 &&
              !isMutating &&
              artifact !== "") ||
            analyzeableApplications.length > 1,
```