### PR TITLE
TACKLE-772: On deleting a table item, remain on current page unless we deleted the last item on the page

### DIFF
--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -418,9 +418,6 @@ export const ApplicationsTableAnalyze: React.FC = () => {
         onConfirm: () => {
           if (row.id) {
             deleteApplication({ id: row.id });
-            if (currentPageItems.length === 1 && paginationProps.page) {
-              setPageNumber(paginationProps.page - 1);
-            }
           }
         },
       })

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -420,8 +420,6 @@ export const ApplicationsTableAnalyze: React.FC = () => {
             deleteApplication({ id: row.id });
             if (currentPageItems.length === 1 && paginationProps.page) {
               setPageNumber(paginationProps.page - 1);
-            } else {
-              setPageNumber(1);
             }
           }
         },

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -493,8 +493,6 @@ export const ApplicationsTable: React.FC = () => {
             deleteApplication({ id: row.id });
             if (currentPageItems.length === 1 && paginationProps.page) {
               setPageNumber(paginationProps.page - 1);
-            } else {
-              setPageNumber(1);
             }
           }
         },

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -491,9 +491,6 @@ export const ApplicationsTable: React.FC = () => {
         onConfirm: () => {
           if (row.id) {
             deleteApplication({ id: row.id });
-            if (currentPageItems.length === 1 && paginationProps.page) {
-              setPageNumber(paginationProps.page - 1);
-            }
           }
         },
       })

--- a/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -301,8 +301,6 @@ export const ManageImports: React.FC = () => {
           deleteImportSummary(row.id);
           if (currentPageItems.length === 1 && paginationProps.page) {
             setPageNumber(paginationProps.page - 1);
-          } else {
-            setPageNumber(1);
           }
         },
       })

--- a/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -299,9 +299,6 @@ export const ManageImports: React.FC = () => {
         cancelBtnLabel: t("actions.cancel"),
         onConfirm: () => {
           deleteImportSummary(row.id);
-          if (currentPageItems.length === 1 && paginationProps.page) {
-            setPageNumber(paginationProps.page - 1);
-          }
         },
       })
     );

--- a/client/src/app/pages/controls/business-services/business-services.tsx
+++ b/client/src/app/pages/controls/business-services/business-services.tsx
@@ -210,8 +210,6 @@ export const BusinessServices: React.FC = () => {
           row.id && deleteBusinessService(row.id);
           if (currentPageItems.length === 1 && paginationProps.page) {
             setPageNumber(paginationProps.page - 1);
-          } else {
-            setPageNumber(1);
           }
         },
       })

--- a/client/src/app/pages/controls/business-services/business-services.tsx
+++ b/client/src/app/pages/controls/business-services/business-services.tsx
@@ -208,9 +208,6 @@ export const BusinessServices: React.FC = () => {
         onConfirm: () => {
           dispatch(confirmDialogActions.processing());
           row.id && deleteBusinessService(row.id);
-          if (currentPageItems.length === 1 && paginationProps.page) {
-            setPageNumber(paginationProps.page - 1);
-          }
         },
       })
     );

--- a/client/src/app/pages/controls/job-functions/job-functions.tsx
+++ b/client/src/app/pages/controls/job-functions/job-functions.tsx
@@ -158,8 +158,6 @@ export const JobFunctions: React.FC = () => {
           row.id && deleteJobFunction(row.id);
           if (currentPageItems.length === 1 && paginationProps.page) {
             setPageNumber(paginationProps.page - 1);
-          } else {
-            setPageNumber(1);
           }
         },
       })

--- a/client/src/app/pages/controls/job-functions/job-functions.tsx
+++ b/client/src/app/pages/controls/job-functions/job-functions.tsx
@@ -156,9 +156,6 @@ export const JobFunctions: React.FC = () => {
         onConfirm: () => {
           dispatch(confirmDialogActions.processing());
           row.id && deleteJobFunction(row.id);
-          if (currentPageItems.length === 1 && paginationProps.page) {
-            setPageNumber(paginationProps.page - 1);
-          }
         },
       })
     );

--- a/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
@@ -257,8 +257,6 @@ export const StakeholderGroups: React.FC = () => {
           row.id && deleteStakeholderGroup(row.id);
           if (currentPageItems.length === 1 && paginationProps.page) {
             setPageNumber(paginationProps.page - 1);
-          } else {
-            setPageNumber(1);
           }
         },
       })

--- a/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
@@ -255,9 +255,6 @@ export const StakeholderGroups: React.FC = () => {
         onConfirm: () => {
           dispatch(confirmDialogActions.processing());
           row.id && deleteStakeholderGroup(row.id);
-          if (currentPageItems.length === 1 && paginationProps.page) {
-            setPageNumber(paginationProps.page - 1);
-          }
         },
       })
     );

--- a/client/src/app/pages/controls/stakeholders/stakeholders.tsx
+++ b/client/src/app/pages/controls/stakeholders/stakeholders.tsx
@@ -274,8 +274,6 @@ export const Stakeholders: React.FC = () => {
           row.id && deleteStakeholder(row.id);
           if (currentPageItems.length === 1 && paginationProps.page) {
             setPageNumber(paginationProps.page - 1);
-          } else {
-            setPageNumber(1);
           }
         },
       })

--- a/client/src/app/pages/controls/stakeholders/stakeholders.tsx
+++ b/client/src/app/pages/controls/stakeholders/stakeholders.tsx
@@ -272,9 +272,6 @@ export const Stakeholders: React.FC = () => {
         onConfirm: () => {
           dispatch(confirmDialogActions.processing());
           row.id && deleteStakeholder(row.id);
-          if (currentPageItems.length === 1 && paginationProps.page) {
-            setPageNumber(paginationProps.page - 1);
-          }
         },
       })
     );

