### PR TITLE
Define defaults for missing ENV variables

### DIFF
--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -14,19 +14,13 @@ import {
   ProposedAction,
   Risk,
 } from "@app/api/models";
-export interface IEnvVars {
-  AUTH_REQUIRED: string;
-  KEYCLOAK_REALM: string;
-  KEYCLOAK_CLIENT_ID: string;
-  KEYCLOAK_SERVER_URL: string;
-  UI_INGRESS_PROXY_BODY_SIZE: string;
-  PROFILE: string;
-}
-export const ENV: IEnvVars = (window as { [key: string]: any })["_env"] || {};
+
+import { ENV } from "./env";
+
 export const isAuthRequired = ENV.AUTH_REQUIRED !== "false";
 export const uploadLimit = ENV.UI_INGRESS_PROXY_BODY_SIZE || "500m";
 export const isPropietaryAllowed =
-  ENV.PROFILE === "konveyor" || ENV.PROFILE === "" ? true : false;
+  ENV.PROFILE === "konveyor" || ENV.PROFILE === "";
 
 export const DEFAULT_PAGINATION: PageQuery = {
   page: 1,

--- a/client/src/app/env.ts
+++ b/client/src/app/env.ts
@@ -16,7 +16,7 @@ declare global {
     _env: EnvVars;
   }
 }
-export const ENV: EnvVars = window._env || {};
+export const ENV: EnvVars = { ...window._env } || {};
 
 ENV_VAR_KEYS.forEach((key) => {
   if (!ENV[key]) ENV[key] = ENV_VAR_DEFAULTS[key];

--- a/client/src/app/env.ts
+++ b/client/src/app/env.ts
@@ -1,0 +1,30 @@
+const ENV_VAR_KEYS = [
+  "AUTH_REQUIRED",
+  "KEYCLOAK_REALM",
+  "KEYCLOAK_CLIENT_ID",
+  "KEYCLOAK_SERVER_URL",
+  "UI_INGRESS_PROXY_BODY_SIZE",
+  "PROFILE",
+] as const;
+
+export type EnvVars = Record<typeof ENV_VAR_KEYS[number], string>;
+
+const ENV_DEFAULTS: EnvVars = {
+  AUTH_REQUIRED: "true",
+  KEYCLOAK_REALM: "",
+  KEYCLOAK_CLIENT_ID: "",
+  KEYCLOAK_SERVER_URL: "",
+  UI_INGRESS_PROXY_BODY_SIZE: "",
+  PROFILE: "konveyor",
+};
+
+declare global {
+  interface Window {
+    _env: EnvVars;
+  }
+}
+export const ENV: EnvVars = window._env || {};
+
+ENV_VAR_KEYS.forEach((key) => {
+  if (!ENV[key]) ENV[key] = ENV_DEFAULTS[key];
+});

--- a/client/src/app/env.ts
+++ b/client/src/app/env.ts
@@ -11,8 +11,8 @@ export type EnvVars = Record<typeof ENV_VAR_KEYS[number], string>;
 
 const ENV_DEFAULTS: EnvVars = {
   AUTH_REQUIRED: "true",
-  KEYCLOAK_REALM: "",
-  KEYCLOAK_CLIENT_ID: "",
+  KEYCLOAK_REALM: "tackle",
+  KEYCLOAK_CLIENT_ID: "tackle-ui",
   KEYCLOAK_SERVER_URL: "",
   UI_INGRESS_PROXY_BODY_SIZE: "",
   PROFILE: "konveyor",

--- a/client/src/app/env.ts
+++ b/client/src/app/env.ts
@@ -1,22 +1,15 @@
-const ENV_VAR_KEYS = [
-  "AUTH_REQUIRED",
-  "KEYCLOAK_REALM",
-  "KEYCLOAK_CLIENT_ID",
-  "KEYCLOAK_SERVER_URL",
-  "UI_INGRESS_PROXY_BODY_SIZE",
-  "PROFILE",
-] as const;
-
-export type EnvVars = Record<typeof ENV_VAR_KEYS[number], string>;
-
-const ENV_DEFAULTS: EnvVars = {
+const ENV_VAR_DEFAULTS = {
   AUTH_REQUIRED: "true",
   KEYCLOAK_REALM: "tackle",
   KEYCLOAK_CLIENT_ID: "tackle-ui",
   KEYCLOAK_SERVER_URL: "",
   UI_INGRESS_PROXY_BODY_SIZE: "",
   PROFILE: "konveyor",
-};
+} as const;
+
+type EnvVarKey = keyof typeof ENV_VAR_DEFAULTS;
+const ENV_VAR_KEYS = Object.keys(ENV_VAR_DEFAULTS) as EnvVarKey[];
+export type EnvVars = Record<EnvVarKey, string>;
 
 declare global {
   interface Window {
@@ -26,5 +19,5 @@ declare global {
 export const ENV: EnvVars = window._env || {};
 
 ENV_VAR_KEYS.forEach((key) => {
-  if (!ENV[key]) ENV[key] = ENV_DEFAULTS[key];
+  if (!ENV[key]) ENV[key] = ENV_VAR_DEFAULTS[key];
 });

--- a/client/src/app/keycloak.ts
+++ b/client/src/app/keycloak.ts
@@ -1,5 +1,5 @@
 import Keycloak, { KeycloakConfig } from "keycloak-js";
-import { ENV } from "./Constants";
+import { ENV } from "./env";
 
 // Setup Keycloak instance as needed
 // Pass initialization options as required or leave blank to load from 'keycloak.json'


### PR DESCRIPTION
Instead of defining `IEnvVars` as an interface, this defines an object `ENV_VAR_DEFAULTS` as a constant, defines the `EnvVarKey` type based on its keys, and defines the `EnvVars` type as `Record<EnvVarKey, string>`. That way, we can map over `Object.keys(ENV_VAR_DEFAULTS)` at run-time to patch in any vars missing from `window._env` based on a set of defaults, and preserve the type safety (the only valid env var keys are the ones defined in `ENV_VAR_DEFAULTS`).

Moves all this to a separate `env.ts` file since it's a bit more verbose now.

![Screen Shot 2022-09-23 at 2 11 41 PM](https://user-images.githubusercontent.com/811963/192030811-56fe0453-e065-43fa-93ee-58b10f5acfe3.png)

This also uses `{ ...window._env }` to define `ENV` before we patch in the defaults for missing vars, so that we can still inspect `window._env` in the console if we want to see exactly what was passed by the server (without defaults added).