### PR TITLE
TACKLE-512: Refetch application assessments and reviews properly when copying/discarding (+ upgrade TypeScript)

### DIFF
--- a/pkg/client/package-lock.json
+++ b/pkg/client/package-lock.json
@@ -106,7 +106,7 @@
         "ts-jest": "^27.0.3",
         "ts-loader": "^9.2.6",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
-        "typescript": "4.0.3",
+        "typescript": "^4.1.0",
         "url-loader": "^4.1.1",
         "webpack": "^5.67.0",
         "webpack-cli": "^4.9.2",
@@ -11389,19 +11389,6 @@
         "readable-stream": "3"
       }
     },
-    "node_modules/i18next-parser/node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -21584,9 +21571,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -32221,12 +32208,6 @@
           "requires": {
             "readable-stream": "3"
           }
-        },
-        "typescript": {
-          "version": "4.5.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-          "dev": true
         }
       }
     },
@@ -40070,9 +40051,9 @@
       "integrity": "sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg=="
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "devOptional": true
     },
     "umd": {

--- a/pkg/client/package.json
+++ b/pkg/client/package.json
@@ -117,7 +117,7 @@
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.6",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
-    "typescript": "4.0.3",
+    "typescript": "^4.1.0",
     "url-loader": "^4.1.1",
     "webpack": "^5.67.0",
     "webpack-cli": "^4.9.2",

--- a/pkg/client/public/locales/en/translation.json
+++ b/pkg/client/public/locales/en/translation.json
@@ -247,6 +247,7 @@
         "stakeholders": "Stakeholders",
         "status": "Status",
         "suggestedAdoptionPlan": "Suggested adoption plan",
+        "summaryImport": "Import summary",
         "svnConfig": "Subversion configuration",
         "tableView": "Table view",
         "tag": "Tag",

--- a/pkg/client/public/locales/en/translation.json
+++ b/pkg/client/public/locales/en/translation.json
@@ -247,7 +247,6 @@
         "stakeholders": "Stakeholders",
         "status": "Status",
         "suggestedAdoptionPlan": "Suggested adoption plan",
-        "summaryImport": "Import summary",
         "svnConfig": "Subversion configuration",
         "tableView": "Table view",
         "tag": "Tag",

--- a/pkg/client/src/app/layout/DefaultLayout/tests/__snapshots__/DefaultLayout.test.tsx.snap
+++ b/pkg/client/src/app/layout/DefaultLayout/tests/__snapshots__/DefaultLayout.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Test snapshot 1`] = `
 <Page
   defaultManagedSidebarIsOpen={true}
   getBreakpoint={[Function]}
-  header={<Unknown />}
+  header={<HeaderApp />}
   isBreadcrumbWidthLimited={false}
   isManagedSidebar={true}
   isNotificationDrawerExpanded={false}
@@ -12,7 +12,7 @@ exports[`Test snapshot 1`] = `
   mainTabIndex={-1}
   onNotificationDrawerExpand={[Function]}
   onPageResize={[Function]}
-  sidebar={<Unknown />}
+  sidebar={<SidebarApp />}
   skipToContent={
     <SkipToContent
       href="#main-content-page-layout-horizontal-nav"

--- a/pkg/client/src/app/layout/HeaderApp/tests/__snapshots__/HeaderApp.test.tsx.snap
+++ b/pkg/client/src/app/layout/HeaderApp/tests/__snapshots__/HeaderApp.test.tsx.snap
@@ -17,9 +17,9 @@ exports[`Test snapshot 1`] = `
         }
       >
         <PageHeaderToolsItem>
-          <Unknown>
+          <AppAboutModalState>
             [Function]
-          </Unknown>
+          </AppAboutModalState>
         </PageHeaderToolsItem>
       </PageHeaderToolsGroup>
       <PageHeaderToolsGroup>
@@ -30,9 +30,9 @@ exports[`Test snapshot 1`] = `
             }
           }
         >
-          <Unknown />
+          <MobileDropdown />
         </PageHeaderToolsItem>
-        <Unknown />
+        <SSOMenu />
       </PageHeaderToolsGroup>
       <Avatar
         alt="Avatar image"

--- a/pkg/client/src/app/layout/SidebarApp/tests/__snapshots__/SidebarApp.test.tsx.snap
+++ b/pkg/client/src/app/layout/SidebarApp/tests/__snapshots__/SidebarApp.test.tsx.snap
@@ -23,6 +23,6 @@ exports[`Renders without crashing 1`] = `
     }
   }
 >
-  <Component />
+  <SidebarApp />
 </Router>
 `;

--- a/pkg/client/src/app/pages/applications/application-assessment/components/application-assessment-page/__snapshots__/application-assessment-page-header.test.tsx.snap
+++ b/pkg/client/src/app/pages/applications/application-assessment/components/application-assessment-page/__snapshots__/application-assessment-page-header.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`ApplicationAssessmentPageHeader Renders without crashing 1`] = `
     }
   }
 >
