### PR TITLE
QE: Add unique ids to Select toggles for proxy credentials selections

### DIFF
--- a/pkg/client/src/app/pages/proxies/proxy-form.tsx
+++ b/pkg/client/src/app/pages/proxies/proxy-form.tsx
@@ -412,6 +412,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                   helperTextInvalid={errors.httpIdentity?.message}
                 >
                   <SimpleSelect
+                    toggleId="http-proxy-credentials-select-toggle"
                     aria-label={HTTP_IDENTITY}
                     value={value ? value : undefined}
                     options={identityOptions}
@@ -523,6 +524,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                   helperTextInvalid={errors.httpsIdentity?.message}
                 >
                   <SimpleSelect
+                    toggleId="https-proxy-credentials-select-toggle"
                     aria-label={HTTPS_IDENTITY}
                     value={value ? value : undefined}
                     options={identityOptions}


### PR DESCRIPTION
Requested by @ibragins . Currently it is not possible for QE automation to distinguish between the dropdown toggles for HTTP and HTTPS credentials in the proxy configuration. Adding `toggleId` to each of these solves the problem.