### PR TITLE
TACKLE-616: Close modal on import with validation errors & show notification with error

### DIFF
--- a/pkg/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
@@ -17,6 +17,7 @@ import { alertActions } from "@app/store/alert";
 
 import { UPLOAD_FILE } from "@app/api/rest";
 import { getAxiosErrorMessage } from "@app/utils/utils";
+import { useDeleteImportSummaryMutation } from "@app/queries/imports";
 
 export interface ImportApplicationsFormProps {
   onSaved: (response: AxiosResponse) => void;
@@ -32,6 +33,8 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<AxiosError>();
+
+  const { mutate: deleteImportSummary } = useDeleteImportSummaryMutation();
 
   // Redux
   const dispatch = useDispatch();
@@ -60,11 +63,14 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
         dispatch(
           alertActions.addSuccess(t("toastr.success.fileSavedToBeProcessed"))
         );
+        console.log("response", response);
 
         setIsSubmitting(false);
         onSaved(response);
       })
       .catch((error) => {
+        console.log("error", error.response);
+        // deleteImportSummary(1);
         setIsSubmitting(false);
         setError(error);
       });

--- a/pkg/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
@@ -17,7 +17,6 @@ import { alertActions } from "@app/store/alert";
 
 import { UPLOAD_FILE } from "@app/api/rest";
 import { getAxiosErrorMessage } from "@app/utils/utils";
-import { useDeleteImportSummaryMutation } from "@app/queries/imports";
 
 export interface ImportApplicationsFormProps {
   onSaved: (response: AxiosResponse) => void;
@@ -33,8 +32,6 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<AxiosError>();
-
-  const { mutate: deleteImportSummary } = useDeleteImportSummaryMutation();
 
   // Redux
   const dispatch = useDispatch();
@@ -63,14 +60,10 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
         dispatch(
           alertActions.addSuccess(t("toastr.success.fileSavedToBeProcessed"))
         );
-        console.log("response", response);
-
         setIsSubmitting(false);
         onSaved(response);
       })
       .catch((error) => {
-        console.log("error", error.response);
-        // deleteImportSummary(1);
         setIsSubmitting(false);
         setError(error);
       });

--- a/pkg/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
@@ -31,7 +31,6 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
   const [isFileRejected, setIsFileRejected] = useState(false);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<AxiosError>();
 
   // Redux
   const dispatch = useDispatch();
@@ -65,21 +64,16 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
       })
       .catch((error) => {
         setIsSubmitting(false);
-        setError(error);
+        if (typeof getAxiosErrorMessage(error) === "string") {
+          dispatch(
+            alertActions.addDanger(`Error: ${getAxiosErrorMessage(error)} `)
+          );
+        }
+        onSaved(error);
       });
   };
   return (
     <Form>
-      {error && (
-        <Alert
-          actionClose={
-            <AlertActionCloseButton onClose={() => setError(undefined)} />
-          }
-          variant="danger"
-          title={getAxiosErrorMessage(error)}
-        />
-      )}
-
       <FormGroup
         fieldId="file"
         label={t("terms.uploadApplicationFile")}
@@ -110,7 +104,7 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
         <Button
           variant="primary"
           onClick={onSubmit}
-          isDisabled={!file || isSubmitting || !!error}
+          isDisabled={!file || isSubmitting}
         >
           {t("actions.import")}
         </Button>

--- a/pkg/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import {
   ActionGroup,
   Alert,
+  AlertActionCloseButton,
   Button,
   FileUpload,
   Form,
@@ -70,7 +71,15 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
   };
   return (
     <Form>
-      {error && <Alert variant="danger" title={getAxiosErrorMessage(error)} />}
+      {error && (
+        <Alert
+          actionClose={
+            <AlertActionCloseButton onClose={() => setError(undefined)} />
+          }
+          variant="danger"
+          title={getAxiosErrorMessage(error)}
+        />
+      )}
 
       <FormGroup
         fieldId="file"
@@ -102,7 +111,7 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
         <Button
           variant="primary"
           onClick={onSubmit}
-          isDisabled={!file || isSubmitting}
+          isDisabled={!file || isSubmitting || !!error}
         >
           {t("actions.import")}
         </Button>

--- a/pkg/client/src/app/queries/imports.ts
+++ b/pkg/client/src/app/queries/imports.ts
@@ -89,8 +89,8 @@ export const useFetchImportSummaryByID = (id: number | string) => {
 };
 
 export const useDeleteImportSummaryMutation = (
-  onSuccess?: () => void,
-  onError?: (err: Error | null) => void
+  onSuccess: () => void,
+  onError: (err: Error | null) => void
 ) => {
   return useMutation(deleteApplicationImportSummary, {
     onSuccess: () => {

--- a/pkg/client/src/app/queries/imports.ts
+++ b/pkg/client/src/app/queries/imports.ts
@@ -89,8 +89,8 @@ export const useFetchImportSummaryByID = (id: number | string) => {
 };
 
 export const useDeleteImportSummaryMutation = (
-  onSuccess: () => void,
-  onError: (err: Error | null) => void
+  onSuccess?: () => void,
+  onError?: (err: Error | null) => void
 ) => {
   return useMutation(deleteApplicationImportSummary, {
     onSuccess: () => {


### PR DESCRIPTION
- Disables import button & allows clearing of the import error within the upload import csv modal. 
https://issues.redhat.com/browse/TACKLE-616
