### PR TITLE
:bug: Description is not a required field for rule bundles

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -434,7 +434,7 @@ export enum RuleBundleKind {
 export interface RuleBundle {
   createTime?: string;
   createUser?: string;
-  description: string;
+  description?: string;
   id: number;
   image?: RuleBundleImage;
   kind?: RuleBundleKind;

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -62,7 +62,7 @@ export interface TargetsStepValues {
 export const ruleBundleSchema: yup.SchemaOf<RuleBundle> = yup.object({
   createTime: yup.string(),
   createUser: yup.string(),
-  description: yup.string().required(),
+  description: yup.string(),
   id: yup.number().required(),
   name: yup.string().required(),
   image: yup.mixed<RuleBundleImage>(),


### PR DESCRIPTION
This fixes a bug causing validation to fail if a custom target is selected with no description in the wizard. 