### PR TITLE
:bug: Add notice about max image size for new custom target

### DIFF
--- a/client/src/app/pages/migration-targets/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/custom-target-form.tsx
@@ -385,7 +385,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
         name="imageID"
         label={t("terms.image")}
         fieldId="custom-migration-target-upload-image"
-        helperText="Upload a png or jpeg file"
+        helperText="Upload a png or jpeg file (Max size: 1 MB)"
         renderInput={({ field: { onChange, name }, fieldState: { error } }) => (
           <FileUpload
             id="custom-migration-target-upload-image"


### PR DESCRIPTION
User's can't upload images >1MB for custom targets, this change let's them know before they try.

https://issues.redhat.com/browse/MTA-299