### PR TITLE
[Backport v2.1.2] Analysis wizard: fix translation key on 'Add rules' text in custom rules empty state (#472)

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -253,7 +253,7 @@ export const CustomRules: React.FunctionComponent = () => {
         <NoDataEmptyState
           title={t("wizard.label.noCustomRules")}
           description={t("composed.add", {
-            what: t("terms.rules").toLowerCase(),
+            what: t("wizard.terms.rules").toLowerCase(),
           })}
         />
       )}


### PR DESCRIPTION
Backports #472

Signed-off-by: Mike Turley <mike.turley@alum.cs.umass.edu>