### PR TITLE
Add unique ids on filter value select toggle buttons

### DIFF
--- a/pkg/client/src/app/shared/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/pkg/client/src/app/shared/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -101,6 +101,7 @@ export const MultiselectFilterControl = <T,>({
       <Select
         variant={SelectVariant.checkbox}
         aria-label={category.title}
+        toggleId={`${category.key}-filter-value-select`}
         onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
         selections={selections || []}
         onSelect={(_, value) => onFilterSelect(value)}

--- a/pkg/client/src/app/shared/components/FilterToolbar/SelectFilterControl.tsx
+++ b/pkg/client/src/app/shared/components/FilterToolbar/SelectFilterControl.tsx
@@ -67,6 +67,7 @@ export const SelectFilterControl = <T,>({
     >
       <Select
         aria-label={category.title}
+        toggleId={`${category.key}-filter-value-select`}
         onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
         selections={selections || []}
         onSelect={(_, value) => onFilterSelect(value)}


### PR DESCRIPTION
For QE: Adds a unique id on the toggle button for selecting filter values in each category for select and multiselect filter types.

The filter category key is used, followed by `-filter-value-select`. For example, `#tags-filter-value-select`. This may not exactly match the name of the filter shown to the user, because to guarantee uniqueness it is based on the underlying filter key.

cc @sshveta 