### PR TITLE
TACKLE-645: Check for undefined tag name causing app to crash

### DIFF
--- a/pkg/client/src/app/pages/applications/applicationsFilter.ts
+++ b/pkg/client/src/app/pages/applications/applicationsFilter.ts
@@ -127,6 +127,7 @@ export const useApplicationsFilterValues = (
         tagTypes
           ?.map((tagType) => tagType?.tags)
           .flat()
+          .filter((tag) => tag && tag.name)
           .map((tag) => ({ key: tag?.name, value: tag?.name }))
       ),
     },

--- a/pkg/client/src/app/pages/controls/tags/tags.tsx
+++ b/pkg/client/src/app/pages/controls/tags/tags.tsx
@@ -108,6 +108,7 @@ export const Tags: React.FC = () => {
         tagTypes
           ?.map((tagType) => tagType?.tags)
           .flat()
+          .filter((tag) => tag && tag.name)
           .map((tag) => ({ key: tag?.name, value: tag?.name }))
       ),
     },

--- a/pkg/client/src/app/shared/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/pkg/client/src/app/shared/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -87,7 +87,7 @@ export const MultiselectFilterControl = <T,>({
         // Note: This is filtering on the `key`, not the `value`, since the `value` isn't necessarily a string.
         // So that assumes your key is an actual string representation of what's shown on screen (usually matching the value)
         // which could become a problem maybe?
-        return optionProps.key.toLowerCase().includes(textInput.toLowerCase());
+        return optionProps?.key.toLowerCase().includes(textInput.toLowerCase());
       })
     );
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TACKLE-645

Checks for undefined key name when building filter options list. Also, filter out empty tag names for unassociated tag types.  An empty value was being populated in the tag name filter when a tag type without a tag is added. 