-  <Component
+  <ApplicationAssessmentPageHeader
     assessment={
       Object {
         "applicationId": 1,
@@ -23,7 +23,7 @@ exports[`ApplicationAssessmentPageHeader Renders without crashing 1`] = `
       }
     }
   >
-    <Component
+    <PageHeader
       breadcrumbs={
         Array [
           Object {
@@ -55,7 +55,7 @@ exports[`ApplicationAssessmentPageHeader Renders without crashing 1`] = `
             <div
               className="pf-l-stack__item"
             >
-              <Component
+              <BreadCrumbPath
                 breadcrumbs={
                   Array [
                     Object {
@@ -159,7 +159,7 @@ exports[`ApplicationAssessmentPageHeader Renders without crashing 1`] = `
                     </ol>
                   </nav>
                 </Breadcrumb>
-              </Component>
+              </BreadCrumbPath>
             </div>
           </StackItem>
           <StackItem>
@@ -219,7 +219,7 @@ exports[`ApplicationAssessmentPageHeader Renders without crashing 1`] = `
           </StackItem>
         </div>
       </Stack>
-    </Component>
+    </PageHeader>
     <Modal
       actions={Array []}
       appendTo={[Function]}
@@ -262,6 +262,6 @@ exports[`ApplicationAssessmentPageHeader Renders without crashing 1`] = `
         />
       </Portal>
     </Modal>
-  </Component>
+  </ApplicationAssessmentPageHeader>
 </Provider>
 `;

--- a/pkg/client/src/app/pages/applications/application-assessment/components/application-assessment-page/__snapshots__/application-assessment-page.test.tsx.snap
+++ b/pkg/client/src/app/pages/applications/application-assessment/components/application-assessment-page/__snapshots__/application-assessment-page.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ApplicationAssessmentPage Renders without crashing 1`] = `
   <PageSection
     variant="light"
   >
-    <Component
+    <ApplicationAssessmentPageHeader
       assessment={
         Object {
           "applicationId": 1,

--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -218,14 +218,10 @@ export const ApplicationsTable: React.FC = () => {
     fetchError: fetchErrorReviews,
   } = useFetchReviews();
 
-  const [appReview, setAppReview] = useState<Review>();
-  useEffect(() => {
-    const appReview = reviews?.find(
-      (review) =>
-        review.id === applicationToCopyAssessmentAndReviewFrom?.review?.id
-    );
-    setAppReview(appReview);
-  }, [applicationToCopyAssessmentAndReviewFrom, reviews]);
+  const appReview = reviews?.find(
+    (review) =>
+      review.id === applicationToCopyAssessmentAndReviewFrom?.review?.id
+  );
 
   // Dependencies modal
   const {

--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -81,7 +81,7 @@ import {
   getApplicationsFilterValues,
 } from "../applicationsFilter";
 import { FilterToolbar } from "@app/shared/components/FilterToolbar/FilterToolbar";
-import { useFetchReviews } from "@app/queries/reviews";
+import { reviewsQueryKey, useFetchReviews } from "@app/queries/reviews";
 import { isAuthRequired } from "@app/Constants";
 import {
   assessmentsQueryKey,
@@ -530,6 +530,7 @@ export const ApplicationsTable: React.FC = () => {
               );
               refetch();
               queryClient.invalidateQueries(assessmentsQueryKey);
+              queryClient.invalidateQueries(reviewsQueryKey);
             })
             .catch((error) => {
               dispatch(confirmDialogActions.closeDialog());

--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -1,15 +1,13 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { AxiosError, AxiosResponse } from "axios";
 import { useTranslation, Trans } from "react-i18next";
-import { useSelectionState } from "@konveyor/lib-ui";
 
 import {
   Button,
   ButtonVariant,
   DropdownItem,
   Modal,
-  ToolbarChip,
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
@@ -46,7 +44,6 @@ import {
 import {
   useTableControls,
   useAssessApplication,
-  useMultipleFetch,
   useEntityModal,
   useApplicationToolbarFilter,
 } from "@app/shared/hooks";
@@ -65,7 +62,6 @@ import { ApplicationBusinessService } from "../components/application-business-s
 import { ApplicationListExpandedArea } from "../components/application-list-expanded-area";
 import { ImportApplicationsForm } from "../components/import-applications-form";
 import { BulkCopyAssessmentReviewForm } from "../components/bulk-copy-assessment-review-form";
-import { ApplicationIdentityForm } from "../components/application-identity-form/application-identity-form";
 import {
   applicationsWriteScopes,
   dependenciesWriteScopes,
@@ -85,21 +81,18 @@ import {
   getApplicationsFilterValues,
 } from "../applicationsFilter";
 import { FilterToolbar } from "@app/shared/components/FilterToolbar/FilterToolbar";
-import { useFetchTags } from "@app/queries/tags";
 import { useFetchReviews } from "@app/queries/reviews";
 import { isAuthRequired } from "@app/Constants";
+import {
+  assessmentsQueryKey,
+  useFetchApplicationAssessments,
+} from "@app/queries/assessments";
+import { useQueryClient } from "react-query";
 
 const ENTITY_FIELD = "entity";
 
 const getRow = (rowData: IRowData): Application => {
   return rowData[ENTITY_FIELD];
-};
-
-const searchAppAssessment = (id: number) => {
-  const result = getAssessments({ applicationId: id }).then(({ data }) =>
-    data[0] ? data[0] : undefined
-  );
-  return result;
 };
 
 export const ApplicationsTable: React.FC = () => {
@@ -139,6 +132,8 @@ export const ApplicationsTable: React.FC = () => {
 
   const { applications, isFetching, fetchError, refetch } =
     useFetchApplications();
+
+  const queryClient = useQueryClient();
 
   const {
     paginationProps,
@@ -246,20 +241,10 @@ export const ApplicationsTable: React.FC = () => {
 
   // Table's assessments
   const {
-    getData: getApplicationAssessment,
-    isFetching: isFetchingApplicationAssessment,
-    fetchError: fetchErrorApplicationAssessment,
-    fetchCount: fetchCountApplicationAssessment,
-    triggerFetch: fetchApplicationsAssessment,
-  } = useMultipleFetch<number, Assessment | undefined>({
-    onFetchPromise: searchAppAssessment,
-  });
-
-  useEffect(() => {
-    if (applications) {
-      fetchApplicationsAssessment(applications?.map((f) => f.id!));
-    }
-  }, [applications, fetchApplicationsAssessment]);
+    getApplicationAssessment,
+    isLoadingApplicationAssessment,
+    fetchErrorApplicationAssessment,
+  } = useFetchApplicationAssessments(applications);
 
   const { mutate: deleteApplication } = useDeleteApplicationMutation(
     onDeleteApplicationSuccess,
@@ -325,9 +310,8 @@ export const ApplicationsTable: React.FC = () => {
           title: (
             <ApplicationAssessment
               assessment={getApplicationAssessment(item.id!)}
-              isFetching={isFetchingApplicationAssessment(item.id!)}
+              isLoading={isLoadingApplicationAssessment(item.id!)}
               fetchError={fetchErrorApplicationAssessment(item.id!)}
-              fetchCount={fetchCountApplicationAssessment(item.id!)}
             />
           ),
         },
@@ -545,6 +529,7 @@ export const ApplicationsTable: React.FC = () => {
                 )
               );
               refetch();
+              queryClient.invalidateQueries(assessmentsQueryKey);
             })
             .catch((error) => {
               dispatch(confirmDialogActions.closeDialog());

--- a/pkg/client/src/app/pages/applications/components/application-assessment/application-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/components/application-assessment/application-assessment.tsx
@@ -8,12 +8,12 @@ import {
   StatusIconType,
 } from "@app/shared/components";
 import { Assessment } from "@app/api/models";
+import { Spinner } from "@patternfly/react-core";
 
 export interface ApplicationAssessmentProps {
   assessment?: Assessment;
-  isFetching: boolean;
+  isLoading: boolean;
   fetchError?: AxiosError;
-  fetchCount: number;
 }
 
 const getStatusIconFrom = (assessment: Assessment): StatusIconType => {
@@ -31,17 +31,16 @@ const getStatusIconFrom = (assessment: Assessment): StatusIconType => {
 
 export const ApplicationAssessment: React.FC<ApplicationAssessmentProps> = ({
   assessment,
-  isFetching,
+  isLoading,
   fetchError,
-  fetchCount,
 }) => {
   const { t } = useTranslation();
 
   if (fetchError) {
     return <EmptyTextMessage message={t("terms.notAvailable")} />;
   }
-  if (isFetching || fetchCount === 0) {
-    return <></>;
+  if (isLoading) {
+    return <Spinner size="md" />;
   }
 
   return assessment ? (

--- a/pkg/client/src/app/pages/applications/components/bulk-copy-assessment-review-form/bulk-copy-assessment-review-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/bulk-copy-assessment-review-form/bulk-copy-assessment-review-form.tsx
@@ -18,8 +18,6 @@ import {
   CardBody,
   Checkbox,
   FormGroup,
-  ToolbarChip,
-  ToolbarItem,
 } from "@patternfly/react-core";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
 import { global_palette_gold_400 as gold } from "@patternfly/react-tokens";
@@ -28,61 +26,34 @@ import { useDispatch } from "react-redux";
 import { alertActions } from "@app/store/alert";
 import { bulkCopyActions } from "@app/store/bulkCopy";
 
-import {
-  ApplicationToolbarToggleGroup,
-  AppTableWithControls,
-  StatusIcon,
-  ToolbarBulkSelector,
-} from "@app/shared/components";
-import {
-  useFetch,
-  useMultipleFetch,
-  useTableControls,
-  useToolbarFilter,
-  useSelectionFromPageState,
-  useFetchPagination,
-} from "@app/shared/hooks";
+import { AppTableWithControls, StatusIcon } from "@app/shared/components";
+import { useFetch } from "@app/shared/hooks";
 
-import {
-  Application,
-  ApplicationPage,
-  Assessment,
-  Review,
-  SortByQuery,
-} from "@app/api/models";
+import { Application, Assessment, Review } from "@app/api/models";
 
 import {
   createBulkCopyAssessment,
   createBulkCopyReview,
   getApplications,
-  getAssessments,
 } from "@app/api/rest";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 
 import { ApplicationBusinessService } from "../application-business-service";
 import { ApplicationAssessment } from "../application-assessment";
 import { usePaginationState } from "@app/shared/hooks/usePaginationState";
-import identities from "@app/pages/identities";
 import {
   FilterCategory,
-  FilterToolbar,
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
 import { useSortState } from "@app/shared/hooks/useSortState";
 import { useSelectionState } from "@konveyor/lib-ui";
+import { useFetchApplicationAssessments } from "@app/queries/assessments";
 
 const ENTITY_FIELD = "entity";
 
 const getRow = (rowData: IRowData): Application => {
   return rowData[ENTITY_FIELD];
-};
-
-const searchAppAssessment = (id: number) => {
-  const result = getAssessments({ applicationId: id }).then(({ data }) =>
-    data[0] ? data[0] : undefined
-  );
-  return result;
 };
 
 interface BulkCopyAssessmentReviewFormProps {
@@ -160,20 +131,10 @@ export const BulkCopyAssessmentReviewForm: React.FC<
 
   // Table's assessments
   const {
-    getData: getApplicationAssessment,
-    isFetching: isFetchingApplicationAssessment,
-    fetchError: fetchErrorApplicationAssessment,
-    fetchCount: fetchCountApplicationAssessment,
-    triggerFetch: fetchApplicationsAssessment,
-  } = useMultipleFetch<number, Assessment | undefined>({
-    onFetchPromise: searchAppAssessment,
-  });
-
-  useEffect(() => {
-    if (applications) {
-      fetchApplicationsAssessment(applications.map((f) => f.id!));
-    }
-  }, [applications, fetchApplicationsAssessment]);
+    getApplicationAssessment,
+    isLoadingApplicationAssessment,
+    fetchErrorApplicationAssessment,
+  } = useFetchApplicationAssessments(applications);
 
   // Select rows
   const {
@@ -241,9 +202,8 @@ export const BulkCopyAssessmentReviewForm: React.FC<
           title: (
             <ApplicationAssessment
               assessment={getApplicationAssessment(item.id!)}
-              isFetching={isFetchingApplicationAssessment(item.id!)}
+              isLoading={isLoadingApplicationAssessment(item.id!)}
               fetchError={fetchErrorApplicationAssessment(item.id!)}
-              fetchCount={fetchCountApplicationAssessment(item.id!)}
             />
           ),
         },

--- a/pkg/client/src/app/queries/applications.ts
+++ b/pkg/client/src/app/queries/applications.ts
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
 import { Application, Assessment } from "@app/api/models";
@@ -21,23 +20,19 @@ export interface IApplicationMutateState {
 export const ApplicationsQueryKey = "applications";
 
 export const useFetchApplications = () => {
-  const [applications, setApplications] = useState<Application[]>([]);
   const queryClient = useQueryClient();
-  const { isLoading, error, refetch } = useQuery(
+  const { data, isLoading, error, refetch } = useQuery(
     ApplicationsQueryKey,
     getApplicationsQuery,
     {
       onSuccess: (data: Application[]) => {
-        setApplications(data);
         queryClient.invalidateQueries(reviewsQueryKey);
       },
-      onError: (err: Error) => {
-        console.log(error);
-      },
+      onError: (err: Error) => console.log(error),
     }
   );
   return {
-    applications,
+    applications: data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/pkg/client/src/app/queries/assessments.ts
+++ b/pkg/client/src/app/queries/assessments.ts
@@ -1,7 +1,8 @@
-import { useMutation } from "react-query";
+import { useMutation, useQueries, UseQueryResult } from "react-query";
 
-import { deleteAssessment } from "@app/api/rest";
+import { deleteAssessment, getAssessments } from "@app/api/rest";
 import { AxiosError } from "axios";
+import { Application, Assessment } from "@app/api/models";
 
 export const useDeleteAssessmentMutation = (
   onSuccess?: () => void,
@@ -15,4 +16,35 @@ export const useDeleteAssessmentMutation = (
       onError && onError(err);
     },
   });
+};
+
+export const assessmentsQueryKey = "assessments";
+
+export const useFetchApplicationAssessments = (
+  applications: Application[] = []
+) => {
+  const queryResults = useQueries(
+    applications.map((application) => ({
+      queryKey: [assessmentsQueryKey, application.id],
+      queryFn: async () => {
+        const response = await getAssessments({
+          applicationId: application.id,
+        });
+        const allAssessmentsForApp = response.data;
+        return allAssessmentsForApp[0];
+      },
+      onError: (error) => console.log("error, ", error),
+    }))
+  );
+  const queryResultsByAppId: Record<number, UseQueryResult<Assessment>> = {};
+  applications.forEach((application, i) => {
+    if (application.id) queryResultsByAppId[application.id] = queryResults[i];
+  });
+  return {
+    getApplicationAssessment: (id: number) => queryResultsByAppId[id].data,
+    isLoadingApplicationAssessment: (id: number) =>
+      queryResultsByAppId[id].isLoading,
+    fetchErrorApplicationAssessment: (id: number) =>
+      queryResultsByAppId[id].error as AxiosError | undefined,
+  };
 };

--- a/pkg/client/src/app/queries/identities.ts
+++ b/pkg/client/src/app/queries/identities.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
 import {
@@ -67,20 +66,15 @@ export const useCreateIdentityMutation = (
 };
 
 export const useFetchIdentities = (): IIdentityFetchState => {
-  const [identities, setIdentities] = React.useState<Identity[]>([]);
-  const { isLoading, error } = useQuery(IdentitiesQueryKey, () =>
-    getIdentities()
-      .then(({ data }) => {
-        setIdentities(data);
-        return data;
-      })
-      .catch((error) => {
-        console.log("error, ", error);
-        return error;
-      })
-  );
+  const {
+    data: response,
+    isLoading,
+    error,
+  } = useQuery(IdentitiesQueryKey, getIdentities, {
+    onError: (error) => console.log("error, ", error),
+  });
   return {
-    identities,
+    identities: response?.data || [],
     isFetching: isLoading,
     fetchError: error,
   };

--- a/pkg/client/src/app/queries/imports.ts
+++ b/pkg/client/src/app/queries/imports.ts
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useMutation, useQuery } from "react-query";
 
 import {
@@ -7,7 +6,6 @@ import {
   getApplicationImportSummaryById,
   getApplicationsImportSummary,
 } from "@app/api/rest";
-import { ApplicationImportSummary, ApplicationImport } from "@app/api/models";
 
 export interface IImportMutateState {
   mutate: any;
@@ -23,19 +21,13 @@ export const useFetchImports = (
   importSummaryID: number,
   isValid: boolean | string
 ) => {
-  const [imports, setImports] = useState<ApplicationImport[]>([]);
-  const { isLoading, error, refetch } = useQuery(
+  const { data, isLoading, error, refetch } = useQuery(
     [ImportsQueryKey, importSummaryID, isValid],
     () => getApplicationImports(importSummaryID, isValid),
-    {
-      onSuccess: (data: ApplicationImport[]) => setImports(data),
-      onError: (err: Error) => {
-        console.log(error);
-      },
-    }
+    { onError: (err: Error) => console.log(error) }
   );
   return {
-    imports,
+    imports: data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,
@@ -43,22 +35,16 @@ export const useFetchImports = (
 };
 
 export const useFetchImportSummaries = () => {
-  const [importSummaries, setImportSummaries] = useState<
-    ApplicationImportSummary[]
-  >([]);
-  const { isLoading, error, refetch } = useQuery(
+  const { data, isLoading, error, refetch } = useQuery(
     ImportSummariesQueryKey,
     getApplicationsImportSummary,
     {
       refetchInterval: 5000,
-      onSuccess: (data: ApplicationImportSummary[]) => setImportSummaries(data),
-      onError: (err: Error) => {
-        console.log(error);
-      },
+      onError: (err: Error) => console.log(error),
     }
   );
   return {
-    importSummaries,
+    importSummaries: data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,
@@ -66,22 +52,14 @@ export const useFetchImportSummaries = () => {
 };
 
 export const useFetchImportSummaryByID = (id: number | string) => {
-  const [importSummary, setImportSummary] =
-    useState<ApplicationImportSummary>();
-
-  const { isLoading, error, refetch } = useQuery(
+  const { data, isLoading, error, refetch } = useQuery(
     [ImportQueryKey, id],
     () => getApplicationImportSummaryById(id),
-    {
-      onSuccess: (data: ApplicationImportSummary) => setImportSummary(data),
-      onError: (err: Error) => {
-        console.log(error);
-      },
-    }
+    { onError: (err: Error) => console.log(error) }
   );
 
   return {
-    importSummary,
+    importSummary: data,
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/pkg/client/src/app/queries/proxies.ts
+++ b/pkg/client/src/app/queries/proxies.ts
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import { AxiosError } from "axios";
-import { createAsyncAction, getType } from "typesafe-actions";
-import { getProxies, PROXIES, updateProxy } from "@app/api/rest";
-import { Proxy } from "@app/api/models";
+import { createAsyncAction } from "typesafe-actions";
+import { getProxies, updateProxy } from "@app/api/rest";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
 export const {
@@ -24,19 +23,13 @@ export interface IFetchState {
 export const useFetchProxies = (
   defaultIsFetching: boolean = false
 ): IFetchState => {
-  const [proxies, setProxies] = useState<Array<Proxy>>([]);
-  const { isLoading, refetch, isError, data, error } = useQuery("proxies", () =>
-    getProxies()
-      .then((res) => res)
-      .then(({ data }) => {
-        setProxies(data);
-      })
-      .catch((error) => {
-        console.log("error, ", error);
-      })
+  const { isLoading, refetch, isError, data, error } = useQuery(
+    "proxies",
+    getProxies,
+    { onError: () => console.log("error, ", error) }
   );
   return {
-    proxies: proxies,
+    proxies: data || [],
     isFetching: isLoading,
     fetchError: error,
   };

--- a/pkg/client/src/app/queries/reviews.ts
+++ b/pkg/client/src/app/queries/reviews.ts
@@ -1,8 +1,6 @@
-import React from "react";
-import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useQuery } from "react-query";
 
 import { getReviews } from "@app/api/rest";
-import { AxiosError } from "axios";
 import { Review } from "@app/api/models";
 
 export interface IReviewFetchState {
@@ -15,20 +13,16 @@ export interface IReviewFetchState {
 export const reviewsQueryKey = "reviews";
 
 export const useFetchReviews = (): IReviewFetchState => {
-  const [reviews, setReviews] = React.useState<Review[]>([]);
-  const { isLoading, error, refetch } = useQuery(reviewsQueryKey, () =>
-    getReviews()
-      .then(({ data }) => {
-        setReviews(data);
-        return data;
-      })
-      .catch((error) => {
-        console.log("error, ", error);
-        return error;
-      })
-  );
+  const {
+    data: response,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery(reviewsQueryKey, getReviews, {
+    onError: (error) => console.log("error, ", error),
+  });
   return {
-    reviews,
+    reviews: response?.data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/pkg/client/src/app/queries/stakeholders.ts
+++ b/pkg/client/src/app/queries/stakeholders.ts
@@ -1,7 +1,5 @@
-import React from "react";
-import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useQuery } from "react-query";
 
-import { AxiosError } from "axios";
 import { Stakeholder } from "@app/api/models";
 import { getStakeholders } from "@app/api/rest";
 
@@ -14,20 +12,15 @@ export interface IStakeholderFetchState {
 export const StakeholdersQueryKey = "stakeholders";
 
 export const useFetchStakeholders = (): IStakeholderFetchState => {
-  const [stakeholders, setStakeholders] = React.useState<Stakeholder[]>([]);
-  const { isLoading, error } = useQuery(StakeholdersQueryKey, () =>
-    getStakeholders()
-      .then(({ data }) => {
-        setStakeholders(data);
-        return data;
-      })
-      .catch((error) => {
-        console.log("error, ", error);
-        return error;
-      })
-  );
+  const {
+    data: response,
+    isLoading,
+    error,
+  } = useQuery(StakeholdersQueryKey, getStakeholders, {
+    onError: (error) => console.log("error, ", error),
+  });
   return {
-    stakeholders,
+    stakeholders: response?.data || [],
     isFetching: isLoading,
     fetchError: error,
   };

--- a/pkg/client/src/app/queries/tags.ts
+++ b/pkg/client/src/app/queries/tags.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { useQuery } from "react-query";
 
 import { getTags, getTagTypes } from "@app/api/rest";
@@ -22,20 +21,16 @@ export const TagsQueryKey = "tags";
 export const TagTypesQueryKey = "tagtypes";
 
 export const useFetchTags = (): ITagFetchState => {
-  const [tags, setTags] = React.useState<Tag[]>([]);
-  const { isLoading, error, refetch } = useQuery(TagsQueryKey, () =>
-    getTags()
-      .then(({ data }) => {
-        setTags(data);
-        return data;
-      })
-      .catch((error) => {
-        console.log("error, ", error);
-        return error;
-      })
-  );
+  const {
+    data: response,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery(TagsQueryKey, getTags, {
+    onError: (error) => console.log("error, ", error),
+  });
   return {
-    tags,
+    tags: response?.data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,
@@ -43,20 +38,16 @@ export const useFetchTags = (): ITagFetchState => {
 };
 
 export const useFetchTagTypes = (): ITagTypeFetchState => {
-  const [tagTypes, setTagTypes] = React.useState<TagType[]>([]);
-  const { isLoading, error, refetch } = useQuery(TagTypesQueryKey, () =>
-    getTagTypes()
-      .then(({ data }) => {
-        setTagTypes(data);
-        return data;
-      })
-      .catch((error) => {
-        console.log("error, ", error);
-        return error;
-      })
-  );
+  const {
+    data: response,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery(TagTypesQueryKey, getTagTypes, {
+    onError: (error) => console.log("error, ", error),
+  });
   return {
-    tagTypes,
+    tagTypes: response?.data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/pkg/client/src/app/queries/volumes.ts
+++ b/pkg/client/src/app/queries/volumes.ts
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import { useMutation, useQuery } from "react-query";
 
 import { cleanRepository, getTaskById, getVolumes } from "@app/api/rest";
@@ -21,20 +20,16 @@ export const VolumesQueryKey = "volumes";
 export const CleanProgressQueryKey = "cleanProgress";
 
 export const useFetchVolumes = (): IVolumeFetchState => {
-  const [volumes, setVolumes] = React.useState<Volume[]>([]);
-  const { isLoading, error, refetch } = useQuery(VolumesQueryKey, () =>
-    getVolumes()
-      .then(({ data }) => {
-        setVolumes(data);
-        return data;
-      })
-      .catch((error) => {
-        console.log("error, ", error);
-        return error;
-      })
-  );
+  const {
+    data: response,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery(VolumesQueryKey, getVolumes, {
+    onError: (error) => console.log("error, ", error),
+  });
   return {
-    volumes,
+    volumes: response?.data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/pkg/client/src/app/shared/components/app-table/tests/__snapshots__/state-no-data.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/app-table/tests/__snapshots__/state-no-data.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StateNoData Renders without crashing 1`] = `
-<Component
+<NoDataEmptyState
   description="message.noDataAvailableBody"
   title="message.noDataAvailableTitle"
 />

--- a/pkg/client/src/app/shared/components/page-header/tests/__snapshots__/page-header.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/page-header/tests/__snapshots__/page-header.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`PageHeader Renders without crashing 1`] = `
   hasGutter={true}
 >
   <StackItem>
-    <Component
+    <BreadCrumbPath
       breadcrumbs={
         Array [
           Object {
@@ -39,7 +39,7 @@ exports[`PageHeader Renders without crashing 1`] = `
         </Button>
       </SplitItem>
       <SplitItem>
-        <Component
+        <MenuActions
           actions={
             Array [
               Object {
@@ -57,7 +57,7 @@ exports[`PageHeader Renders without crashing 1`] = `
     </Split>
   </StackItem>
   <StackItem>
-    <Component
+    <HorizontalNav
       navItems={
         Array [
           Object {

--- a/pkg/client/src/app/shared/components/toolbar-search-filter/__snapshots__/toolbar-search-filter.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/toolbar-search-filter/__snapshots__/toolbar-search-filter.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ToolbarSearchFilter Renders without crashing 1`] = `
 <InputGroup>
-  <Component
+  <SimpleFilterDropdown
     label="Filter 1"
     onSelect={[Function]}
     options={
@@ -30,7 +30,7 @@ exports[`ToolbarSearchFilter Renders without crashing 1`] = `
 
 exports[`ToolbarSearchFilter Renders without crashing when no filter is provided 1`] = `
 <InputGroup>
-  <Component
+  <SimpleFilterDropdown
     onSelect={[Function]}
     options={Array []}
   />

--- a/pkg/client/src/app/shared/containers/bulk-copy-notifications-container/bulk-copy-notifications-container.tsx
+++ b/pkg/client/src/app/shared/containers/bulk-copy-notifications-container/bulk-copy-notifications-container.tsx
@@ -10,6 +10,8 @@ import { useFetch } from "@app/shared/hooks";
 
 import { BulkCopyAssessment, BulkCopyReview } from "@app/api/models";
 import { getBulkCopyAssessment, getBulkCopyReview } from "@app/api/rest";
+import { useQueryClient } from "react-query";
+import { assessmentsQueryKey } from "@app/queries/assessments";
 
 export const BulkCopyNotificationsContainer: React.FC = () => {
   // i18
@@ -17,6 +19,8 @@ export const BulkCopyNotificationsContainer: React.FC = () => {
 
   // Redux
   const dispatch = useDispatch();
+
+  const queryClient = useQueryClient();
 
   const isWatching = useSelector((state: RootState) =>
     bulkCopySelectors.isWatching(state)
@@ -71,6 +75,7 @@ export const BulkCopyNotificationsContainer: React.FC = () => {
   useEffect(() => {
     if (assessmentBulkCopy && assessmentBulkCopy.completed === true) {
       dispatch(bulkCopyActions.assessmentBulkCompleted({}));
+      queryClient.invalidateQueries(assessmentsQueryKey);
     }
   }, [assessmentBulkCopy, dispatch]);
 

--- a/pkg/client/src/app/shared/containers/bulk-copy-notifications-container/bulk-copy-notifications-container.tsx
+++ b/pkg/client/src/app/shared/containers/bulk-copy-notifications-container/bulk-copy-notifications-container.tsx
@@ -12,6 +12,7 @@ import { BulkCopyAssessment, BulkCopyReview } from "@app/api/models";
 import { getBulkCopyAssessment, getBulkCopyReview } from "@app/api/rest";
 import { useQueryClient } from "react-query";
 import { assessmentsQueryKey } from "@app/queries/assessments";
+import { reviewsQueryKey } from "@app/queries/reviews";
 
 export const BulkCopyNotificationsContainer: React.FC = () => {
   // i18
@@ -77,13 +78,14 @@ export const BulkCopyNotificationsContainer: React.FC = () => {
       dispatch(bulkCopyActions.assessmentBulkCompleted({}));
       queryClient.invalidateQueries(assessmentsQueryKey);
     }
-  }, [assessmentBulkCopy, dispatch]);
+  }, [assessmentBulkCopy, dispatch, queryClient]);
 
   useEffect(() => {
     if (reviewBulkCopy && reviewBulkCopy.completed === true) {
       dispatch(bulkCopyActions.reviewBulkCompleted({}));
+      queryClient.invalidateQueries(reviewsQueryKey);
     }
-  }, [reviewBulkCopy, dispatch]);
+  }, [reviewBulkCopy, dispatch, queryClient]);
 
   // Notification
   useEffect(() => {
@@ -99,6 +101,8 @@ export const BulkCopyNotificationsContainer: React.FC = () => {
             : t("toastr.success.assessmentCopied")
         )
       );
+      queryClient.invalidateQueries(assessmentsQueryKey);
+      queryClient.invalidateQueries(reviewsQueryKey);
     }
   }, [
     isWatching,
@@ -107,6 +111,7 @@ export const BulkCopyNotificationsContainer: React.FC = () => {
     reviewBulkCopyId,
     dispatch,
     t,
+    queryClient,
   ]);
 
   return <></>;

--- a/pkg/client/src/app/shared/containers/bulk-copy-notifications-container/bulk-copy-notifications-container.tsx
+++ b/pkg/client/src/app/shared/containers/bulk-copy-notifications-container/bulk-copy-notifications-container.tsx
@@ -13,6 +13,7 @@ import { getBulkCopyAssessment, getBulkCopyReview } from "@app/api/rest";
 import { useQueryClient } from "react-query";
 import { assessmentsQueryKey } from "@app/queries/assessments";
 import { reviewsQueryKey } from "@app/queries/reviews";
+import { ApplicationsQueryKey } from "@app/queries/applications";
 
 export const BulkCopyNotificationsContainer: React.FC = () => {
   // i18
@@ -84,6 +85,7 @@ export const BulkCopyNotificationsContainer: React.FC = () => {
     if (reviewBulkCopy && reviewBulkCopy.completed === true) {
       dispatch(bulkCopyActions.reviewBulkCompleted({}));
       queryClient.invalidateQueries(reviewsQueryKey);
+      queryClient.invalidateQueries(ApplicationsQueryKey);
     }
   }, [reviewBulkCopy, dispatch, queryClient]);
 
@@ -103,6 +105,7 @@ export const BulkCopyNotificationsContainer: React.FC = () => {
       );
       queryClient.invalidateQueries(assessmentsQueryKey);
       queryClient.invalidateQueries(reviewsQueryKey);
+      queryClient.invalidateQueries(ApplicationsQueryKey);
     }
   }, [
     isWatching,


### PR DESCRIPTION
https://issues.redhat.com/browse/TACKLE-512

There were two problems here:
* We weren't triggering a refetch of assessments when completing the discard action in the table.
* Application assessments were being fetched and stored in state local to the table using `useFetchMultiple`, but the bulk copy is an asynchronous task that is later watched elsewhere, so there is no way for the table to know when it is complete and trigger a refetch of this local state.

To solve these, I refactored the assessments fetch logic to use react-query's `useQueries` so that it is stored in the global `queryClient` cache. That way, we can invalidate those queries from wherever we want, which I've done from the notifications container (because that was already watching for this bulk copy to complete. Also, since we rely on the reference to the application review that is present on the application object itself, I also invalidate the applications query there.

Other cleanup includes:
* I made the loading state of the Assessment column a little cleaner: now it will show a spinner instead of just a blank cell, and it will only show that on the initial fetch.
* I removed unused imports from files I touched (habit... maybe shouldn't do this)
* When looking at our other `useQuery` usage I found a number of places where we were duplicating the `data` into separate state, so I simplified those queries to just use the data in the cache directly. Technically this could avoid bugs in the future if we were to manipulate that cache manually, but that's an antipattern anyway. This is just a bit cleaner.

Note: This PR also upgrades TypeScript to ^4.1.0 for tests to pass, because type inference for `useQueries` is incorrect in earlier TS versions. See https://react-query.tanstack.com/typescript