### PR TITLE
[Backport - v2.0.0] TACKLE-661: Ensure all RBAC checks always respect `AUTH_REQUIRED=false`

### DIFF
--- a/pkg/client/src/app/common/RouteWrapper.tsx
+++ b/pkg/client/src/app/common/RouteWrapper.tsx
@@ -18,13 +18,13 @@ export const RouteWrapper = ({
   exact,
 }: IRouteWrapperProps) => {
   const token = keycloak.tokenParsed || undefined;
-  let userRoles = token?.realm_access?.roles,
-    access = userRoles && checkAccess(userRoles, roles);
+  let userRoles = token?.realm_access?.roles || [],
+    access = checkAccess(userRoles, roles);
 
   if (!token && isAuthRequired) {
     //TODO: Handle token expiry & auto logout
     return <Redirect to="/login" />;
-  } else if (token && !access && isAuthRequired) {
+  } else if (token && !access) {
     return <Redirect to="/applications" />;
   }
 

--- a/pkg/client/src/app/common/rbac-utils.tsx
+++ b/pkg/client/src/app/common/rbac-utils.tsx
@@ -1,7 +1,10 @@
+import { isAuthRequired } from "@app/Constants";
+
 export const checkAccess = (
   userPermissions: string[],
   allowedPermissions: string[]
 ) => {
+  if (!isAuthRequired) return true;
   const access = userPermissions.some((userPermission) =>
     allowedPermissions.includes(userPermission)
   );

--- a/pkg/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/pkg/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -24,12 +24,11 @@ import {
 } from "@app/context/LocalStorageContext";
 
 import "./SidebarApp.css";
-import { isAuthRequired } from "@app/Constants";
 
 export const SidebarApp: React.FC = () => {
   const token = keycloak.tokenParsed || undefined;
-  const userRoles = token?.realm_access?.roles,
-    adminAccess = userRoles && checkAccess(userRoles, ["tackle-admin"]);
+  const userRoles = token?.realm_access?.roles || [],
+    adminAccess = checkAccess(userRoles, ["tackle-admin"]);
 
   const { t } = useTranslation();
   const { search } = useLocation();
@@ -51,7 +50,7 @@ export const SidebarApp: React.FC = () => {
       value="Developer"
       isPlaceholder
     />,
-    ...(adminAccess || !isAuthRequired
+    ...(adminAccess
       ? [
           <SelectOption
             key="admin"

--- a/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -71,7 +71,6 @@ import {
   ApplicationTableType,
   useApplicationsFilterValues,
 } from "../applicationsFilter";
-import { isAuthRequired } from "@app/Constants";
 import { ConditionalTooltip } from "@app/shared/components/ConditionalTooltip";
 
 const ENTITY_FIELD = "entity";
@@ -309,14 +308,12 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     }
 
     const actions: (IAction | ISeparator)[] = [];
-    const userScopes: string[] = token?.scope.split(" "),
-      applicationWriteAccess =
-        userScopes && checkAccess(userScopes, applicationsWriteScopes),
-      tasksReadAccess = userScopes && checkAccess(userScopes, tasksReadScopes),
-      tasksWriteAccess =
-        userScopes && checkAccess(userScopes, tasksWriteScopes);
+    const userScopes: string[] = token?.scope.split(" ") || [],
+      applicationWriteAccess = checkAccess(userScopes, applicationsWriteScopes),
+      tasksReadAccess = checkAccess(userScopes, tasksReadScopes),
+      tasksWriteAccess = checkAccess(userScopes, tasksWriteScopes);
 
-    if (applicationWriteAccess || !isAuthRequired) {
+    if (applicationWriteAccess) {
       actions.push(
         {
           title: "Manage credentials",
@@ -329,7 +326,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
       );
     }
 
-    if (tasksReadAccess || !isAuthRequired) {
+    if (tasksReadAccess) {
       actions.push({
         title: t("actions.analysisDetails"),
         isDisabled: !getTask(row),
@@ -340,7 +337,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
       });
     }
 
-    if (tasksWriteAccess || !isAuthRequired) {
+    if (tasksWriteAccess) {
       actions.push({
         title: "Cancel analysis",
         isDisabled: !isTaskCancellable(row),
@@ -403,11 +400,9 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     closeCredentialsModal();
   };
 
-  const userScopes: string[] = token?.scope.split(" "),
-    importWriteAccess =
-      userScopes && checkAccess(userScopes, importsWriteScopes),
-    applicationWriteAccess =
-      userScopes && checkAccess(userScopes, applicationsWriteScopes);
+  const userScopes: string[] = token?.scope.split(" ") || [],
+    importWriteAccess = checkAccess(userScopes, importsWriteScopes),
+    applicationWriteAccess = checkAccess(userScopes, applicationsWriteScopes);
 
   const importDropdownItems = importWriteAccess
     ? [

--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -611,11 +611,9 @@ export const ApplicationsTable: React.FC = () => {
     return assessment === undefined || assessment.status !== "COMPLETE";
   };
 
-  const userScopes: string[] = token?.scope.split(" "),
-    importWriteAccess =
-      userScopes && checkAccess(userScopes, importsWriteScopes),
-    applicationWriteAccess =
-      userScopes && checkAccess(userScopes, applicationsWriteScopes);
+  const userScopes: string[] = token?.scope.split(" ") || [],
+    importWriteAccess = checkAccess(userScopes, importsWriteScopes),
+    applicationWriteAccess = checkAccess(userScopes, applicationsWriteScopes);
 
   const importDropdownItems = importWriteAccess
     ? [

--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -82,7 +82,6 @@ import {
 } from "../applicationsFilter";
 import { FilterToolbar } from "@app/shared/components/FilterToolbar/FilterToolbar";
 import { reviewsQueryKey, useFetchReviews } from "@app/queries/reviews";
-import { isAuthRequired } from "@app/Constants";
 import {
   assessmentsQueryKey,
   useFetchApplicationAssessments,
@@ -405,12 +404,13 @@ export const ApplicationsTable: React.FC = () => {
         },
       });
     }
-    const userScopes: string[] = token?.scope.split(" "),
-      dependenciesWriteAccess =
-        userScopes && checkAccess(userScopes, dependenciesWriteScopes),
-      applicationWriteAccess =
-        userScopes && checkAccess(userScopes, applicationsWriteScopes);
-    if (applicationWriteAccess || !isAuthRequired) {
+    const userScopes: string[] = token?.scope.split(" ") || [],
+      dependenciesWriteAccess = checkAccess(
+        userScopes,
+        dependenciesWriteScopes
+      ),
+      applicationWriteAccess = checkAccess(userScopes, applicationsWriteScopes);
+    if (applicationWriteAccess) {
       actions.push({
         title: t("actions.delete"),
         onClick: (
@@ -424,7 +424,7 @@ export const ApplicationsTable: React.FC = () => {
       });
     }
 
-    if (dependenciesWriteAccess || !isAuthRequired) {
+    if (dependenciesWriteAccess) {
       actions.push({
         title: t("actions.manageDependencies"),
         onClick: (

--- a/pkg/client/src/app/rbac.ts
+++ b/pkg/client/src/app/rbac.ts
@@ -14,12 +14,12 @@ export const RBAC = ({
   if (isAuthRequired) {
     const token = keycloak.tokenParsed || undefined;
     if (rbacType === RBAC_TYPE.Role) {
-      let userRoles = token?.realm_access?.roles,
-        access = userRoles && checkAccess(userRoles, allowedPermissions);
+      let userRoles = token?.realm_access?.roles || [],
+        access = checkAccess(userRoles, allowedPermissions);
       return access && children;
     } else if (rbacType === RBAC_TYPE.Scope) {
-      const userScopes: string[] = token?.scope.split(" ");
-      const access = userScopes && checkAccess(userScopes, allowedPermissions);
+      const userScopes: string[] = token?.scope.split(" ") || [];
+      const access = checkAccess(userScopes, allowedPermissions);
 
       return access && children;
     }


### PR DESCRIPTION
Backports #283, #284 and #285 to v2.0.0.

> When the isAuthRequired constant (based on the AUTH_REQUIRED environment variable) was added in https://github.com/konveyor/tackle2-ui/pull/166/files#diff-d6a22eefc16798dd8630ea7dbf7eea49a64e64949c9a7b6a4fc825b45e6cc7dfR14, the only reusable place it was referenced was in the `<RBAC>` component. This meant any other code that directly called the `checkAccess()` function (which is used inside `<RBAC>`) were not affected.
> 
> For example, the actions kebab above the applications table is shown based on a `checkAccess` call [here](https://github.com/konveyor/tackle2-ui/blob/065711b870291c759c04604dfc6f73fbd0f0b17e/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx#L312-L317) which circumvents the `<RBAC>` component, so currently it does not respect `AUTH_REQUIRED=false` being set.
> 
> This PR adds a one-liner check for `isAuthRequired` in the `checkAccess` function so it takes effect everywhere.
>
> Now that the `isAuthRequired` check is part of `checkAccess()`, any place in the UI that was checking both no longer needs to care about `isAuthRequired`. This PR removes it from those places. To ensure we are always calling `checkAccess()` even when the token is undefined, it also replaces guards like:
> 
> ```ts
> let userRoles = token?.realm_access?.roles,
>     access = userRoles && checkAccess(userRoles, roles);
> ```
> with:
> ```ts
> let userRoles = token?.realm_access?.roles || [],
>     access = checkAccess(userRoles, roles);
> ```
> 
> If the token is defined this makes no difference, but if the token is undefined the `userRoles` array will be `[]` and the `checkAccess` function will still be called (when called with an empty array, it effectively turns into `return !isAuthRequired`).

Resolves https://issues.redhat.com/browse/TACKLE-661

This PR is a lot less invasive than it seems. Each of these places where logic is modified behave the exact same way when a login token exists, so the fix only affects auth-disabled mode. Here's what you can test to be sure there are no regressions (as we did):
* With auth disabled, ensure you can still see the Administrator option in the persona dropdown.
* With auth disabled, ensure you can access all pages and you don't get redirected to `/applications` when navigating to administrator pages.
* With auth disabled, ensure you can see and use the kebab menu above the applications table on both the assessment and analysis tabs.
* With auth enabled, ensure you can see and use this kebab menu as an administrator and that you cannot as a developer.
* Check any other RBAC functionality (all the rest is abstracted to the same component), for example you can only create applications if you have the application write scope.