### PR TITLE
Remove applications cannot be analyzed message for upload binary mode

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -207,7 +207,7 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
     );
 
   const isModeValid = (): boolean => {
-    if (mode === "binary-upload") return !isMutating && artifact !== "";
+    if (mode === "binary-upload") return true;
     if (mode === "binary") return areApplicationsBinaryEnabled();
     else if (mode === "source-code-deps")
       return areApplicationsSourceCodeDepsEnabled();


### PR DESCRIPTION
- This warning does not apply on  the upload binary screen. The next button being disabled should be enough to notify that they have not uploaded a binary. 
![image](https://user-images.githubusercontent.com/11218376/170730277-c459bdd4-a153-4ee6-bba6-5aaf0970b9a8.png)