--- a/client/src/app/pages/controls/tags/tags.tsx
+++ b/client/src/app/pages/controls/tags/tags.tsx
@@ -336,9 +336,6 @@ export const Tags: React.FC = () => {
         onConfirm: () => {
           dispatch(confirmDialogActions.processing());
           row.id && deleteTagType(row.id);
-          if (currentPageItems.length === 1 && paginationProps.page) {
-            setPageNumber(paginationProps.page - 1);
-          }
         },
       })
     );

--- a/client/src/app/pages/controls/tags/tags.tsx
+++ b/client/src/app/pages/controls/tags/tags.tsx
@@ -338,8 +338,6 @@ export const Tags: React.FC = () => {
           row.id && deleteTagType(row.id);
           if (currentPageItems.length === 1 && paginationProps.page) {
             setPageNumber(paginationProps.page - 1);
-          } else {
-            setPageNumber(1);
           }
         },
       })

--- a/client/src/app/pages/identities/identities.tsx
+++ b/client/src/app/pages/identities/identities.tsx
@@ -190,9 +190,6 @@ export const Identities: React.FunctionComponent = () => {
         onConfirm: () => {
           dispatch(confirmDialogActions.processing());
           row.id && deleteIdentity(row.id);
-          if (currentPageItems.length === 1 && paginationProps.page) {
-            setPageNumber(paginationProps.page - 1);
-          }
         },
       })
     );

--- a/client/src/app/pages/identities/identities.tsx
+++ b/client/src/app/pages/identities/identities.tsx
@@ -192,8 +192,6 @@ export const Identities: React.FunctionComponent = () => {
           row.id && deleteIdentity(row.id);
           if (currentPageItems.length === 1 && paginationProps.page) {
             setPageNumber(paginationProps.page - 1);
-          } else {
-            setPageNumber(1);
           }
         },
       })

--- a/client/src/app/shared/hooks/usePaginationState.ts
+++ b/client/src/app/shared/hooks/usePaginationState.ts
@@ -22,6 +22,13 @@ export const usePaginationState = <T>(
   const setPageNumber = (num: number) => baseSetPageNumber(num >= 1 ? num : 1);
   const [itemsPerPage, setItemsPerPage] = React.useState(initialItemsPerPage);
 
+  const lastPageNumber = Math.max(Math.ceil(items.length / itemsPerPage), 1);
+  React.useEffect(() => {
+    if (pageNumber > lastPageNumber) {
+      setPageNumber(lastPageNumber);
+    }
+  });
+
   const pageStartIndex = (pageNumber - 1) * itemsPerPage;
   const currentPageItems = items.slice(
     pageStartIndex,

--- a/client/src/app/shared/hooks/usePaginationState.ts
+++ b/client/src/app/shared/hooks/usePaginationState.ts
@@ -22,6 +22,7 @@ export const usePaginationState = <T>(
   const setPageNumber = (num: number) => baseSetPageNumber(num >= 1 ? num : 1);
   const [itemsPerPage, setItemsPerPage] = React.useState(initialItemsPerPage);
 
+  // When items are removed, make sure the current page still exists
   const lastPageNumber = Math.max(Math.ceil(items.length / itemsPerPage), 1);
   React.useEffect(() => {
     if (pageNumber > lastPageNumber) {

--- a/client/src/app/shared/hooks/usePaginationState.ts
+++ b/client/src/app/shared/hooks/usePaginationState.ts
@@ -18,7 +18,8 @@ export const usePaginationState = <T>(
   items: T[],
   initialItemsPerPage: number
 ): IPaginationStateHook<T> => {
-  const [pageNumber, setPageNumber] = React.useState(1);
+  const [pageNumber, baseSetPageNumber] = React.useState(1);
+  const setPageNumber = (num: number) => baseSetPageNumber(num >= 1 ? num : 1);
   const [itemsPerPage, setItemsPerPage] = React.useState(initialItemsPerPage);
 
   const pageStartIndex = (pageNumber - 1) * itemsPerPage;
@@ -38,5 +39,9 @@ export const usePaginationState = <T>(
     },
   };
 
-  return { currentPageItems, setPageNumber, paginationProps };
+  return {
+    currentPageItems,
+    setPageNumber,
+    paginationProps,
+  };
 };


### PR DESCRIPTION
Fixes [TACKLE-772](https://issues.redhat.com/browse/TACKLE-772)

This was a regression caused by https://github.com/konveyor/tackle2-ui/pull/325, which fixed related issues [TACKLE-635](https://issues.redhat.com/browse/TACKLE-635) and [TACKLE-712](https://issues.redhat.com/browse/TACKLE-712). The original bug was that deleting an item never caused a page change, which left an unexpected empty state if the last item on a page was deleted. https://github.com/konveyor/tackle2-ui/pull/325 changed the behavior such that when an item is deleted, if it was the last item on the page the table will go back 1 page, else the table will go to the first page.

That `else` case was causing this regression. If the deleted item was not the last one on the page, we should stay on the page we were on rather than going back to the first page. Initially I fixed this by removing the else case from each of those delete callbacks, but I then realized we could just replace that per-table behavior entirely by enforcing the "don't allow us to be on a page greater than the last page" logic within `usePaginationState` itself in a `useEffect`.

As part of testing this fix, I found another bug that this PR also fixes: If you deleted the very last item in the table, the above logic would decrement the page number to 0 (page numbers start at 1). If you then added a new item, the pagination state would be screwed up and display negative numbers:

![Screen Shot 2022-10-03 at 1 51 53 PM](https://user-images.githubusercontent.com/811963/193644971-aba450ec-a520-43da-9f4b-97e1ad01a989.png)

To fix this second issue, this PR modifies `usePaginationState` so the returned `setPageNumber` function can never set a page number lower than 1.