### PR TITLE
TACKLE-661: Ensure `checkAccess` is called even when token is undefined, remove unnecessary references to isAuthRequired

### DIFF
--- a/pkg/client/src/app/common/RouteWrapper.tsx
+++ b/pkg/client/src/app/common/RouteWrapper.tsx
@@ -18,13 +18,13 @@ export const RouteWrapper = ({
   exact,
 }: IRouteWrapperProps) => {
   const token = keycloak.tokenParsed || undefined;
-  let userRoles = token?.realm_access?.roles,
-    access = userRoles && checkAccess(userRoles, roles);
+  let userRoles = token?.realm_access?.roles || [],
+    access = checkAccess(userRoles, roles);
 
   if (!token && isAuthRequired) {
     //TODO: Handle token expiry & auto logout
     return <Redirect to="/login" />;
-  } else if (token && !access && isAuthRequired) {
+  } else if (token && !access) {
     return <Redirect to="/applications" />;
   }
 

--- a/pkg/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/pkg/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -24,12 +24,11 @@ import {
 } from "@app/context/LocalStorageContext";
 
 import "./SidebarApp.css";
-import { isAuthRequired } from "@app/Constants";
 
 export const SidebarApp: React.FC = () => {
   const token = keycloak.tokenParsed || undefined;
-  const userRoles = token?.realm_access?.roles,
-    adminAccess = userRoles && checkAccess(userRoles, ["tackle-admin"]);
+  const userRoles = token?.realm_access?.roles || [],
+    adminAccess = checkAccess(userRoles, ["tackle-admin"]);
 
   const { t } = useTranslation();
   const { search } = useLocation();
@@ -51,7 +50,7 @@ export const SidebarApp: React.FC = () => {
       value="Developer"
       isPlaceholder
     />,
-    ...(adminAccess || !isAuthRequired
+    ...(adminAccess
       ? [
           <SelectOption
             key="admin"

--- a/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -71,7 +71,6 @@ import {
   ApplicationTableType,
   useApplicationsFilterValues,
 } from "../applicationsFilter";
-import { isAuthRequired } from "@app/Constants";
 import { ConditionalTooltip } from "@app/shared/components/ConditionalTooltip";
 
 const ENTITY_FIELD = "entity";
@@ -309,14 +308,12 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     }
 
     const actions: (IAction | ISeparator)[] = [];
-    const userScopes: string[] = token?.scope.split(" "),
-      applicationWriteAccess =
-        userScopes && checkAccess(userScopes, applicationsWriteScopes),
-      tasksReadAccess = userScopes && checkAccess(userScopes, tasksReadScopes),
-      tasksWriteAccess =
-        userScopes && checkAccess(userScopes, tasksWriteScopes);
+    const userScopes: string[] = token?.scope.split(" ") || [],
+      applicationWriteAccess = checkAccess(userScopes, applicationsWriteScopes),
+      tasksReadAccess = checkAccess(userScopes, tasksReadScopes),
+      tasksWriteAccess = checkAccess(userScopes, tasksWriteScopes);
 
-    if (applicationWriteAccess || !isAuthRequired) {
+    if (applicationWriteAccess) {
       actions.push(
         {
           title: "Manage credentials",
@@ -329,7 +326,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
       );
     }
 
-    if (tasksReadAccess || !isAuthRequired) {
+    if (tasksReadAccess) {
       actions.push({
         title: t("actions.analysisDetails"),
         isDisabled: !getTask(row),
@@ -340,7 +337,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
       });
     }
 
-    if (tasksWriteAccess || !isAuthRequired) {
+    if (tasksWriteAccess) {
       actions.push({
         title: "Cancel analysis",
         isDisabled: !isTaskCancellable(row),
@@ -403,11 +400,9 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     closeCredentialsModal();
   };
 
-  const userScopes: string[] = token?.scope.split(" "),
-    importWriteAccess =
-      userScopes && checkAccess(userScopes, importsWriteScopes),
-    applicationWriteAccess =
-      userScopes && checkAccess(userScopes, applicationsWriteScopes);
+  const userScopes: string[] = token?.scope.split(" ") || [],
+    importWriteAccess = checkAccess(userScopes, importsWriteScopes),
+    applicationWriteAccess = checkAccess(userScopes, applicationsWriteScopes);
 
   const importDropdownItems = importWriteAccess
     ? [

--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -82,7 +82,6 @@ import {
 } from "../applicationsFilter";
 import { FilterToolbar } from "@app/shared/components/FilterToolbar/FilterToolbar";
 import { reviewsQueryKey, useFetchReviews } from "@app/queries/reviews";
-import { isAuthRequired } from "@app/Constants";
 import {
   assessmentsQueryKey,
   useFetchApplicationAssessments,
@@ -405,12 +404,13 @@ export const ApplicationsTable: React.FC = () => {
         },
       });
     }
-    const userScopes: string[] = token?.scope.split(" "),
-      dependenciesWriteAccess =
-        userScopes && checkAccess(userScopes, dependenciesWriteScopes),
-      applicationWriteAccess =
-        userScopes && checkAccess(userScopes, applicationsWriteScopes);
-    if (applicationWriteAccess || !isAuthRequired) {
+    const userScopes: string[] = token?.scope.split(" ") || [],
+      dependenciesWriteAccess = checkAccess(
+        userScopes,
+        dependenciesWriteScopes
+      ),
+      applicationWriteAccess = checkAccess(userScopes, applicationsWriteScopes);
+    if (applicationWriteAccess) {
       actions.push({
         title: t("actions.delete"),
         onClick: (
@@ -424,7 +424,7 @@ export const ApplicationsTable: React.FC = () => {
       });
     }
 
-    if (dependenciesWriteAccess || !isAuthRequired) {
+    if (dependenciesWriteAccess) {
       actions.push({
         title: t("actions.manageDependencies"),
         onClick: (


### PR DESCRIPTION
Follow-up to https://github.com/konveyor/tackle2-ui/pull/283.

Now that the `isAuthRequired` check is part of `checkAccess()`, any place in the UI that was checking both no longer needs to care about `isAuthRequired`. This PR removes it from those places. To ensure we are always calling `checkAccess()` even when the token is undefined, it also replaces guards like:

```ts
let userRoles = token?.realm_access?.roles,
    access = userRoles && checkAccess(userRoles, roles);
```
with:
```ts
let userRoles = token?.realm_access?.roles || [],
    access = checkAccess(userRoles, roles);
```

If the token is defined this makes no difference, but if the token is undefined the `userRoles` array will be `[]` and the `checkAccess` function will still be called (when called with an empty array, it effectively turns into `return !isAuthRequired`).

Needed for: https://issues.redhat.com/browse/TACKLE-661