### PR TITLE
Run CI checks on PRs and merges to release branches

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     branches:
       - main
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   unit-test:


### PR DESCRIPTION
Currently our backport PRs don't run our CI checks. This PR adds filter patterns to the `push` and `pull_request` branch conditions in our CI actions workflow so any PR targeting a release branch will run the CI checks (once this is backported).

`v[0-9]+.[0-9]+.[0-9]+` matches any branch name that is a semantic version beginning with `v`, such as our `v2.1.2`.

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet