### PR TITLE
:bug: Update to UBI9 to fix arm64 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Builder image
-FROM registry.access.redhat.com/ubi8/nodejs-16 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-16 as builder
 USER 0
 COPY . .
 WORKDIR "/opt/app-root/src" 
 RUN npm install -w client && npm run build -w client && rm -rf node_modules && npm install -w server
 
 # Runner image
-FROM registry.access.redhat.com/ubi8/nodejs-16-minimal
+FROM registry.access.redhat.com/ubi9/nodejs-16-minimal
 
 # Add ps package to allow liveness probe for k8s cluster
 # Add tar package to allow copying files with kubectl scp


### PR DESCRIPTION
Signed-off-by: Jason Montleon <jmontleo@redhat.com>

I know we weren't in a hurry to do this, however multi arch builds are experiencing odd failures on arm64 using UBI8.
https://github.com/konveyor/tackle2-ui/actions/runs/4168992831/jobs/7216425953#step:2:1067
https://github.com/konveyor/tackle2-ui/actions/runs/4174604421/jobs/7228394767#step:2:1077

I can reproduce much of this locally, and was able to workaround it using UBI9 node16 and node18 images without a problem both locally and within github actions:
https://github.com/jmontleon/tackle2-ui/actions/runs/4175222062/jobs/7229841318
https://quay.io/repository/jmontleon/tackle2-ui?tab=tags

I've opened an issue with qemu-user-static to see if there are any known issues we might be hitting, or other debugging  steps we can try to resolve the issue, but this is probably our best bet to move on at the moment.
https://github.com/multiarch/qemu-user-static/issues/185

