### PR TITLE
TACKLE-554 / TACKLE-559: Ensure Analysis report details are always up-to-date

### DIFF
--- a/pkg/client/src/app/pages/applications/components/application-list-expanded-area/application-list-expanded-area-analysis.tsx
+++ b/pkg/client/src/app/pages/applications/components/application-list-expanded-area/application-list-expanded-area-analysis.tsx
@@ -27,17 +27,11 @@ export const ApplicationListExpandedAreaAnalysis: React.FC<
 > = ({ application, task }) => {
   const { t } = useTranslation();
 
-  const [isReport, setIsReport] = React.useState(false);
-
   const { identities, fetchIdentities } = useFetchIdentities();
 
   useEffect(() => {
     fetchIdentities();
   }, [fetchIdentities]);
-
-  useEffect(() => {
-    if (task?.state === "Succeeded") setIsReport(true);
-  }, [task]);
 
   let matchingSourceCredsRef;
   let matchingMavenCredsRef;
@@ -86,7 +80,7 @@ export const ApplicationListExpandedAreaAnalysis: React.FC<
       <DescriptionListGroup>
         <DescriptionListTerm>{t("terms.analysis")}</DescriptionListTerm>
         <DescriptionListDescription cy-data="analysis">
-          {isReport ? (
+          {task?.state === "Succeeded" ? (
             <Tooltip content="Click to view Analysis report">
               <Button variant="link" isInline>
                 <Link


### PR DESCRIPTION
Resolves https://issues.redhat.com/projects/TACKLE/issues/TACKLE-554 and https://issues.redhat.com/projects/TACKLE/issues/TACKLE-559.

The main issue here was the `isReport` state which was being set to true in a `useEffect` whenever the latest analysis task entered the "Succeeded" state, but was never set to false again afterwards. We don't need this state at all because we can simply use the current status of the latest task for each application to drive the rendering logic. So we'll only get a report link if the latest task is still in the succeeded state.

The other changes here in `useFetchTasks` were part of a prior attempt to troubleshoot and aren't required to fix the bug, but I decided to keep them because they are still an improvement:
* The `tasks` state in that hook was duplicating state we can just use from within the `useQuery` return value by using the `select` option to filter the tasks instead of doing that in `onSuccess`.
* The `else uniqLatestTasks.push(task);` branch was being executed even if we already have `aTask` defined, which means more than one task per application can end up in the tasks array. This was not causing a bug because the existing logic did make sure the *first* task in the array for each application was the latest one (so `.find()` still returns the right one), but after adding that task it would continue adding any other matching tasks that occurred sooner. Moving that `.push` to explicitly only happen if `aTask` is not yet defined ensures we will only ever get one task per application.