### PR TITLE
:bug: AppTable `onRowClick`: Fix click propagation issue where buttons in the row trigger the drawer

### DIFF
--- a/client/src/app/shared/components/app-table/app-table.tsx
+++ b/client/src/app/shared/components/app-table/app-table.tsx
@@ -142,10 +142,27 @@ export const AppTable: React.FC<IAppTableProps> = ({
       <TableHeader />
       <TableBody
         onRowClick={(event, row) => {
-          // Only open the details pane if we click outside the row's checkbox
+          // Check if there is a clickable element between the event target and the row such as a
+          // checkbox, button or link. Don't trigger the row click if those are clicked.
+          // This recursive parent check is necessary because the event target could be,
+          // for example, the SVG icon inside a button rather than the button itself.
+          const isClickableElementInTheWay = (element: Element): boolean => {
+            if (
+              ["input", "button", "a"].includes(element.tagName.toLowerCase())
+            ) {
+              return true;
+            }
+            if (
+              !element.parentElement ||
+              element.parentElement?.tagName.toLowerCase() === "tr"
+            ) {
+              return false;
+            }
+            return isClickableElementInTheWay(element.parentElement);
+          };
           if (
             event.target instanceof Element &&
-            event.target.tagName.toLowerCase() !== "input"
+            !isClickableElementInTheWay(event.target)
           ) {
             onAppClick?.(row[ENTITY_FIELD] || null);
           }


### PR DESCRIPTION
The straightforward fix for this would have been to add `event.stopPropagation()` on the click handlers for each of these buttons in the row that are causing the problem, but then if we add more buttons in the future we would need to remember to do this for those as well or the bug would come back. I tried to implement a future-proof fix for this instead: Any click that is either on an `input`, `button` or `a` element or that is on a child/descendant of one of those elements will not trigger the `onRowClick` that opens the drawer.