### PR TITLE
TACKLE-661: Ensure `checkAccess` is called even when token is undefined (missed cases from PR #284)

### DIFF
--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -611,11 +611,9 @@ export const ApplicationsTable: React.FC = () => {
     return assessment === undefined || assessment.status !== "COMPLETE";
   };
 
-  const userScopes: string[] = token?.scope.split(" "),
-    importWriteAccess =
-      userScopes && checkAccess(userScopes, importsWriteScopes),
-    applicationWriteAccess =
-      userScopes && checkAccess(userScopes, applicationsWriteScopes);
+  const userScopes: string[] = token?.scope.split(" ") || [],
+    importWriteAccess = checkAccess(userScopes, importsWriteScopes),
+    applicationWriteAccess = checkAccess(userScopes, applicationsWriteScopes);
 
   const importDropdownItems = importWriteAccess
     ? [

--- a/pkg/client/src/app/rbac.ts
+++ b/pkg/client/src/app/rbac.ts
@@ -14,12 +14,12 @@ export const RBAC = ({
   if (isAuthRequired) {
     const token = keycloak.tokenParsed || undefined;
     if (rbacType === RBAC_TYPE.Role) {
-      let userRoles = token?.realm_access?.roles,
-        access = userRoles && checkAccess(userRoles, allowedPermissions);
+      let userRoles = token?.realm_access?.roles || [],
+        access = checkAccess(userRoles, allowedPermissions);
       return access && children;
     } else if (rbacType === RBAC_TYPE.Scope) {
-      const userScopes: string[] = token?.scope.split(" ");
-      const access = userScopes && checkAccess(userScopes, allowedPermissions);
+      const userScopes: string[] = token?.scope.split(" ") || [];
+      const access = checkAccess(userScopes, allowedPermissions);
 
       return access && children;
     }


### PR DESCRIPTION
See #284. This solves the same problem described there in a couple more places.

Needed for https://issues.redhat.com/browse/TACKLE-661