### PR TITLE
:bug: : Replace keycloak deprecated stanza

### DIFF
--- a/client/src/app/keycloak.ts
+++ b/client/src/app/keycloak.ts
@@ -11,5 +11,5 @@ const config: KeycloakConfig = {
   clientId: ENV.KEYCLOAK_CLIENT_ID || "tackle-ui",
 };
 
-const keycloak = Keycloak(config);
+const keycloak = new Keycloak(config);
 export default keycloak;


### PR DESCRIPTION
Uses `new Keycloak()` 

```
@deprecated — Construct a Keycloak instance using the new keyword instead.

The signature '(config?: string | KeycloakConfig | undefined): Keycloak' of 'Keycloak' is deprecated.ts(6387)
keycloak.d.ts(348, 4): The declaration was marked as deprecated here.
```