### PR TITLE
Add Applications and deps tooltip to Import page

### DIFF
--- a/pkg/client/public/locales/en/translation.json
+++ b/pkg/client/public/locales/en/translation.json
@@ -154,6 +154,7 @@
     },
     "terms": {
         "accepted": "Accepted",
+        "acceptedAppsAndDeps": "Accepted applications and dependencies",
         "add": "Add",
         "additionalNotesOrComments": "Additional notes or comments",
         "adoptionCandidateDistribution": "Adoption candidate distribution",
@@ -241,6 +242,7 @@
         "question": "Question",
         "rank": "Rank",
         "rejected": "Rejected",
+        "rejectedAppsAndDeps": "Rejected applications and dependencies",
         "reports": "Reports",
         "repositoryType": "Repository type",
         "review": "Review",

--- a/pkg/client/public/locales/es/translation.json
+++ b/pkg/client/public/locales/es/translation.json
@@ -154,6 +154,7 @@
     },
     "terms": {
         "accepted": "Aceptado",
+        "acceptedAppsAndDeps": "Aplicaciónes y dependencias adoptadas",
         "add": "Agregar",
         "additionalNotesOrComments": "Notas adicionales o comentarios",
         "adoptionCandidateDistribution": "Distribución de candidatos a la adopción",
@@ -241,6 +242,7 @@
         "question": "Pregunta",
         "rank": "Rango",
         "rejected": "Rechazado",
+        "rejectedAppsAndDeps": "Aplicaciónes y dependencias en desuso",
         "reports": "Reportes",
         "repositoryType": "Tipo de repositorio",
         "review": "Revisión",

--- a/pkg/client/src/app/common/TooltipTitle.tsx
+++ b/pkg/client/src/app/common/TooltipTitle.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Flex, FlexItem, Tooltip } from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
+
+interface IProps {
+  titleText: string;
+  tooltipText: string;
+}
+
+const TooltipTitle: React.FunctionComponent<IProps> = ({
+  titleText,
+  tooltipText,
+}) => {
+  return (
+    <Flex>
+      <FlexItem>{titleText}</FlexItem>
+      <FlexItem>
+        <Tooltip content={tooltipText} position={"top"}>
+          <HelpIcon />
+        </Tooltip>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default TooltipTitle;

--- a/pkg/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/pkg/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -148,8 +148,14 @@ export const ManageImports: React.FC = () => {
       cellTransforms: [truncate],
     },
     { title: t("terms.status"), transforms: [cellWidth(10)] },
-    { title: t("terms.accepted"), transforms: [cellWidth(10)] },
-    { title: t("terms.rejected"), transforms: [cellWidth(10)] },
+    {
+      title: t("terms.accepted"),
+      header: { info: { tooltip: t("terms.acceptedAppsAndDeps") } },
+    },
+    {
+      title: t("terms.rejected"),
+      header: { info: { tooltip: t("terms.rejectedAppsAndDeps") } },
+    },
   ];
 
   const rows: IRow[] = [];

--- a/pkg/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/pkg/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -57,6 +57,7 @@ import {
   FilterType,
 } from "@app/shared/components/FilterToolbar/FilterToolbar";
 import { useSortState } from "@app/shared/hooks/useSortState";
+import TooltipTitle from "@app/common/TooltipTitle";
 
 const ENTITY_FIELD = "entity";
 
@@ -147,14 +148,28 @@ export const ManageImports: React.FC = () => {
       transforms: [sortable, cellWidth(30)],
       cellTransforms: [truncate],
     },
-    { title: t("terms.status"), transforms: [cellWidth(10)] },
     {
-      title: t("terms.accepted"),
-      header: { info: { tooltip: t("terms.acceptedAppsAndDeps") } },
+      title: t("terms.status"),
+      transforms: [cellWidth(10)],
+      cellTransforms: [truncate],
     },
     {
-      title: t("terms.rejected"),
-      header: { info: { tooltip: t("terms.rejectedAppsAndDeps") } },
+      title: (
+        <TooltipTitle
+          titleText={t("terms.accepted")}
+          tooltipText={t("terms.acceptedAppsAndDeps")}
+        ></TooltipTitle>
+      ),
+      transforms: [cellWidth(10)],
+    },
+    {
+      title: (
+        <TooltipTitle
+          titleText={t("terms.rejected")}
+          tooltipText={t("terms.rejectedAppsAndDeps")}
+        ></TooltipTitle>
+      ),
+      transforms: [cellWidth(10)],
     },
   ];
 


### PR DESCRIPTION
Application CSV import page imports counts records have two expected types - Application and Dependency.

In order to not confuse user with misleading amount of applications, adding tooltip to related table columns as suggested by Nandini.

Fixes https://issues.redhat.com/browse/TACKLE-631