### PR TITLE
:bug: Mirror rule bundle target metadata selection in advanced options

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -432,13 +432,15 @@ export enum RuleBundleKind {
 }
 
 export interface RuleBundle {
-  id: number;
-  name: string;
+  createTime?: string;
+  createUser?: string;
   description: string;
-  image: RuleBundleImage;
+  id: number;
+  image?: RuleBundleImage;
   kind?: RuleBundleKind;
+  name: string;
   rulesets: Ruleset[];
-  custom: boolean;
+  custom?: boolean;
   repository?: Repository;
   identity?: Ref;
 }

--- a/client/src/app/common/CustomRules/rules-utils.tsx
+++ b/client/src/app/common/CustomRules/rules-utils.tsx
@@ -47,7 +47,6 @@ export const parseRules = (file: IReadFile): ParsedRule => {
 
 export const getruleBundleTargetList = (ruleBundle: RuleBundle) => {
   return ruleBundle.rulesets.reduce((acc: string[], ruleset) => {
-    acc.push(ruleset?.metadata?.target);
-    return acc;
+    return [...acc, ruleset?.metadata?.target];
   }, []);
 };

--- a/client/src/app/common/CustomRules/rules-utils.tsx
+++ b/client/src/app/common/CustomRules/rules-utils.tsx
@@ -1,4 +1,4 @@
-import { IReadFile, ParsedRule } from "@app/api/models";
+import { IReadFile, ParsedRule, RuleBundle } from "@app/api/models";
 
 export const parseRules = (file: IReadFile): ParsedRule => {
   if (file.data) {
@@ -43,4 +43,11 @@ export const parseRules = (file: IReadFile): ParsedRule => {
       total: 0,
     };
   }
+};
+
+export const getruleBundleTargetList = (ruleBundle: RuleBundle) => {
+  return ruleBundle.rulesets.reduce((acc: string[], ruleset) => {
+    acc.push(ruleset?.metadata?.target);
+    return acc;
+  }, []);
 };

--- a/client/src/app/components/target-card.tsx
+++ b/client/src/app/components/target-card.tsx
@@ -86,7 +86,7 @@ export const TargetCard: React.FC<TargetCardProps> = ({
 
   const getImage = (): React.ComponentType => {
     let result: React.ComponentType<any> = CubesIcon;
-    const imagePath = item.image.id
+    const imagePath = item?.image?.id
       ? `/hub/files/${item.image.id}`
       : DefaultRuleBundleIcon;
     if (item.image) {

--- a/client/src/app/components/target-card.tsx
+++ b/client/src/app/components/target-card.tsx
@@ -26,6 +26,10 @@ import { useTranslation } from "react-i18next";
 import "./target-card.css";
 import DefaultRuleBundleIcon from "@app/images/Icon-Red_Hat-Virtual_server_stack-A-Black-RGB.svg";
 import { RuleBundle } from "@app/api/models";
+import { useFetchRuleBundles } from "@app/queries/rulebundles";
+import { getruleBundleTargetList } from "@app/common/CustomRules/rules-utils";
+import { useFormContext } from "react-hook-form";
+import { AnalysisWizardFormValues } from "@app/pages/applications/analysis-wizard/schema";
 
 export interface TargetCardProps {
   item: RuleBundle;
@@ -55,10 +59,22 @@ export const TargetCard: React.FC<TargetCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const [isCardSelected, setCardSelected] = React.useState(cardSelected);
+
+  const { getValues } = useFormContext<AnalysisWizardFormValues>();
+  const values = getValues();
+
   const [isRuleTargetSelectOpen, setRuleTargetSelectOpen] =
     React.useState(false);
+
+  const prevSelectedTarget = values.formTargets.find(
+    (target) =>
+      item.rulesets
+        .map((ruleset) => ruleset.metadata.target)
+        .indexOf(target) !== -1
+  );
+
   const [selectedRuleTarget, setSelectedRuleTarget] = React.useState(
-    item.rulesets[0]?.metadata?.target
+    prevSelectedTarget || item.rulesets[0]?.metadata?.target
   );
 
   const handleCardClick = (event: React.MouseEvent) => {

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -1,5 +1,13 @@
 import * as yup from "yup";
-import { Application, IReadFile, Ref } from "@app/api/models";
+import {
+  Application,
+  IReadFile,
+  Ref,
+  Repository,
+  RuleBundle,
+  RuleBundleImage,
+  RuleBundleKind,
+} from "@app/api/models";
 import { useTranslation } from "react-i18next";
 import { useAnalyzableApplicationsByMode } from "./utils";
 
@@ -49,14 +57,31 @@ const useModeStepSchema = ({
 
 export interface TargetsStepValues {
   formTargets: string[];
-  formRuleBundles: any[];
+  formRuleBundles: RuleBundle[];
 }
+export const ruleBundleSchema: yup.SchemaOf<RuleBundle> = yup.object({
+  createTime: yup.string(),
+  createUser: yup.string(),
+  description: yup.string().required(),
+  id: yup.number().required(),
+  name: yup.string().required(),
+  image: yup.mixed<RuleBundleImage>(),
+  kind: yup.mixed<RuleBundleKind>(),
+  rulesets: yup.array(),
+  custom: yup.boolean(),
+  repository: yup.mixed<Repository>(),
+  identity: yup.mixed<Ref>(),
+  updateUser: yup.string(),
+});
 
 const useTargetsStepSchema = (): yup.SchemaOf<TargetsStepValues> => {
   const { t } = useTranslation();
   return yup.object({
     formTargets: yup.array(),
-    formRuleBundles: yup.array().min(1, "At least 1 target is required"), // TODO translation here
+    formRuleBundles: yup
+      .array()
+      .of(ruleBundleSchema)
+      .min(1, "At least 1 target is required"), // TODO translation here
   });
 };
 

--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -22,6 +22,7 @@ import { HookFormPFGroupController } from "@app/shared/components/hook-form-pf-f
 import { StringListField } from "@app/shared/components/string-list-field";
 import { useFetchRuleBundles } from "@app/queries/rulebundles";
 import { RuleBundle } from "@app/api/models";
+import { getruleBundleTargetList } from "@app/common/CustomRules/rules-utils";
 
 export const SetOptions: React.FC = () => {
   const { t } = useTranslation();
@@ -40,18 +41,8 @@ export const SetOptions: React.FC = () => {
 
   const [isSelectTargetsOpen, setSelectTargetsOpen] = React.useState(false);
   const [isSelectSourcesOpen, setSelectSourcesOpen] = React.useState(false);
-  const {
-    ruleBundles,
-    isFetching: isFetchingRuleBundles,
-    refetch: refetchRuleBundles,
-  } = useFetchRuleBundles();
+  const { ruleBundles } = useFetchRuleBundles();
 
-  const getruleBundleTargetList = (ruleBundle: RuleBundle) => {
-    return ruleBundle.rulesets.reduce((acc: string[], ruleset) => {
-      acc.push(ruleset?.metadata?.target);
-      return acc;
-    }, []);
-  };
   const allRuleBundleTargets = ruleBundles
     .map((ruleBundle) => getruleBundleTargetList(ruleBundle))
     .flat();

--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -13,23 +13,26 @@ import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 
-import { getValidatedFromErrorTouched } from "@app/utils/utils";
+import { dedupeFunction, getValidatedFromErrorTouched } from "@app/utils/utils";
 import defaultSources from "./sources";
+import { defaultTargets } from "../../../data/targets";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { AnalysisWizardFormValues } from "./schema";
 import { HookFormPFGroupController } from "@app/shared/components/hook-form-pf-fields";
 import { StringListField } from "@app/shared/components/string-list-field";
-import { defaultTargets } from "@app/data/targets";
+import { useFetchRuleBundles } from "@app/queries/rulebundles";
+import { RuleBundle } from "@app/api/models";
 
 export const SetOptions: React.FC = () => {
   const { t } = useTranslation();
 
-  const { watch, control, setValue } =
+  const { watch, control, setValue, getValues } =
     useFormContext<AnalysisWizardFormValues>();
 
   const {
     formSources,
     formTargets,
+    formRuleBundles,
     diva,
     excludedRulesTags,
     autoTaggingEnabled,
@@ -37,6 +40,25 @@ export const SetOptions: React.FC = () => {
 
   const [isSelectTargetsOpen, setSelectTargetsOpen] = React.useState(false);
   const [isSelectSourcesOpen, setSelectSourcesOpen] = React.useState(false);
+  const {
+    ruleBundles,
+    isFetching: isFetchingRuleBundles,
+    refetch: refetchRuleBundles,
+  } = useFetchRuleBundles();
+
+  const getruleBundleTargetList = (ruleBundle: RuleBundle) => {
+    return ruleBundle.rulesets.reduce((acc: string[], ruleset) => {
+      acc.push(ruleset?.metadata?.target);
+      return acc;
+    }, []);
+  };
+  const allRuleBundleTargets = ruleBundles
+    .map((ruleBundle) => getruleBundleTargetList(ruleBundle))
+    .flat();
+
+  const defaultTargetsAndBundleTargets = [
+    ...new Set(defaultTargets.concat(allRuleBundleTargets)),
+  ];
 
   return (
     <Form
@@ -58,21 +80,43 @@ export const SetOptions: React.FC = () => {
         fieldId="targets"
         isRequired
         renderInput={({
-          field: { onChange, onBlur, value },
+          field: { onChange, onBlur, value: selectedFormTargets },
           fieldState: { isTouched, error },
         }) => (
           <Select
-            id="targets"
-            toggleId="targets-toggle"
+            id="ruleBundles"
+            toggleId="rule-bundles-toggle"
             variant={SelectVariant.typeaheadMulti}
             aria-label="Select targets"
-            selections={value}
+            selections={formTargets}
             isOpen={isSelectTargetsOpen}
             onSelect={(_, selection) => {
-              if (!value.includes(selection as string)) {
-                onChange([...value, selection] as string[]);
+              const matchingRuleBundle = ruleBundles.find((ruleBundle) =>
+                getruleBundleTargetList(ruleBundle).includes(
+                  selection as string
+                )
+              );
+              if (!formTargets.includes(selection as string)) {
+                onChange([...selectedFormTargets, selection]);
+                if (matchingRuleBundle)
+                  setValue("formRuleBundles", [
+                    ...formRuleBundles,
+                    matchingRuleBundle,
+                  ]);
               } else {
-                onChange(value.filter((target) => target !== selection));
+                if (matchingRuleBundle)
+                  setValue(
+                    "formRuleBundles",
+                    formRuleBundles.filter(
+                      (formRuleBundle) =>
+                        formRuleBundle.name !== matchingRuleBundle.name
+                    )
+                  );
+                onChange(
+                  selectedFormTargets.filter(
+                    (formTarget) => formTarget !== selection
+                  )
+                );
               }
               onBlur();
               setSelectTargetsOpen(!isSelectTargetsOpen);
@@ -85,8 +129,8 @@ export const SetOptions: React.FC = () => {
             }}
             validated={getValidatedFromErrorTouched(error, isTouched)}
           >
-            {defaultTargets.map((target, index) => (
-              <SelectOption key={index} component="button" value={target} />
+            {defaultTargetsAndBundleTargets.map((targetName, index) => (
+              <SelectOption key={index} component="button" value={targetName} />
             ))}
           </Select>
         )}

--- a/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -72,10 +72,6 @@ export const SetTargets: React.FC = () => {
     const otherSelectedRuleBundles = formRuleBundles.filter(
       (formRuleBundle) => selectedRuleBundle.id !== formRuleBundle.id
     );
-    const selectedRuleBundleRef = {
-      id: selectedRuleBundle.id,
-      name: selectedRuleBundle.name,
-    };
 
     if (isSelecting) {
       const definedSelectedSources: string[] = selectedRuleBundle.rulesets

--- a/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -101,7 +101,7 @@ export const SetTargets: React.FC = () => {
 
       setValue("formRuleBundles", [
         ...otherSelectedRuleBundles,
-        selectedRuleBundleRef,
+        selectedRuleBundle,
       ]);
     } else {
       setValue("formSources", otherSelectedRuleSources);

--- a/client/src/app/pages/migration-targets/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/custom-target-form.tsx
@@ -191,7 +191,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
       id: ruleBundle?.id || 0,
       name: ruleBundle?.name || "",
       description: ruleBundle?.description || "",
-      imageID: ruleBundle?.image.id || 1,
+      imageID: ruleBundle?.image?.id || 1,
       customRulesFiles:
         ruleBundle?.rulesets.map((ruleset): IReadFile => {
           const emptyFile = new File(["empty"], ruleset.name, {


### PR DESCRIPTION
- Currently, advanced options does not reflect the targets selected in the set targets step within the wizard. This fixes that and allows the selection of rule bundle associated targets and non-associated targets alike from the same select dropdown. This is necessary because there are some targets available that are not tied to rulebundles. This functionality was inherited from the windup web console. 
- Fixes a bug when a user selects a target from a "category: "kind" rulebundle in the set-target dropdown, navigates through the wizard, and then navigates back to the set-targets page to find their selection did not persist. This PR adds a check for previously selected targets. 

- Adds typescript support for the RuleBundle form data. 
