### PR TITLE
:sparkles: Add skeleton for new Create Migration Wave modal with an edit mode

### DIFF
--- a/client/src/app/pages/waves/components/create-edit-wave-modal/create-edit-wave-modal.tsx
+++ b/client/src/app/pages/waves/components/create-edit-wave-modal/create-edit-wave-modal.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { AxiosResponse } from "axios";
+
+import { Modal, ModalVariant } from "@patternfly/react-core";
+
+export interface CreateEditWaveModalProps {
+  mode: "create" | "edit" | null;
+  onSaved: (response: AxiosResponse<unknown>) => void;
+  onCancel: () => void;
+}
+
+export const CreateEditWaveModal: React.FC<CreateEditWaveModalProps> = ({
+  mode,
+  onSaved,
+  onCancel,
+}) => {
+  if (mode === null) return null;
+  return (
+    <Modal
+      title={
+        mode === "create" ? "Create migration wave" : "Edit migration wave"
+      }
+      variant={ModalVariant.medium}
+      isOpen
+      onClose={onCancel}
+    >
+      TODO
+    </Modal>
+  );
+};

--- a/client/src/app/pages/waves/components/create-edit-wave-modal/create-edit-wave-modal.tsx
+++ b/client/src/app/pages/waves/components/create-edit-wave-modal/create-edit-wave-modal.tsx
@@ -4,23 +4,25 @@ import { Modal, ModalVariant } from "@patternfly/react-core";
 
 import { WaveForm } from "./wave-form";
 
