### PR TITLE
:bug: Change default tab to first tab when navigating to admin view

### DIFF
--- a/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -69,7 +69,7 @@ export const SidebarApp: React.FC = () => {
             setSelectedPersona(selection as string);
             setIsOpen(!isOpen);
             if (selection === "Administrator") {
-              history.push(Paths.identities);
+              history.push(Paths.general);
             } else {
               history.push(Paths.applications);
             }


### PR DESCRIPTION
Currently the 2nd tab is shown as active when the admin sidenav persona is changed to "administration". This PR changes the default to the new 1st tab which is now "General".