### PR TITLE
docs: Development markdown docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ To install a Tackle2 cluster environment please refer to [Tackle documentation](
 ## Prerequisites
 
 - [NodeJS](https://nodejs.org/en/) >= 16.x
+- [minikube](https://minikube.sigs.k8s.io/docs/start) (optional): setup your local minikube instance with your container manager of choice. (Docker, Hyperkit, Hyper-V, KVM, Parallels, Podman, VirtualBox, or VMware Fusion/Workstation.)
 
 ## Getting Started
 
@@ -75,20 +76,18 @@ By default, Minikube uses the kvm driver with 6,000 MB of memory. This is not en
 
 Then, the following command will download a qcow2 image of Minikube and start a virtual machine from it. It will then wait for the Kubernetes API to be ready.
 
-`$ minikube start`
+`$ minikube start --addons=dashboard --addons=ingress --addons=olm`
 
-We need to enable the dashboard, ingress and olm addons. The dashboard addon installs the dashboard service that exposes the Kubernetes objects in a user interface. The ingress addon allows us to create Ingress CRs to expose the Tackle UI and Tackle Hub API. The olm addon allows us to use an operator to deploy Tackle.
-
-`$ minikube addons enable dashboard`
-`$ minikube addons enable ingress`
-`$ minikube addons enable olm`
+Note: We need to enable the dashboard, ingress and olm addons. The dashboard addon installs the dashboard service that exposes the Kubernetes objects in a user interface. The ingress addon allows us to create Ingress CRs to expose the Tackle UI and Tackle Hub API. The olm addon allows us to use an operator to deploy Tackle.
 
 The following command gives us the IP address assigned to the virtual machine created by Minikube.
 It's used when interacting with tackle UI image installed on the minikube cluster.
 
 ```
+
 $ minikube ip
 192.168.39.23
+
 ```
 
 ### Configuring kubectl (optional)
@@ -97,12 +96,45 @@ Minikube allows us to use the kubectl command with `minikube kubectl. To make th
 The following example shows how to do it for Bash on Fedora 35.
 
 ```
+
 $ mkdir -p ~/.bashrc.d
 $ cat << EOF > ~/.bashrc.d/minikube
 alias kubectl="minikube kubectl --"
 EOF
 $ source ~/.bashrc
+
 ```
+
+### Installing Tackle on Minikube or Kubernetes
+
+For installation on Kubernetes refer to [https://github.com/konveyor/tackle2-operator#readme](Tackle2 operator readme) file.
+
+Create a `konveyor-tackle` namespace and other supporting tackle resources including the tackle CRD.
+
+`kubectl apply -f https://raw.githubusercontent.com/konveyor/tackle2-operator/main/tackle-k8s.yaml `
+
+Deploy the tackle CR:
+
+Note: The below command will fail if the Tackle CRD is not yet established. This may take some time.
+
+```
+cat << EOF | kubectl apply -f -
+kind: Tackle
+apiVersion: tackle.konveyor.io/v1alpha1
+metadata:
+  name: tackle
+  namespace: konveyor-tackle
+spec:
+EOF
+```
+
+Note: If you wish to run tackle without keycloak authentication enabled, append the following field to the above tackle CR spec:
+
+`feature_auth_required: false`
+
+Wait few minutes to make sure tackle is fully deployed:
+
+`kubectl wait deployment tackle-keycloak-sso -n konveyor-tackle --for condition=Available --timeout=5m`
 
 ### Accessing the Kubernetes dashboard
 

--- a/development.md
+++ b/development.md
@@ -1,0 +1,66 @@
+# Development
+
+This document describes the process for running and developing tackle2-ui on your local computer.
+
+## Getting started
+
+Tackle2-ui can be developed using macOS(x86_64 only) or Linux environments.
+
+## React hooks
+
+Our project utilizes [Hooks](https://reactjs.org/docs/hooks-intro.html) wherever possible as this pattern has been proven and settled on in the react community. The hooks pattern is highly testable and provides a clear way to reuse stateful logic without overcomplicating components with complex lifecycle methods. Overall, we have largely left class components behind and have adopted functional components / hooks as the way forward.
+
+## Styling components
+
+For any custom styles, we use standard css with no preprocessors. If a custom style is needed, create a css file and import it within the component.
+For handling spacing/layout requirements that do not fit the standard PF mold, we are able to use the [Patternfly spacing utility classes](https://www.patternfly.org/v4/utilities/spacing).
+
+## Form development
+
+We are using [react-hook-form](https://react-hook-form.com) in tandem with [patternfly](https://www.patternfly.org/v4/). Custom wrapper components have been developed to aid with this integration and their usage can be referenced in the [proxy-form](./client/src/app/pages/proxies/proxy-form.tsx) component.
+
+### Steps to create a form
+
+- Create a TypeScript interface for all your form value keys/types
+
+```
+export interface FormValues {
+  formField: string;
+}
+```
+
+- Define a schema for your values using yup [example](https://github.com/konveyor/tackle2-ui/blob/main/client/src/app/pages/proxies/proxies-validation-schema.ts#L7-L67)
+
+  - For TypeScript to be happy, you may have to chain .defined() on some field schema types so it doesn't yell at you for e.g. Type `string | undefined` is not assignable to type `string`.
+
+  - You want to have your schema returned by a function beginning with the word use, so it can fit with the React Hooks conventions and call `useTranslation()` to get you the `t()` function for translated validation error messages. Or if the form is small enough you can just define the schema inline.
+
+- Call `useForm` (from react-hook-form) and pass it your interface as a `type` param. Pass it an object with `defaultValues`, `resolver: yupResolver(yourSchemaHere)`, and `mode: "onChange"` (this will revalidate when any field changes, as opposed to requiring manual imperative validation. We need this option for the way we render errors).
+
+  - `useForm` returns an object with a bunch of stuff. We usually destructure it in-place like you see here. Important things you'll need to pull out include `control`, probably `formState` if you need to block some buttons based on validation, `getValues` and `setValue` if you need to get/set anything manually (might not be necessary), and `watch` (more info on `watch` [here](https://react-hook-form.com/api/useform/watch/)) .
+
+    - Note: `watch` will not be needed if you are using least one controlled input field via our controller components below since the presence of a controlled input will cause RHF to auto-watch the form values anyway.
+
+- Write an onSubmit function of type `SubmitHandler<YourValuesInterface>`. Wrap your form fields in a PF `<Form>` component with `onSubmit={handleSubmit(onSubmit)}` where `handleSubmit` came from your `useForm` call. That's where you'll eventually want to do the submit logic, probably using [mutations](https://tanstack.com/query/v4/docs/guides/mutations) from react-query.
+
+### react-hook-form / wrapper component usage
+
+- Now you can use our new components for the fields themselves. They will take care of rendering the PF FormGroups and properly styled validation errors. Pass them the `control` prop from your `useForm` call and a name string prop matching the field name key from your form values object. TS is smart enough to infer the right field value type from those 2 props.
+
+  - If you're rendering a basic text input, you can use `HookFormPFTextInput` ([source](https://github.com/konveyor/tackle2-ui/blob/main/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-text-area.tsx), [example](https://github.com/konveyor/tackle2-ui/blob/main/client/src/app/pages/proxies/proxy-form.tsx#L372-L378)). It extends the props of PatternFly's [TextInput](https://www.patternfly.org/v4/components/text-input), so you can pass whatever extra stuff you need directly into it.
+
+  - Same for a multi-line textarea, you can use `HookFormPFTextArea` ([source](https://github.com/konveyor/tackle2-ui/blob/main/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-group-controller.tsx), [example](https://github.com/konveyor/tackle2-ui/blob/main/client/src/app/pages/proxies/proxy-form.tsx#L257-L282)) which extends the props of PF [TextArea](https://www.patternfly.org/v4/components/text-area).
+
+  - For any other type of field that requires a PF `FormGroup` (label, error messages under the field) you can use the `HookFormPFGroupController` that is used internally by those 2 components, and pass it your own `renderField` function. (source, example). For select dropdowns we have a simplified abstraction called [SimpleSelect](https://github.com/konveyor/tackle2-ui/blob/main/client/src/app/shared/components/simple-select/simple-select.tsx).
+
+  - These all use the Controller pattern from react-hook-form (docs [here](https://react-hook-form.com/get-started#IntegratingwithUIlibraries) and [here](https://react-hook-form.com/api/usecontroller/controller)). You generally don't want to use the `{...register('fieldName')}` approach that is all over their docs, it is for uncontrolled inputs (we need controlled inputs to render errors on change).
+  - All of the above components include a formGroupProps prop in case you need to override any of the [props for PF's FormGroup](https://www.patternfly.org/v4/components/form#formgroup) that aren't taken care of for you.
+
+- If you don't need a `FormGroup` around your field (no external label or errors), you can just render a <Controller> for it yourself. That's what we do for [Switch](https://www.patternfly.org/v4/components/switch) fields (because switch has a built in right-aligned label). ([example](https://github.com/konveyor/tackle2-ui/blob/main/client/src/app/pages/proxies/proxy-form.tsx#L286-L300))
+
+## READMEs
+
+For more info about working on the Tackle 2.x UI, check out these READMEs:
+
+- [tests.md](./tests.md)
+- [internationalization.md](./INTERNATIONALIZATION.md)


### PR DESCRIPTION
These docs are intended to improve the developer onboarding experience and should serve as a reference point for all development questions including start up guide, forms, testing,  directory structure, styling, and more. 