### PR TITLE
:seedling: Versioning and PR title enforcement

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,18 @@
+name: PR Checks
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    name: Verify PR contents
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Check Title
+      id: verifier
+      uses: konveyor/release-tools/cmd/verify-pr@main
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,6 @@
+Versioning
+==========
+
+We follow the versioning guidelines laid out in [Konveyor's Versioning
+Guidelines](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md)
+unless otherwise noted below.


### PR DESCRIPTION
This adds the workflow for enforcing our PR title convention laid out in the konveyor/release-tools versioning guidelines. Additionally, we add a link to the konveyor/release-tools versioning guidelines as the baseline for this project's versioning rules/guidelines.

Signed-off-by: David Zager <david.j.zager@gmail.com>