### PR TITLE
Refactor taskGroup handling

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -72,6 +72,13 @@ const defaultTaskData: TaskData = {
   },
 };
 
+const defaultTaskgroup: Taskgroup = {
+  name: "",
+  addon: "",
+  data: defaultTaskData,
+  tasks: [],
+};
+
 const initTask = (application: Application): TaskgroupTask => {
   return {
     name: `${application.name}.${application.id}.windup`,
@@ -205,12 +212,6 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
 
   const { mode, withKnown, hasExcludedPackages } = values;
   const hasIncludedPackages = withKnown.includes("select");
-  const defaultTaskgroup = {
-    name: "",
-    addon: "",
-    data: defaultTaskData,
-    tasks: [],
-  };
 
   const setupTaskgroup = (
     taskgroup: Taskgroup,

--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -104,8 +104,7 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
       title: "Taskgroup creation failed",
       variant: "danger",
     });
-    // TODO
-    //onClose();
+    onClose();
   };
 
   const { mutate: createTaskgroup } = useCreateTaskgroupMutation(

--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -290,12 +290,7 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
   const analyzableApplications = useAnalyzableApplications(applications, mode);
 
   const onModeChange = (mode: AnalysisMode) => {
-    if (
-      values.mode !== mode &&
-      createdTaskgroup &&
-      createdTaskgroup?.id &&
-      createdTaskgroup.id > 0
-    ) {
+    if (values.mode !== mode && createdTaskgroup && createdTaskgroup?.id) {
       deleteTaskgroup(createdTaskgroup.id);
       createTaskgroup(setupTaskgroup(defaultTaskgroup, values));
     }

--- a/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
@@ -6,7 +6,7 @@ import { OptionWithValue, SimpleSelect } from "@app/shared/components";
 import { UploadBinary } from "./components/upload-binary";
 import { toOptionLike } from "@app/utils/model-utils";
 import { AnalysisMode, AnalysisWizardFormValues } from "./schema";
-import { Mode, useFormContext } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import { HookFormPFGroupController } from "@app/shared/components/hook-form-pf-fields";
 
 interface ISetMode {

--- a/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
@@ -6,19 +6,21 @@ import { OptionWithValue, SimpleSelect } from "@app/shared/components";
 import { UploadBinary } from "./components/upload-binary";
 import { toOptionLike } from "@app/utils/model-utils";
 import { AnalysisMode, AnalysisWizardFormValues } from "./schema";
-import { useFormContext } from "react-hook-form";
+import { Mode, useFormContext } from "react-hook-form";
 import { HookFormPFGroupController } from "@app/shared/components/hook-form-pf-fields";
 
 interface ISetMode {
   isSingleApp: boolean;
   taskgroupID: number | null;
   isModeValid: boolean;
+  onModeChange: (value: AnalysisMode) => void;
 }
 
 export const SetMode: React.FC<ISetMode> = ({
   isSingleApp,
   taskgroupID,
   isModeValid,
+  onModeChange,
 }) => {
   const { t } = useTranslation();
 
@@ -75,6 +77,7 @@ export const SetMode: React.FC<ISetMode> = ({
             onChange={(selection) => {
               const option = selection as OptionWithValue<AnalysisMode>;
               setValue(name, option.value);
+              onModeChange(option.value);
             }}
             options={options}
           />

--- a/client/src/app/queries/taskgroups.ts
+++ b/client/src/app/queries/taskgroups.ts
@@ -15,12 +15,8 @@ export const useCreateTaskgroupMutation = (
   onError: (err: Error | unknown) => void
 ) =>
   useMutation(createTaskgroup, {
-    onSuccess: (data) => {
-      onSuccess(data);
-    },
-    onError: (err) => {
-      onError(err);
-    },
+    onSuccess,
+    onError,
   });
 
 export const useSubmitTaskgroupMutation = (
@@ -76,9 +72,7 @@ export const useDeleteTaskgroupMutation = (
   const queryClient = useQueryClient();
 
   return useMutation(deleteTaskgroup, {
-    onSuccess: () => {
-      onSuccess();
-    },
+    onSuccess,
     onError: (err) => {
       onError(err);
       queryClient.invalidateQueries("tasks");


### PR DESCRIPTION
Taskgroup deletion and recreation is now handled by `onModeChange()`  which is passed down to set-mode" component in order to avoid using `useEffect()`.

The initialization of the first taskgroup is handled only first time by initial useEffect().