### PR TITLE
:bug: Fix error validation for image id

### DIFF
--- a/client/src/app/pages/migration-targets/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/custom-target-form.tsx
@@ -419,7 +419,6 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
                 formData: formFile,
                 file: newImageFile,
               });
-              onChange();
             }}
             onClearClick={() => {
               onChange();


### PR DESCRIPTION
Remove redundant onChange handler causing error to flash temporarily when the image is uploading 