### PR TITLE
:sparkles: Expand tag category color palette to 16 colors, add deterministic fallback colors for tag categories

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@hookform/resolvers": "^2.8.0",
     "@hot-loader/react-dom": "^17.0.2",
-    "@migtools/lib-ui": "^8.7.0",
+    "@migtools/lib-ui": "^8.8.0",
     "@patternfly/patternfly": "^4.222.4",
     "@patternfly/react-charts": "^6.94.15",
     "@patternfly/react-core": "^4.267.6",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -50,12 +50,22 @@
     "viewErrorReport": "View error report"
   },
   "colors": {
+    "black": "Black",
     "blue": "Blue",
+    "brown": "Brown",
     "cyan": "Cyan",
+    "gold": "Gold",
+    "gray": "Gray",
     "green": "Green",
+    "lime": "Lime",
+    "magenta": "Magenta",
+    "maroon": "Maroon",
+    "navy": "Navy",
+    "olive": "Olive",
     "orange": "Orange",
     "purple": "Purple",
-    "red": "Red"
+    "red": "Red",
+    "teal": "Teal"
   },
   "composed": {
     "add": "Add {{what}}",

--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -42,6 +42,8 @@ export const DEFAULT_SELECT_MAX_HEIGHT = 200;
 // t('colors.purple')
 // t('colors.red')
 
+// TODO move the TAG_COLORS here and figure out how to make the rest of the UI happy with that
+
 export const DEFAULT_COLOR_LABELS: Map<string, string> = new Map([
   [blue.value, "blue"],
   [cyan.value, "cyan"],

--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -54,6 +54,7 @@ export const DEFAULT_SELECT_MAX_HEIGHT = 200;
 // t('colors.black')
 
 // Colors from https://sashamaps.net/docs/resources/20-colors/ with some colors removed for being too bright
+// and closest equivalent PF colors swapped in where applicable
 export const COLOR_HEX_VALUES_BY_NAME = {
   red: "#d95f55", // (PF red is weird because 100 is too close to Maroon and 50 is too bright)
   green: green.value,

--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -1,11 +1,12 @@
 import {
+  global_palette_black_1000 as black,
+  global_palette_black_500 as gray,
   global_palette_blue_300 as blue,
   global_palette_green_300 as green,
   global_palette_cyan_300 as cyan,
-  global_palette_purple_300 as purple,
+  global_palette_purple_600 as purple,
+  global_palette_gold_300 as gold,
   global_palette_orange_300 as orange,
-  global_palette_red_300 as red,
-  global_palette_black_400 as black,
 } from "@patternfly/react-tokens";
 
 import {
@@ -35,32 +36,49 @@ export const DEFAULT_SELECT_MAX_HEIGHT = 200;
 
 // Colors
 
-// t('colors.blue')
-// t('colors.cyan')
+// t('colors.red')
 // t('colors.green')
+// t('colors.gold')
+// t('colors.blue')
 // t('colors.orange')
 // t('colors.purple')
-// t('colors.red')
+// t('colors.cyan')
+// t('colors.magenta')
+// t('colors.lime')
+// t('colors.teal')
+// t('colors.brown')
+// t('colors.maroon')
+// t('colors.olive')
+// t('colors.navy')
+// t('colors.gray')
+// t('colors.black')
 
-// TODO move the TAG_COLORS here and figure out how to make the rest of the UI happy with that
+// Colors from https://sashamaps.net/docs/resources/20-colors/ with some colors removed for being too bright
+export const COLOR_HEX_VALUES_BY_NAME = {
+  red: "#d95f55", // (PF red is weird because 100 is too close to Maroon and 50 is too bright)
+  green: green.value,
+  gold: gold.value,
+  blue: blue.value,
+  orange: orange.value,
+  purple: purple.value,
+  cyan: cyan.value,
+  magenta: "#f032e6",
+  lime: "#bfef45",
+  teal: "#469990",
+  brown: "#9a6324",
+  maroon: "#800000",
+  olive: "#808000",
+  navy: "#000075",
+  gray: gray.value,
+  black: black.value,
+} as const;
 
-export const DEFAULT_COLOR_LABELS: Map<string, string> = new Map([
-  [blue.value, "blue"],
-  [cyan.value, "cyan"],
-  [green.value, "green"],
-  [orange.value, "orange"],
-  [purple.value, "purple"],
-  [red.value, "red"],
-]);
-
-export const DEFAULT_COLOR_PALETE = [
-  blue.value,
-  cyan.value,
-  green.value,
-  orange.value,
-  purple.value,
-  red.value,
-];
+export const COLOR_NAMES_BY_HEX_VALUE: Record<
+  string,
+  keyof typeof COLOR_HEX_VALUES_BY_NAME | undefined
+> = Object.fromEntries(
+  Object.entries(COLOR_HEX_VALUES_BY_NAME).map((e) => e.reverse())
+);
 
 // Risks
 type RiskListType = {

--- a/client/src/app/pages/applications/application-review/components/application-assessment-donut-chart/tests/__snapshots__/application-assessment-donut-chart.test.tsx.snap
+++ b/client/src/app/pages/applications/application-review/components/application-assessment-donut-chart/tests/__snapshots__/application-assessment-donut-chart.test.tsx.snap
@@ -51,7 +51,7 @@ Object {
                 d="M-56.59479785059055,76.30222051979085A95,95,0,0,1,-0.9368333156413414,-94.99538064210651L-0.9368333156413101,-49.99122266297059A50,50,0,0,0,-30.14201749861381,39.89309189713501Z"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill: #b8bbbe; padding: 8px; stroke: var(--pf-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+                style="fill: #030303; padding: 8px; stroke: var(--pf-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
                 transform="translate(130, 115)"
               />
             </g>
@@ -104,7 +104,7 @@ Object {
       z"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill: #b8bbbe;"
+                style="fill: #030303;"
               />
               <text
                 direction="inherit"
@@ -237,7 +237,7 @@ Object {
               d="M-56.59479785059055,76.30222051979085A95,95,0,0,1,-0.9368333156413414,-94.99538064210651L-0.9368333156413101,-49.99122266297059A50,50,0,0,0,-30.14201749861381,39.89309189713501Z"
               role="presentation"
               shape-rendering="auto"
-              style="fill: #b8bbbe; padding: 8px; stroke: var(--pf-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+              style="fill: #030303; padding: 8px; stroke: var(--pf-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
               transform="translate(130, 115)"
             />
           </g>
@@ -290,7 +290,7 @@ Object {
       z"
               role="presentation"
               shape-rendering="auto"
-              style="fill: #b8bbbe;"
+              style="fill: #030303;"
             />
             <text
               direction="inherit"

--- a/client/src/app/pages/applications/components/application-tags/application-tag-label.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tag-label.tsx
@@ -1,40 +1,11 @@
 import * as React from "react";
 import { Tag, TagCategory } from "@app/api/models";
 import { LabelCustomColor } from "@migtools/lib-ui";
-import {
-  global_palette_black_1000 as black,
-  global_palette_black_500 as gray,
-  global_palette_blue_300 as blue,
-  global_palette_green_300 as green,
-  global_palette_cyan_300 as cyan,
-  global_palette_purple_600 as purple,
-  global_palette_gold_300 as gold,
-  global_palette_orange_300 as orange,
-} from "@patternfly/react-tokens";
-
-// Colors from https://sashamaps.net/docs/resources/20-colors/ with some colors removed for being too bright
-export const TAG_COLORS = {
-  red: "#D95F55", // (PF red is weird because 100 is too close to Maroon and 50 is too bright)
-  green: green.value,
-  gold: gold.value,
-  blue: blue.value,
-  orange: orange.value,
-  purple: purple.value,
-  cyan: cyan.value,
-  magenta: "#F032E6",
-  lime: "#BFEF45",
-  teal: "#469990",
-  brown: "#9A6324",
-  maroon: "#800000",
-  olive: "#808000",
-  navy: "#000075",
-  gray: gray.value,
-  black: black.value,
-};
+import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
 
 const getCategoryFallbackColor = (category?: TagCategory) => {
-  if (!category?.id) return TAG_COLORS.gray;
-  const colorValues = Object.values(TAG_COLORS);
+  if (!category?.id) return COLOR_HEX_VALUES_BY_NAME.gray;
+  const colorValues = Object.values(COLOR_HEX_VALUES_BY_NAME);
   return colorValues[category?.id % colorValues.length];
 };
 

--- a/client/src/app/pages/applications/components/application-tags/application-tag-label.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tag-label.tsx
@@ -1,30 +1,41 @@
 import * as React from "react";
 import { Tag, TagCategory } from "@app/api/models";
 import { LabelCustomColor } from "@migtools/lib-ui";
+import {
+  global_palette_black_1000 as black,
+  global_palette_black_500 as gray,
+  global_palette_blue_300 as blue,
+  global_palette_green_300 as green,
+  global_palette_cyan_300 as cyan,
+  global_palette_purple_600 as purple,
+  global_palette_gold_300 as gold,
+  global_palette_orange_300 as orange,
+} from "@patternfly/react-tokens";
 
 // Colors from https://sashamaps.net/docs/resources/20-colors/ with some colors removed for being too bright
-const TAG_FALLBACK_COLORS = [
-  "#E6194B", // Red
-  "#3CB44B", // Green
-  "#FFE119", // Yellow
-  "#4363D8", // Blue
-  "#F58231", // Orange
-  "#911EB4", // Purple
-  "#42D4F4", // Cyan
-  "#F032E6", // Magenta
-  "#BFEF45", // Lime
-  "#469990", // Teal
-  "#9A6324", // Brown
-  "#800000", // Maroon
-  "#808000", // Olive
-  "#000075", // Navy
-  "#A9A9A9", // Grey
-  "#000000", // Black
-];
+export const TAG_COLORS = {
+  red: "#D95F55", // (PF red is weird because 100 is too close to Maroon and 50 is too bright)
+  green: green.value,
+  gold: gold.value,
+  blue: blue.value,
+  orange: orange.value,
+  purple: purple.value,
+  cyan: cyan.value,
+  magenta: "#F032E6",
+  lime: "#BFEF45",
+  teal: "#469990",
+  brown: "#9A6324",
+  maroon: "#800000",
+  olive: "#808000",
+  navy: "#000075",
+  gray: gray.value,
+  black: black.value,
+};
 
 const getCategoryFallbackColor = (category?: TagCategory) => {
-  if (!category?.id) return "#A9A9A9"; // Grey
-  return TAG_FALLBACK_COLORS[category?.id % TAG_FALLBACK_COLORS.length];
+  if (!category?.id) return TAG_COLORS.gray;
+  const colorValues = Object.values(TAG_COLORS);
+  return colorValues[category?.id % colorValues.length];
 };
 
 export interface ApplicationTagLabelProps {

--- a/client/src/app/pages/applications/components/application-tags/application-tag-label.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tag-label.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { Tag, TagCategory } from "@app/api/models";
+import { LabelCustomColor } from "@migtools/lib-ui";
+
+// Colors from https://sashamaps.net/docs/resources/20-colors/ with some colors removed for being too bright
+const TAG_FALLBACK_COLORS = [
+  "#E6194B", // Red
+  "#3CB44B", // Green
+  "#FFE119", // Yellow
+  "#4363D8", // Blue
+  "#F58231", // Orange
+  "#911EB4", // Purple
+  "#42D4F4", // Cyan
+  "#F032E6", // Magenta
+  "#BFEF45", // Lime
+  "#469990", // Teal
+  "#9A6324", // Brown
+  "#800000", // Maroon
+  "#808000", // Olive
+  "#000075", // Navy
+  "#A9A9A9", // Grey
+  "#000000", // Black
+];
+
+const getCategoryFallbackColor = (category?: TagCategory) => {
+  if (!category?.id) return "#A9A9A9"; // Grey
+  return TAG_FALLBACK_COLORS[category?.id % TAG_FALLBACK_COLORS.length];
+};
+
+export interface ApplicationTagLabelProps {
+  tag: Tag;
+  category?: TagCategory;
+  className?: string;
+}
+
+export const ApplicationTagLabel: React.FC<ApplicationTagLabelProps> = ({
+  tag,
+  category,
+  className,
+}) => (
+  <LabelCustomColor
+    color={category?.colour || getCategoryFallbackColor(category)}
+    className={className}
+  >
+    {tag.name}
+  </LabelCustomColor>
+);

--- a/client/src/app/pages/applications/components/application-tags/application-tags.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tags.tsx
@@ -28,6 +28,7 @@ import {
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
 import { useHistory } from "react-router-dom";
+import { ApplicationTagLabel } from "./application-tag-label";
 
 interface TagWithSource extends Tag {
   source?: string;
@@ -209,9 +210,10 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
                 </Text>
               </TextContent>
               {Array.from(tagCategoriesInThisSource).map((tagCategory) => {
-                const tagsInThisCategoryInThisSource = tagsInThisSource?.filter(
-                  (tag) => tag.category?.id === tagCategory.id
-                );
+                const tagsInThisCategoryInThisSource =
+                  tagsInThisSource?.filter(
+                    (tag) => tag.category?.id === tagCategory.id
+                  ) || [];
                 return (
                   <React.Fragment key={tagCategory.id}>
                     <TextContent>
@@ -223,19 +225,16 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
                       </Text>
                     </TextContent>
                     <Flex>
-                      {tagsInThisCategoryInThisSource &&
-                        tagsInThisCategoryInThisSource.map((tag) => (
-                          <LabelCustomColor
-                            key={tag.id}
-                            color={
-                              tagCategoriesById.get(tag?.category?.id || 0)
-                                ?.colour || "gray"
-                            }
-                            className={spacing.mXs}
-                          >
-                            {tag.name}
-                          </LabelCustomColor>
-                        ))}
+                      {tagsInThisCategoryInThisSource.map((tag) => (
+                        <ApplicationTagLabel
+                          key={tag.id}
+                          tag={tag}
+                          category={tagCategoriesById.get(
+                            tag?.category?.id || 0
+                          )}
+                          className={spacing.mXs}
+                        />
+                      ))}
                     </Flex>
                   </React.Fragment>
                 );

--- a/client/src/app/pages/controls/tags/components/tag-category-form/tag-category-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-category-form/tag-category-form.tsx
@@ -17,7 +17,7 @@ import {
 import { SingleSelectOptionValueFormikField } from "@app/shared/components";
 import {
   DEFAULT_SELECT_MAX_HEIGHT,
-  DEFAULT_COLOR_PALETE as DEFAULT_COLOR_PALETTE,
+  COLOR_HEX_VALUES_BY_NAME,
 } from "@app/Constants";
 import { createTagCategory, updateTagCategory } from "@app/api/rest";
 import { TagCategory } from "@app/api/models";
@@ -208,7 +208,7 @@ export const TagCategoryForm: React.FC<TagCategoryFormProps> = ({
               menuAppendTo: () => document.body,
               maxHeight: DEFAULT_SELECT_MAX_HEIGHT,
             }}
-            options={DEFAULT_COLOR_PALETTE}
+            options={Object.values(COLOR_HEX_VALUES_BY_NAME)}
             toOptionWithValue={colorHexToOptionWithValue}
           />
         </FormGroup>

--- a/client/src/app/pages/controls/tags/tags.tsx
+++ b/client/src/app/pages/controls/tags/tags.tsx
@@ -43,7 +43,6 @@ import {
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
 import { useSortState } from "@app/shared/hooks/useSortState";
-import { DEFAULT_COLOR_LABELS } from "@app/Constants";
 import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
 import {
   useDeleteTagMutation,
@@ -51,6 +50,7 @@ import {
   useFetchTagCategories,
 } from "@app/queries/tags";
 import { NotificationsContext } from "@app/shared/notifications-context";
+import { COLOR_NAMES_BY_HEX_VALUE } from "@app/Constants";
 
 const ENTITY_FIELD = "entity";
 
@@ -217,8 +217,9 @@ export const Tags: React.FC = () => {
           what: t("terms.color").toLowerCase(),
         }) + "...",
       getItemValue: (item) => {
-        const colorLabel = DEFAULT_COLOR_LABELS.get(item?.colour || "");
-        return colorLabel || "";
+        const hex = item?.colour || "";
+        const colorLabel = COLOR_NAMES_BY_HEX_VALUE[hex];
+        return colorLabel || hex;
       },
     },
   ];

--- a/client/src/app/shared/components/color/color.tsx
+++ b/client/src/app/shared/components/color/color.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { Split, SplitItem } from "@patternfly/react-core";
 
-import { DEFAULT_COLOR_LABELS } from "@app/Constants";
+import { COLOR_NAMES_BY_HEX_VALUE } from "@app/Constants";
 import "./color.css";
 
 export interface ColorProps {
@@ -13,7 +13,7 @@ export interface ColorProps {
 export const Color: React.FC<ColorProps> = ({ hex }) => {
   const { t } = useTranslation();
 
-  const colorName = DEFAULT_COLOR_LABELS.get(hex.toLowerCase());
+  const colorName = COLOR_NAMES_BY_HEX_VALUE[hex.toLowerCase()];
 
   return (
     <Split hasGutter>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@hookform/resolvers": "^2.8.0",
         "@hot-loader/react-dom": "^17.0.2",
-        "@migtools/lib-ui": "^8.7.0",
+        "@migtools/lib-ui": "^8.8.0",
         "@patternfly/patternfly": "^4.222.4",
         "@patternfly/react-charts": "^6.94.15",
         "@patternfly/react-core": "^4.267.6",
@@ -1372,9 +1372,9 @@
       "dev": true
     },
     "node_modules/@migtools/lib-ui": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.7.0.tgz",
-      "integrity": "sha512-OCneJoywNFZ2QdKH5MM9x9od9H3F7i35MHgYMWLLYBZp71u/qN0lAW/8qlJGw1CsCZou9PMqkulyxMO9TuJ0VA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.8.0.tgz",
+      "integrity": "sha512-AvMeIIJKKsajgPTsy+4fDbCJJy9GxA5X2ahfsesmVZFeny5fSODyIrG0hxGaXqrodoc8b7w/gWfjhiZ6MmNdzg==",
       "dependencies": {
         "@tanstack/react-query": "^4.26.1",
         "fast-deep-equal": "^3.1.3",
@@ -1382,8 +1382,8 @@
         "yup": "^0.32.9"
       },
       "peerDependencies": {
-        "@patternfly/react-core": "^4.221.3",
-        "@patternfly/react-tokens": "^4.73.3",
+        "@patternfly/react-core": "^4.276.6",
+        "@patternfly/react-tokens": "^4.94.6",
         "axios": "^0.21.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
@@ -14845,9 +14845,9 @@
       "dev": true
     },
     "@migtools/lib-ui": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.7.0.tgz",
-      "integrity": "sha512-OCneJoywNFZ2QdKH5MM9x9od9H3F7i35MHgYMWLLYBZp71u/qN0lAW/8qlJGw1CsCZou9PMqkulyxMO9TuJ0VA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-8.8.0.tgz",
+      "integrity": "sha512-AvMeIIJKKsajgPTsy+4fDbCJJy9GxA5X2ahfsesmVZFeny5fSODyIrG0hxGaXqrodoc8b7w/gWfjhiZ6MmNdzg==",
       "requires": {
         "@tanstack/react-query": "^4.26.1",
         "fast-deep-equal": "^3.1.3",
@@ -16456,7 +16456,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@hookform/resolvers": "^2.8.0",
         "@hot-loader/react-dom": "^17.0.2",
-        "@migtools/lib-ui": "^8.7.0",
+        "@migtools/lib-ui": "^8.8.0",
         "@patternfly/patternfly": "^4.222.4",
         "@patternfly/react-charts": "^6.94.15",
         "@patternfly/react-core": "^4.267.6",


### PR DESCRIPTION
Finishes [MTA-332](https://issues.redhat.com/browse/MTA-332)