### PR TITLE
Fix production error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # production
 /client/dist
 /qa/build
+/dist
 
 # misc
 .DS_Store

--- a/server/package.json
+++ b/server/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
+    "@types/express": "^4.17.13",
     "@types/ejs": "^3.1.0",
     "ejs": "^3.1.7",
     "cookie-parser": "^1.4.6",
@@ -12,8 +13,5 @@
   },
   "scripts": {
     "start": "node index.js"
-  },
-  "devDependencies": {
-    "@types/express": "^4.17.13"
   }
 }


### PR DESCRIPTION
The production build is currently broken due to a missing dependency that was never moved over when we decided to use the production flag for production builds. I have tested this with my image quay.io/ibolton/tackle2-ui:latest with success. 