### PR TITLE
:seedling: Refactor `ComposableTableWithControls` to use render-props pattern for more flexibility, apply changes to Migration Waves and Jira Trackers tables

### DIFF
--- a/client/src/app/pages/jira-trackers/jira-trackers.tsx
+++ b/client/src/app/pages/jira-trackers/jira-trackers.tsx
@@ -21,8 +21,8 @@ import {
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { IComposableRow } from "@app/shared/components/composable-table-with-controls/composable-table-with-controls";
 import { useFetchJiraTrackers } from "@app/queries/jiratrackers";
+import { Tbody, Tr, Td } from "@patternfly/react-table";
 
 export const JiraTrackers: React.FC = () => {
   const { t } = useTranslation();
@@ -68,27 +68,8 @@ export const JiraTrackers: React.FC = () => {
 
   const columnNames = {
     name: "Name",
-    url: "Start date",
-    type: "Type",
-    actions: "",
-  };
-
-  const rows: IComposableRow[] = [];
-  currentPageItems?.forEach((item, index) => {
-    rows.push({
-      name: item.name,
-      cells: [
-        {
-          title: item.name,
-          width: 25,
-        },
-        {
-          title: "url",
-          width: 10,
-        },
-      ],
-    });
-  });
+    url: "URL",
+  } as const;
 
   return (
     <>
@@ -103,7 +84,7 @@ export const JiraTrackers: React.FC = () => {
           then={<AppPlaceholder />}
         >
           <ComposableTableWithControls
-            isSelectable={true}
+            isSelectable
             toolbarActions={
               <>
                 <ToolbarGroup variant="button-group">
@@ -135,7 +116,6 @@ export const JiraTrackers: React.FC = () => {
                 </ToolbarGroup>
               </>
             }
-            rowItems={rows}
             columnNames={columnNames}
             isLoading={isFetching}
             fetchError={fetchError}
@@ -148,7 +128,21 @@ export const JiraTrackers: React.FC = () => {
               />
             }
             toolbarClearAllFilters={handleOnClearAllFilters}
-          ></ComposableTableWithControls>
+            renderTableBody={() => (
+              <Tbody>
+                {currentPageItems?.map((jiraTracker) => (
+                  <Tr key={jiraTracker.name}>
+                    <Td width={25} dataLabel={columnNames.name}>
+                      {jiraTracker.name}
+                    </Td>
+                    <Td width={10} dataLabel={columnNames.url}>
+                      TODO: URL
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            )}
+          />
         </ConditionalRender>
       </PageSection>
     </>

--- a/client/src/app/pages/jira-trackers/jira-trackers.tsx
+++ b/client/src/app/pages/jira-trackers/jira-trackers.tsx
@@ -119,6 +119,7 @@ export const JiraTrackers: React.FC = () => {
             columnNames={columnNames}
             isLoading={isFetching}
             fetchError={fetchError}
+            isNoData={jiraTrackers.length === 0}
             paginationProps={paginationProps}
             toolbarToggle={
               <FilterToolbar<JiraTracker>

--- a/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
+++ b/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
@@ -1,18 +1,21 @@
 import React from "react";
-import { Application } from "@app/api/models";
+import { Application, Wave } from "@app/api/models";
 import { useTranslation } from "react-i18next";
 import { usePaginationState } from "@app/shared/hooks/usePaginationState";
 import { useSortState } from "@app/shared/hooks/useSortState";
 import { ComposableTableWithControls } from "@app/shared/components/composable-table-with-controls";
-import { IComposableRow } from "@app/shared/components/composable-table-with-controls/composable-table-with-controls";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import { Button } from "@patternfly/react-core";
+import { Tbody, Td, Tr } from "@patternfly/react-table";
+import alignment from "@patternfly/react-styles/css/utilities/Alignment/alignment";
 
 export interface IWaveApplicationsTableProps {
+  wave: Wave;
   applications: Application[];
 }
 
 export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
+  wave,
   applications,
 }) => {
   const { t } = useTranslation();
@@ -21,8 +24,7 @@ export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
     description: "Description",
     businessService: "Business service",
     owner: "Owner",
-    actions: "",
-  };
+  } as const;
 
   const getSortValues = (item: Application) => [
     item?.name || "",
@@ -33,6 +35,7 @@ export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
     "", // Action column
   ];
 
+  // TODO add sort stuff to ComposableTableWithControls
   const { sortBy, onSort, sortedItems } = useSortState(
     applications,
     getSortValues
@@ -41,51 +44,39 @@ export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
   const { currentPageItems, setPageNumber, paginationProps } =
     usePaginationState(sortedItems, 10);
 
-  const rows: IComposableRow[] = [];
-  currentPageItems?.forEach((item, index) => {
-    rows.push({
-      id: item.name,
-      cells: [
-        {
-          id: "appName",
-          title: item.name,
-          width: 25,
-        },
-        {
-          id: "description",
-          title: item.description,
-          width: 10,
-        },
-        {
-          id: "businessServiceName",
-          title: item?.businessService?.name,
-          width: 10,
-        },
-        {
-          id: "owner",
-          title: "TODO: Owner",
-          width: 10,
-        },
-        {
-          children: (
-            <Button type="button" variant="plain" onClick={() => {}}>
-              <TrashIcon />
-            </Button>
-          ),
-          width: 10,
-          style: { textAlign: "right" },
-        },
-      ],
-    });
-  });
-
   return (
     <ComposableTableWithControls
       variant="compact"
-      rowItems={rows}
+      aria-label={`Applications table for wave ${wave.name}`}
       columnNames={columnNames}
+      hasActionsColumn
       paginationProps={paginationProps}
       withoutBottomPagination={true}
-    ></ComposableTableWithControls>
+      renderTableBody={() => (
+        <Tbody>
+          {currentPageItems?.map((app) => (
+            <Tr key={app.name}>
+              <Td width={25} dataLabel={columnNames.appName}>
+                {app.name}
+              </Td>
+              <Td width={10} dataLabel={columnNames.description}>
+                {app.description}
+              </Td>
+              <Td width={10} dataLabel={columnNames.businessService}>
+                {app?.businessService?.name}
+              </Td>
+              <Td width={10} dataLabel={columnNames.owner}>
+                TODO: Owner
+              </Td>
+              <Td width={10} className={alignment.textAlignRight}>
+                <Button type="button" variant="plain" onClick={() => {}}>
+                  <TrashIcon />
+                </Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      )}
+    />
   );
 };

--- a/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
+++ b/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
@@ -52,6 +52,7 @@ export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
       hasActionsColumn
       paginationProps={paginationProps}
       withoutBottomPagination={true}
+      isNoData={applications.length === 0}
       renderTableBody={() => (
         <Tbody>
           {currentPageItems?.map((app) => (

--- a/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
+++ b/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
@@ -57,6 +57,7 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
       hasActionsColumn
       paginationProps={paginationProps}
       withoutBottomPagination={true}
+      isNoData={stakeholders.length === 0}
       renderTableBody={() => (
         <>
           {currentPageItems?.map((stakeholder) => (

--- a/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
+++ b/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
@@ -1,18 +1,21 @@
 import React from "react";
-import { Application, Stakeholder, Wave } from "@app/api/models";
+import { Stakeholder, Wave } from "@app/api/models";
 import { useTranslation } from "react-i18next";
 import { usePaginationState } from "@app/shared/hooks/usePaginationState";
 import { useSortState } from "@app/shared/hooks/useSortState";
 import { ComposableTableWithControls } from "@app/shared/components/composable-table-with-controls";
-import { IComposableRow } from "@app/shared/components/composable-table-with-controls/composable-table-with-controls";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import { Button } from "@patternfly/react-core";
+import { Td, Tr } from "@patternfly/react-table";
+import alignment from "@patternfly/react-styles/css/utilities/Alignment/alignment";
 
 export interface IWaveStakeholdersTableProps {
+  wave: Wave;
   stakeholders: Stakeholder[];
 }
 
 export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
+  wave,
   stakeholders,
 }) => {
   const { t } = useTranslation();
@@ -22,8 +25,9 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
   const columnNames = {
     name: "Name",
     jobFunction: "Job Function",
-    role: "role",
-    owner: "Stakeholders",
+    role: "Role",
+    email: "Email",
+    groups: "Stakeholder groups",
     actions: "",
   };
 
@@ -36,6 +40,7 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
     "", // Action column
   ];
 
+  // TODO add sort stuff to ComposableTableWithControls
   const { sortBy, onSort, sortedItems } = useSortState(
     stakeholders,
     getSortValues
@@ -44,56 +49,42 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
   const { currentPageItems, setPageNumber, paginationProps } =
     usePaginationState(sortedItems, 10);
 
-  const rows: IComposableRow[] = [];
-  currentPageItems?.forEach((item, index) => {
-    rows.push({
-      id: item.name,
-      cells: [
-        {
-          id: "name",
-          title: item.name,
-          width: 25,
-        },
-        {
-          id: "jobFunction",
-          title: item.jobFunction?.name,
-          width: 10,
-        },
-        {
-          id: "role",
-          title: "TODO: Role",
-          width: 10,
-        },
-        {
-          id: "email",
-          title: item.email,
-          width: 10,
-        },
-        {
-          id: "groups",
-          title: item?.stakeholderGroups?.length?.toString(),
-          width: 10,
-        },
-        {
-          children: (
-            <Button type="button" variant="plain" onClick={() => {}}>
-              <TrashIcon />
-            </Button>
-          ),
-          width: 10,
-          style: { textAlign: "right" },
-        },
-      ],
-    });
-  });
-
   return (
     <ComposableTableWithControls
       variant="compact"
-      rowItems={rows}
+      aria-label={`Stakeholders table for wave ${wave.name}`}
       columnNames={columnNames}
+      hasActionsColumn
       paginationProps={paginationProps}
       withoutBottomPagination={true}
-    ></ComposableTableWithControls>
+      renderTableBody={() => (
+        <>
+          {currentPageItems?.map((stakeholder) => (
+            <Tr key={stakeholder.name}>
+              <Td width={25} dataLabel={columnNames.name}>
+                {stakeholder.name}
+              </Td>
+              <Td width={10} dataLabel={columnNames.jobFunction}>
+                {stakeholder.jobFunction?.name}
+              </Td>
+              <Td width={10} dataLabel={columnNames.role}>
+                TODO: Role
+              </Td>
+              <Td width={10} dataLabel={columnNames.email}>
+                {stakeholder.email}
+              </Td>
+              <Td width={10} dataLabel={columnNames.groups}>
+                {stakeholder?.stakeholderGroups?.length?.toString()}
+              </Td>
+              <Td width={10} className={alignment.textAlignRight}>
+                <Button type="button" variant="plain" onClick={() => {}}>
+                  <TrashIcon />
+                </Button>
+              </Td>
+            </Tr>
+          ))}
+        </>
+      )}
+    />
   );
 };

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -112,27 +112,6 @@ export const Waves: React.FC = () => {
     status: "Status",
   } as const;
 
-  //Compound expandable code
-  // TODO can we abstract this into the component? should we?
-  const [expandedCells, setExpandedCells] = React.useState<
-    Record<string, keyof typeof columnNames>
-  >({
-    wave1: "applications", // Default to the first cell of the first row being expanded
-  });
-  const setCellExpanded = (
-    wave: Wave,
-    columnKey: keyof typeof columnNames,
-    isExpanding = true
-  ) => {
-    const newExpandedCells = { ...expandedCells };
-    if (isExpanding) {
-      newExpandedCells[wave.name] = columnKey;
-    } else {
-      delete newExpandedCells[wave.name];
-    }
-    setExpandedCells(newExpandedCells);
-  };
-
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -149,12 +128,6 @@ export const Waves: React.FC = () => {
             isSelectable
             isRowSelected={isRowSelected}
             toggleRowSelected={toggleRowSelected}
-            isExpandable
-            isRowExpanded={(wave, columnKey) =>
-              columnKey
-                ? expandedCells[wave.name] === columnKey
-                : !!expandedCells[wave.name]
-            }
             toolbarActions={
               <ToolbarGroup variant="button-group">
                 {/* <RBAC
@@ -227,6 +200,7 @@ export const Waves: React.FC = () => {
             }
             toolbarClearAllFilters={handleOnClearAllFilters}
             renderTableBody={({
+              isCellExpanded,
               getSelectCheckboxTdProps,
               getCompoundExpandTdProps,
               getExpandedContentTdProps,
@@ -234,10 +208,7 @@ export const Waves: React.FC = () => {
               <>
                 {currentPageItems?.map((wave, rowIndex) => {
                   return (
-                    <Tbody
-                      key={wave.id}
-                      isExpanded={!!expandedCells[wave.name]}
-                    >
+                    <Tbody key={wave.id} isExpanded={isCellExpanded(wave)}>
                       <Tr>
                         <Td
                           {...getSelectCheckboxTdProps({
@@ -258,12 +229,6 @@ export const Waves: React.FC = () => {
                             item: wave,
                             rowIndex,
                             columnKey: "applications",
-                            onToggle: () =>
-                              setCellExpanded(
-                                wave,
-                                "applications",
-                                expandedCells[wave.name] !== "applications"
-                              ),
                           })}
                         >
                           {wave?.applications?.length.toString()}
@@ -274,12 +239,6 @@ export const Waves: React.FC = () => {
                             item: wave,
                             rowIndex,
                             columnKey: "stakeholders",
-                            onToggle: () =>
-                              setCellExpanded(
-                                wave,
-                                "stakeholders",
-                                expandedCells[wave.name] !== "stakeholders"
-                              ),
                           })}
                         >
                           {wave?.stakeholders?.length.toString()}
@@ -313,15 +272,11 @@ export const Waves: React.FC = () => {
                           />
                         </Td>
                       </Tr>
-                      {expandedCells[wave.name] ? (
+                      {isCellExpanded(wave) ? (
                         <Tr isExpanded>
-                          <Td
-                            {...getExpandedContentTdProps({
-                              expandedColumnKey: expandedCells[wave.name],
-                            })}
-                          >
+                          <Td {...getExpandedContentTdProps({ item: wave })}>
                             <ExpandableRowContent>
-                              {expandedCells[wave.name] === "applications" ? (
+                              {isCellExpanded(wave, "applications") ? (
                                 // TODO restore this
                                 /*
                                   <WaveApplicationsTable
@@ -331,8 +286,7 @@ export const Waves: React.FC = () => {
                                 <h1>
                                   TODO expanded content here for Applications
                                 </h1>
-                              ) : expandedCells[wave.name] ===
-                                "stakeholders" ? (
+                              ) : isCellExpanded(wave, "stakeholders") ? (
                                 // TODO restore this
                                 /*
                                   <WaveStakeholdersTable

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -179,7 +179,7 @@ export const Waves: React.FC = () => {
             hasActionsColumn
             isLoading={isFetching}
             fetchError={fetchError}
-            isNoData={currentPageItems.length === 0}
+            isNoData={waves.length === 0}
             paginationProps={paginationProps}
             toolbarBulkSelector={
               <ToolbarBulkSelector

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -29,7 +29,7 @@ import {
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
 import { useSelectionState } from "@migtools/lib-ui";
-import { TdProps } from "@patternfly/react-table";
+import { Tbody, Td, TdProps, Tr } from "@patternfly/react-table";
 import dayjs from "dayjs";
 import { IComposableRow } from "@app/shared/components/composable-table-with-controls/composable-table-with-controls";
 import { WaveApplicationsTable } from "./wave-applications-table/wave-applications-table";
@@ -105,65 +105,52 @@ export const Waves: React.FC = () => {
     usePaginationState(sortedItems, 10);
 
   const columnNames = {
-    select: "",
     name: "Name",
     startDate: "Start date",
     endDate: "End date",
     applications: "Applications",
     stakeholders: "Stakeholders",
     status: "Status",
-    actions: "",
   };
 
   //Compound expandable code
   type ColumnKey = keyof typeof columnNames;
 
+  // TODO can we abstract this into the component? should we?
   const [expandedCells, setExpandedCells] = React.useState<
     Record<string, ColumnKey>
   >({
     wave1: "applications", // Default to the first cell of the first row being expanded
   });
   const setCellExpanded = (
-    application: Application,
+    wave: Wave,
     columnKey: ColumnKey,
     isExpanding = true
   ) => {
     const newExpandedCells = { ...expandedCells };
     if (isExpanding) {
-      newExpandedCells[application.name] = columnKey;
+      newExpandedCells[wave.name] = columnKey;
     } else {
-      delete newExpandedCells[application.name];
+      delete newExpandedCells[wave.name];
     }
     setExpandedCells(newExpandedCells);
   };
+
+  // TODO maybe we can integrate this in the abstraction somehow?
   const compoundExpandParams = (
-    application: Application,
+    wave: Wave,
     columnKey: ColumnKey,
     rowIndex: number,
     columnIndex: number
   ): TdProps["compoundExpand"] => ({
-    isExpanded: expandedCells[application.name] === columnKey,
+    isExpanded: expandedCells[wave.name] === columnKey,
     onToggle: () =>
-      setCellExpanded(
-        application,
-        columnKey,
-        expandedCells[application.name] !== columnKey
-      ),
+      setCellExpanded(wave, columnKey, expandedCells[wave.name] !== columnKey),
     expandId: "composable-compound-expandable-example",
     rowIndex,
     columnIndex,
   });
-  const handleIsRowSelected = (row: IComposableRow) => {
-    const matchingWave = waves.find((wave) => wave.name === row.name);
-    return matchingWave ? isRowSelected(matchingWave) : false;
-  };
-  const handleToggleRowSelected = (
-    row: IComposableRow,
-    isSelecting: boolean
-  ) => {
-    const matchingWave = waves.find((wave) => wave.name === row.name);
-    matchingWave && toggleRowSelected(matchingWave, isSelecting);
-  };
+
   //RBAC
   // xxxxWriteAccess = checkAccess(userScopes, waveWriteScopes);
   const waveRowDropdownItems = true //TODO: Check RBAC access
@@ -184,88 +171,7 @@ export const Waves: React.FC = () => {
         </DropdownItem>,
       ]
     : [];
-  //
 
-  const rows: IComposableRow[] = [];
-  currentPageItems?.forEach((item, index) => {
-    const expandedCellKey = expandedCells[item.name];
-    const isRowExpanded = !!expandedCellKey;
-    const isSelected = isRowSelected(item);
-    rows.push({
-      name: item.name,
-      isExpanded: isRowExpanded,
-      expandedCellKey: expandedCellKey,
-      isSelected: isSelected,
-      expandedContentMap: {
-        applications: (
-          <WaveApplicationsTable
-            applications={item.applications}
-          ></WaveApplicationsTable>
-        ),
-        stakeholders: (
-          <WaveStakeholdersTable
-            stakeholders={item.stakeholders}
-          ></WaveStakeholdersTable>
-        ),
-      },
-      cells: [
-        {
-          title: item.name,
-          width: 25,
-        },
-        {
-          title: dayjs(item.startDate).format("DD/MM/YYYY"),
-          width: 10,
-        },
-        {
-          title: dayjs(item.endDate).format("DD/MM/YYYY"),
-          width: 10,
-        },
-        {
-          title: item?.applications?.length.toString(),
-          compoundExpand: compoundExpandParams(item, "applications", index, 1),
-          width: 10,
-        },
-        {
-          title: item?.stakeholders?.length.toString(),
-          compoundExpand: compoundExpandParams(item, "stakeholders", index, 1),
-          width: 10,
-        },
-        {
-          title: "Status",
-          width: 20,
-        },
-        {
-          children: (
-            <KebabDropdown dropdownItems={waveRowDropdownItems}></KebabDropdown>
-          ),
-          width: 10,
-        },
-      ],
-    });
-  });
-
-  //RBAC
-  // xxxxWriteAccess = checkAccess(userScopes, waveWriteScopes);
-  const waveDropdownItems = true //TODO: Check RBAC access
-    ? [
-        <DropdownItem
-          key="bulk-export-to-issue-manager"
-          component="button"
-          // onClick={() => setExportIssueModalOpen(true)}
-        >
-          {t("actions.export")}
-        </DropdownItem>,
-        <DropdownItem
-          key="bulk-delete"
-          // onClick={() => {
-          // }}
-        >
-          {t("actions.delete")}
-        </DropdownItem>,
-      ]
-    : [];
-  //
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -278,47 +184,64 @@ export const Waves: React.FC = () => {
           when={isFetching && !(waves || fetchError)}
           then={<AppPlaceholder />}
         >
-          <ComposableTableWithControls
-            isSelectable={true}
-            handleToggleRowSelected={handleToggleRowSelected}
-            handleIsRowSelected={handleIsRowSelected}
+          <ComposableTableWithControls<Wave>
+            isSelectable
+            isRowSelected={isRowSelected}
+            toggleRowSelected={toggleRowSelected}
+            isExpandable
             toolbarActions={
-              <>
-                <ToolbarGroup variant="button-group">
-                  {/* <RBAC
-                  allowedPermissions={[]}
-                  rbacType={RBAC_TYPE.Scope}
-                > */}
-                  <ToolbarItem>
-                    <Button
-                      type="button"
-                      id="create-wave"
-                      aria-label="Create new wave"
-                      variant={ButtonVariant.primary}
-                      onClick={openCreateWaveModal}
-                    >
-                      {t("actions.createNew")}
-                    </Button>
-                  </ToolbarItem>
-                  {/* </RBAC> */}
-                  {waveDropdownItems.length ? (
+              <ToolbarGroup variant="button-group">
+                {/* <RBAC
+                allowedPermissions={[]}
+                rbacType={RBAC_TYPE.Scope}
+              > */}
+                <ToolbarItem>
+                  <Button
+                    type="button"
+                    id="create-wave"
+                    aria-label="Create new wave"
+                    variant={ButtonVariant.primary}
+                    onClick={openCreateWaveModal}
+                  >
+                    {t("actions.createNew")}
+                  </Button>
+                </ToolbarItem>
+                {/* </RBAC> */}
+                {
+                  //RBAC
+                  // xxxxWriteAccess = checkAccess(userScopes, waveWriteScopes);
+                  true ? ( //TODO: Check RBAC access
                     <ToolbarItem>
                       <KebabDropdown
-                        dropdownItems={waveDropdownItems}
-                      ></KebabDropdown>
+                        dropdownItems={[
+                          <DropdownItem
+                            key="bulk-export-to-issue-manager"
+                            component="button"
+                            // onClick={() => setExportIssueModalOpen(true)}
+                          >
+                            {t("actions.export")}
+                          </DropdownItem>,
+                          <DropdownItem
+                            key="bulk-delete"
+                            // onClick={() => {
+                            // }}
+                          >
+                            {t("actions.delete")}
+                          </DropdownItem>,
+                        ]}
+                      />
                     </ToolbarItem>
-                  ) : (
-                    <></>
-                  )}
-                </ToolbarGroup>
-              </>
+                  ) : null
+                }
+              </ToolbarGroup>
             }
-            rowItems={rows}
             columnNames={columnNames}
             isLoading={isFetching}
             fetchError={fetchError}
+            isNoData={currentPageItems.length === 0}
             paginationProps={paginationProps}
             toolbarBulkSelector={
+              // TODO can we abstract this into the component? should we?
               <ToolbarBulkSelector
                 onSelectAll={selectAll}
                 areAllSelected={areAllSelected}
@@ -329,6 +252,7 @@ export const Waves: React.FC = () => {
               />
             }
             toolbarToggle={
+              // TODO can we abstract this into the component? should we?
               <FilterToolbar<Wave>
                 filterCategories={filterCategories}
                 filterValues={filterValues}
@@ -336,7 +260,97 @@ export const Waves: React.FC = () => {
               />
             }
             toolbarClearAllFilters={handleOnClearAllFilters}
-          ></ComposableTableWithControls>
+            renderTableBody={({
+              renderSelectCheckboxTd,
+              renderExpandedContentTr,
+            }) => (
+              <>
+                {currentPageItems?.map((wave, rowIndex) => {
+                  return (
+                    <Tbody
+                      key={wave.id}
+                      isExpanded={!!expandedCells[wave.name]}
+                    >
+                      <Tr>
+                        {renderSelectCheckboxTd(wave, rowIndex)}
+                        <Td width={25}>{wave.name}</Td>
+                        <Td width={10}>
+                          {dayjs(wave.startDate).format("DD/MM/YYYY")}
+                        </Td>
+                        <Td width={10}>
+                          {dayjs(wave.endDate).format("DD/MM/YYYY")}
+                        </Td>
+                        <Td
+                          width={10}
+                          compoundExpand={compoundExpandParams(
+                            wave,
+                            "applications",
+                            rowIndex,
+                            1 // TODO Is this really the right columnIndex?
+                          )}
+                        >
+                          {wave?.applications?.length.toString()}
+                        </Td>
+                        <Td
+                          width={10}
+                          compoundExpand={compoundExpandParams(
+                            wave,
+                            "stakeholders",
+                            rowIndex,
+                            1 // TODO Is this really the right columnIndex?
+                          )}
+                        >
+                          {wave?.stakeholders?.length.toString()}
+                        </Td>
+                        <Td width={20}>Status</Td>
+                        <Td width={10}>
+                          <KebabDropdown
+                            dropdownItems={
+                              //RBAC
+                              // xxxxWriteAccess = checkAccess(userScopes, waveWriteScopes);
+                              true //TODO: Check RBAC access
+                                ? [
+                                    <DropdownItem
+                                      key="bulk-export-to-issue-manager"
+                                      component="button"
+                                      // onClick={() => setExportIssueModalOpen(true)}
+                                    >
+                                      {t("actions.export")}
+                                    </DropdownItem>,
+                                    <DropdownItem
+                                      key="bulk-delete"
+                                      // onClick={() => {
+                                      // }}
+                                    >
+                                      {t("actions.delete")}
+                                    </DropdownItem>,
+                                  ]
+                                : []
+                            }
+                          />
+                        </Td>
+                      </Tr>
+                      {renderExpandedContentTr({
+                        isExpanded: !!expandedCells[wave.name],
+                        expandedColumnName:
+                          columnNames[expandedCells[wave.name]],
+                        content:
+                          expandedCells[wave.name] === "applications" ? (
+                            <WaveApplicationsTable
+                              applications={wave.applications}
+                            />
+                          ) : expandedCells[wave.name] === "stakeholders" ? (
+                            <WaveStakeholdersTable
+                              stakeholders={wave.stakeholders}
+                            />
+                          ) : null,
+                      })}
+                    </Tbody>
+                  );
+                })}
+              </>
+            )}
+          />
         </ConditionalRender>
       </PageSection>
       <CreateEditWaveModal

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -180,7 +180,6 @@ export const Waves: React.FC = () => {
             isNoData={currentPageItems.length === 0}
             paginationProps={paginationProps}
             toolbarBulkSelector={
-              // TODO can we abstract this into the component? should we?
               <ToolbarBulkSelector
                 onSelectAll={selectAll}
                 areAllSelected={areAllSelected}
@@ -191,7 +190,6 @@ export const Waves: React.FC = () => {
               />
             }
             toolbarToggle={
-              // TODO can we abstract this into the component? should we?
               <FilterToolbar<Wave>
                 filterCategories={filterCategories}
                 filterValues={filterValues}

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -29,7 +29,7 @@ import {
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
 import { useSelectionState } from "@migtools/lib-ui";
-import { Tbody, Td, Tr } from "@patternfly/react-table";
+import { ExpandableRowContent, Tbody, Td, Tr } from "@patternfly/react-table";
 import dayjs from "dayjs";
 import { WaveApplicationsTable } from "./wave-applications-table/wave-applications-table";
 import { WaveStakeholdersTable } from "./wave-stakeholders-table/wave-stakeholders-table";
@@ -113,17 +113,15 @@ export const Waves: React.FC = () => {
   } as const;
 
   //Compound expandable code
-  type ColumnKey = keyof typeof columnNames;
-
   // TODO can we abstract this into the component? should we?
   const [expandedCells, setExpandedCells] = React.useState<
-    Record<string, ColumnKey>
+    Record<string, keyof typeof columnNames>
   >({
     wave1: "applications", // Default to the first cell of the first row being expanded
   });
   const setCellExpanded = (
     wave: Wave,
-    columnKey: ColumnKey,
+    columnKey: keyof typeof columnNames,
     isExpanding = true
   ) => {
     const newExpandedCells = { ...expandedCells };
@@ -229,9 +227,9 @@ export const Waves: React.FC = () => {
             }
             toolbarClearAllFilters={handleOnClearAllFilters}
             renderTableBody={({
-              renderSelectCheckboxTd,
-              renderExpandedContentTr,
-              renderCompoundExpandTd,
+              getSelectCheckboxTdProps,
+              getCompoundExpandTdProps,
+              getExpandedContentTdProps,
             }) => (
               <>
                 {currentPageItems?.map((wave, rowIndex) => {
@@ -241,7 +239,12 @@ export const Waves: React.FC = () => {
                       isExpanded={!!expandedCells[wave.name]}
                     >
                       <Tr>
-                        {renderSelectCheckboxTd(wave, rowIndex)}
+                        <Td
+                          {...getSelectCheckboxTdProps({
+                            item: wave,
+                            rowIndex,
+                          })}
+                        />
                         <Td width={25}>{wave.name}</Td>
                         <Td width={10}>
                           {dayjs(wave.startDate).format("DD/MM/YYYY")}
@@ -249,32 +252,38 @@ export const Waves: React.FC = () => {
                         <Td width={10}>
                           {dayjs(wave.endDate).format("DD/MM/YYYY")}
                         </Td>
-                        {renderCompoundExpandTd({
-                          item: wave,
-                          rowIndex,
-                          columnKey: "applications",
-                          onToggle: () =>
-                            setCellExpanded(
-                              wave,
-                              "applications",
-                              expandedCells[wave.name] !== "applications"
-                            ),
-                          tdProps: { width: 10 },
-                          content: wave?.applications?.length.toString(),
-                        })}
-                        {renderCompoundExpandTd({
-                          item: wave,
-                          rowIndex,
-                          columnKey: "stakeholders",
-                          onToggle: () =>
-                            setCellExpanded(
-                              wave,
-                              "stakeholders",
-                              expandedCells[wave.name] !== "stakeholders"
-                            ),
-                          tdProps: { width: 10 },
-                          content: wave?.applications?.length.toString(),
-                        })}
+                        <Td
+                          width={10}
+                          {...getCompoundExpandTdProps({
+                            item: wave,
+                            rowIndex,
+                            columnKey: "applications",
+                            onToggle: () =>
+                              setCellExpanded(
+                                wave,
+                                "applications",
+                                expandedCells[wave.name] !== "applications"
+                              ),
+                          })}
+                        >
+                          {wave?.applications?.length.toString()}
+                        </Td>
+                        <Td
+                          width={10}
+                          {...getCompoundExpandTdProps({
+                            item: wave,
+                            rowIndex,
+                            columnKey: "stakeholders",
+                            onToggle: () =>
+                              setCellExpanded(
+                                wave,
+                                "stakeholders",
+                                expandedCells[wave.name] !== "stakeholders"
+                              ),
+                          })}
+                        >
+                          {wave?.stakeholders?.length.toString()}
+                        </Td>
 
                         <Td width={20}>Status</Td>
                         <Td width={10}>
@@ -304,28 +313,40 @@ export const Waves: React.FC = () => {
                           />
                         </Td>
                       </Tr>
-                      {renderExpandedContentTr({
-                        item: wave,
-                        expandedColumnKey: expandedCells[wave.name],
-                        content:
-                          expandedCells[wave.name] === "applications" ? (
-                            // TODO restore this
-                            /*
-                            <WaveApplicationsTable
-                              applications={wave.applications}
-                            />
-                            */
-                            <h1>TODO expanded content here for Applications</h1>
-                          ) : expandedCells[wave.name] === "stakeholders" ? (
-                            // TODO restore this
-                            /*
-                            <WaveStakeholdersTable
-                              stakeholders={wave.stakeholders}
-                            />
-                            */
-                            <h1>TODO expanded content here for Stakeholders</h1>
-                          ) : null,
-                      })}
+                      {expandedCells[wave.name] ? (
+                        <Tr isExpanded>
+                          <Td
+                            {...getExpandedContentTdProps({
+                              expandedColumnKey: expandedCells[wave.name],
+                            })}
+                          >
+                            <ExpandableRowContent>
+                              {expandedCells[wave.name] === "applications" ? (
+                                // TODO restore this
+                                /*
+                                  <WaveApplicationsTable
+                                    applications={wave.applications}
+                                  />
+                                */
+                                <h1>
+                                  TODO expanded content here for Applications
+                                </h1>
+                              ) : expandedCells[wave.name] ===
+                                "stakeholders" ? (
+                                // TODO restore this
+                                /*
+                                  <WaveStakeholdersTable
+                                    stakeholders={wave.stakeholders}
+                                  />
+                                */
+                                <h1>
+                                  TODO expanded content here for Stakeholders
+                                </h1>
+                              ) : null}
+                            </ExpandableRowContent>
+                          </Td>
+                        </Tr>
+                      ) : null}
                     </Tbody>
                   );
                 })}

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -95,6 +95,7 @@ export const Waves: React.FC = () => {
     "", // Action column
   ];
 
+  // TODO add sort stuff to ComposableTableWithControls
   const { sortBy, onSort, sortedItems } = useSortState(
     filteredItems,
     getSortValues
@@ -175,6 +176,7 @@ export const Waves: React.FC = () => {
               </ToolbarGroup>
             }
             columnNames={columnNames}
+            hasActionsColumn
             isLoading={isFetching}
             fetchError={fetchError}
             isNoData={currentPageItems.length === 0}
@@ -214,7 +216,14 @@ export const Waves: React.FC = () => {
                             rowIndex,
                           })}
                         />
-                        <Td width={25}>{wave.name}</Td>
+                        <Td
+                          width={25}
+                          dataLabel={
+                            columnNames.name
+                          } /* TODO put dataLabel on the other cells */
+                        >
+                          {wave.name}
+                        </Td>
                         <Td width={10}>
                           {dayjs(wave.startDate).format("DD/MM/YYYY")}
                         </Td>
@@ -275,25 +284,15 @@ export const Waves: React.FC = () => {
                           <Td {...getExpandedContentTdProps({ item: wave })}>
                             <ExpandableRowContent>
                               {isCellExpanded(wave, "applications") ? (
-                                // TODO restore this
-                                /*
-                                  <WaveApplicationsTable
-                                    applications={wave.applications}
-                                  />
-                                */
-                                <h1>
-                                  TODO expanded content here for Applications
-                                </h1>
+                                <WaveApplicationsTable
+                                  wave={wave}
+                                  applications={wave.applications}
+                                />
                               ) : isCellExpanded(wave, "stakeholders") ? (
-                                // TODO restore this
-                                /*
-                                  <WaveStakeholdersTable
-                                    stakeholders={wave.stakeholders}
-                                  />
-                                */
-                                <h1>
-                                  TODO expanded content here for Stakeholders
-                                </h1>
+                                <WaveStakeholdersTable
+                                  wave={wave}
+                                  stakeholders={wave.stakeholders}
+                                />
                               ) : null}
                             </ExpandableRowContent>
                           </Td>

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -216,22 +216,18 @@ export const Waves: React.FC = () => {
                             rowIndex,
                           })}
                         />
-                        <Td
-                          width={25}
-                          dataLabel={
-                            columnNames.name
-                          } /* TODO put dataLabel on the other cells */
-                        >
+                        <Td width={25} dataLabel={columnNames.name}>
                           {wave.name}
                         </Td>
-                        <Td width={10}>
+                        <Td width={10} dataLabel={columnNames.startDate}>
                           {dayjs(wave.startDate).format("DD/MM/YYYY")}
                         </Td>
-                        <Td width={10}>
+                        <Td width={10} dataLabel={columnNames.endDate}>
                           {dayjs(wave.endDate).format("DD/MM/YYYY")}
                         </Td>
                         <Td
                           width={10}
+                          dataLabel={columnNames.applications}
                           {...getCompoundExpandTdProps({
                             item: wave,
                             rowIndex,
@@ -242,6 +238,7 @@ export const Waves: React.FC = () => {
                         </Td>
                         <Td
                           width={10}
+                          dataLabel={columnNames.stakeholders}
                           {...getCompoundExpandTdProps({
                             item: wave,
                             rowIndex,
@@ -250,8 +247,9 @@ export const Waves: React.FC = () => {
                         >
                           {wave?.stakeholders?.length.toString()}
                         </Td>
-
-                        <Td width={20}>Status</Td>
+                        <Td width={20} dataLabel={columnNames.status}>
+                          Status
+                        </Td>
                         <Td width={10}>
                           <KebabDropdown
                             dropdownItems={

--- a/client/src/app/shared/components/composable-table-with-controls/composable-table-with-controls.tsx
+++ b/client/src/app/shared/components/composable-table-with-controls/composable-table-with-controls.tsx
@@ -135,8 +135,6 @@ export const ComposableTableWithControls = <
   // TODO we will need to adapt this to regular-expandable and not just compound-expandable
   // (probably just means the addition of a renderExpandToggleTd in renderTableBody)
 
-  console.log({ isLoading, fetchError, isNoData });
-
   return (
     <div style={{ backgroundColor: "var(--pf-global--BackgroundColor--100)" }}>
       <Toolbar

--- a/client/src/app/shared/components/composable-table-with-controls/composable-table-with-controls.tsx
+++ b/client/src/app/shared/components/composable-table-with-controls/composable-table-with-controls.tsx
@@ -6,7 +6,6 @@ import {
   Th,
   Tbody,
   Td,
-  ExpandableRowContent,
   TableComposableProps,
   TdProps,
 } from "@patternfly/react-table";
@@ -29,7 +28,7 @@ import { StateNoData } from "../app-table/state-no-data";
 export interface IComposableTableWithControlsProps<
   TItem extends { name: string },
   TColumnNames extends Record<string, string>
-> extends TableComposableProps {
+> extends Omit<TableComposableProps, "ref"> {
   withoutTopPagination?: boolean;
   withoutBottomPagination?: boolean;
   toolbarBulkSelector?: React.ReactNode;
@@ -89,9 +88,10 @@ export const ComposableTableWithControls = <
   isSelectable = false,
   isRowSelected = () => false,
   toggleRowSelected = () => {},
-  variant,
   noDataState,
   renderTableBody,
+  variant,
+  ...props
 }: React.PropsWithChildren<
   IComposableTableWithControlsProps<TItem, TColumnNames>
 >): JSX.Element | null => {
@@ -135,8 +135,7 @@ export const ComposableTableWithControls = <
   // TODO we will need to adapt this to regular-expandable and not just compound-expandable
   // (probably just means the addition of a renderExpandToggleTd in renderTableBody)
 
-  // TODO FIXME, this just prevents rendering tables we haven't converted to use render props yet
-  if (typeof renderTableBody !== "function") return null;
+  console.log({ isLoading, fetchError, isNoData });
 
   return (
     <div style={{ backgroundColor: "var(--pf-global--BackgroundColor--100)" }}>
@@ -164,9 +163,10 @@ export const ComposableTableWithControls = <
           )}
         </ToolbarContent>
       </Toolbar>
-      <TableComposable aria-label="waves-table" variant={variant}>
+      <TableComposable variant={variant} {...props}>
         <Thead>
           <Tr>
+            {/* TODO is this a problem if we have a table that needs modifier props on these Th elements? maybe we'll need an optional `tableHeader` prop that overrides this? */}
             {isSelectable ? <Th /> : null}
             {Object.keys(columnNames).map((columnKey: string) => (
               <Th key={columnKey}>{columnNames[columnKey]}</Th>


### PR DESCRIPTION
In preparation for the rest of the dynamic reports work, this PR takes the table abstraction introduced in https://github.com/konveyor/tackle2-ui/pull/598 for migration waves and refactors it to be even more composable. The goal is that all JSX used to render the Tr and Td elements is passed in from the consumer, with functions made available via the render-props pattern for abstracting repetitive props out into the component. This way the consumer can benefit from a simplified way to render tables without losing the flexibility to pass any props necessary on any row/cell.

There are some remaining questions to be answered about this abstraction, to be addressed in followup PRs. Some of these are covered in TODO comments here, in particular how to handle composable access to the props of the Thead/Tr elements without too much repetition, and how to handle non-compound-expandable rows and sorting controls. These will be addressed as part of adding the Issues table for dynamic reports.