### PR TITLE
:bug: Fix ambiguity in custom rules help message

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -171,7 +171,6 @@
     "developer": "Migration",
     "reports": "Reports",
     "waves": "Migration waves"
-
   },
   "terms": {
     "accepted": "Accepted",
@@ -354,7 +353,7 @@
     "label": {
       "advancedOptions": "Specify additional options here.",
       "analysisSource": "Source for analysis",
-      "customRules": "Upload the rules you want to include in the analysis.",
+      "customRules": "Include rules for the analysis by uploading or importing from a repository.",
       "excludePackages": "Exclude packages",
       "noCustomRules": "No custom rules available",
       "notAllAnalyzable": "Some applications cannot be analyzed",


### PR DESCRIPTION
This clarifies that rules can be uploaded or imported from a repository.

https://issues.redhat.com/browse/MTA-378