### PR TITLE
Lockfile changes on npm install after workspaces refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3413,7 +3413,6 @@
             "version": "1.19.2",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
             "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-            "devOptional": true,
             "dependencies": {
                 "@types/connect": "*",
                 "@types/node": "*"
@@ -3441,7 +3440,6 @@
             "version": "3.4.35",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
             "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-            "devOptional": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -3560,7 +3558,6 @@
             "version": "4.17.13",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
             "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-            "devOptional": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.18",
@@ -3572,7 +3569,6 @@
             "version": "4.17.30",
             "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
             "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
-            "devOptional": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -3677,8 +3673,7 @@
         "node_modules/@types/mime": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-            "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-            "devOptional": true
+            "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
         },
         "node_modules/@types/minimatch": {
             "version": "3.0.5",
@@ -3711,14 +3706,12 @@
         "node_modules/@types/qs": {
             "version": "6.9.7",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-            "devOptional": true
+            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-            "devOptional": true
+            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "node_modules/@types/react": {
             "version": "17.0.49",
@@ -3813,7 +3806,6 @@
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
             "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-            "devOptional": true,
             "dependencies": {
                 "@types/mime": "*",
                 "@types/node": "*"
@@ -23022,13 +23014,11 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/ejs": "^3.1.0",
+                "@types/express": "^4.17.13",
                 "cookie-parser": "^1.4.6",
                 "ejs": "^3.1.7",
                 "express": "^4.17.2",
                 "http-proxy-middleware": "^2.0.2"
-            },
-            "devDependencies": {
-                "@types/express": "^4.17.13"
             }
         }
     },
@@ -25435,7 +25425,6 @@
             "version": "1.19.2",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
             "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-            "devOptional": true,
             "requires": {
                 "@types/connect": "*",
                 "@types/node": "*"
@@ -25463,7 +25452,6 @@
             "version": "3.4.35",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
             "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-            "devOptional": true,
             "requires": {
                 "@types/node": "*"
             }
@@ -25582,7 +25570,6 @@
             "version": "4.17.13",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
             "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-            "devOptional": true,
             "requires": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.18",
@@ -25594,7 +25581,6 @@
             "version": "4.17.30",
             "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
             "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
-            "devOptional": true,
             "requires": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -25699,8 +25685,7 @@
         "@types/mime": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-            "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-            "devOptional": true
+            "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
         },
         "@types/minimatch": {
             "version": "3.0.5",
@@ -25733,14 +25718,12 @@
         "@types/qs": {
             "version": "6.9.7",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-            "devOptional": true
+            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
         },
         "@types/range-parser": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-            "devOptional": true
+            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "@types/react": {
             "version": "17.0.49",
@@ -25835,7 +25818,6 @@
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
             "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-            "devOptional": true,
             "requires": {
                 "@types/mime": "*",
                 "@types/node": "*"


### PR DESCRIPTION
FYI @gildub @ibolton336 when I run `npm install` now (using npm 8.15.0) I get some changes to the package-lock.json that differ from what's currently tracked in git. It looks like just this `devOptional` flag got removed from a few places. Not sure what it means...