### PR TITLE
TACKLE-811: Restore missing sort arrows on Manage Imports table

### DIFF
--- a/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -117,10 +117,10 @@ export const ManageImports: React.FC = () => {
   );
 
   const getSortValues = (item: ApplicationImportSummary) => [
-    "",
-    "",
+    item?.importTime,
+    item?.createUser.toLowerCase(),
     item?.filename?.toLowerCase() || "",
-    "",
+    item?.importStatus,
     "", // Action column
   ];
 
@@ -136,11 +136,11 @@ export const ManageImports: React.FC = () => {
   const columns: ICell[] = [
     {
       title: t("terms.date"),
-      transforms: [cellWidth(25)],
+      transforms: [sortable, cellWidth(25)],
     },
     {
       title: t("terms.user"),
-      transforms: [cellWidth(15)],
+      transforms: [sortable, cellWidth(15)],
       cellTransforms: [truncate],
     },
     {
@@ -150,7 +150,7 @@ export const ManageImports: React.FC = () => {
     },
     {
       title: t("terms.status"),
-      transforms: [cellWidth(10)],
+      transforms: [sortable, cellWidth(10)],
       cellTransforms: [truncate],
     },
     {


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/TACKLE-811

Targeted for 2.1.2

Signed-off-by: Mike Turley <mike.turley@alum.cs.umass.edu>