### PR TITLE
Unit Test Analysis-wizard: cancel and warnings

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Test
         working-directory: pkg/client
         run: 
-          npm run test:unit --coverage --watchAll=false
+          npm run test --coverage --watchAll=false
       - uses: codecov/codecov-action@v1
         with:
           flags: unitests

--- a/pkg/client/config/jest.config.js
+++ b/pkg/client/config/jest.config.js
@@ -22,6 +22,7 @@ module.exports = {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/__mocks__/fileMock.js",
     "@app/(.*)": "<rootDir>/src/app/$1",
+    "\\.(xsd)$": "<rootDir>/__mocks__/styleMock.js",
   },
 
   // An array of file extensions your modules use. If you require modules without specifying a file extension,

--- a/pkg/client/package.json
+++ b/pkg/client/package.json
@@ -16,7 +16,7 @@
     "server": "NODE_ENV=development node ../server/index.js",
     "start": "node ../server/index.js -r @cypress/instrument-cra",
     "start:dev": "concurrently -n proxy,server,client -c \"green.bold.inverse,blue.bold.inverse,yellow.bold.inverse\" \"npm:proxy\" \"npm:server\" \"npm:build:dev\"",
-    "test:unit": "$(npm bin)/jest --rootDir=. --config=config/jest.config.js",
+    "test": "$(npm bin)/jest --rootDir=. --config=config/jest.config.js",
     "tsc": "$(npm bin)/tsc -p ./tsconfig.json"
   },
   "dependencies": {

--- a/pkg/client/src/app/layout/HeaderApp/HeaderApp.tsx
+++ b/pkg/client/src/app/layout/HeaderApp/HeaderApp.tsx
@@ -9,7 +9,7 @@ import {
   Button,
   ButtonVariant,
 } from "@patternfly/react-core";
-import { HelpIcon } from "@patternfly/react-icons/dist/esm/icons/help-icon";
+import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
 import { AppAboutModalState } from "../AppAboutModalState";
 import { SSOMenu } from "./SSOMenu";

--- a/pkg/client/src/app/layout/HeaderApp/MobileDropdown.tsx
+++ b/pkg/client/src/app/layout/HeaderApp/MobileDropdown.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Dropdown, DropdownItem, KebabToggle } from "@patternfly/react-core";
-import { HelpIcon } from "@patternfly/react-icons/dist/esm/icons/help-icon";
+import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 import { AppAboutModal } from "../AppAboutModal";
 
 export const MobileDropdown: React.FC = () => {

--- a/pkg/client/src/app/ninja-error-boundary.tsx
+++ b/pkg/client/src/app/ninja-error-boundary.tsx
@@ -7,7 +7,7 @@ import {
   EmptyStateVariant,
   Title,
 } from "@patternfly/react-core";
-import { UserNinjaIcon } from "@patternfly/react-icons/dist/esm/icons/user-ninja-icon";
+import UserNinjaIcon from "@patternfly/react-icons/dist/esm/icons/user-ninja-icon";
 
 interface NinjaErrorBoundaryProps {}
 interface NinjaErrorBoundaryState {

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -202,6 +202,14 @@ describe("<AnalysisWizard />", () => {
     await user.click(screen.getByRole("button", { name: /next/i }));
 
     // review
+    expect(screen.getByText("App1")).toBeInTheDocument();
+    expect(screen.getByText("App2")).toBeInTheDocument();
+    expect(screen.getByText("Binary")).toBeInTheDocument();
+    expect(screen.getByText("cloud-readiness")).toBeInTheDocument();
+    expect(
+      screen.getByText("Application and internal dependencies")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Known Open Source libraries")).toBeInTheDocument();
 
     const runButton = screen.getByRole("button", { name: /run/i });
     expect(runButton).toBeEnabled();

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -235,7 +235,7 @@ describe("<AnalysisWizard />", () => {
     expect(uploadBinary).not.toBeInTheDocument();
   });
 
-  it("can upload a binary file when analyzing one application", async () => {
+  it.skip("can upload a binary file when analyzing one application", async () => {
     render(
       <AnalysisWizard
         applications={[applicationData1]}

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -5,12 +5,9 @@ import userEvent from "@testing-library/user-event";
 import { AnalysisWizard } from "../analysis-wizard";
 import { TASKGROUPS } from "@app/api/rest";
 import mock from "@app/test-config/mockInstance";
-import { Application } from "@app/api/models";
 
 jest.mock("react-i18next");
 jest.mock("react-redux");
-
-let applicationsData: Application[];
 
 const applicationData1 = {
   id: 1,

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -235,7 +235,7 @@ describe("<AnalysisWizard />", () => {
     expect(uploadBinary).not.toBeInTheDocument();
   });
 
-  it.skip("can upload a binary file when analyzing one application", async () => {
+  it("can upload a binary file when analyzing one application", async () => {
     render(
       <AnalysisWizard
         applications={[applicationData1]}

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -157,39 +157,14 @@ describe("<AnalysisWizard />", () => {
     expect(nextButton).toHaveAttribute("disabled", "");
   });
 
-  it.skip("can upload a binary file", async () => {
-    applicationsData = [applicationData1];
-    mock.onGet(`${APPLICATIONS}`).reply(200, [applicationsData]);
-    mock.onPost(`${TASKGROUPS}`).reply(200, taskgroupData);
-    render(
-      <AnalysisWizard
-        applications={applicationsData}
-        isOpen={isAnalyzeModalOpen}
-        onClose={() => {
-          setAnalyzeModalOpen(false);
-        }}
-      />
-    );
-    const user = userEvent.setup();
-
-    const mode = screen.getByText(/binary/i);
-    await user.click(mode);
-
-    const uploadBinary = await screen.findByRole("option", {
-      name: /upload a local binary/i,
-    });
-    await waitFor(() => user.click(uploadBinary), {
-      timeout: 3000,
-    });
-    // await user.click(uploadButton);
-    screen.debug();
-    screen.logTestingPlaygroundURL();
-  });
-
-  it("has next button enabled when applications mode have binary source defined", async () => {
+  it("can run analysis on applications with a binary definition using defaults", async () => {
     const applicationsData = [
       {
         ...applicationData1,
+        binary: "io.konveyor.demo:customers-tomcat:0.0.1-SNAPSHOT:war",
+      },
+      {
+        ...applicationData2,
         binary: "io.konveyor.demo:customers-tomcat:0.0.1-SNAPSHOT:war",
       },
     ];
@@ -208,12 +183,14 @@ describe("<AnalysisWizard />", () => {
     );
 
     const user = userEvent.setup();
+
+    // set default mode "Binary"
     const warning = screen.queryByLabelText(/warning alert/i);
     const nextButton = screen.getByRole("button", { name: /next/i });
     expect(warning).not.toBeInTheDocument();
     expect(nextButton).toBeEnabled();
 
-    // set target
+    // set a target
     await user.click(nextButton);
     const target = await screen.findByRole("heading", {
       name: /containerization/i,
@@ -227,7 +204,16 @@ describe("<AnalysisWizard />", () => {
     });
     await user.click(scope);
     await user.click(screen.getByRole("button", { name: /next/i }));
-    screen.debug();
-    screen.logTestingPlaygroundURL();
+
+    // no custom rules
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    // no advanced options
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    // review
+
+    const runButton = screen.getByRole("button", { name: /run/i });
+    expect(runButton).toBeEnabled();
   });
 });

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -1,29 +1,58 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen } from "@app/test-config/test-utils";
+import { render, screen, waitFor } from "@app/test-config/test-utils";
 import userEvent from "@testing-library/user-event";
 import { AnalysisWizard } from "../analysis-wizard";
-import { APPLICATIONS, TASKGROUPS } from "@app/api/rest";
+import { APPLICATIONS, TASKGROUPS, TASKS } from "@app/api/rest";
 import mock from "@app/test-config/mockInstance";
 import { Application } from "@app/api/models";
 
 jest.mock("react-i18next");
 jest.mock("react-redux");
 
-let applicationsDataDefault: Application[];
+let applicationsData: Application[];
 
-beforeAll(() => {
-  applicationsDataDefault = [
-    {
-      id: 1,
-      name: "App1",
+const applicationData1 = {
+  id: 1,
+  name: "App1",
+};
+
+const applicationData2 = {
+  id: 2,
+  name: "App2",
+};
+
+const taskgroupData = {
+  addon: "windup",
+  data: {
+    mode: {
+      artifact: "",
+      binary: false,
+      withDeps: false,
     },
-    {
-      id: 2,
-      name: "App2",
+    output: "/windup/report",
+    scope: {
+      packages: {
+        excluded: [],
+        included: [],
+      },
+      withKnown: false,
     },
-  ];
-});
+    sources: [],
+    targets: [],
+  },
+  name: "taskgroup.windup",
+  tasks: [
+    {
+      application: {
+        id: 1,
+        name: "App1",
+      },
+      data: {},
+      name: "App1.1.windup",
+    },
+  ],
+};
 
 describe("<AnalysisWizard />", () => {
   let isAnalyzeModalOpen = true;
@@ -31,11 +60,12 @@ describe("<AnalysisWizard />", () => {
     (isAnalyzeModalOpen = toggle);
 
   it("allows to cancel an analysis wizard", async () => {
-    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsDataDefault);
+    applicationsData = [applicationData1, applicationData2];
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
 
     render(
       <AnalysisWizard
-        applications={applicationsDataDefault}
+        applications={applicationsData}
         isOpen={isAnalyzeModalOpen}
         onClose={() => {
           setAnalyzeModalOpen(false);
@@ -48,10 +78,11 @@ describe("<AnalysisWizard />", () => {
   });
 
   it("has next button disabled when applications mode have no binary source defined", async () => {
-    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsDataDefault);
+    applicationsData = [applicationData1, applicationData2];
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
     render(
       <AnalysisWizard
-        applications={applicationsDataDefault}
+        applications={applicationsData}
         isOpen={isAnalyzeModalOpen}
         onClose={() => {
           setAnalyzeModalOpen(false);
@@ -66,10 +97,11 @@ describe("<AnalysisWizard />", () => {
   });
 
   it("has next button disabled when applications mode have no source code defined", async () => {
-    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsDataDefault);
+    applicationsData = [applicationData1, applicationData2];
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
     render(
       <AnalysisWizard
-        applications={applicationsDataDefault}
+        applications={applicationsData}
         isOpen={isAnalyzeModalOpen}
         onClose={() => {
           setAnalyzeModalOpen(false);
@@ -96,10 +128,11 @@ describe("<AnalysisWizard />", () => {
   });
 
   it("has next button disabled when applications mode have no source code + dependencies defined", async () => {
-    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsDataDefault);
+    applicationsData = [applicationData1, applicationData2];
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
     render(
       <AnalysisWizard
-        applications={applicationsDataDefault}
+        applications={applicationsData}
         isOpen={isAnalyzeModalOpen}
         onClose={() => {
           setAnalyzeModalOpen(false);
@@ -124,45 +157,42 @@ describe("<AnalysisWizard />", () => {
     expect(nextButton).toHaveAttribute("disabled", "");
   });
 
+  it.skip("can upload a binary file", async () => {
+    applicationsData = [applicationData1];
+    mock.onGet(`${APPLICATIONS}`).reply(200, [applicationsData]);
+    mock.onPost(`${TASKGROUPS}`).reply(200, taskgroupData);
+    render(
+      <AnalysisWizard
+        applications={applicationsData}
+        isOpen={isAnalyzeModalOpen}
+        onClose={() => {
+          setAnalyzeModalOpen(false);
+        }}
+      />
+    );
+    const user = userEvent.setup();
+
+    const mode = screen.getByText(/binary/i);
+    await user.click(mode);
+
+    const uploadBinary = await screen.findByRole("option", {
+      name: /upload a local binary/i,
+    });
+    await waitFor(() => user.click(uploadBinary), {
+      timeout: 3000,
+    });
+    // await user.click(uploadButton);
+    screen.debug();
+    screen.logTestingPlaygroundURL();
+  });
+
   it("has next button enabled when applications mode have binary source defined", async () => {
     const applicationsData = [
       {
-        ...applicationsDataDefault[0],
+        ...applicationData1,
         binary: "io.konveyor.demo:customers-tomcat:0.0.1-SNAPSHOT:war",
       },
     ];
-
-    const taskgroupData = {
-      addon: "windup",
-      data: {
-        mode: {
-          artifact: "",
-          binary: false,
-          withDeps: false,
-        },
-        output: "/windup/report",
-        scope: {
-          packages: {
-            excluded: [],
-            included: [],
-          },
-          withKnown: false,
-        },
-        sources: [],
-        targets: [],
-      },
-      name: "taskgroup.windup",
-      tasks: [
-        {
-          application: {
-            id: 1,
-            name: "App1",
-          },
-          data: {},
-          name: "App1.1.windup",
-        },
-      ],
-    };
 
     mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
     mock.onPost(`${TASKGROUPS}`).reply(200, taskgroupData);
@@ -196,6 +226,8 @@ describe("<AnalysisWizard />", () => {
       name: /wizard\.label\.scopealldeps/i,
     });
     await user.click(scope);
-    // await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    screen.debug();
+    screen.logTestingPlaygroundURL();
   });
 });

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@app/test-config/test-utils";
+import userEvent from "@testing-library/user-event";
+import { AnalysisWizard } from "../analysis-wizard";
+import { APPLICATIONS } from "@app/api/rest";
+import mock from "@app/test-config/mockInstance";
+
+jest.mock("react-i18next");
+jest.mock("react-redux");
+
+describe("<AnalysisWizard />", () => {
+  let isAnalyzeModalOpen = true;
+  const setAnalyzeModalOpen = (toggle: boolean) =>
+    (isAnalyzeModalOpen = toggle);
+
+  it("allows to cancel an analysis wizard", async () => {
+    const applicationsData = [
+      {
+        id: 1,
+        name: "App1",
+      },
+    ];
+
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+
+    render(
+      <AnalysisWizard
+        applications={applicationsData}
+        isOpen={isAnalyzeModalOpen}
+        onClose={() => {
+          setAnalyzeModalOpen(false);
+        }}
+      />
+    );
+
+    const cancelButton = await screen.findByRole("button", { name: /Cancel/ });
+    expect(cancelButton).toBeEnabled();
+  });
+
+  it("has next button disabled when applications mode have no binary source defined", async () => {
+    const applicationsData = [
+      {
+        id: 1,
+        name: "App1",
+      },
+      {
+        id: 2,
+        name: "App2",
+      },
+    ];
+
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+    render(
+      <AnalysisWizard
+        applications={applicationsData}
+        isOpen={isAnalyzeModalOpen}
+        onClose={() => {
+          setAnalyzeModalOpen(false);
+        }}
+      />
+    );
+
+    const alert = screen.getByText(/warning alert:/i);
+    const runButton = screen.getByRole("button", { name: /next/i });
+    expect(alert).toBeEnabled();
+    expect(runButton).toHaveAttribute("disabled", "");
+  });
+
+  it("has next button disabled when applications mode have no source code defined", async () => {
+    const applicationsData = [
+      {
+        id: 1,
+        name: "App1",
+      },
+      {
+        id: 2,
+        name: "App2",
+      },
+    ];
+
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+    render(
+      <AnalysisWizard
+        applications={applicationsData}
+        isOpen={isAnalyzeModalOpen}
+        onClose={() => {
+          setAnalyzeModalOpen(false);
+        }}
+      />
+    );
+
+    const user = userEvent.setup();
+
+    const mode = screen.getByText(/binary/i);
+    await user.click(mode);
+
+    const sourceCode = await screen.findByRole("option", {
+      name: "Source code",
+      hidden: true,
+    });
+
+    await user.click(sourceCode);
+
+    const alert = screen.getByText(/warning alert:/i);
+    const runButton = screen.getByRole("button", { name: /next/i });
+    expect(alert).toBeEnabled();
+    expect(runButton).toHaveAttribute("disabled", "");
+  });
+
+  it("has next button disabled when applications mode have no source code + dependencies defined", async () => {
+    const applicationsData = [
+      {
+        id: 1,
+        name: "App1",
+      },
+      {
+        id: 2,
+        name: "App2",
+      },
+    ];
+
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+    render(
+      <AnalysisWizard
+        applications={applicationsData}
+        isOpen={isAnalyzeModalOpen}
+        onClose={() => {
+          setAnalyzeModalOpen(false);
+        }}
+      />
+    );
+    const user = userEvent.setup();
+
+    const mode = screen.getByText(/binary/i);
+    await user.click(mode);
+
+    const sourceCodePlusDependencies = await screen.findByRole("option", {
+      name: "Source code + dependencies",
+      hidden: true,
+    });
+
+    await user.click(sourceCodePlusDependencies);
+
+    const alert = screen.getByText(/warning alert:/i);
+    const runButton = screen.getByRole("button", { name: /next/i });
+    expect(alert).toBeEnabled();
+    expect(runButton).toHaveAttribute("disabled", "");
+  });
+});

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -1,13 +1,29 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@app/test-config/test-utils";
+import { render, screen } from "@app/test-config/test-utils";
 import userEvent from "@testing-library/user-event";
 import { AnalysisWizard } from "../analysis-wizard";
-import { APPLICATIONS } from "@app/api/rest";
+import { APPLICATIONS, TASKGROUPS } from "@app/api/rest";
 import mock from "@app/test-config/mockInstance";
+import { Application } from "@app/api/models";
 
 jest.mock("react-i18next");
 jest.mock("react-redux");
+
+let applicationsDataDefault: Application[];
+
+beforeAll(() => {
+  applicationsDataDefault = [
+    {
+      id: 1,
+      name: "App1",
+    },
+    {
+      id: 2,
+      name: "App2",
+    },
+  ];
+});
 
 describe("<AnalysisWizard />", () => {
   let isAnalyzeModalOpen = true;
@@ -15,18 +31,11 @@ describe("<AnalysisWizard />", () => {
     (isAnalyzeModalOpen = toggle);
 
   it("allows to cancel an analysis wizard", async () => {
-    const applicationsData = [
-      {
-        id: 1,
-        name: "App1",
-      },
-    ];
-
-    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsDataDefault);
 
     render(
       <AnalysisWizard
-        applications={applicationsData}
+        applications={applicationsDataDefault}
         isOpen={isAnalyzeModalOpen}
         onClose={() => {
           setAnalyzeModalOpen(false);
@@ -39,21 +48,10 @@ describe("<AnalysisWizard />", () => {
   });
 
   it("has next button disabled when applications mode have no binary source defined", async () => {
-    const applicationsData = [
-      {
-        id: 1,
-        name: "App1",
-      },
-      {
-        id: 2,
-        name: "App2",
-      },
-    ];
-
-    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsDataDefault);
     render(
       <AnalysisWizard
-        applications={applicationsData}
+        applications={applicationsDataDefault}
         isOpen={isAnalyzeModalOpen}
         onClose={() => {
           setAnalyzeModalOpen(false);
@@ -62,27 +60,16 @@ describe("<AnalysisWizard />", () => {
     );
 
     const alert = screen.getByText(/warning alert:/i);
-    const runButton = screen.getByRole("button", { name: /next/i });
+    const nextButton = screen.getByRole("button", { name: /next/i });
     expect(alert).toBeEnabled();
-    expect(runButton).toHaveAttribute("disabled", "");
+    expect(nextButton).toHaveAttribute("disabled", "");
   });
 
   it("has next button disabled when applications mode have no source code defined", async () => {
-    const applicationsData = [
-      {
-        id: 1,
-        name: "App1",
-      },
-      {
-        id: 2,
-        name: "App2",
-      },
-    ];
-
-    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsDataDefault);
     render(
       <AnalysisWizard
-        applications={applicationsData}
+        applications={applicationsDataDefault}
         isOpen={isAnalyzeModalOpen}
         onClose={() => {
           setAnalyzeModalOpen(false);
@@ -103,27 +90,16 @@ describe("<AnalysisWizard />", () => {
     await user.click(sourceCode);
 
     const alert = screen.getByText(/warning alert:/i);
-    const runButton = screen.getByRole("button", { name: /next/i });
+    const nextButton = screen.getByRole("button", { name: /next/i });
     expect(alert).toBeEnabled();
-    expect(runButton).toHaveAttribute("disabled", "");
+    expect(nextButton).toHaveAttribute("disabled", "");
   });
 
   it("has next button disabled when applications mode have no source code + dependencies defined", async () => {
-    const applicationsData = [
-      {
-        id: 1,
-        name: "App1",
-      },
-      {
-        id: 2,
-        name: "App2",
-      },
-    ];
-
-    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsDataDefault);
     render(
       <AnalysisWizard
-        applications={applicationsData}
+        applications={applicationsDataDefault}
         isOpen={isAnalyzeModalOpen}
         onClose={() => {
           setAnalyzeModalOpen(false);
@@ -143,8 +119,83 @@ describe("<AnalysisWizard />", () => {
     await user.click(sourceCodePlusDependencies);
 
     const alert = screen.getByText(/warning alert:/i);
-    const runButton = screen.getByRole("button", { name: /next/i });
+    const nextButton = screen.getByRole("button", { name: /next/i });
     expect(alert).toBeEnabled();
-    expect(runButton).toHaveAttribute("disabled", "");
+    expect(nextButton).toHaveAttribute("disabled", "");
+  });
+
+  it("has next button enabled when applications mode have binary source defined", async () => {
+    const applicationsData = [
+      {
+        ...applicationsDataDefault[0],
+        binary: "io.konveyor.demo:customers-tomcat:0.0.1-SNAPSHOT:war",
+      },
+    ];
+
+    const taskgroupData = {
+      addon: "windup",
+      data: {
+        mode: {
+          artifact: "",
+          binary: false,
+          withDeps: false,
+        },
+        output: "/windup/report",
+        scope: {
+          packages: {
+            excluded: [],
+            included: [],
+          },
+          withKnown: false,
+        },
+        sources: [],
+        targets: [],
+      },
+      name: "taskgroup.windup",
+      tasks: [
+        {
+          application: {
+            id: 1,
+            name: "App1",
+          },
+          data: {},
+          name: "App1.1.windup",
+        },
+      ],
+    };
+
+    mock.onGet(`${APPLICATIONS}`).reply(200, applicationsData);
+    mock.onPost(`${TASKGROUPS}`).reply(200, taskgroupData);
+
+    render(
+      <AnalysisWizard
+        applications={applicationsData}
+        isOpen={isAnalyzeModalOpen}
+        onClose={() => {
+          setAnalyzeModalOpen(false);
+        }}
+      />
+    );
+
+    const user = userEvent.setup();
+    const warning = screen.queryByLabelText(/warning alert/i);
+    const nextButton = screen.getByRole("button", { name: /next/i });
+    expect(warning).not.toBeInTheDocument();
+    expect(nextButton).toBeEnabled();
+
+    // set target
+    await user.click(nextButton);
+    const target = await screen.findByRole("heading", {
+      name: /containerization/i,
+    });
+    await user.click(target);
+    await user.click(nextButton);
+
+    // set scope
+    const scope = screen.getByRole("radio", {
+      name: /wizard\.label\.scopealldeps/i,
+    });
+    await user.click(scope);
+    // await user.click(screen.getByRole("button", { name: /next/i }));
   });
 });

--- a/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -234,36 +234,4 @@ describe("<AnalysisWizard />", () => {
 
     expect(uploadBinary).not.toBeInTheDocument();
   });
-
-  it.skip("can upload a binary file when analyzing one application", async () => {
-    render(
-      <AnalysisWizard
-        applications={[applicationData1]}
-        isOpen={isAnalyzeModalOpen}
-        onClose={() => {
-          setAnalyzeModalOpen(false);
-        }}
-      />
-    );
-    const user = userEvent.setup();
-
-    const mode = screen.getByText(/binary/i);
-    await user.click(mode);
-
-    const uploadBinary = await screen.findByRole("option", {
-      name: "Upload a local binary",
-      hidden: true,
-    });
-
-    await user.click(uploadBinary);
-
-    const warning = screen.queryByLabelText(/warning alert/i);
-    const nextButton = screen.getByRole("button", { name: /next/i });
-    expect(warning).not.toBeInTheDocument();
-    // TODO Fix Upload binary file
-    // Upload button is not available
-
-    // TODO - Once uploaded, nextButton should be enabled
-    expect(nextButton).toBeEnabled();
-  });
 });

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -47,6 +47,7 @@ export const CustomRules: React.FunctionComponent = () => {
   const targets: string[] = getValues("targets");
   const customRulesFiles: IReadFile[] = getValues("customRulesFiles");
 
+  const [rules, setRules] = React.useState<Rule[]>([]);
   const [readFileData, setReadFileData] = React.useState<IReadFile[]>([]);
   const [isAddCustomRulesModalOpen, setCustomRulesModalOpen] =
     React.useState(false);
@@ -56,7 +57,7 @@ export const CustomRules: React.FunctionComponent = () => {
     setReadFileData([]);
   };
 
-  const rules = React.useMemo(() => {
+  React.useEffect(() => {
     const getRules = (file: IReadFile) => {
       if (!file.data) return [];
 
@@ -109,7 +110,7 @@ export const CustomRules: React.FunctionComponent = () => {
       if (file.data) rules = [...rules, ...getRules(file)];
     });
 
-    return rules.flat();
+    setRules(rules.flat());
   }, [customRulesFiles, sources, targets, setValue]);
 
   const filterCategories: FilterCategory<Rule>[] = [

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -22,8 +22,8 @@ import {
 } from "@patternfly/react-table";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { FilterIcon } from "@patternfly/react-icons/dist/esm/icons/filter-icon";
-import { TrashIcon } from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
+import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 
 import { AddCustomRules } from "./components/add-custom-rules";
 import {

--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -33,7 +33,7 @@ import {
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
 import { Rule } from "@app/api/models";
-import { NoDataEmptyState } from "@app/shared/components";
+import { NoDataEmptyState } from "@app/shared/components/no-data-empty-state";
 import { IReadFile } from "./analysis-wizard";
 
 import "./wizard.css";

--- a/pkg/client/src/app/pages/applications/application-assessment/application-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/application-assessment/application-assessment.tsx
@@ -11,7 +11,7 @@ import {
   Wizard,
   WizardStep,
 } from "@patternfly/react-core";
-import { BanIcon } from "@patternfly/react-icons/dist/esm/icons/ban-icon";
+import BanIcon from "@patternfly/react-icons/dist/esm/icons/ban-icon";
 
 import { useDispatch } from "react-redux";
 import { alertActions } from "@app/store/alert";

--- a/pkg/client/src/app/pages/applications/application-assessment/components/questionnaire-form/questionnaire-form.tsx
+++ b/pkg/client/src/app/pages/applications/application-assessment/components/questionnaire-form/questionnaire-form.tsx
@@ -12,7 +12,7 @@ import {
   TextArea,
   TextContent,
 } from "@patternfly/react-core";
-import { HelpIcon } from "@patternfly/react-icons/dist/esm/icons/help-icon";
+import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
 import { QuestionnaireCategory } from "@app/api/models";
 import { getValidatedFromError } from "@app/utils/utils";

--- a/pkg/client/src/app/pages/applications/application-review/application-review.tsx
+++ b/pkg/client/src/app/pages/applications/application-review/application-review.tsx
@@ -18,8 +18,8 @@ import {
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import { BanIcon } from "@patternfly/react-icons/dist/esm/icons/ban-icon";
-import { InfoCircleIcon } from "@patternfly/react-icons/dist/esm/icons/info-circle-icon";
+import BanIcon from "@patternfly/react-icons/dist/esm/icons/ban-icon";
+import InfoCircleIcon from "@patternfly/react-icons/dist/esm/icons/info-circle-icon";
 
 import {
   AppPlaceholder,

--- a/pkg/client/src/app/pages/applications/application-review/components/application-assessment-summary-table/components/select-risk-filter/select-risk-filter.tsx
+++ b/pkg/client/src/app/pages/applications/application-review/components/application-assessment-summary-table/components/select-risk-filter/select-risk-filter.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import { SelectVariant, ToolbarChip } from "@patternfly/react-core";
-import { FilterIcon } from "@patternfly/react-icons/dist/esm/icons/filter-icon";
+import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
 
 import { OptionWithValue, SimpleSelect } from "@app/shared/components";
 

--- a/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -23,8 +23,8 @@ import {
   sortable,
   TableText,
 } from "@patternfly/react-table";
-import { TagIcon } from "@patternfly/react-icons/dist/esm/icons/tag-icon";
-import { PencilAltIcon } from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
+import TagIcon from "@patternfly/react-icons/dist/esm/icons/tag-icon";
+import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
 import { useDispatch } from "react-redux";
 import keycloak from "@app/keycloak";
 

--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -23,8 +23,8 @@ import {
   sortable,
   TableText,
 } from "@patternfly/react-table";
-import { TagIcon } from "@patternfly/react-icons/dist/esm/icons/tag-icon";
-import { PencilAltIcon } from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
+import TagIcon from "@patternfly/react-icons/dist/esm/icons/tag-icon";
+import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
 
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@app/store/rootReducer";

--- a/pkg/client/src/app/pages/applications/components/application-identity-form/application-identity-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/application-identity-form/application-identity-form.tsx
@@ -13,7 +13,7 @@ import {
   TextInput,
   Text,
 } from "@patternfly/react-core";
-import { WarningTriangleIcon } from "@patternfly/react-icons/dist/esm/icons/warning-triangle-icon";
+import WarningTriangleIcon from "@patternfly/react-icons/dist/esm/icons/warning-triangle-icon";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 import { Application, Identity, Ref } from "@app/api/models";
 import { SingleSelectFetchOptionValueFormikField } from "@app/shared/components";

--- a/pkg/client/src/app/pages/applications/components/bulk-copy-assessment-review-form/bulk-copy-assessment-review-form.tsx
+++ b/pkg/client/src/app/pages/applications/components/bulk-copy-assessment-review-form/bulk-copy-assessment-review-form.tsx
@@ -19,7 +19,7 @@ import {
   Checkbox,
   FormGroup,
 } from "@patternfly/react-core";
-import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
 import { global_palette_gold_400 as gold } from "@patternfly/react-tokens";
 
 import { useDispatch } from "react-redux";

--- a/pkg/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/pkg/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -25,7 +25,7 @@ import {
   sortable,
   truncate,
 } from "@patternfly/react-table";
-import { InProgressIcon } from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
+import InProgressIcon from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
 
 import { useDispatch } from "react-redux";
 import { alertActions } from "@app/store/alert";

--- a/pkg/client/src/app/pages/reports/reports.tsx
+++ b/pkg/client/src/app/pages/reports/reports.tsx
@@ -25,7 +25,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { HelpIcon } from "@patternfly/react-icons/dist/esm/icons/help-icon";
+import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
 import {
   AppPlaceholder,

--- a/pkg/client/src/app/shared/components/app-table/state-error.tsx
+++ b/pkg/client/src/app/shared/components/app-table/state-error.tsx
@@ -6,7 +6,7 @@ import {
   Title,
   EmptyStateBody,
 } from "@patternfly/react-core";
-import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 import { global_danger_color_200 as globalDangerColor200 } from "@patternfly/react-tokens";
 
 export const StateError: React.FC = () => {

--- a/pkg/client/src/app/shared/components/app-table/state-no-results.tsx
+++ b/pkg/client/src/app/shared/components/app-table/state-no-results.tsx
@@ -8,7 +8,7 @@ import {
   EmptyStateVariant,
   Title,
 } from "@patternfly/react-core";
-import { SearchIcon } from "@patternfly/react-icons/dist/esm/icons/search-icon";
+import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
 
 export const StateNoResults: React.FC = () => {
   const { t } = useTranslation();

--- a/pkg/client/src/app/shared/components/app-table/tests/__snapshots__/state-error.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/app-table/tests/__snapshots__/state-error.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`StateError Renders without crashing 1`] = `
 >
   <EmptyStateIcon
     color="#a30000"
+    icon="test-file-stub"
   />
   <Title
     headingLevel="h2"

--- a/pkg/client/src/app/shared/components/app-table/tests/__snapshots__/state-no-results.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/app-table/tests/__snapshots__/state-no-results.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`StateNoResults Renders without crashing 1`] = `
 <EmptyState
   variant="small"
 >
-  <EmptyStateIcon />
+  <EmptyStateIcon
+    icon="test-file-stub"
+  />
   <Title
     headingLevel="h2"
     size="lg"

--- a/pkg/client/src/app/shared/components/input-text-filter/__snapshots__/input-text-filter.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/input-text-filter/__snapshots__/input-text-filter.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`InputTextFilter Renders without crashing 1`] = `
     onClick={[Function]}
     variant="control"
   >
-    <Component />
+    <test-file-stub />
   </Button>
 </InputGroup>
 `;

--- a/pkg/client/src/app/shared/components/input-text-filter/input-text-filter.tsx
+++ b/pkg/client/src/app/shared/components/input-text-filter/input-text-filter.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button, InputGroup, TextInput } from "@patternfly/react-core";
-import { SearchIcon } from "@patternfly/react-icons/dist/esm/icons/search-icon";
+import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
 
 export interface InputTextFilterProps {
   onApplyFilter: (filterText: string) => void;

--- a/pkg/client/src/app/shared/components/menu-actions/menu-actions.tsx
+++ b/pkg/client/src/app/shared/components/menu-actions/menu-actions.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Dropdown, DropdownItem, DropdownToggle } from "@patternfly/react-core";
-import { CaretDownIcon } from "@patternfly/react-icons/dist/esm/icons/caret-down-icon";
+import CaretDownIcon from "@patternfly/react-icons/dist/esm/icons/caret-down-icon";
 
 export interface MenuActionsProps {
   actions: { label: string; callback: () => void }[];

--- a/pkg/client/src/app/shared/components/menu-actions/tests/__snapshots__/menu-actions.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/menu-actions/tests/__snapshots__/menu-actions.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`MenuActions Renders without crashing 1`] = `
   toggle={
     <DropdownToggle
       onToggle={[Function]}
+      toggleIndicator="test-file-stub"
     >
       Actions
     </DropdownToggle>

--- a/pkg/client/src/app/shared/components/no-data-empty-state/no-data-empty-state.tsx
+++ b/pkg/client/src/app/shared/components/no-data-empty-state/no-data-empty-state.tsx
@@ -6,7 +6,7 @@ import {
   EmptyStateVariant,
   Title,
 } from "@patternfly/react-core";
-import { CubesIcon } from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
 
 export interface NoDataEmptyStateProps {
   title: string;

--- a/pkg/client/src/app/shared/components/no-data-empty-state/no-data-empty-state.tsx
+++ b/pkg/client/src/app/shared/components/no-data-empty-state/no-data-empty-state.tsx
@@ -13,10 +13,9 @@ export interface NoDataEmptyStateProps {
   description?: string;
 }
 
-export const NoDataEmptyState: React.FC<NoDataEmptyStateProps> = ({
-  title,
-  description,
-}) => {
+export const NoDataEmptyState: React.FunctionComponent<
+  NoDataEmptyStateProps
+> = ({ title, description }) => {
   return (
     <EmptyState variant={EmptyStateVariant.small}>
       <EmptyStateIcon icon={CubesIcon} />

--- a/pkg/client/src/app/shared/components/no-data-empty-state/tests/__snapshots__/no-data-empty-state.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/no-data-empty-state/tests/__snapshots__/no-data-empty-state.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`NoDataEmptyState Renders without crashing 1`] = `
 <EmptyState
   variant="small"
 >
-  <EmptyStateIcon />
+  <EmptyStateIcon
+    icon="test-file-stub"
+  />
   <Title
     headingLevel="h2"
     size="lg"

--- a/pkg/client/src/app/shared/components/search-filter/search-filter.tsx
+++ b/pkg/client/src/app/shared/components/search-filter/search-filter.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button, InputGroup, TextInput } from "@patternfly/react-core";
-import { SearchIcon } from "@patternfly/react-icons/dist/esm/icons/search-icon";
+import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
 
 import { SimpleFilterDropdown } from "@app/shared/components";
 import { DropdownOption } from "@app/shared/components/simple-filter-dropdown/simple-filter-dropdown";

--- a/pkg/client/src/app/shared/components/simple-empty-state/tests/__snapshots__/simple-empty-state.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/simple-empty-state/tests/__snapshots__/simple-empty-state.test.tsx.snap
@@ -20,6 +20,9 @@ exports[`SimpleEmptyState Renders with icon 1`] = `
 <EmptyState
   variant="small"
 >
+  <EmptyStateIcon
+    icon="test-file-stub"
+  />
   <Title
     headingLevel="h2"
     size="lg"

--- a/pkg/client/src/app/shared/components/simple-empty-state/tests/simple-empty-state.test.tsx
+++ b/pkg/client/src/app/shared/components/simple-empty-state/tests/simple-empty-state.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { AdIcon } from "@patternfly/react-icons/dist/esm/icons/ad-icon";
+import AdIcon from "@patternfly/react-icons/dist/esm/icons/ad-icon";
 
 import { SimpleEmptyState } from "../simple-empty-state";
 

--- a/pkg/client/src/app/shared/components/simple-filter-dropdown/simple-filter-dropdown.tsx
+++ b/pkg/client/src/app/shared/components/simple-filter-dropdown/simple-filter-dropdown.tsx
@@ -5,7 +5,7 @@ import {
   DropdownToggle,
   DropdownItem,
 } from "@patternfly/react-core";
-import { FilterIcon } from "@patternfly/react-icons/dist/esm/icons/filter-icon";
+import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
 
 export interface DropdownOption {
   key: string;

--- a/pkg/client/src/app/shared/components/simple-filter-dropdown/tests/__snapshots__/simple-filter-dropdown.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/simple-filter-dropdown/tests/__snapshots__/simple-filter-dropdown.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`SimpleFilterDropdown Renders without crashing 1`] = `
     <DropdownToggle
       onToggle={[Function]}
     >
-      <UNDEFINED />
+      <test-file-stub />
        
       My label
     </DropdownToggle>

--- a/pkg/client/src/app/shared/components/simple-select/simple-select-fetch.tsx
+++ b/pkg/client/src/app/shared/components/simple-select/simple-select-fetch.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AxiosError } from "axios";
 
-import { WarningTriangleIcon } from "@patternfly/react-icons/dist/esm/icons/warning-triangle-icon";
+import WarningTriangleIcon from "@patternfly/react-icons/dist/esm/icons/warning-triangle-icon";
 
 import { getAxiosErrorMessage } from "@app/utils/utils";
 import { ISimpleSelectProps, SimpleSelect } from "./simple-select";

--- a/pkg/client/src/app/shared/components/status-icon/status-icon.tsx
+++ b/pkg/client/src/app/shared/components/status-icon/status-icon.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Flex, FlexItem, SpinnerProps } from "@patternfly/react-core";
-import { CheckCircleIcon } from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
-import { TimesCircleIcon } from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
-import { InProgressIcon } from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
+import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
+import TimesCircleIcon from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
+import InProgressIcon from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
 import { SVGIconProps } from "@patternfly/react-icons/dist/js/createIcon";
-import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
-import { UnknownIcon } from "@patternfly/react-icons/dist/esm/icons/unknown-icon";
+import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import UnknownIcon from "@patternfly/react-icons/dist/esm/icons/unknown-icon";
 import {
   global_disabled_color_200 as disabledColor,
   global_success_color_100 as successColor,

--- a/pkg/client/src/app/shared/components/status-icon/tests/__snapshots__/status-icon.test.tsx.snap
+++ b/pkg/client/src/app/shared/components/status-icon/tests/__snapshots__/status-icon.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`StatusIcon Renders without crashing 1`] = `
   }
 >
   <FlexItem>
-    <Component
+    <test-file-stub
       className=""
       color="#6a6e73"
     />


### PR DESCRIPTION
Adds
- Test for analysis wizard cancellation
- Test analysis wizard warning is displayed when related applications have "binary", "source code" or "source code + dependencies" and at least one application doesn't have the associated definition in their data.
- Test run analysis for application with binary using defaults.
- Replaces all PF import icons using default export to avoid error with jest.
- Replaces `npm test:unit` to `npm test` to allow running single test file more easily: 

`npm test pkg/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx --`