### PR TITLE
:bug: Fix regression with form validation messages not being shown 

### DIFF
--- a/client/src/app/pages/identities/components/update-identity-modal/update-identity-modal.tsx
+++ b/client/src/app/pages/identities/components/update-identity-modal/update-identity-modal.tsx
@@ -5,6 +5,7 @@ import { Modal, ModalVariant } from "@patternfly/react-core";
 
 import { Identity } from "@app/api/models";
 import { IdentityForm } from "../identity-form";
+import { validateXML } from "../identity-form/validateXML";
 
 export interface UpdateIdentityModalProps {
   identity?: Identity;
@@ -24,7 +25,12 @@ export const UpdateIdentityModal: React.FC<UpdateIdentityModalProps> = ({
       isOpen={!!identity}
       onClose={onCancel}
     >
-      <IdentityForm identity={identity} onSaved={onSaved} onCancel={onCancel} />
+      <IdentityForm
+        identity={identity}
+        onSaved={onSaved}
+        onCancel={onCancel}
+        xmlValidator={validateXML}
+      />
     </Modal>
   );
 };

--- a/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-group-controller.tsx
+++ b/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-group-controller.tsx
@@ -59,6 +59,7 @@ export const HookFormPFGroupController = <
           fieldId={fieldId}
           className={className}
           isRequired={isRequired}
+          onBlur={field.onBlur}
           validated={
             errorsSuppressed
               ? "default"


### PR DESCRIPTION
- Adds onBlur method to  hook-form-pf-group-controller component to fix missing validation
- Adds missing xmlValidation prop for edit identity form