### PR TITLE
TACKLE-669: Add Pending state to exclusion list

### DIFF
--- a/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -479,7 +479,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
         !tasks.some(
           (task) =>
             task.application?.id === app.id &&
-            task.state?.match(/(Created|Running|Ready)/)
+            task.state?.match(/(Created|Running|Ready|Pending)/)
         )
     );
 


### PR DESCRIPTION
Adding "Pending" state to the exclusion list of  `isAnalyzingAllowed()` avoids the UI to flip the analysis button as the task goes from "Ready" to "Pending" before going to next state.

https://issues.redhat.com/browse/TACKLE-669