### PR TITLE
Disable proxy-cred add if no valid cred exists

### DIFF
--- a/pkg/client/src/app/pages/proxies/proxy-form.tsx
+++ b/pkg/client/src/app/pages/proxies/proxy-form.tsx
@@ -390,6 +390,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                     aria-label={HTTP_IDENTITY}
                     value={value ? value : undefined}
                     options={identityOptions}
+                    isDisabled={!!!identityOptions.length}
                     onChange={(selection) => {
                       const selectionValue = selection as OptionWithValue<any>;
                       onChange(selectionValue.value);
@@ -522,6 +523,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                     aria-label={HTTPS_IDENTITY}
                     value={value ? value : undefined}
                     options={identityOptions}
+                    isDisabled={!!!identityOptions.length}
                     onChange={(selection) => {
                       const selectionValue = selection as OptionWithValue<any>;
                       onChange(selectionValue.value);


### PR DESCRIPTION
![Screenshot from 2022-07-20 11-23-59](https://user-images.githubusercontent.com/11218376/180022093-ab39923a-cf87-4a50-a8b9-4ee813474b37.png)
Currently, an empty dropdown is rendered when there are no valid proxy credentials available to add.

![Screenshot from 2022-07-20 11-27-16](https://user-images.githubusercontent.com/11218376/180022089-36c5d21c-cecb-408a-85c2-b3db5bc86266.png)

This PR disables the dropdown when no valid proxy cred is available. 