### PR TITLE
:sparkles: Custom targets: Remove unused RBAC scopes

### DIFF
--- a/client/src/app/rbac.ts
+++ b/client/src/app/rbac.ts
@@ -66,9 +66,6 @@ export const adminWriteScopes = [
   "proxies:put",
   "proxies:post",
   "proxies:delete",
-  "customTargets:put",
-  "customTargets:post",
-  "customTargets:delete",
 ];
 
 export const controlsWriteScopes = [


### PR DESCRIPTION
The Administration routes are authorized based upon the user's role in RouteWrapper
Therefore there is no need to create scope for customTargets.
Removing previously defined scopes which don't have a match in the hub since where there were never created.

Resolves https://github.com/konveyor/tackle2-ui/issues/608