### PR TITLE
:bug: Do not refresh token when feature disabled

### DIFF
--- a/client/src/app/common/KeycloakProvider.tsx
+++ b/client/src/app/common/KeycloakProvider.tsx
@@ -47,10 +47,10 @@ export const KeycloakProvider: React.FC<IKeycloakProviderProps> = ({
             </Flex>
           }
           isLoadingCheck={(keycloak) => {
-            if (keycloak.authenticated && keycloak.refreshToken) {
+            if (keycloak.authenticated) {
               initInterceptors(() => {
                 return new Promise<string>((resolve, reject) => {
-                  if (keycloak.token) {
+                  if (keycloak.token && keycloak.refreshToken) {
                     keycloak
                       .updateToken(60)
                       .then(() => {
@@ -62,6 +62,8 @@ export const KeycloakProvider: React.FC<IKeycloakProviderProps> = ({
                         console.log("err", err);
                         return reject("Failed to refresh token");
                       });
+                  } else if (keycloak.token) {
+                    return resolve(keycloak.token!);
                   } else {
                     keycloak.login();
                     reject("Not logged in");

--- a/client/src/app/common/KeycloakProvider.tsx
+++ b/client/src/app/common/KeycloakProvider.tsx
@@ -47,7 +47,7 @@ export const KeycloakProvider: React.FC<IKeycloakProviderProps> = ({
             </Flex>
           }
           isLoadingCheck={(keycloak) => {
-            if (keycloak.authenticated) {
+            if (keycloak.authenticated && keycloak.refreshToken) {
               initInterceptors(() => {
                 return new Promise<string>((resolve, reject) => {
                   if (keycloak.token) {

--- a/client/src/app/common/KeycloakProvider.tsx
+++ b/client/src/app/common/KeycloakProvider.tsx
@@ -48,28 +48,29 @@ export const KeycloakProvider: React.FC<IKeycloakProviderProps> = ({
           }
           isLoadingCheck={(keycloak) => {
             if (keycloak.authenticated) {
-              initInterceptors(() => {
-                return new Promise<string>((resolve, reject) => {
-                  if (keycloak.token && keycloak.refreshToken) {
-                    keycloak
-                      .updateToken(60)
-                      .then(() => {
-                        deleteCookie("keycloak_cookie");
-                        checkAuthCookie();
-                        return resolve(keycloak.token!);
-                      })
-                      .catch((err) => {
-                        console.log("err", err);
-                        return reject("Failed to refresh token");
-                      });
-                  } else if (keycloak.token) {
-                    return resolve(keycloak.token!);
-                  } else {
-                    keycloak.login();
-                    reject("Not logged in");
-                  }
-                });
-              });
+              initInterceptors(
+                () =>
+                  new Promise<string>((resolve, reject) => {
+                    if (keycloak.token) {
+                      if (keycloak.refreshToken) {
+                        keycloak
+                          .updateToken(60)
+                          .then(() => {
+                            deleteCookie("keycloak_cookie");
+                            checkAuthCookie();
+                            return resolve(keycloak.token!);
+                          })
+                          .catch((err) => {
+                            console.log("err", err);
+                            return reject("Failed to refresh token");
+                          });
+                      } else return resolve(keycloak.token!);
+                    } else {
+                      keycloak.login();
+                      reject("Not logged in");
+                    }
+                  })
+              );
 
               const kcLocale = (keycloak.tokenParsed as any)["locale"];
               if (kcLocale) {


### PR DESCRIPTION
When the "Use Refresh Token" (OpenID Connect Compatibility Modes) is off the refresh_token is not generated.

Resolves https://issues.redhat.com/browse/MTA-41