### PR TITLE
Fix regressions related to useQuery refactoring

### DIFF
--- a/pkg/client/src/app/api/rest.tsx
+++ b/pkg/client/src/app/api/rest.tsx
@@ -430,7 +430,7 @@ export const getBulkCopyAssessment = (
   return APIClient.get<BulkCopyAssessment>(`${ASSESSMENTS}/bulk/${id}`);
 };
 
-export const getIdentities = (): AxiosPromise<Array<any>> => {
+export const getIdentities = (): AxiosPromise<Array<Identity>> => {
   return APIClient.get(`${IDENTITIES}`, jsonHeaders);
 };
 
@@ -462,7 +462,7 @@ export const createSetting = (obj: Setting): AxiosPromise<Setting> => {
   return APIClient.post(`${SETTINGS}`, obj);
 };
 
-export const getProxies = (): AxiosPromise<Array<any>> => {
+export const getProxies = (): AxiosPromise<Array<Proxy>> => {
   return APIClient.get(`${PROXIES}`, jsonHeaders);
 };
 

--- a/pkg/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AxiosError, AxiosPromise, AxiosResponse } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 import { useFormik, FormikProvider, FormikHelpers } from "formik";
 import { object, string, StringSchema } from "yup";
 import {
@@ -11,7 +11,6 @@ import {
   ExpandableSection,
   Form,
   FormGroup,
-  SelectOption,
   TextArea,
   TextInput,
 } from "@patternfly/react-core";
@@ -24,7 +23,7 @@ import {
 } from "@app/shared/components";
 import { useFetchBusinessServices, useFetchTagTypes } from "@app/shared/hooks";
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
-import { Application, Ref, Tag } from "@app/api/models";
+import { Application, Ref } from "@app/api/models";
 import {
   duplicateNameCheck,
   getAxiosErrorMessage,
@@ -44,11 +43,10 @@ import {
 
 import "./application-form.css";
 import {
-  ApplicationsQueryKey,
   useCreateApplicationMutation,
+  useFetchApplications,
   useUpdateApplicationMutation,
 } from "@app/queries/applications";
-import { useQueryClient } from "react-query";
 export interface FormValues {
   name: string;
   description: string;
@@ -189,7 +187,6 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
     version: getBinaryInitialValue(application, "version"),
     packaging: getBinaryInitialValue(application, "packaging"),
   };
-  const queryClient = useQueryClient();
 
   const customURLValidation = (schema: StringSchema) => {
     const gitUrlRegex =
@@ -209,6 +206,8 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
     });
   };
 
+  const { applications } = useFetchApplications();
+
   const validationSchema = object().shape(
     {
       name: string()
@@ -219,15 +218,8 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
         .test(
           "Duplicate name",
           "An application with this name already exists. Please use a different name.",
-          (value) => {
-            const applications: Application[] =
-              queryClient.getQueryData(ApplicationsQueryKey) || [];
-            return duplicateNameCheck(
-              applications,
-              application || null,
-              value || ""
-            );
-          }
+          (value) =>
+            duplicateNameCheck(applications, application || null, value || "")
         ),
       description: string()
         .trim()

--- a/pkg/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
+++ b/pkg/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
@@ -42,11 +42,7 @@ import {
   toIStakeholderGroupDropdown,
   isIModelEqual,
 } from "@app/utils/model-utils";
-import {
-  StakeholdersQueryKey,
-  useFetchStakeholders,
-} from "@app/queries/stakeholders";
-import { useQueryClient } from "react-query";
+import { useFetchStakeholders } from "@app/queries/stakeholders";
 
 export interface FormValues {
   email: string;
@@ -70,11 +66,7 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
 
   const [error, setError] = useState<AxiosError>();
 
-  const {
-    stakeholders,
-    isFetching: isFetchingStakeholders,
-    fetchError: fetchErrorStakeholders,
-  } = useFetchStakeholders();
+  const { stakeholders } = useFetchStakeholders();
 
   const {
     jobFunctions,
@@ -118,8 +110,6 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
     stakeholderGroups: stakeholderGroupsInitialValue,
   };
 
-  const queryClient = useQueryClient();
-
   const validationSchema = object().shape({
     email: string()
       .trim()
@@ -130,16 +120,13 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
       .test(
         "Duplicate email",
         "A stakeholder with this email address already exists. Please use a different email address.",
-        (value) => {
-          const stakeholders: Stakeholder[] =
-            queryClient.getQueryData(StakeholdersQueryKey) || [];
-          return duplicateFieldCheck(
+        (value) =>
+          duplicateFieldCheck(
             "email",
             stakeholders,
             stakeholder || null,
             value || ""
-          );
-        }
+          )
       ),
     name: string()
       .trim()
@@ -149,15 +136,8 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
       .test(
         "Duplicate name",
         "A stakeholder with this name already exists. Please use a different name.",
-        (value) => {
-          const stakeholders: Stakeholder[] =
-            queryClient.getQueryData(StakeholdersQueryKey) || [];
-          return duplicateNameCheck(
-            stakeholders,
-            stakeholder || null,
-            value || ""
-          );
-        }
+        (value) =>
+          duplicateNameCheck(stakeholders, stakeholder || null, value || "")
       ),
   });
 

--- a/pkg/client/src/app/pages/controls/tags/components/tag-form/tag-form.tsx
+++ b/pkg/client/src/app/pages/controls/tags/components/tag-form/tag-form.tsx
@@ -49,12 +49,7 @@ export const TagForm: React.FC<TagFormProps> = ({ tag, onSaved, onCancel }) => {
   const { t } = useTranslation();
   const [error, setError] = useState<AxiosError>();
 
-  const {
-    tags,
-    isFetching: isFetchingTags,
-    fetchError: fetchErrorTags,
-    refetch,
-  } = useFetchTags();
+  const { tags } = useFetchTags();
 
   const {
     tagTypes,
@@ -76,8 +71,6 @@ export const TagForm: React.FC<TagFormProps> = ({ tag, onSaved, onCancel }) => {
     tagType: tagTypeInitialValue,
   };
 
-  const queryClient = useQueryClient();
-
   const validationSchema = object().shape({
     name: string()
       .trim()
@@ -87,10 +80,7 @@ export const TagForm: React.FC<TagFormProps> = ({ tag, onSaved, onCancel }) => {
       .test(
         "Duplicate name",
         "An tag with this name already exists. Please use a different name.",
-        (value) => {
-          const tags: Tag[] = queryClient.getQueryData(TagsQueryKey) || [];
-          return duplicateNameCheck(tags, tag || null, value || "");
-        }
+        (value) => duplicateNameCheck(tags, tag || null, value || "")
       ),
     tagType: mixed().required(t("validation.required")),
   });

--- a/pkg/client/src/app/pages/identities/components/identity-form.tsx
+++ b/pkg/client/src/app/pages/identities/components/identity-form.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AxiosError, AxiosPromise, AxiosResponse } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 import { object, string } from "yup";
 import {
   ActionGroup,
@@ -25,21 +25,17 @@ import {
 } from "@app/utils/utils";
 import schema from "./schema.xsd";
 import { toOptionLike } from "@app/utils/model-utils";
-const xmllint = require("xmllint");
-const { XMLValidator } = require("fast-xml-parser");
 
 import "./identity-form.css";
-import { useQueryClient } from "react-query";
 import {
-  IdentitiesQueryKey,
   useCreateIdentityMutation,
   useFetchIdentities,
   useUpdateIdentityMutation,
 } from "@app/queries/identities";
-import { useDispatch } from "react-redux";
-import { alertActions } from "@app/store/alert";
 import KeyDisplayToggle from "@app/common/KeyDisplayToggle";
 
+const xmllint = require("xmllint");
+const { XMLValidator } = require("fast-xml-parser");
 export interface IdentityFormProps {
   identity?: Identity;
   onSaved: (response: AxiosResponse<Identity>) => void;
@@ -62,7 +58,6 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
     e.stopPropagation();
     setIsPasswordHidden(!isPasswordHidden);
   };
-  const queryClient = useQueryClient();
 
   useEffect(() => {
     setIdentity(initialIdentity);

--- a/pkg/client/src/app/pages/identities/components/identity-form.tsx
+++ b/pkg/client/src/app/pages/identities/components/identity-form.tsx
@@ -33,6 +33,7 @@ import { useQueryClient } from "react-query";
 import {
   IdentitiesQueryKey,
   useCreateIdentityMutation,
+  useFetchIdentities,
   useUpdateIdentityMutation,
 } from "@app/queries/identities";
 import { useDispatch } from "react-redux";
@@ -144,6 +145,8 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
     }
   };
 
+  const { identities } = useFetchIdentities();
+
   const validationSchema = object().shape({
     name: string()
       .trim()
@@ -153,11 +156,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
       .test(
         "Duplicate name",
         "An identity with this name already exists. Please use a different name.",
-        (value) => {
-          const identities: Identity[] =
-            queryClient.getQueryData(IdentitiesQueryKey) || [];
-          return duplicateNameCheck(identities, identity || null, value || "");
-        }
+        (value) => duplicateNameCheck(identities, identity || null, value || "")
       ),
     description: string()
       .trim()

--- a/pkg/client/src/app/queries/applications.ts
+++ b/pkg/client/src/app/queries/applications.ts
@@ -19,6 +19,7 @@ export interface IApplicationMutateState {
 }
 export const ApplicationsQueryKey = "applications";
 
+// TODO: this has the same name as useFetchApplications in src/app/shared/hooks, we should probably eliminate that one in favor of this one
 export const useFetchApplications = () => {
   const queryClient = useQueryClient();
   const { data, isLoading, error, refetch } = useQuery(

--- a/pkg/client/src/app/queries/identities.ts
+++ b/pkg/client/src/app/queries/identities.ts
@@ -66,15 +66,15 @@ export const useCreateIdentityMutation = (
 };
 
 export const useFetchIdentities = (): IIdentityFetchState => {
-  const {
-    data: response,
-    isLoading,
-    error,
-  } = useQuery(IdentitiesQueryKey, getIdentities, {
-    onError: (error) => console.log("error, ", error),
-  });
+  const { data, isLoading, error } = useQuery(
+    IdentitiesQueryKey,
+    async () => (await getIdentities()).data,
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
   return {
-    identities: response?.data || [],
+    identities: data || [],
     isFetching: isLoading,
     fetchError: error,
   };

--- a/pkg/client/src/app/queries/proxies.ts
+++ b/pkg/client/src/app/queries/proxies.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { AxiosError } from "axios";
 import { createAsyncAction } from "typesafe-actions";
 import { getProxies, updateProxy } from "@app/api/rest";
+import { Proxy } from "@app/api/models";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
 export const {
@@ -14,24 +15,24 @@ export const {
   "useFetchProxies/fetch/failure"
 )<void, any, AxiosError>();
 
-export interface IFetchState {
-  proxies: any;
+export interface IProxyFetchState {
+  proxies: Proxy[];
   isFetching: boolean;
-  fetchError: any;
+  fetchError: AxiosError;
 }
 
 export const useFetchProxies = (
   defaultIsFetching: boolean = false
-): IFetchState => {
-  const { isLoading, refetch, isError, data, error } = useQuery(
+): IProxyFetchState => {
+  const { isLoading, data, error } = useQuery(
     "proxies",
-    getProxies,
+    async () => (await getProxies()).data,
     { onError: () => console.log("error, ", error) }
   );
   return {
     proxies: data || [],
     isFetching: isLoading,
-    fetchError: error,
+    fetchError: error as AxiosError,
   };
 };
 

--- a/pkg/client/src/app/queries/reviews.ts
+++ b/pkg/client/src/app/queries/reviews.ts
@@ -13,16 +13,15 @@ export interface IReviewFetchState {
 export const reviewsQueryKey = "reviews";
 
 export const useFetchReviews = (): IReviewFetchState => {
-  const {
-    data: response,
-    isLoading,
-    error,
-    refetch,
-  } = useQuery(reviewsQueryKey, getReviews, {
-    onError: (error) => console.log("error, ", error),
-  });
+  const { data, isLoading, error, refetch } = useQuery(
+    reviewsQueryKey,
+    async () => (await getReviews()).data,
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
   return {
-    reviews: response?.data || [],
+    reviews: data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/pkg/client/src/app/queries/stakeholders.ts
+++ b/pkg/client/src/app/queries/stakeholders.ts
@@ -12,15 +12,15 @@ export interface IStakeholderFetchState {
 export const StakeholdersQueryKey = "stakeholders";
 
 export const useFetchStakeholders = (): IStakeholderFetchState => {
-  const {
-    data: response,
-    isLoading,
-    error,
-  } = useQuery(StakeholdersQueryKey, getStakeholders, {
-    onError: (error) => console.log("error, ", error),
-  });
+  const { data, isLoading, error } = useQuery(
+    StakeholdersQueryKey,
+    async () => (await getStakeholders()).data,
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
   return {
-    stakeholders: response?.data || [],
+    stakeholders: data || [],
     isFetching: isLoading,
     fetchError: error,
   };

--- a/pkg/client/src/app/queries/tags.ts
+++ b/pkg/client/src/app/queries/tags.ts
@@ -21,16 +21,15 @@ export const TagsQueryKey = "tags";
 export const TagTypesQueryKey = "tagtypes";
 
 export const useFetchTags = (): ITagFetchState => {
-  const {
-    data: response,
-    isLoading,
-    error,
-    refetch,
-  } = useQuery(TagsQueryKey, getTags, {
-    onError: (error) => console.log("error, ", error),
-  });
+  const { data, isLoading, error, refetch } = useQuery(
+    TagsQueryKey,
+    async () => (await getTags()).data,
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
   return {
-    tags: response?.data || [],
+    tags: data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,
@@ -38,16 +37,15 @@ export const useFetchTags = (): ITagFetchState => {
 };
 
 export const useFetchTagTypes = (): ITagTypeFetchState => {
-  const {
-    data: response,
-    isLoading,
-    error,
-    refetch,
-  } = useQuery(TagTypesQueryKey, getTagTypes, {
-    onError: (error) => console.log("error, ", error),
-  });
+  const { data, isLoading, error, refetch } = useQuery(
+    TagTypesQueryKey,
+    async () => (await getTagTypes()).data,
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
   return {
-    tagTypes: response?.data || [],
+    tagTypes: data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/pkg/client/src/app/queries/volumes.ts
+++ b/pkg/client/src/app/queries/volumes.ts
@@ -20,16 +20,15 @@ export const VolumesQueryKey = "volumes";
 export const CleanProgressQueryKey = "cleanProgress";
 
 export const useFetchVolumes = (): IVolumeFetchState => {
-  const {
-    data: response,
-    isLoading,
-    error,
-    refetch,
-  } = useQuery(VolumesQueryKey, getVolumes, {
-    onError: (error) => console.log("error, ", error),
-  });
+  const { data, isLoading, error, refetch } = useQuery(
+    VolumesQueryKey,
+    async () => (await getVolumes()).data,
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
   return {
-    volumes: response?.data || [],
+    volumes: data || [],
     isFetching: isLoading,
     fetchError: error,
     refetch,

--- a/pkg/client/src/app/shared/hooks/useFetchApplications/useFetchApplications.ts
+++ b/pkg/client/src/app/shared/hooks/useFetchApplications/useFetchApplications.ts
@@ -75,6 +75,7 @@ export interface IState {
   fetchApplications: () => void;
 }
 
+// TODO: this has the same name as useFetchApplications in src/app/queries/applications, we should probably eliminate this one
 export const useFetchApplications = (
   defaultIsFetching: boolean = false
 ): IState => {


### PR DESCRIPTION
Turns out TypeScript didn't save me from this particular foot-gun. We were using `queryClient.getQueryData()` in a few places, which returns `unknown`, so TS couldn't catch that I had inadvertently changed the structure of data in the cache with #261. This PR removes that direct cache usage, but it also ensures Axios objects will not end up in the cache so that the cache contains the same bare data arrays that we return from our query hooks (in case we need to directly use the cache for some reason in the future).