### PR TITLE
:sparkles: Bump nodejs to version 18.x 

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Builder image
-FROM registry.access.redhat.com/ubi9/nodejs-16 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-18 as builder
 USER 0
 COPY . .
 WORKDIR "/opt/app-root/src" 
 RUN npm install -w client && npm run build -w client && rm -rf node_modules && npm install -w server
 
 # Runner image
-FROM registry.access.redhat.com/ubi9/nodejs-16-minimal
+FROM registry.access.redhat.com/ubi9/nodejs-18-minimal
 
 # Add ps package to allow liveness probe for k8s cluster
 # Add tar package to allow copying files with kubectl scp
@@ -27,7 +27,7 @@ LABEL name="konveyor/tackle2-ui" \
       io.k8s.display-name="tackle2-ui" \
       io.k8s.description="Konveyor for Tackle - User Interface" \
       io.openshift.expose-services="80:http" \
-      io.openshift.tags="operator,konveyor,ui,nodejs16" \
+      io.openshift.tags="operator,konveyor,ui,nodejs18" \
       io.openshift.min-cpu="100m" \
       io.openshift.min-memory="350Mi"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Builder image
-FROM registry.access.redhat.com/ubi9/nodejs-18 as builder
+FROM registry.access.redhat.com/ubi8/nodejs-18 as builder
 USER 0
 COPY . .
 WORKDIR "/opt/app-root/src" 
 RUN npm install -w client && npm run build -w client && rm -rf node_modules && npm install -w server
 
 # Runner image
-FROM registry.access.redhat.com/ubi9/nodejs-18-minimal
+FROM registry.access.redhat.com/ubi8/nodejs-18-minimal
 
 # Add ps package to allow liveness probe for k8s cluster
 # Add tar package to allow copying files with kubectl scp


### PR DESCRIPTION
From nodejs version 18.x, [LTS support started with 18.12.1](https://nodejs.org/en/download/releases/).

This makes the build based on ubi8/nodejs-18 (building image) and ubi8/nodejs18-minimal (Runtime pod) - Both are currently based on nodejs 18.12.1) 

The same is also supported on UBI9 allowing to benefit from latest features and performances from Red Hat Entreprise Linux 9.