### PR TITLE
TACKLE-451: Check for duplicate email address when creating a stakeholder

### DIFF
--- a/pkg/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
+++ b/pkg/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
@@ -27,7 +27,7 @@ import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { createStakeholder, updateStakeholder } from "@app/api/rest";
 import { JobFunction, Stakeholder, StakeholderGroup } from "@app/api/models";
 import {
-  duplicateEmailCheck,
+  duplicateFieldCheck,
   duplicateNameCheck,
   getAxiosErrorMessage,
   getValidatedFromError,
@@ -133,7 +133,8 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
         (value) => {
           const stakeholders: Stakeholder[] =
             queryClient.getQueryData(StakeholdersQueryKey) || [];
-          return duplicateEmailCheck(
+          return duplicateFieldCheck(
+            "email",
             stakeholders,
             stakeholder || null,
             value || ""

--- a/pkg/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
+++ b/pkg/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
@@ -27,6 +27,7 @@ import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { createStakeholder, updateStakeholder } from "@app/api/rest";
 import { JobFunction, Stakeholder, StakeholderGroup } from "@app/api/models";
 import {
+  duplicateEmailCheck,
   duplicateNameCheck,
   getAxiosErrorMessage,
   getValidatedFromError,
@@ -125,7 +126,20 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
       .required(t("validation.required"))
       .min(3, t("validation.minLength", { length: 3 }))
       .max(120, t("validation.maxLength", { length: 120 }))
-      .email(t("validation.email")),
+      .email(t("validation.email"))
+      .test(
+        "Duplicate email",
+        "A stakeholder with this email address already exists. Please use a different email address.",
+        (value) => {
+          const stakeholders: Stakeholder[] =
+            queryClient.getQueryData(StakeholdersQueryKey) || [];
+          return duplicateEmailCheck(
+            stakeholders,
+            stakeholder || null,
+            value || ""
+          );
+        }
+      ),
     name: string()
       .trim()
       .required(t("validation.required"))

--- a/pkg/client/src/app/utils/utils.ts
+++ b/pkg/client/src/app/utils/utils.ts
@@ -62,43 +62,20 @@ export const formatDate = (value: Date, includeTime = true) => {
   return value.toLocaleDateString("en", options);
 };
 
+export const duplicateFieldCheck = <T>(
+  fieldKey: keyof T,
+  itemList: T[],
+  currentItem: T | null,
+  fieldValue: T[keyof T]
+) =>
+  (currentItem && currentItem[fieldKey] === fieldValue) ||
+  !itemList.some((item) => item[fieldKey] === fieldValue);
+
 export const duplicateNameCheck = <T extends { name?: string }>(
   itemList: T[],
   currentItem: T | null,
-  nameValue: string
-) => {
-  let duplicateList = [...itemList];
-  if (currentItem) {
-    const index = duplicateList.findIndex((id) => id.name === currentItem.name);
-    if (index > -1) {
-      duplicateList.splice(index, 1);
-    }
-  }
-  const hasDuplicate = duplicateList.some(
-    (application) => application.name === nameValue
-  );
-  return !hasDuplicate;
-};
-
-export const duplicateEmailCheck = <T extends { email?: string }>(
-  itemList: T[],
-  currentItem: T | null,
-  emailValue: string
-) => {
-  let duplicateList = [...itemList];
-  if (currentItem) {
-    const index = duplicateList.findIndex(
-      (id) => id.email === currentItem.email
-    );
-    if (index > -1) {
-      duplicateList.splice(index, 1);
-    }
-  }
-  const hasDuplicate = duplicateList.some(
-    (application) => application.email === emailValue
-  );
-  return !hasDuplicate;
-};
+  nameValue: T["name"]
+) => duplicateFieldCheck("name", itemList, currentItem, nameValue);
 
 export const dedupeFunction = (arr) =>
   arr?.filter(

--- a/pkg/client/src/app/utils/utils.ts
+++ b/pkg/client/src/app/utils/utils.ts
@@ -80,6 +80,26 @@ export const duplicateNameCheck = <T extends { name?: string }>(
   return !hasDuplicate;
 };
 
+export const duplicateEmailCheck = <T extends { email?: string }>(
+  itemList: T[],
+  currentItem: T | null,
+  emailValue: string
+) => {
+  let duplicateList = [...itemList];
+  if (currentItem) {
+    const index = duplicateList.findIndex(
+      (id) => id.email === currentItem.email
+    );
+    if (index > -1) {
+      duplicateList.splice(index, 1);
+    }
+  }
+  const hasDuplicate = duplicateList.some(
+    (application) => application.email === emailValue
+  );
+  return !hasDuplicate;
+};
+
 export const dedupeFunction = (arr) =>
   arr?.filter(
     (value, index, self) =>


### PR DESCRIPTION
Resolves https://issues.redhat.com/projects/TACKLE/issues/TACKLE-451

![Screen Shot 2022-05-12 at 4 08 34 PM](https://user-images.githubusercontent.com/811963/168159601-60b87188-87db-4590-ae57-a337d6673e9e.png)

Also simplifies and abstracts the logic from the existing `duplicateNameCheck` into a `duplicateFieldCheck` function that can check based on any field. The type signature uses `keyof T` to enforce that the field key you pass is present in the objects you're checking.