### PR TITLE
Downgrade css-loader to 5.2.7 to fix font loading issues

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -84,7 +84,7 @@
     "camelcase": "^6.3.0",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "copy-webpack-plugin": "^11.0.0",
-    "css-loader": "^6.7.1",
+    "css-loader": "^5.2.7",
     "css-minimizer-webpack-plugin": "^3.4.1",
     "cypress": "8.4.0",
     "cypress-file-upload": "^5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
                 "camelcase": "^6.3.0",
                 "case-sensitive-paths-webpack-plugin": "^2.4.0",
                 "copy-webpack-plugin": "^11.0.0",
-                "css-loader": "^6.7.1",
+                "css-loader": "^5.2.7",
                 "css-minimizer-webpack-plugin": "^3.4.1",
                 "cypress": "8.4.0",
                 "cypress-file-upload": "^5.0.8",
@@ -6728,29 +6728,49 @@
             }
         },
         "node_modules/css-loader": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
-            "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+            "version": "5.2.7",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
+            "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
             "dev": true,
             "dependencies": {
                 "icss-utils": "^5.1.0",
-                "postcss": "^8.4.7",
+                "loader-utils": "^2.0.0",
+                "postcss": "^8.2.15",
                 "postcss-modules-extract-imports": "^3.0.0",
                 "postcss-modules-local-by-default": "^4.0.0",
                 "postcss-modules-scope": "^3.0.0",
                 "postcss-modules-values": "^4.0.0",
-                "postcss-value-parser": "^4.2.0",
+                "postcss-value-parser": "^4.1.0",
+                "schema-utils": "^3.0.0",
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 10.13.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.0.0"
+                "webpack": "^4.27.0 || ^5.0.0"
+            }
+        },
+        "node_modules/css-loader/node_modules/schema-utils": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/css-loader/node_modules/semver": {
@@ -27637,7 +27657,7 @@
                 "camelcase": "^6.3.0",
                 "case-sensitive-paths-webpack-plugin": "^2.4.0",
                 "copy-webpack-plugin": "^11.0.0",
-                "css-loader": "^6.7.1",
+                "css-loader": "^5.2.7",
                 "css-minimizer-webpack-plugin": "^3.4.1",
                 "cypress": "8.4.0",
                 "cypress-file-upload": "^5.0.8",
@@ -28160,21 +28180,34 @@
             "requires": {}
         },
         "css-loader": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
-            "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+            "version": "5.2.7",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
+            "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
             "dev": true,
             "requires": {
                 "icss-utils": "^5.1.0",
-                "postcss": "^8.4.7",
+                "loader-utils": "^2.0.0",
+                "postcss": "^8.2.15",
                 "postcss-modules-extract-imports": "^3.0.0",
                 "postcss-modules-local-by-default": "^4.0.0",
                 "postcss-modules-scope": "^3.0.0",
                 "postcss-modules-values": "^4.0.0",
-                "postcss-value-parser": "^4.2.0",
+                "postcss-value-parser": "^4.1.0",
+                "schema-utils": "^3.0.0",
                 "semver": "^7.3.5"
             },
             "dependencies": {
+                "schema-utils": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+                    "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.8",
+                        "ajv": "^6.12.5",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                },
                 "semver": {
                     "version": "7.3.7",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",


### PR DESCRIPTION
As part of #400, `css-loader` was upgraded from `^5.2.6` to `^6.7.1`. Something about this upgrade seems to have caused our PatternFly Fonts to fail to load.

![image (27)](https://user-images.githubusercontent.com/811963/191324974-03f53fbc-4cb5-4ee1-8b55-65bb1f677531.png)

Troubleshooting this with @ibolton336, I tried to `curl` one of the font files exposed by webpack-dev-server by copying its path from the browser dev tools network tab, and I found that its contents were not binary font data, but JS:
```
$ curl http://localhost:8080/101eb68a37edfa8a2f9a.woff
export default __webpack_public_path__ + "fonts/overpass-bold.woff";
```

This indicated that it was something about a loader change, and `css-loader` was the only webpack loader with a recent major version bump. Indeed, downgrading it seems to have solved the problem. I'm not certain I understand why, though... here are the breaking changes listed in the [css-loader 6.0.0 release notes](https://github.com/webpack-contrib/css-loader/releases/tag/v6.0.0).