### PR TITLE
:bug: Fix empty assessments query error in console

### DIFF
--- a/client/src/app/pages/migration-targets/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/custom-target-form.tsx
@@ -224,20 +224,6 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
     onUpdateRuleBundleFailure
   );
 
-  //
-  const values = getValues();
-  console.log("values", values);
-  console.log(
-    "errors",
-    errors,
-    isSubmitting,
-    isValidating,
-    isValid,
-    isDirty,
-    touchedFields,
-    isLoading
-  );
-
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
       <HookFormPFTextInput

--- a/client/src/app/queries/assessments.ts
+++ b/client/src/app/queries/assessments.ts
@@ -31,7 +31,7 @@ export const useFetchApplicationAssessments = (
           applicationId: application.id,
         });
         const allAssessmentsForApp = response.data;
-        return allAssessmentsForApp[0];
+        return allAssessmentsForApp[0] || [];
       },
       onError: (error: any) => console.log("error, ", error),
     })),


### PR DESCRIPTION
- Assessments query needs a default return value when no assessments exist for an app. 