### PR TITLE
WIP (Abandoned) - Try converting react-hook-form code to Formik

### DIFF
--- a/pkg/client/package-lock.json
+++ b/pkg/client/package-lock.json
@@ -24,7 +24,7 @@
         "ejs": "^3.1.7",
         "fast-xml-parser": "^4.0.3",
         "file-saver": "^2.0.5",
-        "formik": "^2.2.6",
+        "formik": "^2.2.9",
         "i18next": "^19.8.4",
         "i18next-http-backend": "^1.0.22",
         "keycloak-js": "^16.1.1",

--- a/pkg/client/package.json
+++ b/pkg/client/package.json
@@ -36,7 +36,7 @@
     "ejs": "^3.1.7",
     "fast-xml-parser": "^4.0.3",
     "file-saver": "^2.0.5",
-    "formik": "^2.2.6",
+    "formik": "^2.2.9",
     "i18next": "^19.8.4",
     "i18next-http-backend": "^1.0.22",
     "keycloak-js": "^16.1.1",

--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useIsMutating } from "react-query";
-import { FieldValues, FormProvider, useForm } from "react-hook-form";
+import { FieldValues, FormProvider, useForm } from "react-hook-form"; // TODO replace with Formik -- note that FieldValues has `any` as every value currently, there will be type errors
 import { useDispatch } from "react-redux";
 import {
   Truncate,

--- a/pkg/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -17,7 +17,8 @@ import mugIcon from "@app/images/Icon-Red_Hat-Mug-A-Black-RGB.svg";
 import multiplyIcon from "@app/images/Icon-Red_Hat-Multiply-A-Black-RGB.svg";
 
 import { SelectCard } from "./components/select-card";
-import { useFormContext } from "react-hook-form";
+import { useFormikContext } from "formik";
+import { IAnalysisWizardFormValues } from "./analysis-wizard";
 
 export interface TransformationTargets {
   label: string;
@@ -105,20 +106,22 @@ export const SetTargets: React.FunctionComponent = () => {
     },
   ];
 
-  const { getValues, setValue } = useFormContext();
-  const targets: string[] = getValues("targets");
+  const formik = useFormikContext<IAnalysisWizardFormValues>();
 
   const handleOnCardChange = (
     isNewCard: boolean,
     selectionValue: string,
     card: TransformationTargets
   ) => {
-    const selectedTargets = targets.filter(
+    const selectedTargets = formik.values.targets.filter(
       (target) => !card.options.has(target)
     );
-
-    if (isNewCard) setValue("targets", [...selectedTargets, selectionValue]);
-    else setValue("targets", selectedTargets);
+    formik.setValues((prevValues) => ({
+      ...prevValues,
+      targets: isNewCard
+        ? [...selectedTargets, selectionValue]
+        : selectedTargets,
+    }));
   };
 
   return (
@@ -137,7 +140,7 @@ export const SetTargets: React.FunctionComponent = () => {
                 <SelectCard
                   item={elem}
                   cardSelected={[...elem.options.keys()].some((key) =>
-                    targets.includes(key)
+                    formik.values.targets.includes(key)
                   )}
                   onChange={(isNewCard: boolean, selectionValue: string) => {
                     handleOnCardChange(isNewCard, selectionValue, elem);


### PR DESCRIPTION
Our UI currently has uses Formik in 9 files and react-hook-form in 7 files.

In an earlier discussion with @ibolton336, we determined that it would be ideal to pick one and stick with it. We had concluded that we should see how it feels to convert everything to Formik, since it has ergonomics that fit better with PatternFly (controlled inputs) and it has improved a bit since we gave up on it in MTV years ago.

This PR is the result of me beginning to convert the Analysis wizard's forms from RHF to Formik. I ran into some issues with its TypeScript support that led me to question our decision.

After further discussion with @ibolton336, we decided to pause this effort, step back and reevaluate react-hook-form. I'm opening and immediately closing this PR for posterity, and will follow up with some additional PRs to improve the type safety of our existing react-hook-form usage as part of trying to see whether we should stick with it.

cc @gildub 