### PR TITLE
TACKLE-537: Fix validation on encrypted Maven settings field so we can save edits, fix SCM private key field to behave consistently

### DIFF
--- a/pkg/client/src/app/pages/identities/components/identity-form.tsx
+++ b/pkg/client/src/app/pages/identities/components/identity-form.tsx
@@ -525,7 +525,8 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                 label={
                   "Upload your [SCM Private Key] file or paste its contents below."
                 }
-                helperTextInvalid="You should select a private key file."
+                validated={getValidatedFromError(errors.key)}
+                helperTextInvalid={!isLoading && errors?.key?.message}
                 isRequired
                 //TODO: PKI crypto validation
                 // validated={isFileRejected ? "error" : "default"}
@@ -533,15 +534,15 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                 <Controller
                   control={control}
                   name="key"
-                  render={({ field: { value, name } }) => (
+                  render={({ field: { onChange, value, name } }) => (
                     <FileUpload
                       id="file"
                       name={name}
                       type="text"
-                      value={value}
+                      value={value && "[Encrypted]"}
                       filename={values.keyFilename}
                       onChange={(value, filename) => {
-                        setValue("key", value as string);
+                        onChange(value);
                         setValue("keyFilename", filename);
                       }}
                       dropzoneProps={{
@@ -552,8 +553,8 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                       validated={isFileRejected ? "error" : "default"}
                       filenamePlaceholder="Drag and drop a file or upload one"
                       onClearClick={() => {
-                        resetField("key");
-                        resetField("keyFilename");
+                        onChange("");
+                        setValue("keyFilename", "");
                       }}
                       allowEditingUploadedText
                       browseButtonText="Upload"

--- a/pkg/client/src/app/pages/identities/components/identity-form.tsx
+++ b/pkg/client/src/app/pages/identities/components/identity-form.tsx
@@ -168,6 +168,9 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
       then: string().test({
         name: "xml-validation",
         test: function (value) {
+          // If the field is unchanged, it must be valid (it's encrypted, so we can't parse it as XML)
+          if (value === identity?.settings) return true;
+
           if (value) {
             const validationObject = XMLValidator.validate(value, {
               allowBooleanAttributes: true,
@@ -622,8 +625,8 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                   validated={isSettingsFileRejected ? "error" : "default"}
                   filenamePlaceholder="Drag and drop a file or upload one"
                   onClearClick={() => {
-                    resetField("settings");
-                    resetField("settingsFilename");
+                    onChange("");
+                    setValue("settingsFilename", "");
                   }}
                   onReadStarted={() => setIsLoading(true)}
                   onReadFinished={() => setIsLoading(false)}


### PR DESCRIPTION
Resolves https://issues.redhat.com/projects/TACKLE/issues/TACKLE-537.

The bug here was caused by the Yup validation of the Maven settings field being unaware that its value is encrypted when prefilling for editing. The field was failing validation because its encrypted form cannot be parsed as XML, and that validation error was not appearing on the screen because the form is configured to only update the validation errors when a field changes (not when its initial value is set -- this is done so that "this field is required" doesn't appear on all required fields when a form first renders).

The solution is to short circuit the validation if the field's value has not changed relative to the credential being edited. If it was valid before, we assume it is still valid. If the field has been changed, we assume the user is replacing it with cleartext XML, so it validates as normal.

I noticed a few related quirks while fixing this that I fixed while I'm in here:
* For both file upload fields in this form (this one and the SCM private key field) the Clear buttons were not actually clearing the field when in edit mode, but resetting to the saved value. I fixed them so the Clear button actually fully clears the field.
* The SCM private key field was not showing [Encrypted] in its body, so if you are editing a credential with this field, it will show you the encrypted key (confusing and inconsistent). I changed it so it behaves the same as the Maven settings file (shows [Encrypted] if there is a value in the field).
* The SCM private key fields was never triggering validation errors, because it was not using the `onChange` event (it was directly calling `setValue` which circumvents the event). react-hook-form doesn't allow the form to submit because the field is invalid, but it doesn't display the reason to the user because it doesn't realize the value was changed by the user. I switched this field to use `onChange` like the Maven settings file field does, so now it properly shows the validation error when you change it. (it only validates that it is required, so this only matters when it is cleared).