### PR TITLE
Use React.FC vs React.FunctionComponent

### DIFF
--- a/client/src/app/common/KeyDisplayToggle.tsx
+++ b/client/src/app/common/KeyDisplayToggle.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import { Button } from '@patternfly/react-core';
-import EyeSlashIcon from '@patternfly/react-icons/dist/js/icons/eye-slash-icon';
-import EyeIcon from '@patternfly/react-icons/dist/js/icons/eye-icon';
+import * as React from "react";
+import { Button } from "@patternfly/react-core";
+import EyeSlashIcon from "@patternfly/react-icons/dist/js/icons/eye-slash-icon";
+import EyeIcon from "@patternfly/react-icons/dist/js/icons/eye-icon";
 // TODO this is a good candidate for lib-ui
 
 interface IKeyDisplayToggleProps {
@@ -10,13 +10,15 @@ interface IKeyDisplayToggleProps {
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-const KeyDisplayToggle: React.FunctionComponent<IKeyDisplayToggleProps> = ({
+const KeyDisplayToggle: React.FC<IKeyDisplayToggleProps> = ({
   keyName,
   isKeyHidden,
   onClick,
 }: IKeyDisplayToggleProps) => (
   <Button variant="link" aria-label={`Show/hide ${keyName}`} onClick={onClick}>
-    <span className="pf-c-icon pf-m-info">{isKeyHidden ? <EyeSlashIcon /> : <EyeIcon />}</span>
+    <span className="pf-c-icon pf-m-info">
+      {isKeyHidden ? <EyeSlashIcon /> : <EyeIcon />}
+    </span>
   </Button>
 );
 

--- a/client/src/app/common/KeycloakProvider.tsx
+++ b/client/src/app/common/KeycloakProvider.tsx
@@ -12,9 +12,9 @@ interface IKeycloakProviderProps {
   children: React.ReactNode;
 }
 
-export const KeycloakProvider: React.FunctionComponent<
-  IKeycloakProviderProps
-> = ({ children }) => {
+export const KeycloakProvider: React.FC<IKeycloakProviderProps> = ({
+  children,
+}) => {
   const checkAuthCookie = () => {
     if (!getCookie("keycloak_cookie") && keycloak?.token) {
       setCookie("keycloak_cookie", keycloak.token, 365);

--- a/client/src/app/common/TooltipTitle.tsx
+++ b/client/src/app/common/TooltipTitle.tsx
@@ -8,10 +8,7 @@ interface IProps {
   tooltipText: string;
 }
 
-const TooltipTitle: React.FunctionComponent<IProps> = ({
-  titleText,
-  tooltipText,
-}) => {
+const TooltipTitle: React.FC<IProps> = ({ titleText, tooltipText }) => {
   return (
     <Flex>
       <FlexItem>{titleText}</FlexItem>

--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -91,7 +91,7 @@ const initTask = (application: Application): TaskgroupTask => {
   };
 };
 
-export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
+export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
   applications,
   onClose,
   isOpen,

--- a/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/add-custom-rules.tsx
@@ -25,7 +25,7 @@ interface IParsedXMLFileStatus {
   message?: string;
 }
 
-export const AddCustomRules: React.FunctionComponent<IAddCustomRules> = ({
+export const AddCustomRules: React.FC<IAddCustomRules> = ({
   customRulesFiles,
   readFileData,
   setReadFileData,

--- a/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
@@ -23,9 +23,7 @@ interface IUploadBinary {
   taskgroupID: number;
 }
 
-export const UploadBinary: React.FunctionComponent<IUploadBinary> = ({
-  taskgroupID,
-}) => {
+export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
   const { setValue, getValues } = useFormContext();
   const { artifact } = getValues();
   const initialCurrentFile = new File([""], artifact, { type: "text/html" });

--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -38,7 +38,7 @@ import { IReadFile } from "./analysis-wizard";
 
 import "./wizard.css";
 
-export const CustomRules: React.FunctionComponent = () => {
+export const CustomRules: React.FC = () => {
   const { t } = useTranslation();
 
   const { getValues, setValue } = useFormContext();

--- a/client/src/app/pages/applications/analysis-wizard/review.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/review.tsx
@@ -34,10 +34,7 @@ const defaultScopes: Map<string, string> = new Map([
   ["select", "List of packages to be analyzed manually"],
 ]);
 
-export const Review: React.FunctionComponent<IReview> = ({
-  applications,
-  mode,
-}) => {
+export const Review: React.FC<IReview> = ({ applications, mode }) => {
   const { t } = useTranslation();
 
   const { getValues } = useFormContext<IAnalysisWizardFormValues>();

--- a/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
@@ -21,7 +21,7 @@ interface ISetMode {
   setMode: (mode: string) => void;
 }
 
-export const SetMode: React.FunctionComponent<ISetMode> = ({
+export const SetMode: React.FC<ISetMode> = ({
   mode,
   isSingleApp,
   taskgroupID,

--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -21,7 +21,7 @@ import { defaultSources, defaultTargets } from "./targets";
 import DelIcon from "@patternfly/react-icons/dist/esm/icons/error-circle-o-icon";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
-export const SetOptions: React.FunctionComponent = () => {
+export const SetOptions: React.FC = () => {
   const { t } = useTranslation();
 
   const { getValues, setValue } = useFormContext();

--- a/client/src/app/pages/applications/analysis-wizard/set-scope.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-scope.tsx
@@ -20,7 +20,7 @@ import { getValidatedFromError } from "@app/utils/utils";
 
 import "./wizard.css";
 
-export const SetScope: React.FunctionComponent = () => {
+export const SetScope: React.FC = () => {
   const { t } = useTranslation();
 
   const { getValues, setValue } = useFormContext();

--- a/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -14,7 +14,7 @@ import { useFormContext } from "react-hook-form";
 import { SelectCard } from "./components/select-card";
 import { ITransformationTargets, transformationTargets } from "./targets";
 
-export const SetTargets: React.FunctionComponent = () => {
+export const SetTargets: React.FC = () => {
   const { t } = useTranslation();
 
   const { getValues, setValue } = useFormContext();

--- a/client/src/app/pages/applications/analysis-wizard/validation-wizard/sampleform.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/validation-wizard/sampleform.tsx
@@ -7,7 +7,7 @@ interface ISampleForm {
   onChange: (isvalid: boolean, value: any) => void;
 }
 
-export const SampleForm: React.FunctionComponent<ISampleForm> = ({
+export const SampleForm: React.FC<ISampleForm> = ({
   formValue = "",
   isFormValid = false,
   onChange,

--- a/client/src/app/pages/applications/analysis-wizard/validation-wizard/validation-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/validation-wizard/validation-wizard.tsx
@@ -12,7 +12,7 @@ import {
 import SampleForm from "./sampleform";
 import { Link } from "react-router-dom";
 
-export const ValidationWizard: React.FunctionComponent = () => {
+export const ValidationWizard: React.FC = () => {
   const [isFormValid, setFormValid] = React.useState(false);
   const [formValue, setFormValue] = React.useState("Thirty");
   const [allStepsValid, setallStepsValid] = React.useState(false);

--- a/client/src/app/pages/identities/identities.tsx
+++ b/client/src/app/pages/identities/identities.tsx
@@ -50,7 +50,7 @@ import { NotificationsContext } from "@app/shared/notifications-context";
 
 const ENTITY_FIELD = "entity";
 
-export const Identities: React.FunctionComponent = () => {
+export const Identities: React.FC = () => {
   const { t } = useTranslation();
 
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] =

--- a/client/src/app/pages/proxies/proxies.tsx
+++ b/client/src/app/pages/proxies/proxies.tsx
@@ -17,7 +17,7 @@ import { ProxyForm } from "./proxy-form";
 import { useFetchProxies } from "@app/queries/proxies";
 import "./proxies.css";
 
-export const Proxies: React.FunctionComponent = () => {
+export const Proxies: React.FC = () => {
   const { t } = useTranslation();
 
   const { proxies, isFetching } = useFetchProxies();

--- a/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -62,9 +62,7 @@ interface IAdoptionCandidateTable {
   allApplications?: Application[];
 }
 
-export const AdoptionCandidateTable: React.FunctionComponent<
-  IAdoptionCandidateTable
-> = () => {
+export const AdoptionCandidateTable: React.FC<IAdoptionCandidateTable> = () => {
   // i18
   const { t } = useTranslation();
 

--- a/client/src/app/pages/repositories/Git.tsx
+++ b/client/src/app/pages/repositories/Git.tsx
@@ -19,7 +19,7 @@ import { Setting } from "@app/api/models";
 import { AxiosError, AxiosPromise } from "axios";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 
-export const RepositoriesGit: React.FunctionComponent = () => {
+export const RepositoriesGit: React.FC = () => {
   const { t } = useTranslation();
   const [error, setError] = React.useState<AxiosError>();
 

--- a/client/src/app/pages/repositories/Mvn.tsx
+++ b/client/src/app/pages/repositories/Mvn.tsx
@@ -31,7 +31,7 @@ import {
 import { useFetchTasks } from "@app/queries/tasks";
 import { ConfirmDialog } from "@app/shared/components";
 
-export const RepositoriesMvn: React.FunctionComponent = () => {
+export const RepositoriesMvn: React.FC = () => {
   const { t } = useTranslation();
 
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] =

--- a/client/src/app/pages/repositories/Svn.tsx
+++ b/client/src/app/pages/repositories/Svn.tsx
@@ -19,7 +19,7 @@ import { useCallback, useEffect } from "react";
 import { useFetch } from "@app/shared/hooks";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 
-export const RepositoriesSvn: React.FunctionComponent = () => {
+export const RepositoriesSvn: React.FC = () => {
   const { t } = useTranslation();
   const [error, setError] = React.useState<AxiosError>();
 

--- a/client/src/app/shared/components/ConditionalTooltip.tsx
+++ b/client/src/app/shared/components/ConditionalTooltip.tsx
@@ -7,7 +7,9 @@ export interface IConditionalTooltipProps extends TooltipProps {
 }
 
 // TODO: lib-ui candidate
-export const ConditionalTooltip: React.FunctionComponent<
-  IConditionalTooltipProps
-> = ({ isTooltipEnabled, children, ...props }: IConditionalTooltipProps) =>
+export const ConditionalTooltip: React.FC<IConditionalTooltipProps> = ({
+  isTooltipEnabled,
+  children,
+  ...props
+}: IConditionalTooltipProps) =>
   isTooltipEnabled ? <Tooltip {...props}>{children}</Tooltip> : children;

--- a/client/src/app/shared/components/no-data-empty-state/no-data-empty-state.tsx
+++ b/client/src/app/shared/components/no-data-empty-state/no-data-empty-state.tsx
@@ -13,9 +13,10 @@ export interface NoDataEmptyStateProps {
   description?: string;
 }
 
-export const NoDataEmptyState: React.FunctionComponent<
-  NoDataEmptyStateProps
-> = ({ title, description }) => {
+export const NoDataEmptyState: React.FC<NoDataEmptyStateProps> = ({
+  title,
+  description,
+}) => {
   return (
     <EmptyState variant={EmptyStateVariant.small}>
       <EmptyStateIcon icon={CubesIcon} />

--- a/client/src/app/shared/components/proposed-action-label/proposed-action-label.tsx
+++ b/client/src/app/shared/components/proposed-action-label/proposed-action-label.tsx
@@ -9,9 +9,9 @@ export interface IProposedActionLabelProps {
   action: ProposedAction;
 }
 
-export const ProposedActionLabel: React.FunctionComponent<
-  IProposedActionLabelProps
-> = ({ action }: IProposedActionLabelProps) => {
+export const ProposedActionLabel: React.FC<IProposedActionLabelProps> = ({
+  action,
+}: IProposedActionLabelProps) => {
   const { t } = useTranslation();
 
   const data = PROPOSED_ACTION_LIST[action];

--- a/client/src/app/shared/components/risk-label/risk-label.tsx
+++ b/client/src/app/shared/components/risk-label/risk-label.tsx
@@ -10,7 +10,7 @@ export interface IRiskLabelProps {
   risk: Risk;
 }
 
-export const RiskLabel: React.FunctionComponent<IRiskLabelProps> = ({
+export const RiskLabel: React.FC<IRiskLabelProps> = ({
   risk,
 }: IRiskLabelProps) => {
   const { t } = useTranslation();

--- a/client/src/app/shared/components/status-icon/status-icon.tsx
+++ b/client/src/app/shared/components/status-icon/status-icon.tsx
@@ -27,9 +27,7 @@ export type StatusIconType =
 
 type IconListType = {
   [key in StatusIconType]: {
-    Icon:
-      | React.ComponentClass<SVGIconProps>
-      | React.FunctionComponent<SpinnerProps>;
+    Icon: React.ComponentClass<SVGIconProps> | React.FC<SpinnerProps>;
     color: { name: string; value: string; var: string };
   };
 };
@@ -70,7 +68,7 @@ export interface IStatusIconProps {
   className?: string;
 }
 
-export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
+export const StatusIcon: React.FC<IStatusIconProps> = ({
   status,
   isDisabled = false,
   className = "",

--- a/client/src/typings.d.ts
+++ b/client/src/typings.d.ts
@@ -52,7 +52,7 @@ declare module "*.webp" {
 declare module "*.svg" {
   import * as React from "react";
 
-  export const ReactComponent: React.FunctionComponent<
+  export const ReactComponent: React.FC<
     React.SVGProps<SVGSVGElement> & { title?: string }
   >;
 


### PR DESCRIPTION
React.FC is actually an alias for React.FunctionComponent.
So either one can be used meanwhile let's be consistent.
This patch sets FC everywhere.

Signed-off-by: Gilles Dubreuil <gilles@redhat.com>