### PR TITLE
[Backport v2.1.2] Fix regression: allow excluded rules tags field to be empty without losing validation

### DIFF
--- a/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -163,7 +163,7 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
     return yup.object().shape({
       ruleTagToExclude: yup
         .string()
-        .min(2, t("validation.minLength", { length: 2 }))
+        .matches(/^(|.{2,})$/, t("validation.minLength", { length: 2 })) // Either 0 or 2+ characters
         .max(60, t("validation.maxLength", { length: 60 })),
     });
   };
@@ -183,6 +183,7 @@ export const AnalysisWizard: React.FunctionComponent<IAnalysisWizard> = ({
       hasExcludedPackages: false,
     },
     resolver: yupResolver(useWizardValidationSchema()),
+    mode: "onChange",
   });
 
   const { handleSubmit, watch, reset } = methods;

--- a/pkg/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/pkg/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -115,7 +115,10 @@ export const SetOptions: React.FunctionComponent = () => {
                   what: t("wizard.terms.rulesTags"),
                 })}
                 fieldId="ruleTagToExclude"
-                validated={getValidatedFromError(error?.message)}
+                validated={getValidatedFromErrorTouched(
+                  error?.message,
+                  isTouched
+                )}
                 helperTextInvalid={error?.message}
               >
                 <InputGroup>
@@ -123,11 +126,11 @@ export const SetOptions: React.FunctionComponent = () => {
                     name={name}
                     id={name}
                     aria-label="Rule tag to exclude"
-                    onChange={(val, e) => {
-                      trigger(name);
-                      onChange(val, e);
-                    }}
-                    validated={getValidatedFromError(error?.message)}
+                    onChange={onChange}
+                    validated={getValidatedFromErrorTouched(
+                      error?.message,
+                      isTouched
+                    )}
                     value={value}
                     onBlur={onBlur}
                     ref={ref}
@@ -135,7 +138,7 @@ export const SetOptions: React.FunctionComponent = () => {
                   <Button
                     id="add-rule-tag"
                     variant="control"
-                    isDisabled={!!error || !isDirty}
+                    isDisabled={!!error || !isDirty || value.length === 0}
                     onClick={() => {
                       setValue("excludedRulesTags", [
                         ...excludedRulesTags,


### PR DESCRIPTION
Backports #482 

Signed-off-by: Mike Turley <mike.turley@alum.cs.umass.edu>