+type MigrationWave = any; // TODO add a real MigrationWave type and queries
+
 export interface CreateEditWaveModalProps {
-  mode: "create" | "edit" | null; // TODO should we just drive this from waveBeingEdited and an open boolean?
+  isOpen: boolean;
+  waveBeingEdited: MigrationWave;
   onSaved: (response: AxiosResponse<unknown>) => void;
   onCancel: () => void;
 }
 
 export const CreateEditWaveModal: React.FC<CreateEditWaveModalProps> = ({
-  mode,
+  isOpen,
+  waveBeingEdited,
   onSaved,
   onCancel,
 }) => {
-  if (mode === null) return null;
+  if (!isOpen) return null;
   return (
     <Modal
-      title={
-        mode === "create" ? "Create migration wave" : "Edit migration wave"
-      }
+      title={!waveBeingEdited ? "Create migration wave" : "Edit migration wave"}
       variant={ModalVariant.small}
       isOpen
       onClose={onCancel}

--- a/client/src/app/pages/waves/components/create-edit-wave-modal/create-edit-wave-modal.tsx
+++ b/client/src/app/pages/waves/components/create-edit-wave-modal/create-edit-wave-modal.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import * as React from "react";
 import { AxiosResponse } from "axios";
-
 import { Modal, ModalVariant } from "@patternfly/react-core";
 
+import { WaveForm } from "./wave-form";
+
 export interface CreateEditWaveModalProps {
-  mode: "create" | "edit" | null;
+  mode: "create" | "edit" | null; // TODO should we just drive this from waveBeingEdited and an open boolean?
   onSaved: (response: AxiosResponse<unknown>) => void;
   onCancel: () => void;
 }
@@ -20,11 +21,11 @@ export const CreateEditWaveModal: React.FC<CreateEditWaveModalProps> = ({
       title={
         mode === "create" ? "Create migration wave" : "Edit migration wave"
       }
-      variant={ModalVariant.medium}
+      variant={ModalVariant.small}
       isOpen
       onClose={onCancel}
     >
-      TODO
+      <WaveForm onCancel={onCancel} />
     </Modal>
   );
 };

--- a/client/src/app/pages/waves/components/create-edit-wave-modal/index.ts
+++ b/client/src/app/pages/waves/components/create-edit-wave-modal/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-edit-wave-modal";

--- a/client/src/app/pages/waves/components/create-edit-wave-modal/wave-form.tsx
+++ b/client/src/app/pages/waves/components/create-edit-wave-modal/wave-form.tsx
@@ -17,9 +17,10 @@ interface WaveFormValues {
   stakeholderGroups: StakeholderGroup[];
 }
 
+type MigrationWave = any; // TODO add a real MigrationWave type and queries
+
 export interface WaveFormProps {
-  // waveBeingEdited?: MigrationWave;
-  waveBeingEdited?: any; // TODO
+  waveBeingEdited?: MigrationWave;
   onCancel: () => void;
 }
 

--- a/client/src/app/pages/waves/components/create-edit-wave-modal/wave-form.tsx
+++ b/client/src/app/pages/waves/components/create-edit-wave-modal/wave-form.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import * as yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { ActionGroup, Button, Form } from "@patternfly/react-core";
+
+import { Stakeholder, StakeholderGroup } from "@app/api/models";
+import { duplicateNameCheck } from "@app/utils/utils";
+import { HookFormPFTextInput } from "@app/shared/components/hook-form-pf-fields";
+
+interface WaveFormValues {
+  name: string;
+  startDate: Date | null;
+  endDate: Date | null;
+  stakeholders: Stakeholder[];
+  stakeholderGroups: StakeholderGroup[];
+}
+
+export interface WaveFormProps {
+  // waveBeingEdited?: MigrationWave;
+  waveBeingEdited?: any; // TODO
+  onCancel: () => void;
+}
+
+export const WaveForm: React.FC<WaveFormProps> = ({
+  waveBeingEdited,
+  onCancel,
+}) => {
+  const { t } = useTranslation();
+
+  const waves: { name: string }[] = []; // TODO query this from the API, add a type for MigrationWaves
+  const isLoading = false; // TODO
+
+  const validationSchema: yup.SchemaOf<WaveFormValues> = yup.object().shape({
+    name: yup
+      .string()
+      .trim()
+      .required(t("validation.required"))
+      .min(3, t("validation.minLength", { length: 3 }))
+      .max(120, t("validation.maxLength", { length: 120 }))
+      .test(
+        "Duplicate name",
+        "An identity with this name already exists. Use a different name.",
+        (value) =>
+          duplicateNameCheck(waves, waveBeingEdited || null, value || "")
+      ),
+    startDate: yup.date().required(t("validation.required")),
+    endDate: yup.date().required(t("validation.required")),
+    stakeholders: yup.array(),
+    stakeholderGroups: yup.array(),
+  });
+
+  const {
+    handleSubmit,
+    formState: { isSubmitting, isValidating, isValid, isDirty },
+    setValue,
+    control,
+    watch,
+  } = useForm<WaveFormValues>({
+    defaultValues: {
+      name: "",
+      startDate: null,
+      endDate: null,
+      stakeholders: [],
+      stakeholderGroups: [],
+    },
+    resolver: yupResolver(validationSchema),
+    mode: "onChange",
+  });
+
+  const values = watch();
+
+  const onSubmit = (formValues: WaveFormValues) => {
+    // TODO
+  };
+
+  // TODO grid layout
+  // TODO datepickers
+  // TODO multiselects for stakeholders/groups? are they interdependent? reuse existing query
+
+  return (
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <HookFormPFTextInput
+        control={control}
+        name="name"
+        label="Name"
+        fieldId="name"
+        isRequired
+      />
+      <ActionGroup>
+        <Button
+          type="submit"
+          aria-label="submit"
+          id="wave-form-submit"
+          variant="primary"
+          isDisabled={
+            !isValid || isSubmitting || isValidating || isLoading || !isDirty
+          }
+        >
+          {!waveBeingEdited ? "Create" : "Save"}
+        </Button>
+        <Button
+          type="button"
+          id="cancel"
+          aria-label="cancel"
+          variant="link"
+          isDisabled={isSubmitting || isValidating}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -34,21 +34,26 @@ import dayjs from "dayjs";
 import { IComposableRow } from "@app/shared/components/composable-app-table/composable-app-table";
 import { WaveApplicationsTable } from "./wave-applications-table/wave-applications-table";
 import { WaveStakeholdersTable } from "./wave-stakeholders-table/wave-stakeholders-table";
-import {
-  CreateEditWaveModal,
-  CreateEditWaveModalProps,
-} from "./components/create-edit-wave-modal";
+import { CreateEditWaveModal } from "./components/create-edit-wave-modal";
 
 export const Waves: React.FC = () => {
   const { t } = useTranslation();
 
   const { waves, isFetching, fetchError } = useFetchWaves();
 
-  const [waveModalMode, setWaveModalMode] =
-    React.useState<CreateEditWaveModalProps["mode"]>(null);
-  const openCreateWaveModal = () => setWaveModalMode("create");
-  const openEditWaveModal = () => setWaveModalMode("edit");
-  const closeWaveModal = () => setWaveModalMode(null);
+  type MigrationWave = any; // TODO add a real MigrationWave type and queries
+  // When waveModalState is:
+  //   'create': the modal is open for creating a new wave.
+  //   A MigrationWave: the modal is open for editing that wave.
+  //   null: the modal is closed.
+  const [waveModalState, setWaveModalState] = React.useState<
+    "create" | MigrationWave | null
+  >(null);
+  const isWaveModalOpen = waveModalState !== null;
+  const waveBeingEdited = waveModalState !== "create" ? waveModalState : null;
+  const openCreateWaveModal = () => setWaveModalState("create");
+  const openEditWaveModal = (wave: MigrationWave) => setWaveModalState(wave);
+  const closeWaveModal = () => setWaveModalState(null);
 
   const filterCategories: FilterCategory<Wave>[] = [
     {
@@ -336,7 +341,8 @@ export const Waves: React.FC = () => {
         </ConditionalRender>
       </PageSection>
       <CreateEditWaveModal
-        mode={waveModalMode}
+        isOpen={isWaveModalOpen}
+        waveBeingEdited={waveBeingEdited}
         onSaved={() => {}}
         onCancel={closeWaveModal}
       />

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -34,11 +34,21 @@ import dayjs from "dayjs";
 import { IComposableRow } from "@app/shared/components/composable-app-table/composable-app-table";
 import { WaveApplicationsTable } from "./wave-applications-table/wave-applications-table";
 import { WaveStakeholdersTable } from "./wave-stakeholders-table/wave-stakeholders-table";
+import {
+  CreateEditWaveModal,
+  CreateEditWaveModalProps,
+} from "./components/create-edit-wave-modal";
 
 export const Waves: React.FC = () => {
   const { t } = useTranslation();
 
   const { waves, isFetching, fetchError } = useFetchWaves();
+
+  const [waveModalMode, setWaveModalMode] =
+    React.useState<CreateEditWaveModalProps["mode"]>(null);
+  const openCreateWaveModal = () => setWaveModalMode("create");
+  const openEditWaveModal = () => setWaveModalMode("edit");
+  const closeWaveModal = () => setWaveModalMode(null);
 
   const filterCategories: FilterCategory<Wave>[] = [
     {
@@ -281,7 +291,7 @@ export const Waves: React.FC = () => {
                       id="create-wave"
                       aria-label="Create new wave"
                       variant={ButtonVariant.primary}
-                      // onClick={openCreateWaveModal}
+                      onClick={openCreateWaveModal}
                     >
                       {t("actions.createNew")}
                     </Button>
@@ -325,6 +335,11 @@ export const Waves: React.FC = () => {
           ></ComposableAppTable>
         </ConditionalRender>
       </PageSection>
+      <CreateEditWaveModal
+        mode={waveModalMode}
+        onSaved={() => {}}
+        onCancel={closeWaveModal}
+      />
     </>
   );
 };


### PR DESCRIPTION
Part of #574

Boilerplate for the modal and form state is in place. Next steps:
* TypeScript type for MigrationWave, and API queries/mutations for fetching and creating them (need the fetch to validate unique names of new waves)
* Remaining form fields (including #575)
* Populating waves in the table (minimal, row contents can come later), wiring up the kebab Edit action to the state added in this PR
* Form logic for editing (Default values to the ones from `waveBeingEdited` if present)
* Mutation logic for editing (patch request)
* Move on to the waves table itself