### PR TITLE
Fix application import errors list

### DIFF
--- a/pkg/client/src/app/api/rest.tsx
+++ b/pkg/client/src/app/api/rest.tsx
@@ -490,8 +490,15 @@ export const getApplicationImportSummaryById = (id: number | string) =>
 export const deleteApplicationImportSummary = (id: number) =>
   axios.delete<APIClient>(`${APP_IMPORT_SUMMARY}/${id}`);
 
-export const getApplicationImports = () =>
-  axios.get<ApplicationImport[]>(APP_IMPORT).then((response) => response.data);
+export const getApplicationImports = (
+  importSummaryID: number,
+  isValid: boolean | string
+) =>
+  axios
+    .get<ApplicationImport[]>(
+      `${APP_IMPORT}?importSummary.id=${importSummaryID}&isValid=${isValid}`
+    )
+    .then((response) => response.data);
 
 export const getTasks = () =>
   axios.get<Task[]>(TASKS).then((response) => response.data);

--- a/pkg/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
+++ b/pkg/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
@@ -64,7 +64,10 @@ export const ManageImportsDetails: React.FC = () => {
     },
   ];
 
-  const { imports, isFetching, fetchError } = useFetchImports();
+  const { imports, isFetching, fetchError } = useFetchImports(
+    parseInt(importId),
+    false
+  );
 
   const { importSummary } = useFetchImportSummaryByID(importId);
 

--- a/pkg/client/src/app/queries/imports.ts
+++ b/pkg/client/src/app/queries/imports.ts
@@ -19,11 +19,14 @@ export const ImportSummariesQueryKey = "importsummaries";
 export const ImportsQueryKey = "imports";
 export const ImportQueryKey = "import";
 
-export const useFetchImports = () => {
+export const useFetchImports = (
+  importSummaryID: number,
+  isValid: boolean | string
+) => {
   const [imports, setImports] = useState<ApplicationImport[]>([]);
   const { isLoading, error, refetch } = useQuery(
-    ImportsQueryKey,
-    getApplicationImports,
+    [ImportsQueryKey, importSummaryID, isValid],
+    () => getApplicationImports(importSummaryID, isValid),
     {
       onSuccess: (data: ApplicationImport[]) => setImports(data),
       onError: (err: Error) => {


### PR DESCRIPTION
Application import errors list showed all imports from all ImportSummaries and both sucessful&errored.

Updating query to ask API only for Imports for given ImportSummary and valid field is false (as API is expecting it).

Fixes https://issues.redhat.com/browse/TACKLE-589