### PR TITLE
:sparkles: App detail drawer: group tags by source and category, add filters

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -272,6 +272,7 @@
     "settingsAllowApps": "Allow reviewing applications without running an assessment first",
     "settingsCSVReports": "Enable downloads for CSV reports",
     "settingsHTMLReports": "Enable downloads for HTML reports",
+    "source": "Source",
     "sourceBranch": "Branch",
     "sourceCode": "Source code",
     "sourceRepo": "Source Repository",

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -79,12 +79,7 @@ export const ApplicationDetailDrawer: React.FC<
           {detailsTabMainContent}
         </Tab>
         <Tab eventKey={TabKey.Tags} title={<TabTitleText>Tags</TabTitleText>}>
-          <TextContent className={spacing.mtMd}>
-            <Text component="small">
-              {/* TODO(mturley): group tabs by source and tag-type, add filter dropdowns */}
-              {application && <ApplicationTags application={application} />}
-            </Text>
-          </TextContent>
+          {application && <ApplicationTags application={application} />}
         </Tab>
         {reportsTabContent && (
           <Tab

--- a/client/src/app/pages/applications/components/application-tags/application-tags.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tags.tsx
@@ -12,8 +12,7 @@ import {
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
-import toggleGroupStyles from "@patternfly/react-styles/css/components/ToggleGroup/toggle-group";
-import { FilterIcon } from "@patternfly/react-icons";
+import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
 import { DEFAULT_COLOR_LABELS } from "@app/Constants";
 import { ConditionalRender } from "@app/shared/components";
 import { Application, Tag, TagCategory } from "@app/api/models";
@@ -172,14 +171,15 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
     <ConditionalRender when={isFetching} then={<Spinner isSVG size="md" />}>
       <Toolbar
         clearAllFilters={() => setFilterValues({})}
-        clearFiltersButtonText="Clear filters"
+        clearFiltersButtonText={t("actions.clearAllFilters")}
       >
-        <ToolbarContent>
+        <ToolbarContent className={spacing.p_0}>
           <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
             <FilterToolbar<TagWithSource>
               filterCategories={filterCategories}
               filterValues={filterValues}
               setFilterValues={setFilterValues}
+              showFiltersSideBySide
             />
           </ToolbarToggleGroup>
         </ToolbarContent>

--- a/client/src/app/pages/applications/components/application-tags/application-tags.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tags.tsx
@@ -6,9 +6,14 @@ import {
   Spinner,
   TextContent,
   Text,
+  Toolbar,
+  ToolbarContent,
+  ToolbarToggleGroup,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
+import toggleGroupStyles from "@patternfly/react-styles/css/components/ToggleGroup/toggle-group";
+import { FilterIcon } from "@patternfly/react-icons";
 import { DEFAULT_COLOR_LABELS } from "@app/Constants";
 import { ConditionalRender } from "@app/shared/components";
 import { Application, Tag, TagCategory } from "@app/api/models";
@@ -126,6 +131,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
         .sort(compareSources)
         .map((source) => source || "Manual")
         .map((source) => ({ key: source, value: source })),
+      logicOperator: "OR",
     },
     {
       key: "tagCategory",
@@ -142,6 +148,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
           key: tagCategoryName,
           value: tagCategoryName,
         })),
+      logicOperator: "OR",
     },
   ];
 
