### PR TITLE
TACKLE-665: AddCustomRules: use customFileHandler

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -41,12 +41,15 @@ interface IAnalysisWizard {
   onClose: () => void;
   isOpen: boolean;
 }
+
 export interface IReadFile {
   fileName: string;
-  loadResult?: "danger" | "success";
   loadError?: DOMException;
-  file?: File;
+  loadPercentage?: number;
+  loadResult?: "danger" | "success";
+  data?: string;
 }
+
 export interface IAnalysisWizardFormValues {
   artifact: string;
   targets: string[];

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
@@ -20,7 +20,7 @@ interface IAddCustomRules {
   readFileData: IReadFile[];
   setReadFileData: (setReadFile: React.SetStateAction<IReadFile[]>) => void;
 }
-interface IParseXMLFileStatus {
+interface IParsedXMLFileStatus {
   state: "valid" | "error";
   message?: string;
 }
@@ -50,7 +50,7 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
     }
   };
 
-  const validateXMLFile = (data: string): IParseXMLFileStatus => {
+  const validateXMLFile = (data: string): IParsedXMLFileStatus => {
     // Filter out "data:text/xml;base64," from data
     const payload = atob(data.substring(21));
     const validationObject = XMLValidator.validate(payload, {

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
@@ -33,7 +33,6 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
   const [error, setError] = React.useState("");
   const [currentFiles, setCurrentFiles] = React.useState<File[]>([]);
   const [showStatus, setShowStatus] = React.useState(false);
-  const [statusIcon, setStatusIcon] = React.useState("inProgress");
 
   // only show the status component once a file has been uploaded, but keep the status list component itself even if all files are removed
   if (!showStatus && currentFiles.length > 0) {
@@ -41,15 +40,15 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
   }
 
   // determine the icon that should be shown for the overall status list
-  React.useEffect(() => {
+  const setStatus = () => {
     if (readFileData.length < currentFiles.length) {
-      setStatusIcon("inProgress");
+      return "inProgress";
     } else if (readFileData.every((file) => file.loadResult === "success")) {
-      setStatusIcon("success");
+      return "success";
     } else {
-      setStatusIcon("danger");
+      return "danger";
     }
-  }, [readFileData, currentFiles]);
+  };
 
   const validateXMLFile = (data: string): IParseXMLFileStatus => {
     // Filter out "data:text/xml;base64," from data
@@ -223,7 +222,7 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
         {showStatus && (
           <MultipleFileUploadStatus
             statusToggleText={`${successfullyReadFileCount} of ${currentFiles.length} files uploaded`}
-            statusToggleIcon={statusIcon}
+            statusToggleIcon={setStatus()}
           >
             {currentFiles.map((file) => (
               <MultipleFileUploadStatusItem

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
@@ -119,8 +119,9 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
           if (validateXMLFile(data as string))
             handleReadSuccess(data as string, file);
           else {
-            // TODO propagate xml validation error
-            const error = new DOMException("Not a valid XML");
+            const error = new DOMException(
+              `File ${file.name} is not a valid XML`
+            );
             handleReadFail(error, 100, file);
           }
         }

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
@@ -13,13 +13,19 @@ import { XMLValidator } from "fast-xml-parser";
 import XSDSchema from "./windup-jboss-ruleset.xsd";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { IReadFile } from "../analysis-wizard";
-import { useFormContext } from "react-hook-form";
 
 const xmllint = require("xmllint");
+interface IAddCustomRules {
+  customRulesFiles: IReadFile[];
+  readFileData: IReadFile[];
+  setReadFileData: (setReadFile: React.SetStateAction<IReadFile[]>) => void;
+}
 
-export const AddCustomRules: React.FunctionComponent = () => {
-  const { getValues, setValue } = useFormContext();
-  const [readFileData, setReadFileData] = React.useState<IReadFile[]>([]);
+export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
+  customRulesFiles,
+  readFileData,
+  setReadFileData,
+}: IAddCustomRules) => {
   const [error, setError] = React.useState("");
   const [currentFiles, setCurrentFiles] = React.useState<File[]>([]);
   const [showStatus, setShowStatus] = React.useState(false);
@@ -40,11 +46,6 @@ export const AddCustomRules: React.FunctionComponent = () => {
       setStatusIcon("danger");
     }
   }, [readFileData, currentFiles]);
-
-  React.useEffect(() => {
-    const customRulesFiles: IReadFile[] = getValues("customRulesFiles");
-    setValue("customRulesFiles", [...readFileData, ...customRulesFiles]);
-  }, [readFileData, getValues, setValue]);
 
   const validateXMLFile = (data: string) => {
     // Filter out "data:text/xml;base64," from data
@@ -70,12 +71,6 @@ export const AddCustomRules: React.FunctionComponent = () => {
     } else {
       return false;
     }
-  };
-
-  const isFileIncluded = (name: string) => {
-    // currentFiles.some((file) => file.name === name) ||
-    const customRulesFiles: IReadFile[] = getValues("customRulesFiles");
-    return customRulesFiles.some((file) => file.fileName === name);
   };
 
   // callback that will be called by the react dropzone with the newly dropped file objects
@@ -108,6 +103,9 @@ export const AddCustomRules: React.FunctionComponent = () => {
       reader.readAsDataURL(file);
     });
   }
+
+  const isFileIncluded = (name: string) =>
+    customRulesFiles.some((file) => file.fileName === name);
 
   const handleFile = (file: File) => {
     readFile(file)
@@ -150,10 +148,13 @@ export const AddCustomRules: React.FunctionComponent = () => {
   };
 
   const handleReadSuccess = (data: string, file: File) => {
-    setReadFileData((prevReadFiles) => [
-      ...prevReadFiles,
-      { data, fileName: file.name, loadResult: "success", loadPercentage: 100 },
-    ]);
+    const newFile: IReadFile = {
+      data,
+      fileName: file.name,
+      loadResult: "success",
+      loadPercentage: 100,
+    };
+    setReadFileData((prevReadFiles) => [...prevReadFiles, newFile]);
   };
 
   const handleReadFail = (error: DOMException, percentage, file: File) => {

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
@@ -64,12 +64,12 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
       });
 
       if (validationResult.errors) {
-        return false;
+        return validationResult?.errors?.toString();
       } else {
-        return true;
+        return "";
       }
     } else {
-      return false;
+      return validationObject?.err?.msg?.toString();
     }
   };
 
@@ -116,11 +116,11 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
           );
           handleReadFail(error, 100, file);
         } else {
-          if (validateXMLFile(data as string))
-            handleReadSuccess(data as string, file);
+          const validatedXML = validateXMLFile(data as string);
+          if (validatedXML === "") handleReadSuccess(data as string, file);
           else {
             const error = new DOMException(
-              `File ${file.name} is not a valid XML`
+              `File ${file.name} is not a valid XML: ${validatedXML}`
             );
             handleReadFail(error, 100, file);
           }

--- a/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
@@ -97,10 +97,10 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
       );
   };
 
