### PR TITLE
Not require Accept header in API Proxy

### DIFF
--- a/server/setupProxy.js
+++ b/server/setupProxy.js
@@ -28,7 +28,7 @@ module.exports = function (app) {
       },
       onProxyRes: (proxyRes, req, res) => {
         const includesJsonHeaders =
-          req.headers.accept.includes("application/json");
+          req.headers.accept?.includes("application/json");
         if (
           (!includesJsonHeaders && proxyRes.statusCode === 401) ||
           (!includesJsonHeaders && proxyRes.statusMessage === "Unauthorized")


### PR DESCRIPTION
Proxy response handler expected Accept header to check if it is "application/json", Maayan reported failure in this code when the Accept header was ommited (and the request was fulfilled by backend hub API). Adding safe navigation operator to Accept headers lookup.

Signed-off-by: Marek Aufart <maufart@redhat.com>