@@ -163,11 +170,21 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
 
   return (
     <ConditionalRender when={isFetching} then={<Spinner isSVG size="md" />}>
-      <FilterToolbar<TagWithSource>
-        filterCategories={filterCategories}
-        filterValues={filterValues}
-        setFilterValues={setFilterValues}
-      />
+      <Toolbar
+        clearAllFilters={() => setFilterValues({})}
+        clearFiltersButtonText="Clear filters"
+      >
+        <ToolbarContent>
+          <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+            <FilterToolbar<TagWithSource>
+              filterCategories={filterCategories}
+              filterValues={filterValues}
+              setFilterValues={setFilterValues}
+            />
+          </ToolbarToggleGroup>
+        </ToolbarContent>
+      </Toolbar>
+
       {Array.from(tagsBySource.keys())
         .sort(compareSources)
         .map((source) => {

--- a/client/src/app/pages/applications/components/application-tags/application-tags.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tags.tsx
@@ -9,6 +9,7 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarToggleGroup,
+  ToolbarItem,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
@@ -122,9 +123,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
       key: "source",
       title: t("terms.source"),
       type: FilterType.multiselect,
-      placeholderText: `${t("actions.filterBy", {
-        what: t("terms.source").toLowerCase(),
-      })}...`,
+      placeholderText: t("terms.source"),
       getItemValue: (tag) => tag.source || "Manual",
       selectOptions: Array.from(sources)
         .sort(compareSources)
@@ -136,9 +135,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
       key: "tagCategory",
       title: t("terms.tagCategory"),
       type: FilterType.multiselect,
-      placeholderText: `${t("actions.filterBy", {
-        what: t("terms.tagCategory").toLowerCase(),
-      })}...`,
+      placeholderText: t("terms.tagCategory"),
       getItemValue: (tag) => tag.category?.name || "",
       selectOptions: Array.from(tagCategoriesById.values())
         .map((tagCategory) => tagCategory.name)
@@ -174,6 +171,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
         clearFiltersButtonText={t("actions.clearAllFilters")}
       >
         <ToolbarContent className={spacing.p_0}>
+          <ToolbarItem>Filter by:</ToolbarItem>
           <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
             <FilterToolbar<TagWithSource>
               filterCategories={filterCategories}

--- a/client/src/app/shared/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/shared/components/FilterToolbar/FilterToolbar.tsx
@@ -32,6 +32,7 @@ export interface IBasicFilterCategory<T> {
 
 export interface IMultiselectFilterCategory<T> extends IBasicFilterCategory<T> {
   selectOptions: OptionPropsWithKey[];
+  logicOperator?: "AND" | "OR";
 }
 
 export interface ISelectFilterCategory<T> extends IBasicFilterCategory<T> {
@@ -43,8 +44,9 @@ export interface ISearchFilterCategory<T> extends IBasicFilterCategory<T> {
 }
 
 export type FilterCategory<T> =
-  | ISearchFilterCategory<T>
-  | ISelectFilterCategory<T>;
+  | IMultiselectFilterCategory<T>
+  | ISelectFilterCategory<T>
+  | ISearchFilterCategory<T>;
 
 export interface IFilterValues {
   [categoryKey: string]: FilterValue;

--- a/client/src/app/shared/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/shared/components/FilterToolbar/FilterToolbar.tsx
@@ -59,6 +59,7 @@ export interface IFilterToolbarProps<T> {
   beginToolbarItems?: JSX.Element;
   endToolbarItems?: JSX.Element;
   pagination?: JSX.Element;
+  showFiltersSideBySide?: boolean;
 }
 
 export const FilterToolbar = <T,>({
@@ -66,6 +67,7 @@ export const FilterToolbar = <T,>({
   filterValues,
   setFilterValues,
   pagination,
+  showFiltersSideBySide = false,
 }: React.PropsWithChildren<IFilterToolbarProps<T>>): JSX.Element | null => {
   const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] =
     React.useState(false);
@@ -91,31 +93,36 @@ export const FilterToolbar = <T,>({
         variant="filter-group"
         toggleIcon={<FilterIcon />}
         breakpoint="2xl"
+        spaceItems={
+          showFiltersSideBySide ? { default: "spaceItemsMd" } : undefined
+        }
       >
-        <ToolbarItem>
-          <Dropdown
-            toggle={
-              <DropdownToggle
-                id="filtered-by"
-                onToggle={() =>
-                  setIsCategoryDropdownOpen(!isCategoryDropdownOpen)
-                }
-              >
-                <FilterIcon /> {currentFilterCategory?.title}
-              </DropdownToggle>
-            }
-            isOpen={isCategoryDropdownOpen}
-            dropdownItems={filterCategories.map((category) => (
-              <DropdownItem
-                id={`filter-category-${category.key}`}
-                key={category.key}
-                onClick={() => onCategorySelect(category)}
-              >
-                {category.title}
-              </DropdownItem>
-            ))}
-          />
-        </ToolbarItem>
+        {!showFiltersSideBySide && (
+          <ToolbarItem>
+            <Dropdown
+              toggle={
+                <DropdownToggle
+                  id="filtered-by"
+                  onToggle={() =>
+                    setIsCategoryDropdownOpen(!isCategoryDropdownOpen)
+                  }
+                >
+                  <FilterIcon /> {currentFilterCategory?.title}
+                </DropdownToggle>
+              }
+              isOpen={isCategoryDropdownOpen}
+              dropdownItems={filterCategories.map((category) => (
+                <DropdownItem
+                  id={`filter-category-${category.key}`}
+                  key={category.key}
+                  onClick={() => onCategorySelect(category)}
+                >
+                  {category.title}
+                </DropdownItem>
+              ))}
+            />
+          </ToolbarItem>
+        )}
 
         {filterCategories.map((category) => (
           <FilterControl<T>
@@ -123,7 +130,10 @@ export const FilterToolbar = <T,>({
             category={category}
             filterValue={filterValues[category.key]}
             setFilterValue={(newValue) => setFilterValue(category, newValue)}
-            showToolbarItem={currentFilterCategory?.key === category.key}
+            showToolbarItem={
+              showFiltersSideBySide ||
+              currentFilterCategory?.key === category.key
+            }
           />
         ))}
       </ToolbarToggleGroup>

--- a/client/src/app/shared/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/shared/components/FilterToolbar/FilterToolbar.tsx
@@ -32,6 +32,7 @@ export interface IBasicFilterCategory<T> {
 
 export interface IMultiselectFilterCategory<T> extends IBasicFilterCategory<T> {
   selectOptions: OptionPropsWithKey[];
+  placeholderText?: string;
   logicOperator?: "AND" | "OR";
 }
 

--- a/client/src/app/shared/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/shared/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import {
   ToolbarFilter,
   Select,
@@ -26,6 +27,8 @@ export const MultiselectFilterControl = <T,>({
 }: React.PropsWithChildren<
   IMultiselectFilterControlProps<T>
 >): JSX.Element | null => {
+  const { t } = useTranslation();
+
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = React.useState(false);
 
   const getOptionKeyFromOptionValue = (
@@ -93,6 +96,12 @@ export const MultiselectFilterControl = <T,>({
       })
     );
 
+  const placeholderText =
+    category.placeholderText ||
+    `${t("actions.filterBy", {
+      what: category.title,
+    })}...`;
+
   return (
     <ToolbarFilter
       chips={chips}
@@ -108,9 +117,7 @@ export const MultiselectFilterControl = <T,>({
         selections={selections || []}
         onSelect={(_, value) => onFilterSelect(value)}
         isOpen={isFilterDropdownOpen}
-        placeholderText={`Filter by ${category.title
-          .charAt(0)
-          .toLowerCase()}${category.title.slice(1)}`}
+        placeholderText={category.placeholderText}
         hasInlineFilter
         onFilter={onOptionsFilter}
         isDisabled={category.selectOptions.length === 0}

--- a/client/src/app/shared/hooks/useFilterState.ts
+++ b/client/src/app/shared/hooks/useFilterState.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { useSessionStorage } from "@migtools/lib-ui";
-import { IFilterValues, FilterCategory } from "../components/FilterToolbar";
+import {
+  IFilterValues,
+  FilterCategory,
+  IMultiselectFilterCategory,
+} from "../components/FilterToolbar";
 
 export interface IFilterStateHook<T> {
   filterValues: IFilterValues;
@@ -28,12 +32,18 @@ export const useFilterState = <T>(
       if (filterCategory?.getItemValue) {
         itemValue = filterCategory.getItemValue(item);
       }
-      return values.every((filterValue) => {
-        if (!itemValue) return false;
-        const lowerCaseItemValue = String(itemValue).toLowerCase();
-        const lowerCaseFilterValue = String(filterValue).toLowerCase();
-        return lowerCaseItemValue.indexOf(lowerCaseFilterValue) !== -1;
-      });
+      const logicOperator =
+        (filterCategory &&
+          (filterCategory as IMultiselectFilterCategory<T>).logicOperator) ||
+        "AND";
+      return values[logicOperator === "AND" ? "every" : "some"](
+        (filterValue) => {
+          if (!itemValue) return false;
+          const lowerCaseItemValue = String(itemValue).toLowerCase();
+          const lowerCaseFilterValue = String(filterValue).toLowerCase();
+          return lowerCaseItemValue.indexOf(lowerCaseFilterValue) !== -1;
+        }
+      );
     })
   );
   return { filterValues, setFilterValues, filteredItems };


### PR DESCRIPTION
* Displays tag categories grouped by source in the drawer
  * Adjusts fetch / indexing logic of tags and tag categories to support grouping by source
* Adds filter dropdowns for source and tag category
  * Enhances FilterToolbar so we can render multiple filter dropdowns side by side
  * Enhances useFilterState so we can have filter values applied with OR logic rather than AND in certain circumstances (multi-selecting tag categories and sources only makes sense with OR because they are mutually exclusive, so otherwise there would only ever be 1 or 0 matches for a filter)

![Screenshot 2023-03-07 at 2 28 47 PM](https://user-images.githubusercontent.com/811963/223531776-59325d05-d9b1-4aed-b482-5af3da7a1d39.png)

  
![Screenshot 2023-03-07 at 2 29 09 PM](https://user-images.githubusercontent.com/811963/223531735-5e4b0e19-ce87-4b94-a2cd-e052694baf94.png)
