### PR TITLE
Check for application/json headers before rerouting

### DIFF
--- a/client/src/app/common/KeycloakProvider.tsx
+++ b/client/src/app/common/KeycloakProvider.tsx
@@ -50,18 +50,15 @@ export const KeycloakProvider: React.FunctionComponent<
             if (keycloak.authenticated) {
               initInterceptors(() => {
                 return new Promise<string>((resolve, reject) => {
+                  console.log("cookie", getCookie("keycloak_cookie"));
+                  console.log("keycloak.token", keycloak.token);
                   if (keycloak.token) {
                     keycloak
                       .updateToken(60)
-                      .then((refreshed) => {
-                        if (refreshed) {
-                          deleteCookie("keycloak_cookie");
-                          checkAuthCookie();
-                          return resolve(keycloak.token!);
-                        } else {
-                          checkAuthCookie();
-                          return resolve(keycloak.token!);
-                        }
+                      .then(() => {
+                        deleteCookie("keycloak_cookie");
+                        checkAuthCookie();
+                        return resolve(keycloak.token!);
                       })
                       .catch((err) => {
                         console.log("err", err);

--- a/client/src/app/common/KeycloakProvider.tsx
+++ b/client/src/app/common/KeycloakProvider.tsx
@@ -50,8 +50,6 @@ export const KeycloakProvider: React.FunctionComponent<
             if (keycloak.authenticated) {
               initInterceptors(() => {
                 return new Promise<string>((resolve, reject) => {
-                  console.log("cookie", getCookie("keycloak_cookie"));
-                  console.log("keycloak.token", keycloak.token);
                   if (keycloak.token) {
                     keycloak
                       .updateToken(60)

--- a/server/setupProxy.js
+++ b/server/setupProxy.js
@@ -27,9 +27,11 @@ module.exports = function (app) {
         }
       },
       onProxyRes: (proxyRes, req, res) => {
+        const includesJsonHeaders =
+          req.headers.accept.includes("application/json");
         if (
-          proxyRes.statusCode === 401 ||
-          proxyRes.statusMessage === "Unauthorized"
+          (!includesJsonHeaders && proxyRes.statusCode === 401) ||
+          (!includesJsonHeaders && proxyRes.statusMessage === "Unauthorized")
         ) {
           res.redirect("/");
         }


### PR DESCRIPTION
This change to [redirect unauthenticated hub routes ](https://github.com/konveyor/tackle2-ui/pull/397/files#diff-911dd5321bcea406fc2f0e84100123245e5286454fdaa310faa81506c6d106d6R34) has caused a regression with no_auth. 

 This ^ change redirects the user back through the keycloak authentication when attempting to process unauthenticated requests to pathfinder from an externally served reports.html tab.
 
This PR adds a check for 'application/json header' before redirecting the users. This ensures when auth_required is set to false,  narrow the specific reports.html redirect down to only redirect unauthenticated text/html requests.

Additionally, this PR solves a bug with the keycloak refresh token not being equal to the set cookie in memory. This is because when keycloak refreshes a token, it appends onto the existing token which was bypassing our cookie update logic.