### PR TITLE
[Tech debt] Move common useFetch to react query

### DIFF
--- a/client/src/app/pages/applications/components/application-list-expanded-area/application-risk.tsx
+++ b/client/src/app/pages/applications/components/application-list-expanded-area/application-risk.tsx
@@ -1,10 +1,7 @@
-import React, { useCallback, useEffect } from "react";
-
+import React, { useEffect } from "react";
 import { RiskLabel } from "@app/shared/components";
-import { useFetch } from "@app/shared/hooks";
-
-import { Application, Assessment, AssessmentRisk } from "@app/api/models";
-import { getAssessmentLandscape } from "@app/api/rest";
+import { Application, Assessment } from "@app/api/models";
+import { useFetchRisks } from "@app/queries/risks";
 
 export interface IApplicationRiskProps {
   application: Application;
@@ -15,24 +12,17 @@ export const ApplicationRisk: React.FC<IApplicationRiskProps> = ({
   application,
   assessment,
 }) => {
-  // Risk
-  const fetchRiskData = useCallback(() => {
-    return getAssessmentLandscape([application.id!]).then(
-      ({ data }) => data[0]
-    );
-  }, [application]);
-
-  const { data: applicationRisk, requestFetch: fetchRisk } =
-    useFetch<AssessmentRisk>({
-      defaultIsFetching: true,
-      onFetchPromise: fetchRiskData,
-    });
+  const { risks: assessmentRisks, refetch: fetchRisk } = useFetchRisks([
+    application.id!,
+  ]);
 
   useEffect(() => {
     fetchRisk();
   }, [fetchRisk, application, assessment]);
 
   return (
-    <RiskLabel risk={applicationRisk ? applicationRisk.risk : "UNKNOWN"} />
+    <RiskLabel
+      risk={assessmentRisks?.length ? assessmentRisks[0].risk : "UNKNOWN"}
+    />
   );
 };

--- a/client/src/app/pages/applications/components/bulk-copy-assessment-review-form/bulk-copy-assessment-review-form.tsx
+++ b/client/src/app/pages/applications/components/bulk-copy-assessment-review-form/bulk-copy-assessment-review-form.tsx
@@ -83,8 +83,7 @@ export const BulkCopyAssessmentReviewForm: React.FC<
   const [requestConfirmation, setRequestConfirmation] = useState(false);
   const [confirmationAccepted, setConfirmationAccepted] = useState(false);
 
-  const { applications, isFetching, fetchError, refetch } =
-    useFetchApplications();
+  const { applications, isFetching, fetchError } = useFetchApplications();
 
   const { tagTypes } = useFetchTagTypes();
 

--- a/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
@@ -30,7 +30,6 @@ import {
   global_palette_white as white,
 } from "@patternfly/react-tokens";
 
-import { useFetch } from "@app/shared/hooks";
 import { ConditionalRender, StateError } from "@app/shared/components";
 
 import { EFFORT_ESTIMATE_LIST, PROPOSED_ACTION_LIST } from "@app/Constants";
@@ -46,6 +45,7 @@ import { CartesianSquare } from "./cartesian-square";
 import { Arrow } from "./arrow";
 import { useFetchReviews } from "@app/queries/reviews";
 import useFetchApplicationDependencies from "@app/shared/hooks/useFetchApplicationDependencies/useFetchApplicationDependencies";
+import { useQuery } from "react-query";
 
 interface Line {
   from: LinePoint;
@@ -136,25 +136,23 @@ export const AdoptionCandidateGraph: React.FC = () => {
   const [showDependencies, setShowDependencies] = useState(true);
 
   // Confidence
-  const fetchChartData = useCallback(() => {
-    if (applications.length > 0) {
-      return getAssessmentConfidence(applications.map((f) => f.id!)).then(
-        ({ data }) => data
-      );
-    } else {
-      return Promise.resolve([]);
-    }
-  }, [applications]);
-
   const {
     data: confidences,
+    refetch: refreshChart,
     isFetching,
-    fetchError,
-    requestFetch: refreshChart,
-  } = useFetch<AssessmentConfidence[]>({
-    defaultIsFetching: true,
-    onFetchPromise: fetchChartData,
-  });
+    error: fetchError,
+  } = useQuery<AssessmentConfidence[]>(
+    "assessmentconfidence",
+    async () =>
+      (
+        await getAssessmentConfidence(
+          applications.length > 0 ? applications.map((f) => f.id!) : []
+        )
+      ).data,
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
 
   useEffect(() => {
     refreshChart();

--- a/client/src/app/pages/reports/components/adoption-plan/adoption-plan.tsx
+++ b/client/src/app/pages/reports/components/adoption-plan/adoption-plan.tsx
@@ -11,7 +11,6 @@ import {
   ChartVoronoiContainer,
 } from "@patternfly/react-charts";
 
-import { useFetch } from "@app/shared/hooks";
 import { ConditionalRender, StateError } from "@app/shared/components";
 
 import { PROPOSED_ACTION_LIST } from "@app/Constants";
@@ -20,6 +19,7 @@ import { getApplicationAdoptionPlan } from "@app/api/rest";
 
 import { ApplicationSelectionContext } from "../../application-selection-context";
 import { NoApplicationSelectedEmptyState } from "../no-application-selected-empty-state";
+import { useQuery } from "react-query";
 
 interface IChartData {
   applicationId: number;
@@ -37,26 +37,23 @@ export const AdoptionPlan: React.FC = () => {
     ApplicationSelectionContext
   );
 
-  // Data
-  const fetchChartData = useCallback(() => {
-    if (applications.length > 0) {
-      return getApplicationAdoptionPlan(applications.map((f) => f.id!)).then(
-        ({ data }) => data
-      );
-    } else {
-      return Promise.resolve([]);
-    }
-  }, [applications]);
-
   const {
     data: adoptionPlan,
+    refetch: refreshChart,
+    error: fetchError,
     isFetching,
-    fetchError,
-    requestFetch: refreshChart,
-  } = useFetch<ApplicationAdoptionPlan[]>({
-    defaultIsFetching: true,
-    onFetchPromise: fetchChartData,
-  });
+  } = useQuery<ApplicationAdoptionPlan[]>(
+    "adoptionplan",
+    async () =>
+      (
+        await getApplicationAdoptionPlan(
+          applications.length > 0 ? applications.map((f) => f.id!) : []
+        )
+      ).data,
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
 
   useEffect(() => {
     refreshChart();

--- a/client/src/app/pages/reports/components/landscape/landscape.tsx
+++ b/client/src/app/pages/reports/components/landscape/landscape.tsx
@@ -1,18 +1,17 @@
-import React, { useCallback, useContext, useEffect, useMemo } from "react";
+import React, { useContext, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Skeleton, Split, SplitItem } from "@patternfly/react-core";
 
 import { ConditionalRender, StateError } from "@app/shared/components";
-import { useFetch } from "@app/shared/hooks";
 
 import { RISK_LIST } from "@app/Constants";
 import { AssessmentRisk } from "@app/api/models";
-import { getAssessmentLandscape } from "@app/api/rest";
 
 import { ApplicationSelectionContext } from "../../application-selection-context";
 import { NoApplicationSelectedEmptyState } from "../no-application-selected-empty-state";
 import { Donut } from "./donut";
+import { useFetchRisks } from "@app/queries/risks";
 
 interface ILandscapeData {
   low: number;
@@ -48,38 +47,17 @@ const extractLandscapeData = (
   return { low, medium, high, unassesed };
 };
 
-export interface ILandscapeProps {}
-
-export const Landscape: React.FC<ILandscapeProps> = () => {
+export const Landscape: React.FC = () => {
   const { t } = useTranslation();
 
   // Context
   const { allItems: applications } = useContext(ApplicationSelectionContext);
 
-  // Data
-  const fetchLandscapeData = useCallback(() => {
-    if (applications.length > 0) {
-      return getAssessmentLandscape(applications.map((f) => f.id!)).then(
-        ({ data }) => data
-      );
-    } else {
-      return Promise.resolve([]);
-    }
-  }, [applications]);
-
   const {
-    data: assessmentRisks,
+    risks: assessmentRisks,
     isFetching,
-    fetchError,
-    requestFetch: refreshChart,
-  } = useFetch<AssessmentRisk[]>({
-    defaultIsFetching: true,
-    onFetchPromise: fetchLandscapeData,
-  });
-
-  useEffect(() => {
-    refreshChart();
-  }, [applications, refreshChart]);
+    error: fetchError,
+  } = useFetchRisks(applications.map((app) => app.id!));
 
   const landscapeData = useMemo(() => {
     if (applications.length > 0 && assessmentRisks) {

--- a/client/src/app/pages/repositories/Git.tsx
+++ b/client/src/app/pages/repositories/Git.tsx
@@ -12,16 +12,27 @@ import {
 import { useTranslation } from "react-i18next";
 
 import "./Repositories.css";
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 import { getSettingById, updateSetting } from "@app/api/rest";
-import { useFetch } from "@app/shared/hooks";
 import { Setting } from "@app/api/models";
 import { AxiosError, AxiosPromise } from "axios";
 import { getAxiosErrorMessage } from "@app/utils/utils";
+import { useQuery } from "react-query";
 
 export const RepositoriesGit: React.FC = () => {
   const { t } = useTranslation();
   const [error, setError] = React.useState<AxiosError>();
+
+  const { data: gitInsecureSetting, refetch: refreshGitInsecureSetting } =
+    useQuery<boolean>(
+      ["setting"],
+      async () => {
+        return (await getSettingById("git.insecure.enabled")).data;
+      },
+      {
+        onError: (error) => console.log("error, ", error),
+      }
+    );
 
   const onChange = () => {
     const setting: Setting = {
@@ -44,16 +55,6 @@ export const RepositoriesGit: React.FC = () => {
         setError(error);
       });
   };
-
-  const fetchGitInsecureSetting = useCallback(() => {
-    return getSettingById("git.insecure.enabled");
-  }, []);
-
-  const { data: gitInsecureSetting, requestFetch: refreshGitInsecureSetting } =
-    useFetch<boolean>({
-      defaultIsFetching: true,
-      onFetch: fetchGitInsecureSetting,
-    });
 
   useEffect(() => {
     refreshGitInsecureSetting();

--- a/client/src/app/pages/repositories/Mvn.tsx
+++ b/client/src/app/pages/repositories/Mvn.tsx
@@ -19,17 +19,16 @@ import { useTranslation } from "react-i18next";
 
 import "./Repositories.css";
 import { AxiosError, AxiosPromise } from "axios";
-import { Setting, Volume } from "@app/api/models";
+import { Setting } from "@app/api/models";
 import { getSettingById, updateSetting } from "@app/api/rest";
-import { useFetch } from "@app/shared/hooks/useFetch";
 import { useEffect, useState } from "react";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 import {
   useCleanRepositoryMutation,
   useFetchVolumes,
 } from "@app/queries/volumes";
-import { useFetchTasks } from "@app/queries/tasks";
 import { ConfirmDialog } from "@app/shared/components";
+import { useQuery } from "react-query";
 
 export const RepositoriesMvn: React.FC = () => {
   const { t } = useTranslation();
@@ -37,10 +36,23 @@ export const RepositoriesMvn: React.FC = () => {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] =
     React.useState<Boolean>(false);
 
-  const [forcedSettingError, setForcedSettingError] =
-    React.useState<AxiosError>();
   const [insecureSettingError, setInsecureSettingError] =
     React.useState<AxiosError>();
+
+  const { data: mvnInsecureSetting, refetch: refreshMvnInsecureSetting } =
+    useQuery<boolean>(
+      ["mvninsecuresetting"],
+      async () => {
+        return (await getSettingById("mvn.insecure.enabled")).data;
+      },
+      {
+        onError: (error) => console.log("error, ", error),
+      }
+    );
+
+  useEffect(() => {
+    refreshMvnInsecureSetting();
+  }, [refreshMvnInsecureSetting]);
 
   const onChangeInsecure = () => {
     const setting: Setting = {
@@ -63,56 +75,47 @@ export const RepositoriesMvn: React.FC = () => {
         setInsecureSettingError(error);
       });
   };
+  //TODO: Implement mvn forced setting
 
-  const onChangeForced = () => {
-    const setting: Setting = {
-      key: "mvn.dependencies.update.forced",
-      value: !mvnForcedSetting,
-    };
+  // const [forcedSettingError, setForcedSettingError] =
+  //   React.useState<AxiosError>();
 
-    let promise: AxiosPromise<Setting>;
-    if (mvnInsecureSetting !== undefined) {
-      promise = updateSetting(setting);
-    } else {
-      promise = updateSetting(setting);
-    }
+  // const { data: mvnForcedSetting, refetch: refreshMvnForcedSetting } =
+  //   useQuery<boolean>(
+  //     ["mvnforcedsetting"],
+  //     async () => {
+  //       return (await getSettingById("mvn.dependencies.update.forced")).data;
+  //     },
+  //     {
+  //       onError: (error) => console.log("error, ", error),
+  //     }
+  //   );
 
-    promise
-      .then((response) => {
-        refreshMvnForcedSetting();
-      })
-      .catch((error) => {
-        setForcedSettingError(error);
-      });
-  };
+  // useEffect(() => {
+  //   refreshMvnForcedSetting();
+  // }, [refreshMvnForcedSetting]);
 
-  const fetchMvnForcedSetting = React.useCallback(() => {
-    return getSettingById("mvn.dependencies.update.forced");
-  }, []);
+  // const onChangeForced = () => {
+  //   const setting: Setting = {
+  //     key: "mvn.dependencies.update.forced",
+  //     value: !mvnForcedSetting,
+  //   };
 
-  const fetchMvnInsecureSetting = React.useCallback(() => {
-    return getSettingById("mvn.insecure.enabled");
-  }, []);
+  //   let promise: AxiosPromise<Setting>;
+  //   if (mvnInsecureSetting !== undefined) {
+  //     promise = updateSetting(setting);
+  //   } else {
+  //     promise = updateSetting(setting);
+  //   }
 
-  const { data: mvnInsecureSetting, requestFetch: refreshMvnInsecureSetting } =
-    useFetch<boolean>({
-      defaultIsFetching: true,
-      onFetch: fetchMvnInsecureSetting,
-    });
-
-  const { data: mvnForcedSetting, requestFetch: refreshMvnForcedSetting } =
-    useFetch<boolean>({
-      defaultIsFetching: true,
-      onFetch: fetchMvnForcedSetting,
-    });
-
-  useEffect(() => {
-    refreshMvnInsecureSetting();
-  }, [refreshMvnInsecureSetting]);
-
-  useEffect(() => {
-    refreshMvnForcedSetting();
-  }, [refreshMvnForcedSetting]);
+  //   promise
+  //     .then((response) => {
+  //       refreshMvnForcedSetting();
+  //     })
+  //     .catch((error) => {
+  //       setForcedSettingError(error);
+  //     });
+  // };
 
   const { volumes, refetch } = useFetchVolumes();
   const [storageValue, setStorageValue] = useState<string>();
@@ -167,13 +170,13 @@ export const RepositoriesMvn: React.FC = () => {
                 >
                   Clear repository
                 </Button>
-                {forcedSettingError && (
+                {/* {forcedSettingError && (
                   <Alert
                     variant="danger"
                     isInline
                     title={getAxiosErrorMessage(forcedSettingError)}
                   />
-                )}
+                )} */}
               </FormGroup>
               <FormGroup fieldId="isInsecure">
                 {insecureSettingError && (

--- a/client/src/app/pages/repositories/Svn.tsx
+++ b/client/src/app/pages/repositories/Svn.tsx
@@ -15,13 +15,28 @@ import "./Repositories.css";
 import { Setting } from "@app/api/models";
 import { getSettingById, updateSetting } from "@app/api/rest";
 import { AxiosError, AxiosPromise } from "axios";
-import { useCallback, useEffect } from "react";
-import { useFetch } from "@app/shared/hooks";
+import { useEffect } from "react";
 import { getAxiosErrorMessage } from "@app/utils/utils";
+import { useQuery } from "react-query";
 
 export const RepositoriesSvn: React.FC = () => {
   const { t } = useTranslation();
   const [error, setError] = React.useState<AxiosError>();
+
+  const { data: svnInsecureSetting, refetch: refreshSvnInsecureSetting } =
+    useQuery<boolean>(
+      ["svnsetting"],
+      async () => {
+        return (await getSettingById("svn.insecure.enabled")).data;
+      },
+      {
+        onError: (error) => console.log("error, ", error),
+      }
+    );
+
+  useEffect(() => {
+    refreshSvnInsecureSetting();
+  }, [refreshSvnInsecureSetting]);
 
   const onChange = () => {
     const setting: Setting = {
@@ -44,20 +59,6 @@ export const RepositoriesSvn: React.FC = () => {
         setError(error);
       });
   };
-
-  const fetchSvnInsecureSetting = useCallback(() => {
-    return getSettingById("svn.insecure.enabled");
-  }, []);
-
-  const { data: svnInsecureSetting, requestFetch: refreshSvnInsecureSetting } =
-    useFetch<boolean>({
-      defaultIsFetching: true,
-      onFetch: fetchSvnInsecureSetting,
-    });
-
-  useEffect(() => {
-    refreshSvnInsecureSetting();
-  }, [refreshSvnInsecureSetting]);
 
   return (
     <>

--- a/client/src/app/queries/proxies.ts
+++ b/client/src/app/queries/proxies.ts
@@ -1,19 +1,8 @@
 import { useState } from "react";
 import { AxiosError } from "axios";
-import { createAsyncAction } from "typesafe-actions";
 import { getProxies, updateProxy } from "@app/api/rest";
 import { Proxy } from "@app/api/models";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-
-export const {
-  request: fetchRequest,
-  success: fetchSuccess,
-  failure: fetchFailure,
-} = createAsyncAction(
-  "useFetchProxies/fetch/request",
-  "useFetchProxies/fetch/success",
-  "useFetchProxies/fetch/failure"
-)<void, any, AxiosError>();
 
 export interface IProxyFetchState {
   proxies: Proxy[];

--- a/client/src/app/queries/risks.ts
+++ b/client/src/app/queries/risks.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "react-query";
+import { AssessmentRisk } from "@app/api/models";
+import { getAssessmentLandscape } from "@app/api/rest";
+
+export const RisksQueryKey = "risks";
+
+export const useFetchRisks = (applicationIDs: number[]) => {
+  const { data, refetch, isFetching, error } = useQuery<AssessmentRisk[]>(
+    ["assessmentrisks", applicationIDs],
+    async () => {
+      return (await getAssessmentLandscape(applicationIDs)).data;
+    },
+    {
+      onError: (error) => console.log("error, ", error),
+    }
+  );
+  return {
+    risks: data || [],
+    isFetching,
+    error,
+    refetch,
+  };
+};


### PR DESCRIPTION
- Replaces dated Tackle 1.2 instances of useFetch- a custom fetch hook that implements common fetching utility functions. This logic can be easily replaced by react-query. 

- Should be merged before [this related PR. ](https://github.com/konveyor/tackle2-ui/pull/485 ) which replaces the  polling logic for bulk notification status with a react-query polling approach we have agreed on in the past. 
