### PR TITLE
:sparkles: Move Migration Waves behind a disabled feature flag + some renaming

### DIFF
--- a/client/src/app/FeatureFlags.ts
+++ b/client/src/app/FeatureFlags.ts
@@ -1,3 +1,3 @@
 export const FEATURES_ENABLED = {
-  migrationWaves: true,
+  migrationWaves: false,
 };

--- a/client/src/app/FeatureFlags.ts
+++ b/client/src/app/FeatureFlags.ts
@@ -1,0 +1,3 @@
+export const FEATURES_ENABLED = {
+  migrationWaves: true,
+};

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -12,6 +12,7 @@ import { RouteWrapper } from "./common/RouteWrapper";
 import { adminRoles, devRoles } from "./rbac";
 import { ErrorBoundary } from "react-error-boundary";
 import { ErrorFallback } from "@app/common/ErrorFallback";
+import { FEATURES_ENABLED } from "./FeatureFlags";
 
 const Applications = lazy(() => import("./pages/applications"));
 const ManageImports = lazy(() => import("./pages/applications/manage-imports"));
@@ -72,11 +73,15 @@ export const devRoutes: IRoute[] = [
     comp: Reports,
     exact: false,
   },
-  {
-    path: Paths.waves,
-    comp: Waves,
-    exact: false,
-  },
+  ...(FEATURES_ENABLED.migrationWaves
+    ? [
+        {
+          path: Paths.waves,
+          comp: Waves,
+          exact: false,
+        },
+      ]
+    : []),
 ];
 
 export const adminRoutes: IRoute[] = [

--- a/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -20,6 +20,7 @@ import keycloak from "@app/keycloak";
 import "./SidebarApp.css";
 import { useLocalStorage } from "@migtools/lib-ui";
 import { LocalStorageKey } from "@app/Constants";
+import { FEATURES_ENABLED } from "@app/FeatureFlags";
 
 export const SidebarApp: React.FC = () => {
   const token = keycloak.tokenParsed || undefined;
@@ -101,11 +102,13 @@ export const SidebarApp: React.FC = () => {
               {t("sidebar.controls")}
             </NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink to={Paths.waves} activeClassName="pf-m-current">
-              {t("sidebar.waves")}
-            </NavLink>
-          </NavItem>
+          {FEATURES_ENABLED.migrationWaves ? (
+            <NavItem>
+              <NavLink to={Paths.waves} activeClassName="pf-m-current">
+                {t("sidebar.waves")}
+              </NavLink>
+            </NavItem>
+          ) : null}
         </NavList>
       ) : (
         <NavList title="Admin">

--- a/client/src/app/pages/jira-trackers/jira-trackers.tsx
+++ b/client/src/app/pages/jira-trackers/jira-trackers.tsx
@@ -10,7 +10,7 @@ import {
   ToolbarItem,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import { ComposableAppTable } from "@app/shared/components/composable-app-table";
+import { ComposableTableWithControls } from "@app/shared/components/composable-table-with-controls";
 import { AppPlaceholder, ConditionalRender } from "@app/shared/components";
 import { usePaginationState } from "@app/shared/hooks/usePaginationState";
 import { useSortState } from "@app/shared/hooks/useSortState";
@@ -21,7 +21,7 @@ import {
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { IComposableRow } from "@app/shared/components/composable-app-table/composable-app-table";
+import { IComposableRow } from "@app/shared/components/composable-table-with-controls/composable-table-with-controls";
 import { useFetchJiraTrackers } from "@app/queries/jiratrackers";
 
 export const JiraTrackers: React.FC = () => {
@@ -102,7 +102,7 @@ export const JiraTrackers: React.FC = () => {
           when={isFetching && !(jiraTrackers || fetchError)}
           then={<AppPlaceholder />}
         >
-          <ComposableAppTable
+          <ComposableTableWithControls
             isSelectable={true}
             toolbarActions={
               <>
@@ -148,7 +148,7 @@ export const JiraTrackers: React.FC = () => {
               />
             }
             toolbarClearAllFilters={handleOnClearAllFilters}
-          ></ComposableAppTable>
+          ></ComposableTableWithControls>
         </ConditionalRender>
       </PageSection>
     </>

--- a/client/src/app/pages/waves/components/create-edit-wave-modal/create-edit-wave-modal.tsx
+++ b/client/src/app/pages/waves/components/create-edit-wave-modal/create-edit-wave-modal.tsx
@@ -3,12 +3,11 @@ import { AxiosResponse } from "axios";
 import { Modal, ModalVariant } from "@patternfly/react-core";
 
 import { WaveForm } from "./wave-form";
-
-type MigrationWave = any; // TODO add a real MigrationWave type and queries
+import { Wave } from "@app/api/models";
 
 export interface CreateEditWaveModalProps {
   isOpen: boolean;
-  waveBeingEdited: MigrationWave;
+  waveBeingEdited: Wave | null;
   onSaved: (response: AxiosResponse<unknown>) => void;
   onCancel: () => void;
 }

--- a/client/src/app/pages/waves/components/create-edit-wave-modal/wave-form.tsx
+++ b/client/src/app/pages/waves/components/create-edit-wave-modal/wave-form.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { ActionGroup, Button, Form } from "@patternfly/react-core";
 
-import { Stakeholder, StakeholderGroup } from "@app/api/models";
+import { Stakeholder, StakeholderGroup, Wave } from "@app/api/models";
 import { duplicateNameCheck } from "@app/utils/utils";
 import { HookFormPFTextInput } from "@app/shared/components/hook-form-pf-fields";
 
@@ -17,10 +17,8 @@ interface WaveFormValues {
   stakeholderGroups: StakeholderGroup[];
 }
 
-type MigrationWave = any; // TODO add a real MigrationWave type and queries
-
 export interface WaveFormProps {
-  waveBeingEdited?: MigrationWave;
+  waveBeingEdited?: Wave;
   onCancel: () => void;
 }
 
@@ -30,7 +28,7 @@ export const WaveForm: React.FC<WaveFormProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const waves: { name: string }[] = []; // TODO query this from the API, add a type for MigrationWaves
+  const waves: Wave[] = []; // TODO use the useFetchWaves query here
   const isLoading = false; // TODO
 
   const validationSchema: yup.SchemaOf<WaveFormValues> = yup.object().shape({

--- a/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
+++ b/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
@@ -3,8 +3,8 @@ import { Application } from "@app/api/models";
 import { useTranslation } from "react-i18next";
 import { usePaginationState } from "@app/shared/hooks/usePaginationState";
 import { useSortState } from "@app/shared/hooks/useSortState";
-import { ComposableAppTable } from "@app/shared/components/composable-app-table";
-import { IComposableRow } from "@app/shared/components/composable-app-table/composable-app-table";
+import { ComposableTableWithControls } from "@app/shared/components/composable-table-with-controls";
+import { IComposableRow } from "@app/shared/components/composable-table-with-controls/composable-table-with-controls";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import { Button } from "@patternfly/react-core";
 
@@ -80,12 +80,12 @@ export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
   });
 
   return (
-    <ComposableAppTable
+    <ComposableTableWithControls
       variant="compact"
       rowItems={rows}
       columnNames={columnNames}
       paginationProps={paginationProps}
       withoutBottomPagination={true}
-    ></ComposableAppTable>
+    ></ComposableTableWithControls>
   );
 };

--- a/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
+++ b/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
@@ -3,8 +3,8 @@ import { Application, Stakeholder, Wave } from "@app/api/models";
 import { useTranslation } from "react-i18next";
 import { usePaginationState } from "@app/shared/hooks/usePaginationState";
 import { useSortState } from "@app/shared/hooks/useSortState";
-import { ComposableAppTable } from "@app/shared/components/composable-app-table";
-import { IComposableRow } from "@app/shared/components/composable-app-table/composable-app-table";
+import { ComposableTableWithControls } from "@app/shared/components/composable-table-with-controls";
+import { IComposableRow } from "@app/shared/components/composable-table-with-controls/composable-table-with-controls";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import { Button } from "@patternfly/react-core";
 
@@ -88,12 +88,12 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
   });
 
   return (
-    <ComposableAppTable
+    <ComposableTableWithControls
       variant="compact"
       rowItems={rows}
       columnNames={columnNames}
       paginationProps={paginationProps}
       withoutBottomPagination={true}
-    ></ComposableAppTable>
+    ></ComposableTableWithControls>
   );
 };

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -41,18 +41,17 @@ export const Waves: React.FC = () => {
 
   const { waves, isFetching, fetchError } = useFetchWaves();
 
-  type MigrationWave = any; // TODO add a real MigrationWave type and queries
   // When waveModalState is:
   //   'create': the modal is open for creating a new wave.
-  //   A MigrationWave: the modal is open for editing that wave.
+  //   A Wave: the modal is open for editing that wave.
   //   null: the modal is closed.
   const [waveModalState, setWaveModalState] = React.useState<
-    "create" | MigrationWave | null
+    "create" | Wave | null
   >(null);
   const isWaveModalOpen = waveModalState !== null;
   const waveBeingEdited = waveModalState !== "create" ? waveModalState : null;
   const openCreateWaveModal = () => setWaveModalState("create");
-  const openEditWaveModal = (wave: MigrationWave) => setWaveModalState(wave);
+  const openEditWaveModal = (wave: Wave) => setWaveModalState(wave);
   const closeWaveModal = () => setWaveModalState(null);
 
   const filterCategories: FilterCategory<Wave>[] = [

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -12,7 +12,7 @@ import {
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { useFetchWaves } from "@app/queries/waves";
-import { ComposableAppTable } from "@app/shared/components/composable-app-table";
+import { ComposableTableWithControls } from "@app/shared/components/composable-table-with-controls";
 import {
   AppPlaceholder,
   ConditionalRender,
@@ -31,7 +31,7 @@ import { useFilterState } from "@app/shared/hooks/useFilterState";
 import { useSelectionState } from "@migtools/lib-ui";
 import { TdProps } from "@patternfly/react-table";
 import dayjs from "dayjs";
-import { IComposableRow } from "@app/shared/components/composable-app-table/composable-app-table";
+import { IComposableRow } from "@app/shared/components/composable-table-with-controls/composable-table-with-controls";
 import { WaveApplicationsTable } from "./wave-applications-table/wave-applications-table";
 import { WaveStakeholdersTable } from "./wave-stakeholders-table/wave-stakeholders-table";
 import { CreateEditWaveModal } from "./components/create-edit-wave-modal";
@@ -278,7 +278,7 @@ export const Waves: React.FC = () => {
           when={isFetching && !(waves || fetchError)}
           then={<AppPlaceholder />}
         >
-          <ComposableAppTable
+          <ComposableTableWithControls
             isSelectable={true}
             handleToggleRowSelected={handleToggleRowSelected}
             handleIsRowSelected={handleIsRowSelected}
@@ -336,7 +336,7 @@ export const Waves: React.FC = () => {
               />
             }
             toolbarClearAllFilters={handleOnClearAllFilters}
-          ></ComposableAppTable>
+          ></ComposableTableWithControls>
         </ConditionalRender>
       </PageSection>
       <CreateEditWaveModal

--- a/client/src/app/shared/components/composable-app-table/index.ts
+++ b/client/src/app/shared/components/composable-app-table/index.ts
@@ -1,1 +1,0 @@
-export { ComposableAppTable } from "./composable-app-table";

--- a/client/src/app/shared/components/composable-table-with-controls/composable-table-with-controls.tsx
+++ b/client/src/app/shared/components/composable-table-with-controls/composable-table-with-controls.tsx
@@ -41,7 +41,7 @@ export interface IComposableRow extends TrProps {
 }
 type ColumnNameObj = { [key: string]: string };
 
-export interface IComposableWaveTableWithControlsProps
+export interface IComposableTableWithControlsProps
   extends TableComposableProps {
   withoutTopPagination?: boolean;
   withoutBottomPagination?: boolean;
@@ -66,8 +66,8 @@ export interface IComposableWaveTableWithControlsProps
   noDataState?: any;
 }
 
-export const ComposableAppTable: React.FC<
-  IComposableWaveTableWithControlsProps
+export const ComposableTableWithControls: React.FC<
+  IComposableTableWithControlsProps
 > = ({
   withoutTopPagination,
   withoutBottomPagination,

--- a/client/src/app/shared/components/composable-table-with-controls/index.ts
+++ b/client/src/app/shared/components/composable-table-with-controls/index.ts
@@ -1,0 +1,1 @@
+export { ComposableTableWithControls } from "./composable-table-with-controls";


### PR DESCRIPTION
Mostly this PR makes it possible for us to merge `feature-migration-waves` to main in a non-disruptive way by disabling the waves route and nav item with a boolean feature flag. I also renamed some things and replaced my TODO comments about introducing a `MigrationWave` type with the existing `Wave` type I had forgotten we already had.