### PR TITLE
:bug: Disable add button when file with error is present

### DIFF
--- a/client/src/app/common/CustomRules/useRuleFiles.tsx
+++ b/client/src/app/common/CustomRules/useRuleFiles.tsx
@@ -171,6 +171,9 @@ export default function useRuleFiles(
         )
     );
     setRuleFiles(updatedRuleFilesList);
+    if (!updatedRuleFilesList.some((file) => file.loadResult === "danger")) {
+      setUploadError("");
+    }
     if (methods) {
       methods.setValue(
         "customRulesFiles",

--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -407,7 +407,8 @@ export const CustomRules: React.FC<CustomRulesProps> = (props) => {
               key="add"
               variant="primary"
               isDisabled={
-                !ruleFiles.find((file) => file.loadResult === "success")
+                !ruleFiles.find((file) => file.loadResult === "success") ||
+                ruleFiles.some((file) => file.loadResult === "danger")
               }
               onClick={(event) => {
                 let hasExistingRuleFile = null;


### PR DESCRIPTION
- Fixes https://issues.redhat.com/browse/MTA-443
- Clears error alert when no files with error state exist after removal 