### PR TITLE
TACKLE-538: Only allow toggling password visibility if the password is not encrypted (contains a fresh user-entered value)

### DIFF
--- a/pkg/client/src/app/pages/identities/components/identity-form.tsx
+++ b/pkg/client/src/app/pages/identities/components/identity-form.tsx
@@ -328,6 +328,8 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
     },
   ];
 
+  const isPasswordEncrypted = identity?.password === values.password;
+
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
       {axiosError && (
@@ -480,13 +482,17 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
               </FormGroup>
               <FormGroup
                 label="Password"
-                labelIcon={
-                  <KeyDisplayToggle
-                    keyName="password"
-                    isKeyHidden={isPasswordHidden}
-                    onClick={toggleHidePassword}
-                  />
-                }
+                {...(!isPasswordEncrypted
+                  ? {
+                      labelIcon: (
+                        <KeyDisplayToggle
+                          keyName="password"
+                          isKeyHidden={isPasswordHidden}
+                          onClick={toggleHidePassword}
+                        />
+                      ),
+                    }
+                  : {})}
                 fieldId="password"
                 isRequired={true}
                 validated={getValidatedFromError(errors.password)}
@@ -565,13 +571,17 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
               <FormGroup
                 label="Private Key Passphrase"
                 fieldId="password"
-                labelIcon={
-                  <KeyDisplayToggle
-                    keyName="password"
-                    isKeyHidden={isPasswordHidden}
-                    onClick={toggleHidePassword}
-                  />
-                }
+                {...(!isPasswordEncrypted
+                  ? {
+                      labelIcon: (
+                        <KeyDisplayToggle
+                          keyName="password"
+                          isKeyHidden={isPasswordHidden}
+                          onClick={toggleHidePassword}
+                        />
+                      ),
+                    }
+                  : {})}
               >
                 <Controller
                   control={control}
@@ -673,13 +683,17 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           </FormGroup>
           <FormGroup
             label="Password"
-            labelIcon={
-              <KeyDisplayToggle
-                keyName="password"
-                isKeyHidden={isPasswordHidden}
-                onClick={toggleHidePassword}
-              />
-            }
+            {...(!isPasswordEncrypted
+              ? {
+                  labelIcon: (
+                    <KeyDisplayToggle
+                      keyName="password"
+                      isKeyHidden={isPasswordHidden}
+                      onClick={toggleHidePassword}
+                    />
+                  ),
+                }
+              : {})}
             fieldId="password"
             isRequired={true}
             validated={getValidatedFromError(errors.password)}


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/TACKLE-538