### PR TITLE
Fix React warning in Application table filters: don't generate empty select options, disable dropdown when there are no options

### DIFF
--- a/client/src/app/pages/applications/applicationsFilter.ts
+++ b/client/src/app/pages/applications/applicationsFilter.ts
@@ -61,6 +61,7 @@ export const useApplicationsFilterValues = (
       type: FilterType.select,
       selectOptions: dedupeFunction(
         applications
+          .filter((app) => !!app.businessService?.name)
           .map((app) => app.businessService?.name)
           .map((name) => ({ key: name, value: name }))
       ),

--- a/client/src/app/shared/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/shared/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -113,6 +113,7 @@ export const MultiselectFilterControl = <T,>({
           .toLowerCase()}${category.title.slice(1)}`}
         hasInlineFilter
         onFilter={onOptionsFilter}
+        isDisabled={category.selectOptions.length === 0}
       >
         {renderSelectOptions(category.selectOptions)}
       </Select>

--- a/client/src/app/shared/components/FilterToolbar/SelectFilterControl.tsx
+++ b/client/src/app/shared/components/FilterToolbar/SelectFilterControl.tsx
@@ -74,6 +74,7 @@ export const SelectFilterControl = <T,>({
         onSelect={(_, value) => onFilterSelect(value)}
         isOpen={isFilterDropdownOpen}
         placeholderText="Any"
+        isDisabled={category.selectOptions.length === 0}
       >
         {category.selectOptions.map((optionProps) => (
           <SelectOption {...optionProps} key={optionProps.key} />


### PR DESCRIPTION
I've been seeing this warning whenever I'm on the Application Inventory page:

![Screen Shot 2022-09-22 at 1 16 14 PM](https://user-images.githubusercontent.com/811963/191814175-8274135e-4916-441f-a151-bc7355e93056.png)

I found that this is happening because when you have applications with no associated business service, the business service filter dropdown's `selectOptions` array ends up with an element `{ key: undefined, value: undefined }`. To fix this, we can filter out any apps with no business service before mapping over apps to produce this list of filter options.

However, that still results in a Select dropdown with no options inside which looks broken when you click on it. This PR also disables the dropdowns for SelectFilterControl and MultiselectFilterControl if there are no options to select.

Before:

![Screen Shot 2022-09-22 at 1 40 33 PM](https://user-images.githubusercontent.com/811963/191815340-d84925e9-17c9-4446-9b7a-82f6ead07d45.png)


After:

![Screen Shot 2022-09-22 at 1 41 12 PM](https://user-images.githubusercontent.com/811963/191815354-e982c428-6aa9-4aff-8bdb-9576fa0c9ac6.png)

cc @gildub @ibolton336 