### PR TITLE
TACKLE-861: UploadBinary - Fix artifact state

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -157,7 +157,7 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
 
   const methods = useForm<AnalysisWizardFormValues>({
     defaultValues: {
-      artifact: undefined,
+      artifact: null,
       mode: "binary",
       targets: [],
       sources: [],

--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -157,7 +157,7 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
 
   const methods = useForm<AnalysisWizardFormValues>({
     defaultValues: {
-      artifact: "",
+      artifact: undefined,
       mode: "binary",
       targets: [],
       sources: [],

--- a/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
@@ -24,8 +24,8 @@ interface IUploadBinary {
 }
 
 export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
-  const { setValue, getValues } = useFormContext<AnalysisWizardFormValues>();
-  const { artifact } = getValues();
+  const { setValue, watch } = useFormContext<AnalysisWizardFormValues>();
+  const artifact = watch("artifact");
 
   const [error, setError] = React.useState<AxiosError>();
 

--- a/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
@@ -31,7 +31,7 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
 
   const [fileUploadProgress, setFileUploadProgress] = React.useState<
     number | undefined
-  >(artifact.size > 0 ? 100 : undefined);
+  >(artifact ? (artifact.size > 0 ? 100 : undefined) : undefined);
 
   const [fileUploadStatus, setFileUploadStatus] = React.useState<
     "danger" | "success" | "warning" | undefined
@@ -66,7 +66,7 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
     });
     setFileUploadStatus(undefined);
     setFileUploadProgress(undefined);
-    setValue("artifact", "");
+    setValue("artifact", undefined);
   };
 
   const failedRemove = (error: AxiosError) => {
@@ -126,7 +126,7 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
   const handleFile = (file: File) => {
     if (!artifact)
       readFile(file).catch((error: DOMException) => {
-        setValue("artifact", "");
+        setValue("artifact", undefined);
         setFileUploadProgress(0);
         setFileUploadStatus("danger");
       });
@@ -172,7 +172,7 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
                 id: taskgroupID,
                 path: `binary/${artifact}`,
               });
-              setValue("artifact", "");
+              setValue("artifact", undefined);
             }}
             progressAriaLabel={"text"}
             progressValue={fileUploadProgress}

--- a/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
@@ -151,11 +151,16 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
       >
         <MultipleFileUploadMain
           titleIcon={<UploadIcon />}
-          titleText="Drag and drop files here"
+          titleText="Drag and drop file here"
           titleTextSeparator="or"
-          infoText={`Accepted file types: war, ear, jar or zip; Upload size limit: ${
-            uploadLimitInBytes / 1000
-          } Kilobyte`}
+          infoText={
+            <>
+              <div>Accepted file types: war, ear, jar or zip</div>
+              <div>
+                Upload size limit: {Math.round(uploadLimitInBytes / 1000000)} MB
+              </div>
+            </>
+          }
         />
         {artifact && (
           <MultipleFileUploadStatusItem

--- a/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
@@ -66,7 +66,7 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
     });
     setFileUploadStatus(undefined);
     setFileUploadProgress(undefined);
-    setValue("artifact", undefined);
+    setValue("artifact", null);
   };
 
   const failedRemove = (error: AxiosError) => {
@@ -172,7 +172,7 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
                 id: taskgroupID,
                 path: `binary/${artifact}`,
               });
-              setValue("artifact", undefined);
+              setValue("artifact", null);
             }}
             progressAriaLabel={"text"}
             progressValue={fileUploadProgress}

--- a/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {
   Alert,
-  Modal,
   MultipleFileUpload,
   MultipleFileUploadMain,
   MultipleFileUploadStatusItem,
@@ -25,24 +24,18 @@ interface IUploadBinary {
 }
 
 export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
-  const { setValue, watch } = useFormContext<AnalysisWizardFormValues>();
-  const artifact = watch("artifact");
-  const initialCurrentFile = new File([""], artifact, { type: "text/html" });
+  const { setValue, getValues } = useFormContext<AnalysisWizardFormValues>();
+  const { artifact } = getValues();
 
-  const [currentFile, setCurrentFile] = React.useState<File | null>(
-    artifact ? initialCurrentFile : null
-  );
-
-  const [modalText, setModalText] = React.useState("");
   const [error, setError] = React.useState<AxiosError>();
 
   const [fileUploadProgress, setFileUploadProgress] = React.useState<
     number | undefined
-  >(undefined);
+  >(artifact.size > 0 ? 100 : undefined);
 
   const [fileUploadStatus, setFileUploadStatus] = React.useState<
     "danger" | "success" | "warning" | undefined
-  >(undefined);
+  >(artifact ? "success" : undefined);
 
   const { pushNotification } = React.useContext(NotificationsContext);
 
@@ -71,8 +64,9 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
       title: "Removed binary file.",
       variant: "success",
     });
-    setFileUploadStatus("success");
-    setFileUploadProgress(100);
+    setFileUploadStatus(undefined);
+    setFileUploadProgress(undefined);
+    setValue("artifact", "");
   };
 
   const failedRemove = (error: AxiosError) => {
@@ -108,32 +102,11 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
         path: `binary/${droppedFiles[0].name}`,
         file: form,
       });
-      setValue("artifact", droppedFiles[0].name as string);
-      setCurrentFile(droppedFiles[0]);
+      setValue("artifact", droppedFiles[0]);
     }
   };
 
