### PR TITLE
Persist app inventory page filters to `sessionStorage`

### DIFF
--- a/pkg/client/package-lock.json
+++ b/pkg/client/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^2.8.0",
         "@hot-loader/react-dom": "^17.0.2",
-        "@migtools/lib-ui": "^8.5.0",
+        "@migtools/lib-ui": "^8.6.0",
         "@patternfly/patternfly": "^4.206.3",
         "@patternfly/react-charts": "^6.84.8",
         "@patternfly/react-core": "^4.231.8",
@@ -2740,9 +2740,9 @@
       }
     },
     "node_modules/@migtools/lib-ui": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.5.0.tgz",
-      "integrity": "sha512-vl2cFtD3lbHUFXvdnEZBPZSzcMpbVmbTDg8rbf60kdwvtLfJHXoNJfkn1S+Yb06xCgsG1DOK2XW38GxC7agG+g==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.6.0.tgz",
+      "integrity": "sha512-Wj0WM5KcyfrA5gQn+f1rST6lHO8ZMxwMP6v0+xipSAJ4WYhygabxHHigL81IfDrM7kpplBj0+iFGQoFxwbXVsQ==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "react-query": "^3.26.0",
@@ -25305,9 +25305,9 @@
       }
     },
     "@migtools/lib-ui": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.5.0.tgz",
-      "integrity": "sha512-vl2cFtD3lbHUFXvdnEZBPZSzcMpbVmbTDg8rbf60kdwvtLfJHXoNJfkn1S+Yb06xCgsG1DOK2XW38GxC7agG+g==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.6.0.tgz",
+      "integrity": "sha512-Wj0WM5KcyfrA5gQn+f1rST6lHO8ZMxwMP6v0+xipSAJ4WYhygabxHHigL81IfDrM7kpplBj0+iFGQoFxwbXVsQ==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "react-query": "^3.26.0",

--- a/pkg/client/package.json
+++ b/pkg/client/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@hookform/resolvers": "^2.8.0",
     "@hot-loader/react-dom": "^17.0.2",
-    "@migtools/lib-ui": "^8.5.0",
+    "@migtools/lib-ui": "^8.6.0",
     "@patternfly/patternfly": "^4.206.3",
     "@patternfly/react-charts": "^6.84.8",
     "@patternfly/react-core": "^4.231.8",

--- a/pkg/client/src/app/pages/applications/applicationsFilter.ts
+++ b/pkg/client/src/app/pages/applications/applicationsFilter.ts
@@ -152,7 +152,8 @@ export const useApplicationsFilterValues = (
 
   const { filterValues, setFilterValues, filteredItems } = useFilterState(
     applications || [],
-    filterCategories
+    filterCategories,
+    "applicationsFilter"
   );
 
   const handleOnClearAllFilters = () => {

--- a/pkg/client/src/app/shared/hooks/useFilterState.ts
+++ b/pkg/client/src/app/shared/hooks/useFilterState.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useLocalStorage } from "@migtools/lib-ui";
 import { IFilterValues, FilterCategory } from "../components/FilterToolbar";
 
 export interface IFilterStateHook<T> {
@@ -9,9 +10,12 @@ export interface IFilterStateHook<T> {
 
 export const useFilterState = <T>(
   items: T[],
-  filterCategories: FilterCategory<T>[]
+  filterCategories: FilterCategory<T>[],
+  storageKey?: string
 ): IFilterStateHook<T> => {
-  const [filterValues, setFilterValues] = React.useState<IFilterValues>({});
+  const state = React.useState<IFilterValues>({});
+  const storage = useLocalStorage<IFilterValues>(storageKey || "", {});
+  const [filterValues, setFilterValues] = storageKey ? storage : state;
 
   const filteredItems = items.filter((item) =>
     Object.keys(filterValues).every((categoryKey) => {

--- a/pkg/client/src/app/shared/hooks/useFilterState.ts
+++ b/pkg/client/src/app/shared/hooks/useFilterState.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useLocalStorage } from "@migtools/lib-ui";
+import { useSessionStorage } from "@migtools/lib-ui";
 import { IFilterValues, FilterCategory } from "../components/FilterToolbar";
 
 export interface IFilterStateHook<T> {
@@ -14,7 +14,7 @@ export const useFilterState = <T>(
   storageKey?: string
 ): IFilterStateHook<T> => {
   const state = React.useState<IFilterValues>({});
-  const storage = useLocalStorage<IFilterValues>(storageKey || "", {});
+  const storage = useSessionStorage<IFilterValues>(storageKey || "", {});
   const [filterValues, setFilterValues] = storageKey ? storage : state;
 
   const filteredItems = items.filter((item) =>


### PR DESCRIPTION
Adds an optional `storageKey` argument to `useFilterState` and uses it on the application inventory tables. When a `storageKey` is passed to `useFilterState` like this, the filter values will be persisted to sessionStorage using the new `useSessionStorage` hook added to lib-ui in https://github.com/migtools/lib-ui/pull/114. If `storageKey` is not passed, regular React state will be used instead.

Filters set on either app inventory page will now be persisted for the lifetime of the current browser tab (reloading the page or navigating away/back won't clear them, but closing and reopening the tab will). Separate tabs can have separate filter values because they don't share session storage.