### PR TITLE
Upgrade lib-ui, use `isItemSelectable` on copy assessment and review form

### DIFF
--- a/pkg/client/package-lock.json
+++ b/pkg/client/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^2.8.0",
         "@hot-loader/react-dom": "^17.0.2",
-        "@migtools/lib-ui": "^8.4.1",
+        "@migtools/lib-ui": "^8.5.0",
         "@patternfly/patternfly": "^4.206.3",
         "@patternfly/react-charts": "^6.84.8",
         "@patternfly/react-core": "^4.231.8",
@@ -2740,9 +2740,9 @@
       }
     },
     "node_modules/@migtools/lib-ui": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.4.1.tgz",
-      "integrity": "sha512-QJEh3Vq7IkHcRCiOQh3NhX30b8BvHB1XBBkbGyp+lcwP90pPl/ateOJzac1v44OIa7DAgK4iNS+v+hay3EK5cg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.5.0.tgz",
+      "integrity": "sha512-vl2cFtD3lbHUFXvdnEZBPZSzcMpbVmbTDg8rbf60kdwvtLfJHXoNJfkn1S+Yb06xCgsG1DOK2XW38GxC7agG+g==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "react-query": "^3.26.0",
@@ -25305,9 +25305,9 @@
       }
     },
     "@migtools/lib-ui": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.4.1.tgz",
-      "integrity": "sha512-QJEh3Vq7IkHcRCiOQh3NhX30b8BvHB1XBBkbGyp+lcwP90pPl/ateOJzac1v44OIa7DAgK4iNS+v+hay3EK5cg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.5.0.tgz",
+      "integrity": "sha512-vl2cFtD3lbHUFXvdnEZBPZSzcMpbVmbTDg8rbf60kdwvtLfJHXoNJfkn1S+Yb06xCgsG1DOK2XW38GxC7agG+g==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "react-query": "^3.26.0",

--- a/pkg/client/package.json
+++ b/pkg/client/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@hookform/resolvers": "^2.8.0",
     "@hot-loader/react-dom": "^17.0.2",
-    "@migtools/lib-ui": "^8.4.1",
+    "@migtools/lib-ui": "^8.5.0",
     "@patternfly/patternfly": "^4.206.3",
     "@patternfly/react-charts": "^6.84.8",
     "@patternfly/react-core": "^4.231.8",


### PR DESCRIPTION
In the Copy Assessment and Review modal, this PR uses the new `isItemSelectable` option added to `useSelectionState` in https://github.com/migtools/lib-ui/pull/112 to prevent the "select all" action from checking the disabled checkbox next to the current application. This also removes the `.filter()` added in https://github.com/konveyor/tackle2-ui/pull/387 since it is no longer necessary (the current application can never become part of the selection state, so there's no reason to filter it out).

This PR also renames some variables that used the `item` and `row` naming in a slightly confusing way, since we are mapping over `Application` objects to create `IRow` objects. I figured it would be nice to be clear what is an `app` and what is a `row` type-wise via the names.