### PR TITLE
TACKLE-634: Mention unknown records in Import rejected title

### DIFF
--- a/pkg/client/public/locales/en/translation.json
+++ b/pkg/client/public/locales/en/translation.json
@@ -242,7 +242,7 @@
         "question": "Question",
         "rank": "Rank",
         "rejected": "Rejected",
-        "rejectedAppsAndDeps": "Rejected applications and dependencies",
+        "rejectedAppsAndDeps": "Rejected applications and dependencies or unknown records",
         "reports": "Reports",
         "repositoryType": "Repository type",
         "review": "Review",

--- a/pkg/client/public/locales/es/translation.json
+++ b/pkg/client/public/locales/es/translation.json
@@ -242,7 +242,7 @@
         "question": "Pregunta",
         "rank": "Rango",
         "rejected": "Rechazado",
-        "rejectedAppsAndDeps": "Aplicaciónes y dependencias en desuso",
+        "rejectedAppsAndDeps": "Aplicaciónes y dependencias en desuso o registros desconocidos",
         "reports": "Reportes",
         "repositoryType": "Tipo de repositorio",
         "review": "Revisión",


### PR DESCRIPTION
Adding more descriptive tooltip title to CSV import table mentioning
that rejected records might include also records with unwknown record
type (not application or dependency).

Fixes https://issues.redhat.com/browse/TACKLE-634