### PR TITLE
TACKLE-617: Followup - also clear username when clearing password on type change

### DIFF
--- a/pkg/client/src/app/pages/identities/components/identity-form.tsx
+++ b/pkg/client/src/app/pages/identities/components/identity-form.tsx
@@ -414,7 +414,9 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
               onChange={(selection) => {
                 const selectionValue = selection as OptionWithValue<any>;
                 setValue(name, selectionValue.value);
-                setValue("password", ""); // So we don't retain the value from the wrong type of credential
+                // So we don't retain the values from the wrong type of credential
+                setValue("user", "");
+                setValue("password", "");
               }}
             />
           )}
@@ -446,7 +448,9 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                   onChange={(selection) => {
                     const selectionValue = selection as OptionWithValue<any>;
                     setValue(name, selectionValue.value);
-                    setValue("password", ""); // So we don't retain the value from the wrong type of credential
+                    // So we don't retain the values from the wrong type of credential
+                    setValue("user", "");
+                    setValue("password", "");
                   }}
                 />
               )}


### PR DESCRIPTION
Resolves something I missed in #232 (https://issues.redhat.com/browse/TACKLE-617).

We need to clear the username as well as the password when the user changes credential types.