### PR TITLE
Bump keycloak-js to 18.0.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -39,7 +39,7 @@
     "formik": "^2.2.6",
     "i18next": "^19.8.4",
     "i18next-http-backend": "^1.0.22",
-    "keycloak-js": "^16.1.1",
+    "keycloak-js": "^18.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.27.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "formik": "^2.2.6",
         "i18next": "^19.8.4",
         "i18next-http-backend": "^1.0.22",
-        "keycloak-js": "^16.1.1",
+        "keycloak-js": "^18.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.27.1",
@@ -5315,9 +5315,23 @@
       }
     },
     "node_modules/base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -14425,12 +14439,12 @@
       }
     },
     "node_modules/keycloak-js": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-16.1.1.tgz",
-      "integrity": "sha512-AkRNIJFSMLfQKIBKK31UL4FGI59MQFf68Bf8I+PFbOSKNtnfGVPYLiZeJgy03Kv5ddswHBjVZOY5T0f5RpZpLw==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-18.0.1.tgz",
+      "integrity": "sha512-IRXToYpbIrkyfLeNNJly2OjUCf11ncx2Sdsg257NVDwjOYE923osu47w8pfxEVWpTaS14/Y2QjbTHciuBK0RBQ==",
       "dependencies": {
-        "base64-js": "1.3.1",
-        "js-sha256": "0.9.0"
+        "base64-js": "^1.5.1",
+        "js-sha256": "^0.9.0"
       }
     },
     "node_modules/kind-of": {
@@ -26969,9 +26983,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "batch": {
       "version": "0.6.1",
@@ -27669,7 +27683,7 @@
         "jest-enzyme": "^7.1.2",
         "jest-resolve": "^27.4.6",
         "jest-watch-typeahead": "^1.0.0",
-        "keycloak-js": "^16.1.1",
+        "keycloak-js": "18.0.1",
         "lint-staged": "^10.5.3",
         "mini-css-extract-plugin": "^2.5.2",
         "prettier": "^2.2.1",
@@ -34120,12 +34134,12 @@
       }
     },
     "keycloak-js": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-16.1.1.tgz",
-      "integrity": "sha512-AkRNIJFSMLfQKIBKK31UL4FGI59MQFf68Bf8I+PFbOSKNtnfGVPYLiZeJgy03Kv5ddswHBjVZOY5T0f5RpZpLw==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-18.0.1.tgz",
+      "integrity": "sha512-IRXToYpbIrkyfLeNNJly2OjUCf11ncx2Sdsg257NVDwjOYE923osu47w8pfxEVWpTaS14/Y2QjbTHciuBK0RBQ==",
       "requires": {
-        "base64-js": "1.3.1",
-        "js-sha256": "0.9.0"
+        "base64-js": "^1.5.1",
+        "js-sha256": "^0.9.0"
       }
     },
     "kind-of": {


### PR DESCRIPTION
Align keycloak client keycloak-js to back-end version.

See  https://github.com/konveyor/tackle2-operator/pull/115

Using keycloak-js 18.0.1 as 18.0.2 is not available on npm.