### PR TITLE
Bug fix: Prevent duplicate notifications & fix dismiss bug

### DIFF
--- a/client/src/app/shared/components/Notifications.tsx
+++ b/client/src/app/shared/components/Notifications.tsx
@@ -11,19 +11,16 @@ export const Notifications: React.FunctionComponent = () => {
   return (
     <AlertGroup isToast aria-live="polite">
       {appContext.notifications.map((notification) => {
-        const key = notification.key
-          ? notification.key
-          : `${notification.title}`;
         return (
           <Alert
             title={notification.title}
             variant={notification.variant}
-            key={key}
+            key={notification.title}
             {...(!notification.hideCloseButton && {
               actionClose: (
                 <AlertActionCloseButton
                   onClose={() => {
-                    appContext.dismissNotification(key);
+                    appContext.dismissNotification(notification.title);
                   }}
                 />
               ),

--- a/client/src/app/shared/notifications-context.tsx
+++ b/client/src/app/shared/notifications-context.tsx
@@ -4,7 +4,6 @@ import { AlertProps } from "@patternfly/react-core";
 export type INotification = {
   title: string;
   variant: AlertProps["variant"];
-  key?: string;
   message?: React.ReactNode;
   hideCloseButton?: boolean;
   timeout?: number | boolean;
@@ -36,14 +35,19 @@ export const NotificationsProvider: React.FunctionComponent<
   const [notifications, setNotifications] = React.useState<INotification[]>([]);
 
   const pushNotification = (notification: INotification) => {
-    setNotifications([
-      ...notifications,
-      { ...notificationDefault, ...notification },
-    ]);
+    const hasDupe = notifications.find((n) => n.title === notification.title);
+    if (!hasDupe) {
+      setNotifications([
+        ...notifications,
+        { ...notificationDefault, ...notification },
+      ]);
+    }
   };
 
-  const dismissNotification = (key: string) => {
-    const remainingNotifications = notifications.filter((n) => n.key !== key);
+  const dismissNotification = (title: string) => {
+    const remainingNotifications = notifications.filter(
+      (n) => n.title !== title
+    );
     setNotifications(remainingNotifications);
   };
 


### PR DESCRIPTION
- Currently, you cannot dismiss a push notification that was created without a 'key' prop. Rather than adding this prop to all areas of the app, I changed the logic to use title for the key. 
- Adds a check for duplicate notifications before pushing 