### PR TITLE
Create CA certs bundle

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,6 @@ if [[ -z "$TACKLE_HUB_URL" ]]; then
   exit 1
 fi
 
-
-
 if [[ $AUTH_REQUIRED != "false" ]]; then
 
   if [[ -z "$KEYCLOAK_REALM" ]]; then
@@ -24,5 +22,23 @@ if [[ $AUTH_REQUIRED != "false" ]]; then
     exit 1
   fi
 fi
+
+# Copy the Kube API and service CA bundle to /opt/app-root/src/ca.crt if they exist
+
+# Add Kube API CA
+if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then
+   cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt ${NODE_EXTRA_CA_CERTS}
+fi
+
+# Add service serving CA
+if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" ]; then
+    cat /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt >> ${NODE_EXTRA_CA_CERTS}
+fi
+
+# Add custom ingress CA if it exists
+if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ]; then
+    cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem >> ${NODE_EXTRA_CA_CERTS}
+fi
+
 cd server
 exec node index.js


### PR DESCRIPTION
- Update entrypoint.sh to import Kube API CA, Service CA and Custom Ingress CAs if they exist at runtime
- Necessary for RH-SSO integration which only listens on HTTPS with self serving certificates OCP generated, also will also support users with custom ingress CAs in their clusters
- Depends on https://github.com/konveyor/tackle2-operator/pull/117
- Target 2.1.2 release

Signed-off-by: Franco Bladilo <fbladilo@redhat.com>