### PR TITLE
TACKLE-759: Filter out current app from copy to list when selecting all

### DIFF
--- a/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/pkg/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -391,6 +391,7 @@ export const ApplicationsTable: React.FC = () => {
     }
     if (
       row.review &&
+      applicationAssessment?.status === "COMPLETE" &&
       checkAccessAll(userScopes, ["assessments:patch", "reviews:post"])
     ) {
       actions.push({


### PR DESCRIPTION
When selecting ALL applications in the bulk copy assessment/review form, the source application was being selected. This led to the api not receiving the correct list of apps & caused some errors with overwriting the source application data. 

This PR also prevents applications without an assessmend & review from being copied from. [See here](https://github.com/konveyor/tackle2-ui/pull/387/files#diff-38b35274202426ae47eb724b71f4d5dc739f74351444c5bb38bfad24d9d1c636R394)