### PR TITLE
:bug: [backport-6.1] Fix deletion for Applications assessment/review  (#715)

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -317,7 +317,8 @@
       "assessmentAndReviewCopied": "Success! Assessment and review copied to selected applications",
       "assessmentCopied": "Success! Assessment copied to selected applications",
       "assessmentDiscarded": "Success! Assessment discarded for {{application}}.",
-      "fileSavedToBeProcessed": "Success! file saved to be processed."
+      "fileSavedToBeProcessed": "Success! file saved to be processed.",
+      "reviewDiscarded": "Success! Review discarded for {{application}}."
     }
   },
   "validation": {

--- a/client/public/locales/es/translation.json
+++ b/client/public/locales/es/translation.json
@@ -315,7 +315,8 @@
       "assessmentAndReviewCopied": "Éxito! Evaluación y revisión copiada a las aplicaciones seleccionadas",
       "assessmentCopied": "Éxito! Evaluación copiada a las aplicaciones seleccionadas",
       "assessmentDiscarded": "Éxito! Evaluación de {{application}} desechada.",
-      "fileSavedToBeProcessed": "Éxito! El archivo fue guardado para ser procesado."
+      "fileSavedToBeProcessed": "Éxito! El archivo fue guardado para ser procesado.",
+      "reviewDiscarded": "Éxito! Revisión de {{application}} desechada."
     }
   },
   "validation": {

--- a/client/src/app/queries/assessments.ts
+++ b/client/src/app/queries/assessments.ts
@@ -1,22 +1,13 @@
-import { useMutation, useQueries, UseQueryResult } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQueryClient,
+  UseQueryResult,
+} from "@tanstack/react-query";
 
 import { deleteAssessment, getAssessments } from "@app/api/rest";
-import { AxiosError } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 import { Application, Assessment } from "@app/api/models";
-
-export const useDeleteAssessmentMutation = (
-  onSuccess?: () => void,
-  onError?: (err: AxiosError) => void
-) => {
-  return useMutation(deleteAssessment, {
-    onSuccess: () => {
-      onSuccess && onSuccess();
-    },
-    onError: (err: AxiosError) => {
-      onError && onError(err);
-    },
-  });
-};
 
 export const assessmentsQueryKey = "assessments";
 
@@ -47,4 +38,24 @@ export const useFetchApplicationAssessments = (
     fetchErrorApplicationAssessment: (id: number) =>
       queryResultsByAppId[id].error as AxiosError | undefined,
   };
+};
+export interface IAssessementMutation {
+  id: number;
+  name: string;
+}
+
+export const useDeleteAssessmentMutation = (
+  onSuccess: (name: string) => void,
+  onError: (err: AxiosError) => void
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (args: IAssessementMutation) => deleteAssessment(args.id),
+    onSuccess: (_, args) => {
+      onSuccess(args.name);
+      queryClient.invalidateQueries([assessmentsQueryKey]);
+    },
+    onError: onError,
+  });
 };

--- a/client/src/app/queries/reviews.ts
+++ b/client/src/app/queries/reviews.ts
@@ -1,7 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { getReviews } from "@app/api/rest";
+import { deleteReview, getReviews } from "@app/api/rest";
 import { Review } from "@app/api/models";
+import { AxiosError, AxiosResponse } from "axios";
 
 export interface IReviewFetchState {
   reviews: Review[];
@@ -26,4 +27,25 @@ export const useFetchReviews = (): IReviewFetchState => {
     fetchError: error,
     refetch,
   };
+};
+
+export interface IReviewMutation {
+  id: number;
+  name: string;
+}
+
+export const useDeleteReviewMutation = (
+  onSuccess: (name: string) => void,
+  onError: (err: AxiosError) => void
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (args: IReviewMutation) => deleteReview(args.id),
+    onSuccess: (_, args) => {
+      onSuccess(args.name);
+      queryClient.invalidateQueries([reviewsQueryKey]);
+    },
+    onError: onError,
+  });
 };


### PR DESCRIPTION
* No discard option unless there is an assessment or review
* Fix assessment/review deletion
* Refetch applications
* Refresh data
* force application fetch
* force fetch after assessment discard too
* Handling success or error callbacks
* With application name for success
* use interface instead of any
* Reducing arguments
* remove async
* cleanup

(cherry picked from commit 8b3574d5d1ff89ae699db664d89566aa91dc169c)