### PR TITLE
[Backport 2.1.0]  TACKLE-xxx: i18n missing entry for "credential"  (#354)

### DIFF
--- a/pkg/client/i18next-parser.config.js
+++ b/pkg/client/i18next-parser.config.js
@@ -3,7 +3,7 @@ module.exports = {
 
   indentation: 4, // Indentation of the catalog files
 
-  keepRemoved: false, // Keep keys from the catalog that are no longer in code
+  keepRemoved: true, // Keep keys from the catalog that are no longer in code
 
   lexers: {
     js: ["JsxLexer"],

--- a/pkg/client/public/locales/en/translation.json
+++ b/pkg/client/public/locales/en/translation.json
@@ -188,6 +188,7 @@
         "confidence": "Confidence",
         "controls": "Controls",
         "createdBy": "Created By",
+        "credential": "Credential",
         "credentials": "Credentials",
         "credentialType": "Credential type",
         "criticality": "Criticality",

--- a/pkg/client/public/locales/es/translation.json
+++ b/pkg/client/public/locales/es/translation.json
@@ -188,6 +188,7 @@
         "confidence": "Confianza",
         "controls": "Controles",
         "createdBy": "Creado Por",
+        "credential": "Credencial",
         "credentials": "Credenciales",
         "credentialType": "Tipo de credenciale",
         "criticality": "Criticidad",

--- a/pkg/client/src/app/pages/identities/identities.tsx
+++ b/pkg/client/src/app/pages/identities/identities.tsx
@@ -206,7 +206,7 @@ export const Identities: React.FunctionComponent = () => {
         alertActions.addSuccess(
           t("toastr.success.added", {
             what: response.data.name,
-            type: t("terms.identity").toLowerCase(),
+            type: t("terms.credential").toLowerCase(),
           })
         )
       );


### PR DESCRIPTION
* i18n error for identity

* Stop autoremoving entries in language.json