### PR TITLE
:bug: Fix firefox html/csv report download

### DIFF
--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
@@ -120,7 +120,7 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                         className={spacing.pXs}
                       >
                         <Link
-                          to={`${APPLICATIONS}/${application.id}/bucket${task?.data?.output}`}
+                          to={`${APPLICATIONS}/${application.id}/bucket${task?.data?.output}?filter=*`}
                           target="_blank"
                           download
                         >

--- a/server/setupProxy.js
+++ b/server/setupProxy.js
@@ -19,6 +19,9 @@ module.exports = function (app) {
       },
       logLevel: process.env.DEBUG ? "debug" : "info",
       onProxyReq: (proxyReq, req, res) => {
+        if (req.originalUrl.includes("windup/report/?filter")) {
+          proxyReq.setHeader("Accept", "");
+        }
         if (req.cookies.keycloak_cookie && !req.headers["authorization"]) {
           proxyReq.setHeader(
             "Authorization",


### PR DESCRIPTION
Currently, the report download feature does not work in firefox. This fixes the issue by ensuring the accept headers are cleared when requesting a file download. The 'download' html attribute handles this in chrome, but fails to work in firefox. 