### PR TITLE
Enable CreateUser field in Identities

### DIFF
--- a/pkg/client/src/app/pages/identities/identities.tsx
+++ b/pkg/client/src/app/pages/identities/identities.tsx
@@ -235,7 +235,9 @@ export const Identities: React.FunctionComponent = () => {
           ),
         },
         {
-          title: <TableText wrapModifier="truncate">John Doe</TableText>,
+          title: (
+            <TableText wrapModifier="truncate">{item.createUser}</TableText>
+          ),
         },
         {
           title: (

--- a/pkg/client/src/app/pages/identities/identities.tsx
+++ b/pkg/client/src/app/pages/identities/identities.tsx
@@ -115,6 +115,15 @@ export const Identities: React.FunctionComponent = () => {
         return item.kind || "";
       },
     },
+    {
+      key: "createdBy",
+      title: "Created By",
+      type: FilterType.search,
+      placeholderText: "Filter by created by User...",
+      getItemValue: (item) => {
+        return item.createUser || "";
+      },
+    },
   ];
 
   const { filterValues, setFilterValues, filteredItems } = useFilterState(


### PR DESCRIPTION
Replacing User placeholder with the API provided createUser field.

Related to https://github.com/konveyor/tackle2-hub/pull/103 but can be merged before it (the field would be empty until Hub API provides the username).

https://issues.redhat.com/browse/TACKLE-424