-  const handleDropRejected = (
-    files: File[],
-    _event: React.DragEvent<HTMLElement>
-  ) => {
-    if (files.length === 1) {
-      if (files[0].size > uploadLimitConverted) {
-        setModalText(
-          `${files[0].name} exceeds the file size limit of ${uploadLimit}.`
-        );
-      } else {
-        setModalText(`${files[0].name} is not an accepted file type`);
-      }
-    } else {
-      const rejectedMessages = files.reduce(
-        (acc, file) => (acc += `${file.name}, `),
-        ""
-      );
-      setModalText(`${rejectedMessages}are not accepted file types`);
-    }
-  };
-  const uploadLimitConverted =
+  const uploadLimitInBytes =
     parseInt(uploadLimit.slice(0, -1)) * Math.pow(1024, 2);
 
   const readFile = (file: File) => {
@@ -151,11 +124,12 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
   };
 
   const handleFile = (file: File) => {
-    readFile(file).catch((error: DOMException) => {
-      setCurrentFile(null);
-      setFileUploadProgress(0);
-      setFileUploadStatus("danger");
-    });
+    if (!artifact)
+      readFile(file).catch((error: DOMException) => {
+        setValue("artifact", "");
+        setFileUploadProgress(0);
+        setFileUploadStatus("danger");
+      });
   };
 
   return (
@@ -172,44 +146,34 @@ export const UploadBinary: React.FC<IUploadBinary> = ({ taskgroupID }) => {
         onFileDrop={handleFileDrop}
         dropzoneProps={{
           accept: ".war, .ear, .jar, .zip",
-          onDropRejected: handleDropRejected,
-          maxSize: uploadLimitConverted,
+          maxSize: uploadLimitInBytes,
         }}
       >
         <MultipleFileUploadMain
           titleIcon={<UploadIcon />}
           titleText="Drag and drop files here"
           titleTextSeparator="or"
-          infoText="Accepted file types: war, ear, jar or zip"
+          infoText={`Accepted file types: war, ear, jar or zip; Upload size limit: ${
+            uploadLimitInBytes / 1000
+          } Kilobyte`}
         />
-        {currentFile && (
+        {artifact && (
           <MultipleFileUploadStatusItem
-            file={currentFile}
-            key={currentFile.name}
+            file={artifact}
+            key={artifact.name}
+            customFileHandler={handleFile}
             onClearClick={() => {
               removeFile({
                 id: taskgroupID,
                 path: `binary/${artifact}`,
               });
-              setCurrentFile(null);
               setValue("artifact", "");
             }}
-            customFileHandler={handleFile}
+            progressAriaLabel={"text"}
             progressValue={fileUploadProgress}
             progressVariant={fileUploadStatus}
           />
         )}
-        <Modal
-          isOpen={!!modalText}
-          title="Unsupported file"
-          titleIconVariant="warning"
-          variant="medium"
-          showClose
-          aria-label="unsupported file upload attempted"
-          onClose={() => setModalText("")}
-        >
-          {modalText}
-        </Modal>
       </MultipleFileUpload>
     </>
   );

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -16,7 +16,7 @@ export type AnalysisScope = "app" | "app,oss" | "app,oss,select";
 
 export interface ModeStepValues {
   mode: AnalysisMode;
-  artifact: File | undefined;
+  artifact: File | undefined | null;
 }
 
 const useModeStepSchema = ({

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -16,7 +16,7 @@ export type AnalysisScope = "app" | "app,oss" | "app,oss,select";
 
 export interface ModeStepValues {
   mode: AnalysisMode;
-  artifact: string;
+  artifact: File;
 }
 
 const useModeStepSchema = ({
@@ -41,13 +41,7 @@ const useModeStepSchema = ({
           return analyzableApplications.length > 0;
         }
       ),
-    artifact: yup
-      .string()
-      .defined()
-      .when("mode", {
-        is: "binary-upload",
-        then: (schema) => schema.required(),
-      }),
+    artifact: yup.object() as yup.SchemaOf<File>,
   });
 };
 

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -16,7 +16,7 @@ export type AnalysisScope = "app" | "app,oss" | "app,oss,select";
 
 export interface ModeStepValues {
   mode: AnalysisMode;
-  artifact: File;
+  artifact: File | undefined;
 }
 
 const useModeStepSchema = ({
@@ -41,7 +41,10 @@ const useModeStepSchema = ({
           return analyzableApplications.length > 0;
         }
       ),
-    artifact: yup.object() as yup.SchemaOf<File>,
+    artifact: yup.mixed<File>().when("mode", {
+      is: "binary-upload",
+      then: (schema) => schema.required(),
+    }),
   });
 };
 


### PR DESCRIPTION
Fix status and progress when, in the wizard, after an initial binary upload, going back into that first step so uploaded file details are properly displayed.

Little refactor since more recent version of MultipleFileUpload automatically filters out file types and upload file size from `dropzoneProps`.

This introduces a slight visual change.
Effectively now instead of getting an error when the file is too big, no file bigger than the limit is permitted for upload.
Therefore the user needs to be informed upfront what's the upload size limit: 

![image](https://user-images.githubusercontent.com/1901741/200425477-db8c6fdb-01d7-4f09-850a-223b75690346.png)

https://issues.redhat.com/browse/TACKLE-861