### PR TITLE
Cookie management improvements

### DIFF
--- a/pkg/client/src/app/App.tsx
+++ b/pkg/client/src/app/App.tsx
@@ -13,14 +13,9 @@ import "@redhat-cloud-services/frontend-components-notifications/index.css";
 
 import { ConfirmDialogContainer } from "./shared/containers/confirm-dialog-container";
 import { BulkCopyNotificationsContainer } from "./shared/containers/bulk-copy-notifications-container";
-import { useFetchCookie } from "./queries/cookies";
-import keycloak from "./keycloak";
 import "./app.css";
 
 const App: React.FC = () => {
-  // Automatically updates cookie
-  useFetchCookie(keycloak.token);
-
   return (
     <BrowserRouter>
       <DefaultLayout>

--- a/pkg/client/src/app/common/KeycloakProvider.tsx
+++ b/pkg/client/src/app/common/KeycloakProvider.tsx
@@ -58,7 +58,6 @@ export const KeycloakProvider: React.FunctionComponent<
                 return new Promise<string>((resolve, reject) => {
                   if (keycloak.token) {
                     keycloak
-                      //TODO lengthen refresh time
                       .updateToken(60)
                       .then((refreshed) => {
                         if (refreshed) {

--- a/pkg/client/src/app/common/KeycloakProvider.tsx
+++ b/pkg/client/src/app/common/KeycloakProvider.tsx
@@ -59,7 +59,7 @@ export const KeycloakProvider: React.FunctionComponent<
                   if (keycloak.token) {
                     keycloak
                       //TODO lengthen refresh time
-                      .updateToken(1)
+                      .updateToken(60)
                       .then((refreshed) => {
                         if (refreshed) {
                           deleteCookie("keycloak_cookie");

--- a/pkg/client/src/app/common/KeycloakProvider.tsx
+++ b/pkg/client/src/app/common/KeycloakProvider.tsx
@@ -16,14 +16,8 @@ export const KeycloakProvider: React.FunctionComponent<
   IKeycloakProviderProps
 > = ({ children }) => {
   const checkAuthCookie = () => {
-    let currentCookie = getCookie("keycloak_cookie");
-    if (currentCookie !== "" && currentCookie !== null) {
-    } else {
-      currentCookie = keycloak?.token || "";
-
-      if (currentCookie != "" && currentCookie != null) {
-        setCookie("keycloak_cookie", currentCookie, 365);
-      }
+    if (!getCookie("keycloak_cookie") && keycloak?.token) {
+      setCookie("keycloak_cookie", keycloak.token, 365);
     }
   };
   if (isAuthRequired) {

--- a/pkg/client/src/app/queries/cookies.ts
+++ b/pkg/client/src/app/queries/cookies.ts
@@ -1,52 +1,27 @@
-import { useQuery } from "react-query";
-import keycloak from "@app/keycloak";
+type CookieNames = "keycloak_cookie";
 
-export const CookieQueryKey = "cookies";
+export const deleteCookie = (name: CookieNames) => {
+  document.cookie = `${name} =; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+};
 
-export const useFetchCookie = (token) => {
-  const deleteCookie = (name: string) => {
-    document.cookie = `${name} =; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
-  };
+export const setCookie = (
+  name: CookieNames,
+  value: string,
+  expDays: number
+) => {
+  let date = new Date();
+  date.setTime(date.getTime() + expDays * 24 * 60 * 60 * 1000);
+  const expires = "expires=" + date.toUTCString();
+  document.cookie = `${name} = ${value}; ${expires}; path=/`;
+};
 
-  const setCookie = (cName: string, cValue: string, expDays: number) => {
-    let date = new Date();
-    date.setTime(date.getTime() + expDays * 24 * 60 * 60 * 1000);
-    const expires = "expires=" + date.toUTCString();
-    document.cookie = `${cName} = ${cValue}; ${expires}; path=/`;
-  };
-
-  const getCookie = (token: string) => {
-    let cookieArr = document.cookie.split(";");
-    for (let i = 0; i < cookieArr.length; i++) {
-      let cookiePair = cookieArr[i].split("=");
-      if (token == cookiePair[0].trim()) {
-        return decodeURIComponent(cookiePair[1]);
-      }
+export const getCookie = (name: CookieNames) => {
+  let cookieArr = document.cookie.split(";");
+  for (let i = 0; i < cookieArr.length; i++) {
+    let cookiePair = cookieArr[i].split("=");
+    if (name == cookiePair[0].trim()) {
+      return decodeURIComponent(cookiePair[1]);
     }
-    return null;
-  };
-
-  useQuery(
-    [CookieQueryKey, token],
-    () => {
-      if (token) {
-        deleteCookie("proxyToken");
-        let token = getCookie("proxyToken");
-        if (token !== "" && token !== null) {
-        } else {
-          token = keycloak?.token || "";
-
-          if (token != "" && token != null) {
-            setCookie("proxyToken", token, 365);
-          }
-        }
-      }
-    },
-    {
-      enabled: !!keycloak.token,
-      refetchInterval: 5000,
-      refetchIntervalInBackground: true,
-      refetchOnWindowFocus: false,
-    }
-  );
+  }
+  return null;
 };

--- a/pkg/client/src/app/queries/cookies.ts
+++ b/pkg/client/src/app/queries/cookies.ts
@@ -19,7 +19,7 @@ export const getCookie = (name: CookieNames) => {
   let cookieArr = document.cookie.split(";");
   for (let i = 0; i < cookieArr.length; i++) {
     let cookiePair = cookieArr[i].split("=");
-    if (name == cookiePair[0].trim()) {
+    if (name === cookiePair[0].trim()) {
       return decodeURIComponent(cookiePair[1]);
     }
   }

--- a/pkg/server/setupProxy.js
+++ b/pkg/server/setupProxy.js
@@ -31,8 +31,7 @@ module.exports = function (app) {
           proxyRes.statusCode === 401 ||
           proxyRes.statusMessage === "Unauthorized"
         ) {
-          //TODO fix redirect to /login broken currently. Renders an empty page.
-          res.redirect("/applications");
+          res.redirect("/");
         }
       },
     })

--- a/pkg/server/setupProxy.js
+++ b/pkg/server/setupProxy.js
@@ -1,4 +1,12 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
+function relayRequestHeaders(proxyReq, req) {
+  if (req.cookies.keycloak_cookie) {
+    proxyReq.setHeader(
+      "Authorization",
+      `Bearer ${req.cookies.keycloak_cookie}`
+    );
+  }
+}
 
 module.exports = function (app) {
   app.use(
@@ -9,7 +17,6 @@ module.exports = function (app) {
       logLevel: process.env.DEBUG ? "debug" : "info",
     })
   );
-
   app.use(
     "/hub",
     createProxyMiddleware({
@@ -19,11 +26,7 @@ module.exports = function (app) {
         "^/hub": "",
       },
       logLevel: process.env.DEBUG ? "debug" : "info",
-      onProxyReq: (proxyReq, req, res) => {
-        if (req.cookies.proxyToken) {
-          proxyReq.setHeader('Authorization', `Bearer ${req.cookies.proxyToken}`)
-        }
-      },
+      onProxyReq: relayRequestHeaders,
     })
   );
 };

--- a/pkg/server/setupProxy.js
+++ b/pkg/server/setupProxy.js
@@ -1,13 +1,4 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
-function relayRequestHeaders(proxyReq, req) {
-  if (req.cookies.keycloak_cookie && proxyReq.headers) {
-    console.log("set auth header");
-    proxyReq.setHeader(
-      "Authorization",
-      `Bearer ${req.cookies.keycloak_cookie}`
-    );
-  }
-}
 
 module.exports = function (app) {
   app.use(


### PR DESCRIPTION
Addresses #393 

- Change token expiration to 1 hour to reduce auto logout token expiry redirects on 3rd party api served external html pages
- Remove useFetchCookie query hook in favor of leaning on keycloak-js's internal token initialization logic. Since we run the keycloak token validation check on every outgoing Axios request, we can refresh the cookie at this time if it is stale. 
- Automatically redirect to the main apps home page if an authentication error occurs on a 3rd party api served external html page. This will trigger the keycloak authentication init logic upon routing here. 



Depends on: https://github.com/konveyor/tackle2-ui/pull/401

There is an issue with navigating to the /login route. A blank page is rendered and requires the user to click a navigation item to continue using the app. This is fixed by [this PR](https://github.com/konveyor/tackle2-ui/pull/401)