### PR TITLE
Analysis wizard: fix translation key on 'Add rules' text in custom rules empty state

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -253,7 +253,7 @@ export const CustomRules: React.FC = () => {
         <NoDataEmptyState
           title={t("wizard.label.noCustomRules")}
           description={t("composed.add", {
-            what: t("terms.rules").toLowerCase(),
+            what: t("wizard.terms.rules").toLowerCase(),
           })}
         />
       )}


### PR DESCRIPTION
Before:
![Screen Shot 2022-10-12 at 1 05 59 PM](https://user-images.githubusercontent.com/811963/195407666-3758ab2d-0bbd-407a-8cf1-54c68714ddd9.png)

After:
![Screen Shot 2022-10-12 at 1 20 39 PM](https://user-images.githubusercontent.com/811963/195407680-73f76fc0-690d-484e-a8ed-081830ee0c36.png)
