### PR TITLE
QE: Add missing toggle IDs for dropdowns  

### DIFF
--- a/client/src/app/pages/applications/application-assessment/components/stakeholders-form/stakeholders-form.tsx
+++ b/client/src/app/pages/applications/application-assessment/components/stakeholders-form/stakeholders-form.tsx
@@ -71,6 +71,7 @@ export const StakeholdersForm: React.FC<StakeholdersFormProps> = () => {
                 }}
                 selectConfig={{
                   variant: "typeaheadmulti",
+                  toggleId: "stakeholders-toggle",
                   "aria-label": "stakeholders",
                   "aria-describedby": "stakeholders",
                   typeAheadAriaLabel: "stakeholders",
@@ -101,6 +102,7 @@ export const StakeholdersForm: React.FC<StakeholdersFormProps> = () => {
                 }}
                 selectConfig={{
                   variant: "typeaheadmulti",
+                  toggleId: "stakeholder-groups-toggle",
                   "aria-label": "stakeholder groups",
                   "aria-describedby": "stakeholder-groups",
                   typeAheadAriaLabel: "stakeholder-groups",

--- a/client/src/app/pages/applications/application-review/components/review-form/review-form.tsx
+++ b/client/src/app/pages/applications/application-review/components/review-form/review-form.tsx
@@ -197,6 +197,7 @@ export const ReviewForm: React.FC<IReviewFormProps> = ({
             fieldConfig={{ name: "action" }}
             selectConfig={{
               variant: "typeahead",
+              toggleId: "action-toggle",
               "aria-label": "action",
               "aria-describedby": "action",
               placeholderText: t("terms.select"),
@@ -219,6 +220,7 @@ export const ReviewForm: React.FC<IReviewFormProps> = ({
             fieldConfig={{ name: "effort" }}
             selectConfig={{
               variant: "typeahead",
+              toggleId: "effort-toggle",
               "aria-label": "effort",
               "aria-describedby": "effort",
               placeholderText: t("terms.select"),

--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -483,6 +483,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
                 data-testid="business-service-select"
                 selectConfig={{
                   variant: "typeahead",
+                  toggleId: "business-service-toggle",
                   "aria-label": "Select business service",
                   "aria-describedby": "business-service-select-input",
                   typeAheadAriaLabel: "business-service-dropdown",
@@ -517,6 +518,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
                 }}
                 selectConfig={{
                   variant: "typeaheadmulti",
+                  toggleId: "tags",
                   "aria-label": "tags",
                   "aria-describedby": "tags",
                   typeAheadAriaLabel: "tags",

--- a/client/src/app/pages/applications/components/application-identity-form/application-identity-form.tsx
+++ b/client/src/app/pages/applications/components/application-identity-form/application-identity-form.tsx
@@ -205,6 +205,7 @@ export const ApplicationIdentityForm: React.FC<
             fieldConfig={{ name: SOURCE_CREDENTIALS }}
             selectConfig={{
               variant: "typeahead",
+              toggleId: "source-credentials-toggle",
               "aria-label": "source credentials",
               "aria-describedby": "sourceCredentials",
               typeAheadAriaLabel: "sourceCredentials",
@@ -226,6 +227,7 @@ export const ApplicationIdentityForm: React.FC<
             fieldConfig={{ name: MAVEN_SETTINGS }}
             selectConfig={{
               variant: "typeahead",
+              toggleId: "maven-settings-toggle",
               "aria-label": "maven settings",
               "aria-describedby": "mavenSettings",
               typeAheadAriaLabel: "mavenSettings",

--- a/client/src/app/pages/controls/business-services/components/business-service-form/business-service-form.tsx
+++ b/client/src/app/pages/controls/business-services/components/business-service-form/business-service-form.tsx
@@ -209,6 +209,7 @@ export const BusinessServiceForm: React.FC<BusinessServiceFormProps> = ({
             fieldConfig={{ name: "owner" }}
             selectConfig={{
               variant: "typeahead",
+              toggleId: "owner-toggle",
               "aria-label": "owner",
               "aria-describedby": "owner",
               typeAheadAriaLabel: "owner",

--- a/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
+++ b/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
@@ -238,8 +238,8 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
           <SingleSelectFetchOptionValueFormikField<JobFunction>
             fieldConfig={{ name: "jobFunction" }}
             selectConfig={{
-              toggleId: "job-function-toggle",
               variant: "typeahead",
+              toggleId: "job-function-toggle",
               "aria-label": "Job function",
               "aria-describedby": "job-function",
               typeAheadAriaLabel: "job-function",

--- a/client/src/app/pages/controls/tags/components/tag-type-form/tag-type-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-type-form/tag-type-form.tsx
@@ -192,8 +192,8 @@ export const TagTypeForm: React.FC<TagTypeFormProps> = ({
           <SingleSelectOptionValueFormikField<string>
             fieldConfig={{ name: "color" }}
             selectConfig={{
-              toggleId: "color-toggle",
               variant: "single",
+              toggleId: "color-toggle",
               "aria-label": "color",
               "aria-describedby": "color",
               typeAheadAriaLabel: "color",

--- a/client/src/app/shared/components/confirm-dialog/confirm-dialog.tsx
+++ b/client/src/app/shared/components/confirm-dialog/confirm-dialog.tsx
@@ -69,6 +69,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
 
   return (
     <Modal
+      id="confirm-dialog"
       variant={ModalVariant.small}
       title={title}
       titleIconVariant={titleIconVariant}

--- a/client/src/app/shared/components/confirm-dialog/tests/__snapshots__/confirm-dialog.test.tsx.snap
+++ b/client/src/app/shared/components/confirm-dialog/tests/__snapshots__/confirm-dialog.test.tsx.snap
@@ -19,13 +19,13 @@ Object {
           <div
             aria-describedby="pf-modal-part-2"
             aria-label="Confirm dialog"
-            aria-labelledby="pf-modal-part-0 pf-modal-part-1"
+            aria-labelledby="confirm-dialog pf-modal-part-1"
             aria-modal="true"
             class="pf-c-modal-box pf-m-sm"
             data-ouia-component-id="OUIA-Generated-Modal-small-1"
             data-ouia-component-type="PF4/ModalContent"
             data-ouia-safe="true"
-            id="pf-modal-part-0"
+            id="confirm-dialog"
             role="dialog"
           >
             <button


### PR DESCRIPTION
This adds a unique ID for the selector dropdowns to help avoid selector conflicts with pf autogenerated IDs. 