### PR TITLE
:bug: Aggregate target sources

### DIFF
--- a/client/src/app/components/target-card.tsx
+++ b/client/src/app/components/target-card.tsx
@@ -31,6 +31,7 @@ export interface TargetCardProps {
   cardSelected?: boolean;
   isEditable?: boolean;
   onCardClick?: (isSelecting: boolean, value: string) => void;
+  onSelectedCardTargetChange?: (value: string) => void;
   handleProps?: any;
   readOnly?: boolean;
   onEdit?: () => void;
@@ -46,6 +47,7 @@ export const TargetCard: React.FC<TargetCardProps> = ({
   readOnly,
   cardSelected,
   onCardClick,
+  onSelectedCardTargetChange,
   handleProps,
   onEdit,
   onDelete,
@@ -74,6 +76,11 @@ export const TargetCard: React.FC<TargetCardProps> = ({
     event.stopPropagation();
     setRuleTargetSelectOpen(false);
     setSelectedRuleTarget(selection as string);
+
+    //update the formTargets if this card is selected
+    if (isCardSelected && onSelectedCardTargetChange) {
+      onSelectedCardTargetChange(selection as string);
+    }
   };
 
   const getImage = (): React.ComponentType => {

--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -27,7 +27,7 @@ export const SetOptions: React.FC = () => {
   const { watch, control, setValue } =
     useFormContext<AnalysisWizardFormValues>();
 
-  const { formSources, diva, excludedRulesTags } = watch();
+  const { formSources, formTargets, diva, excludedRulesTags } = watch();
 
   const [isSelectTargetsOpen, setSelectTargetsOpen] = React.useState(false);
   const [isSelectSourcesOpen, setSelectSourcesOpen] = React.useState(false);

--- a/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -36,12 +36,42 @@ export const SetTargets: React.FC = () => {
   const { watch, setValue } = useFormContext<AnalysisWizardFormValues>();
   const formTargets = watch("formTargets");
   const formRuleBundles = watch("formRuleBundles");
+  const formSources = watch("formSources");
+
+  const handleOnSelectedCardTargetChange = (
+    selectedRuleTarget: string,
+    selectedRuleBundle: RuleBundle
+  ) => {
+    const otherSelectedRuleTargets = formTargets.filter(
+      (formTarget) =>
+        !selectedRuleBundle.rulesets
+          .map((rule) => rule.metadata.target)
+          .includes(formTarget)
+    );
+    const definedSelectedTargets: string[] =
+      selectedRuleBundle.kind === "category"
+        ? [selectedRuleTarget]
+        : selectedRuleBundle.rulesets
+            .map((rulesets) => rulesets?.metadata?.target || "")
+            .filter((target) => !!target);
+
+    setValue("formTargets", [
+      ...otherSelectedRuleTargets,
+      ...definedSelectedTargets,
+    ]);
+  };
 
   const handleOnCardClick = (
     isSelecting: boolean,
     selectedRuleTarget: string,
     selectedRuleBundle: RuleBundle
   ) => {
+    const otherSelectedRuleSources = formSources.filter(
+      (formSource) =>
+        !selectedRuleBundle.rulesets
+          .map((rule) => rule.metadata.source)
+          .includes(formSource)
+    );
     const otherSelectedRuleTargets = formTargets.filter(
       (formTarget) =>
         !selectedRuleBundle.rulesets
@@ -58,20 +88,37 @@ export const SetTargets: React.FC = () => {
     };
 
     if (isSelecting) {
+      const definedSelectedSources: string[] = selectedRuleBundle.rulesets
+        .map((rulesets) => rulesets?.metadata?.source || "")
+        .filter((source) => !!source);
+
+      setValue("formSources", [
+        ...otherSelectedRuleSources,
+        ...definedSelectedSources,
+      ]);
+
+      const definedSelectedTargets: string[] =
+        selectedRuleBundle.kind === "category"
+          ? [selectedRuleTarget]
+          : selectedRuleBundle.rulesets
+              .map((rulesets) => rulesets?.metadata?.target || "")
+              .filter((target) => !!target);
+
       setValue("formTargets", [
         ...otherSelectedRuleTargets,
-        selectedRuleTarget,
+        ...definedSelectedTargets,
       ]);
+
       setValue("formRuleBundles", [
         ...otherSelectedRuleBundles,
         selectedRuleBundleRef,
       ]);
     } else {
+      setValue("formSources", otherSelectedRuleSources);
       setValue("formTargets", otherSelectedRuleTargets);
       setValue("formRuleBundles", otherSelectedRuleBundles);
     }
   };
-
   return (
     <Form
       onSubmit={(event) => {
@@ -95,9 +142,15 @@ export const SetTargets: React.FC = () => {
                 <TargetCard
                   readOnly
                   item={matchingRuleBundle}
-                  cardSelected={matchingRuleBundle.rulesets.some((ruleset) =>
-                    formTargets.includes(ruleset.metadata.target)
-                  )}
+                  cardSelected={formRuleBundles
+                    .map((formRuleBundle) => formRuleBundle.name)
+                    .includes(matchingRuleBundle.name)}
+                  onSelectedCardTargetChange={(selectedRuleTarget: string) => {
+                    handleOnSelectedCardTargetChange(
+                      selectedRuleTarget,
+                      matchingRuleBundle
+                    );
+                  }}
                   onCardClick={(
                     isSelecting: boolean,
                     selectedRuleTarget: string


### PR DESCRIPTION
- Aggregates all sources and targets from selected rule bundles and sets the source/target field values accordingly. 
- This required the cardSelected check to change from the target values to the ruleBundle values to allow multiple targets to be assigned from a single rulebundle (in the case of a custom target). 
- Fixes a bug when the formTargets were not being updated when a selected card's target dropdown value changes. Before the targets were only updated on card click. 