### PR TITLE
:sparkles: Rebump UBI9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Builder image
-FROM registry.access.redhat.com/ubi8/nodejs-18 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-18 as builder
 USER 0
 COPY . .
 WORKDIR "/opt/app-root/src" 
 RUN npm install -w client && npm run build -w client && rm -rf node_modules && npm install -w server
 
 # Runner image
-FROM registry.access.redhat.com/ubi8/nodejs-18-minimal
+FROM registry.access.redhat.com/ubi9/nodejs-18-minimal
 
 # Add ps package to allow liveness probe for k8s cluster
 # Add tar package to allow copying files with kubectl scp


### PR DESCRIPTION
Bump from UBI8 to UBI9 was lost because https://github.com/konveyor/tackle2-ui/pull/685 needed a rebase after https://github.com/konveyor/tackle2-ui/pull/685 was merged.

Resolves https://github.com/konveyor/tackle2-ui/issues/638