### PR TITLE
TACKLE-748: Reset tags when they are all cleared from an application

### DIFF
--- a/pkg/client/src/app/pages/applications/components/application-tags/application-tags.tsx
+++ b/pkg/client/src/app/pages/applications/components/application-tags/application-tags.tsx
@@ -88,6 +88,9 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
         .catch(() => {
           setIsFetching(false);
         });
+    } else {
+      setTagTypes(new Map());
+      setTags(new Map());
     }
   }, [application]);
 


### PR DESCRIPTION
Line [29](https://github.com/konveyor/tackle2-ui/compare/main...ibolton336:tackle-748?expand=1#diff-212c4e915d8a7bd1a1b8dce1ddfee220f3eb215d073f52c47feffd65f2a03d42R29) was causing the ui logic to short-circuit when tags are all removed from an application. This PR adds in a condition to reset the tags to default state if no tags are attached to an application. 