### PR TITLE
Fix regression: allow excluded rules tags field to be empty without losing validation

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -175,7 +175,7 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
     return yup.object().shape({
       ruleTagToExclude: yup
         .string()
-        .min(2, t("validation.minLength", { length: 2 }))
+        .matches(/^(|.{2,})$/, t("validation.minLength", { length: 2 })) // Either 0 or 2+ characters
         .max(60, t("validation.maxLength", { length: 60 })),
     });
   };
@@ -195,6 +195,7 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
       hasExcludedPackages: false,
     },
     resolver: yupResolver(useWizardValidationSchema()),
+    mode: "onChange",
   });
 
   const { handleSubmit, watch, reset } = methods;

--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -115,7 +115,10 @@ export const SetOptions: React.FC = () => {
                   what: t("wizard.terms.rulesTags"),
                 })}
                 fieldId="ruleTagToExclude"
-                validated={getValidatedFromError(error?.message)}
+                validated={getValidatedFromErrorTouched(
+                  error?.message,
+                  isTouched
+                )}
                 helperTextInvalid={error?.message}
               >
                 <InputGroup>
@@ -123,11 +126,11 @@ export const SetOptions: React.FC = () => {
                     name={name}
                     id={name}
                     aria-label="Rule tag to exclude"
-                    onChange={(val, e) => {
-                      trigger(name);
-                      onChange(val, e);
-                    }}
-                    validated={getValidatedFromError(error?.message)}
+                    onChange={onChange}
+                    validated={getValidatedFromErrorTouched(
+                      error?.message,
+                      isTouched
+                    )}
                     value={value}
                     onBlur={onBlur}
                     ref={ref}
@@ -135,7 +138,7 @@ export const SetOptions: React.FC = () => {
                   <Button
                     id="add-rule-tag"
                     variant="control"
-                    isDisabled={!!error || !isDirty}
+                    isDisabled={!!error || !isDirty || value.length === 0}
                     onClick={() => {
                       setValue("excludedRulesTags", [
                         ...excludedRulesTags,


### PR DESCRIPTION
Fixes a regression found by @djzager caused by https://github.com/konveyor/tackle2-ui/pull/468 (which fixed https://issues.redhat.com/browse/TACKLE-844).

Targets 2.1.2 since it fixes a regression that was backported (in https://github.com/konveyor/tackle2-ui/pull/471).

The problem here is that the text field we're validating here is transient; it is only to enter the text of a tag that may or may not be added to the exclusion list. So we need to validate a value that is entered in it if present, but it is also valid for the field to be empty. The validation added in #468 requires some text to remain in the field for the wizard to be submitted.

This PR fixes the issue by changing the `.min(2, ...)` validation to a regular expression which will match if the string is either empty or longer than 2 characters (solution [found here](https://github.com/jquense/yup/issues/1267#issuecomment-817027605)). It also changes the yup validation mode to `onChange` so we don't need the `trigger` in the `onChange` function of the field itself, which was triggering one keystroke late (without that change, the error would remain after you typed your second character and only be removed when you typed a third character). Additionally, this PR switches from `getValidatedFromError` to `getValidatedFromErrorTouched`, so the error will only appear if the user leaves an invalid string in the field and clicks away (otherwise an error always appears as they start typing).

Signed-off-by: Mike Turley <mike.turley@alum.cs.umass.edu>