### PR TITLE
TACKLE-566: Case-insensitive sorting in 'manage imports' table

### DIFF
--- a/pkg/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/pkg/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -118,7 +118,7 @@ export const ManageImports: React.FC = () => {
   const getSortValues = (item: ApplicationImportSummary) => [
     "",
     "",
-    item?.filename || "",
+    item?.filename?.toLowerCase() || "",
     "",
     "", // Action column
   ];


### PR DESCRIPTION
Resolves https://issues.redhat.com/projects/TACKLE/issues/TACKLE-566.

Sorting was actually working properly in this view except that `useSortState` uses a straight `<` / `>` comparison on the strings which is sorting by unicode character id order rather than alphabetical order. This means all uppercase letters are considered to come before all lowercase letters.

Calling `.toLowerCase()` on the values being compared fixes this, but it might be worth revisiting this to see if `localeCompare` should be used inside `useSortState` to prevent this problem in the future. This is something I was considering in https://github.com/konveyor/lib-ui/pull/73#issuecomment-894476380 which I'll try to return to.