### PR TITLE
Only consider windup tasks on the Analysis table

### DIFF
--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -118,7 +118,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     setPageNumber,
   } = useApplicationsFilterValues(applications, ApplicationTableType.Analysis);
 
-  const { tasks } = useFetchTasks();
+  const { tasks } = useFetchTasks({ addon: "windup" });
 
   const completedCancelTask = () => {
     pushNotification({

--- a/client/src/app/pages/repositories/Mvn.tsx
+++ b/client/src/app/pages/repositories/Mvn.tsx
@@ -115,7 +115,6 @@ export const RepositoriesMvn: React.FC = () => {
   }, [refreshMvnForcedSetting]);
 
   const { volumes, refetch } = useFetchVolumes();
-  const { tasks } = useFetchTasks();
   const [storageValue, setStorageValue] = useState<string>();
   const [currCleanId, setCurrCleanId] = useState<number>(0);
 

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -3,12 +3,21 @@ import { useMutation, useQuery } from "react-query";
 import { Task } from "@app/api/models";
 import { cancelTask, deleteTask, getTasks } from "@app/api/rest";
 
-export const useFetchTasks = () => {
+interface FetchTasksFilters {
+  addon?: string;
+}
+
+export const useFetchTasks = (filters: FetchTasksFilters = {}) => {
   const { isLoading, error, refetch, data } = useQuery("tasks", getTasks, {
     refetchInterval: 5000,
     select: (allTasks) => {
+      const filteredTasks = filters
+        ? allTasks.filter((task) => {
+            return !filters.addon || task.addon === filters.addon;
+          })
+        : allTasks;
       let uniqLatestTasks: Task[] = [];
-      allTasks.forEach((task) => {
+      filteredTasks.forEach((task) => {
         const aTask = uniqLatestTasks.find(
           (item) => task.application?.id === item.application?.id
         );


### PR DESCRIPTION
Adds a `filters` argument to the `useFetchTasks` hook so that we can query only tasks that matter for a particular view. For now the only filter is `addon`, and it is only used in the Analysis table to filter on `{ addon: "windup" }`. These filters are applied BEFORE the selection logic in the query hook (finding the latest unique task per application).

cc @djzager

Signed-off-by: Mike Turley <mike.turley@alum.cs.umass.edu>