### PR TITLE
Fix AUTH_REQUIRED flag not affecting direct calls to checkAccess function

### DIFF
--- a/pkg/client/src/app/common/rbac-utils.tsx
+++ b/pkg/client/src/app/common/rbac-utils.tsx
@@ -1,7 +1,10 @@
+import { isAuthRequired } from "@app/Constants";
+
 export const checkAccess = (
   userPermissions: string[],
   allowedPermissions: string[]
 ) => {
+  if (!isAuthRequired) return true;
   const access = userPermissions.some((userPermission) =>
     allowedPermissions.includes(userPermission)
   );


### PR DESCRIPTION
When the `isAuthRequired` constant (based on the `AUTH_REQUIRED` environment variable) was added in https://github.com/konveyor/tackle2-ui/pull/166/files#diff-d6a22eefc16798dd8630ea7dbf7eea49a64e64949c9a7b6a4fc825b45e6cc7dfR14, the only reusable place it was referenced was in the `<RBAC>` component. This meant any other code that directly called the `checkAccess()` function (which is used inside `<RBAC>`) were not affected.

For example, the actions kebab above the applications table is shown based on a `checkAccess` call [here](https://github.com/konveyor/tackle2-ui/blob/065711b870291c759c04604dfc6f73fbd0f0b17e/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx#L312-L317) which circumvents the `<RBAC>` component, so currently it does not respect `AUTH_REQUIRED=false` being set.

This PR simply adds a one-liner check for `isAuthRequired` in the `checkAccess` function so it takes effect everywhere.