### PR TITLE
:bug: Don't enforce .windup.xml filename suffixes because it doesn't work reliably

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -434,7 +434,7 @@ export const CustomRules: React.FC<CustomRulesProps> = (props) => {
             <MultipleFileUpload
               onFileDrop={handleFileDrop}
               dropzoneProps={{
-                accept: ".windup.xml",
+                accept: ".xml",
               }}
             >
               <MultipleFileUploadMain

--- a/client/src/app/pages/migration-targets/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/custom-target-form.tsx
@@ -465,7 +465,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
           <MultipleFileUpload
             onFileDrop={handleFileDrop}
             dropzoneProps={{
-              accept: ".windup.xml",
+              accept: ".xml",
             }}
             {...register("customRulesFiles")}
           >


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-55

In the custom rules and custom targets forms where we have file upload fields that expect files ending in `.windup.xml`, the `accept` prop of `react-dropzone` was not reliably enforcing that filename suffix on mac. There doesn't seem to be a real fix available to us with the dependency versions we have, so this works around the issue by only restricting the fields to `.xml` files.

Note: We are stuck with `react-dropzone@9.0.0` until PatternFly upgrades to the newer versions of that dependency in their `MultipleFileUpload` component eventually. That is something they won't do until their upcoming breaking change release. When we can eventually make that upgrade we may be able to resolve this issue and restore the requirement for `.windup.xml` filenames.