-  function readFile(file: File) {
-    return new Promise((resolve, reject) => {
+  const readFile = (file: File) => {
+    return new Promise<string | null>((resolve, reject) => {
       const reader = new FileReader();
-      reader.onload = () => resolve(reader.result);
+      reader.onload = () => resolve(reader.result as string);
       reader.onerror = () => reject(reader.error);
       reader.onprogress = (data) => {
         if (data.lengthComputable) {
@@ -109,7 +109,7 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
       };
       reader.readAsDataURL(file);
     });
-  }
+  };
 
   const isFileIncluded = (name: string) =>
     customRulesFiles.some((file) => file.fileName === name);
@@ -123,14 +123,16 @@ export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
           );
           handleReadFail(error, 100, file);
         } else {
-          const validatedXMLResult = validateXMLFile(data as string);
-          if (validatedXMLResult.state === "valid")
-            handleReadSuccess(data as string, file);
-          else {
-            const error = new DOMException(
-              `File "${file.name}" is not a valid XML: ${validatedXMLResult.message}`
-            );
-            handleReadFail(error, 100, file);
+          if (data) {
+            const validatedXMLResult = validateXMLFile(data);
+            if (validatedXMLResult.state === "valid")
+              handleReadSuccess(data, file);
+            else {
+              const error = new DOMException(
+                `File "${file.name}" is not a valid XML: ${validatedXMLResult.message}`
+              );
+              handleReadFail(error, 100, file);
+            }
           }
         }
       })

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -268,7 +268,10 @@ export const CustomRules: React.FunctionComponent = () => {
             <Button
               key="cancel"
               variant="link"
-              onClick={() => setCustomRulesModalOpen(false)}
+              onClick={() => {
+                setCustomRulesModalOpen(false);
+                setReadFileData([]);
+              }}
             >
               Cancel
             </Button>,

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -36,7 +36,6 @@ import { NoDataEmptyState } from "@app/shared/components";
 
 import "./wizard.css";
 import { IReadFile } from "./analysis-wizard";
-import { useEffect } from "react";
 
 export const CustomRules: React.FunctionComponent = () => {
   const { getValues, setValue } = useFormContext();
@@ -45,74 +44,65 @@ export const CustomRules: React.FunctionComponent = () => {
   const targets: string[] = getValues("targets");
   const customRulesFiles: IReadFile[] = getValues("customRulesFiles");
   const [currentFiles, setCurrentFiles] = React.useState<IReadFile[]>([]);
-  const [rules, setRules] = React.useState<Rule[]>([]);
 
   const [isAddCustomRulesModalOpen, setCustomRulesModalOpen] =
     React.useState(false);
 
-  useEffect(() => {
-    let rules: Rule[] = [];
-    if (customRulesFiles.length) {
-      for (const file of customRulesFiles) {
-        if (file.file) {
-          const getRules = async function (file: IReadFile) {
-            if (!file.file) return [];
+  const rules = React.useMemo(() => {
+    const getRules = (file: IReadFile) => {
+      if (!file.data) return [];
 
-            let source: string | null = null;
-            let target: string | null = null;
-            let rulesCount = 0;
-            const text = await file.file.text();
+      let source: string | null = null;
+      let target: string | null = null;
+      let rulesCount = 0;
 
-            const parser = new DOMParser();
-            const xml = parser.parseFromString(text, "text/xml");
+      const payload = atob(file.data.substring(21));
+      const parser = new DOMParser();
+      const xml = parser.parseFromString(payload, "text/xml");
 
-            const ruleSets = xml.getElementsByTagName("ruleset");
+      const ruleSets = xml.getElementsByTagName("ruleset");
 
-            if (ruleSets && ruleSets.length > 0) {
-              const metadata = ruleSets[0].getElementsByTagName("metadata");
+      if (ruleSets && ruleSets.length > 0) {
+        const metadata = ruleSets[0].getElementsByTagName("metadata");
 
-              if (metadata && metadata.length > 0) {
-                const sources =
-                  metadata[0].getElementsByTagName("sourceTechnology");
-                if (sources && sources.length > 0) source = sources[0].id;
+        if (metadata && metadata.length > 0) {
+          const sources = metadata[0].getElementsByTagName("sourceTechnology");
+          if (sources && sources.length > 0) source = sources[0].id;
 
-                const targets =
-                  metadata[0].getElementsByTagName("targetTechnology");
-                if (targets && targets.length > 0) target = targets[0].id;
-              }
-
-              const rulesGroup = ruleSets[0].getElementsByTagName("rules");
-              if (rulesGroup && rulesGroup.length > 0)
-                rulesCount = rulesGroup[0].getElementsByTagName("rule").length;
-            }
-
-            const rules: Rule[] = [
-              {
-                name: file.fileName,
-                source: source,
-                target: target,
-                total: rulesCount,
-              },
-            ];
-
-            if (source && !sources.includes(source))
-              setValue("sources", [...sources, source]);
-
-            if (target && !targets.includes(target))
-              setValue("targets", [...targets, target]);
-
-            return rules;
-          };
-          getRules(file).then((res) => {
-            rules = [...rules, ...res];
-            setRules(rules);
-          });
+          const targets = metadata[0].getElementsByTagName("targetTechnology");
+          if (targets && targets.length > 0) target = targets[0].id;
         }
+
+        const rulesGroup = ruleSets[0].getElementsByTagName("rules");
+        if (rulesGroup && rulesGroup.length > 0)
+          rulesCount = rulesGroup[0].getElementsByTagName("rule").length;
       }
-    } else {
-      setRules([]);
-    }
-  }, [customRulesFiles, sources]);
+
+      const rules: Rule[] = [
+        {
+          name: file.fileName,
+          source: source,
+          target: target,
+          total: rulesCount,
+        },
+      ];
+
+      if (source && !sources.includes(source))
+        setValue("sources", [...sources, source]);
+
+      if (target && !targets.includes(target))
+        setValue("targets", [...targets, target]);
+
+      return rules;
+    };
+
+    let rules: Rule[] = [];
+    customRulesFiles.forEach((file) => {
+      if (file.data) rules = [...rules, ...getRules(file)];
+    });
+
+    return rules.flat();
+  }, [customRulesFiles, sources, targets, setValue]);
 
   const filterCategories: FilterCategory<Rule>[] = [
     {

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -240,7 +240,10 @@ export const CustomRules: React.FunctionComponent = () => {
           isOpen={isAddCustomRulesModalOpen}
           variant="medium"
           title="Add rules"
-          onClose={() => setCustomRulesModalOpen(false)}
+          onClose={() => {
+            setCustomRulesModalOpen(false);
+            setReadFileData([]);
+          }}
           actions={[
             <Button
               key="add"

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -33,9 +33,9 @@ import {
 import { useFilterState } from "@app/shared/hooks/useFilterState";
 import { Rule } from "@app/api/models";
 import { NoDataEmptyState } from "@app/shared/components";
+import { IReadFile } from "./analysis-wizard";
 
 import "./wizard.css";
-import { IReadFile } from "./analysis-wizard";
 
 export const CustomRules: React.FunctionComponent = () => {
   const { getValues, setValue } = useFormContext();
@@ -43,8 +43,8 @@ export const CustomRules: React.FunctionComponent = () => {
   const sources: string[] = getValues("sources");
   const targets: string[] = getValues("targets");
   const customRulesFiles: IReadFile[] = getValues("customRulesFiles");
-  const [currentFiles, setCurrentFiles] = React.useState<IReadFile[]>([]);
 
+  const [readFileData, setReadFileData] = React.useState<IReadFile[]>([]);
   const [isAddCustomRulesModalOpen, setCustomRulesModalOpen] =
     React.useState(false);
 
@@ -181,6 +181,9 @@ export const CustomRules: React.FunctionComponent = () => {
     });
   });
 
+  console.log("customRulesFiles", customRulesFiles);
+  console.log("readFileData", readFileData);
+
   return (
     <>
       <TextContent>
@@ -245,13 +248,19 @@ export const CustomRules: React.FunctionComponent = () => {
             <Button
               key="add"
               variant="primary"
+              isDisabled={
+                !readFileData.find((file) => file.loadResult === "success")
+              }
               onClick={(event) => {
                 setCustomRulesModalOpen(false);
+                const validFiles = readFileData.filter(
+                  (file) => file.loadResult === "success"
+                );
                 setValue("customRulesFiles", [
                   ...customRulesFiles,
-                  ...currentFiles,
+                  ...validFiles,
                 ]);
-                setCurrentFiles([]);
+                setReadFileData([]);
               }}
             >
               Add
@@ -266,8 +275,9 @@ export const CustomRules: React.FunctionComponent = () => {
           ]}
         >
           <AddCustomRules
-            currentFiles={currentFiles}
-            setCurrentFiles={setCurrentFiles}
+            customRulesFiles={customRulesFiles}
+            readFileData={readFileData}
+            setReadFileData={setReadFileData}
           />
         </Modal>
       )}

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -181,9 +181,6 @@ export const CustomRules: React.FunctionComponent = () => {
     });
   });
 
-  console.log("customRulesFiles", customRulesFiles);
-  console.log("readFileData", readFileData);
-
   return (
     <>
       <TextContent>

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -48,6 +48,11 @@ export const CustomRules: React.FunctionComponent = () => {
   const [isAddCustomRulesModalOpen, setCustomRulesModalOpen] =
     React.useState(false);
 
+  const onCloseCustomRuleModal = () => {
+    setCustomRulesModalOpen(false);
+    setReadFileData([]);
+  };
+
   const rules = React.useMemo(() => {
     const getRules = (file: IReadFile) => {
       if (!file.data) return [];
@@ -240,10 +245,7 @@ export const CustomRules: React.FunctionComponent = () => {
           isOpen={isAddCustomRulesModalOpen}
           variant="medium"
           title="Add rules"
-          onClose={() => {
-            setCustomRulesModalOpen(false);
-            setReadFileData([]);
-          }}
+          onClose={onCloseCustomRuleModal}
           actions={[
             <Button
               key="add"
@@ -268,10 +270,7 @@ export const CustomRules: React.FunctionComponent = () => {
             <Button
               key="cancel"
               variant="link"
-              onClick={() => {
-                setCustomRulesModalOpen(false);
-                setReadFileData([]);
-              }}
+              onClick={onCloseCustomRuleModal}
             >
               Cancel
             </Button>,


### PR DESCRIPTION
Use updated version of "file upload multiple" from PF
Use `customFileHandler` prop to have a granular control of duplicate files and XML validation (against schema).
Fixes ability to remove a file from upload list. See https://issues.redhat.com/browse/TACKLE-665 for details.

Note: Latest "file upload multiple" doesn't use a modal to warn about unsupported file selected for upload because files without the correct extension are simply ignored.