### PR TITLE
TACKLE-814: Add error parsing check for cyclic deps error

### DIFF
--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -10,6 +10,11 @@ export const getAxiosErrorMessage = (axiosError: AxiosError) => {
     axiosError.response.data.errorMessage
   ) {
     return axiosError.response.data.errorMessage;
+  } else if (
+    axiosError.response?.data?.error &&
+    typeof axiosError?.response?.data?.error === "string"
+  ) {
+    return axiosError?.response?.data?.error;
   } else {
     return axiosError.message;
   }


### PR DESCRIPTION
Signed-off-by: ibolton336 <ibolton@redhat.com>

- This PR accounts for the "error" field in the api error response object. This is needed to correctly parse the "cyclic dependencies are not allowed" error. 
Notes: We should add i18n for these special case errors that are passed from the api. The current string is:

![image](https://user-images.githubusercontent.com/11218376/194895470-c798347f-5d1f-4919-9754-23c6b5bdf3b3.png)

I didn't want to change too much here is this is a regression bug. Something to consider for future releases, though. 