### PR TITLE
Fix CSV template dependencies format

### DIFF
--- a/pkg/client/public/template_application_import.csv
+++ b/pkg/client/public/template_application_import.csv
@@ -2,5 +2,5 @@ Record Type 1,Application Name,Description,Comments,Business Service,Dependency,
 1,Customers,Legacy Customers management service,,Retail,,,corp.acme.demo,customers-tomcat,0.0.1-SNAPSHOT,war,git,https://git-acme.local/customers.git,main,,Operating System,RHEL 8,Database,Oracle,Language,Java,Runtime,Tomcat,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 1,Inventory,Inventory service,,Retail,,,corp.acme.demo,inventory,0.1.1-SNAPSHOT,war,git,https://git-acme.local/inventory.git,main,,Operating System,RHEL 8,Database,Postgresql,Language,Java,Runtime,Quarkus,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 1,Gateway,API Gateway,,Retail,,,corp.acme.demo,gateway,0.1.1-SNAPSHOT,war,git,https://git-acme.local/gateway.git,main,,Operating System,RHEL 8,,,Language,Java,Runtime,Spring Boot,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-2,Gateway,,,,Inventory,southbound,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-2,Gateway,,,,Customers,southbound,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2,Gateway,,,,Inventory,southbound
+2,Gateway,,,,Customers,southbound


### PR DESCRIPTION
CSV application import can include rows with RecordType=2 dependencies
which should not have trailing empty columns. (this should fit to
Tackle1)