### PR TITLE
:seedling: Improve separation of concerns in `useSortState` and `usePaginationState`, use column key union type in generics instead of entire columnNames object type

### DIFF
--- a/client/src/app/pages/applications/application-review/components/application-assessment-summary-table/application-assessment-summary-table.tsx
+++ b/client/src/app/pages/applications/application-review/components/application-assessment-summary-table/application-assessment-summary-table.tsx
@@ -18,8 +18,8 @@ import {
   Risk,
 } from "@app/api/models";
 
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import {
   FilterCategory,
   FilterToolbar,
@@ -101,7 +101,7 @@ export const ApplicationAssessmentSummaryTable: React.FC<
     RISK_LIST[tableItem.riskValue].sortFactor || "",
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
@@ -110,7 +110,7 @@ export const ApplicationAssessmentSummaryTable: React.FC<
   };
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const columns: ICell[] = [
     {

--- a/client/src/app/pages/applications/applicationsFilter.ts
+++ b/client/src/app/pages/applications/applicationsFilter.ts
@@ -10,8 +10,8 @@ import {
   FilterType,
 } from "@app/shared/components/FilterToolbar/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { dedupeFunction } from "@app/utils/utils";
 import { useSelectionState } from "@migtools/lib-ui";
 export enum ApplicationTableType {
@@ -177,7 +177,7 @@ export const useApplicationsFilterValues = (
     "", // Action column
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
@@ -196,7 +196,7 @@ export const useApplicationsFilterValues = (
   });
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const [activeAppInDetailDrawer, openDetailDrawer] =
     React.useState<Application | null>(null);

--- a/client/src/app/pages/applications/components/bulk-copy-assessment-review-form/bulk-copy-assessment-review-form.tsx
+++ b/client/src/app/pages/applications/components/bulk-copy-assessment-review-form/bulk-copy-assessment-review-form.tsx
@@ -34,14 +34,14 @@ import { dedupeFunction } from "@app/utils/utils";
 
 import { ApplicationBusinessService } from "../application-business-service";
 import { ApplicationAssessment } from "../application-assessment";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import {
   FilterCategory,
   FilterToolbar,
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { useSelectionState } from "@migtools/lib-ui";
 import { useFetchApplicationAssessments } from "@app/queries/assessments";
 import { useFetchApplications } from "@app/queries/applications";
@@ -164,13 +164,13 @@ export const BulkCopyAssessmentReviewForm: React.FC<
     item.businessService?.name || "",
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   //Bulk selection
   const {

--- a/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
+++ b/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
@@ -22,7 +22,7 @@ import { ImportSummaryRoute, Paths } from "@app/Paths";
 import { getApplicationSummaryCSV } from "@app/api/rest";
 import { ApplicationImport } from "@app/api/models";
 import { getAxiosErrorMessage } from "@app/utils/utils";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import {
   useFetchImports,
   useFetchImportSummaryByID,
@@ -32,7 +32,7 @@ import {
   FilterType,
 } from "@app/shared/components/FilterToolbar/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { NotificationsContext } from "@app/shared/notifications-context";
 
 const ENTITY_FIELD = "entity";
@@ -123,13 +123,13 @@ export const ManageImportsDetails: React.FC = () => {
     "", // Action column
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   return (
     <>

--- a/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -41,7 +41,7 @@ import { ApplicationImportSummary } from "@app/api/models";
 import { formatDate, getAxiosErrorMessage } from "@app/utils/utils";
 
 import { ImportApplicationsForm } from "../components/import-applications-form";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import { AxiosError } from "axios";
 import {
   useDeleteImportSummaryMutation,
@@ -53,7 +53,7 @@ import {
   FilterToolbar,
   FilterType,
 } from "@app/shared/components/FilterToolbar/FilterToolbar";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import TooltipTitle from "@app/common/TooltipTitle";
 import { NotificationsContext } from "@app/shared/notifications-context";
 
@@ -132,13 +132,13 @@ export const ManageImports: React.FC = () => {
     "", // Action column
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   // Table
   const columns: ICell[] = [

--- a/client/src/app/pages/controls/business-services/business-services.tsx
+++ b/client/src/app/pages/controls/business-services/business-services.tsx
@@ -30,14 +30,14 @@ import { getAxiosErrorMessage } from "@app/utils/utils";
 
 import { NewBusinessServiceModal } from "./components/new-business-service-modal";
 import { UpdateBusinessServiceModal } from "./components/update-business-service-modal";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import {
   FilterCategory,
   FilterToolbar,
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
 import { useFetchApplications } from "@app/queries/applications";
 import {
@@ -136,13 +136,13 @@ export const BusinessServices: React.FC = () => {
     "", // Action column
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const columns: ICell[] = [
     { title: t("terms.name"), transforms: [sortable, cellWidth(25)] },

--- a/client/src/app/pages/controls/job-functions/job-functions.tsx
+++ b/client/src/app/pages/controls/job-functions/job-functions.tsx
@@ -34,8 +34,8 @@ import {
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { useSortState } from "@app/shared/hooks/useSortState";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
 import {
   useDeleteJobFunctionMutation,
@@ -85,13 +85,13 @@ export const JobFunctions: React.FC = () => {
     "", // Action column
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const [isNewModalOpen, setIsNewModalOpen] = useState(false);
   const [rowToUpdate, setRowToUpdate] = useState<JobFunction>();

--- a/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
@@ -38,14 +38,14 @@ import { StakeholderGroup } from "@app/api/models";
 
 import { NewStakeholderGroupModal } from "./components/new-stakeholder-group-modal";
 import { UpdateStakeholderGroupModal } from "./components/update-stakeholder-group-modal";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import {
   FilterCategory,
   FilterToolbar,
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
 import {
   useDeleteStakeholderGroupMutation,
@@ -175,12 +175,12 @@ export const StakeholderGroups: React.FC = () => {
     "", // Action column
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const rows: IRow[] = [];
   currentPageItems?.forEach((item) => {

--- a/client/src/app/pages/controls/stakeholders/stakeholders.tsx
+++ b/client/src/app/pages/controls/stakeholders/stakeholders.tsx
@@ -35,14 +35,14 @@ import { getAxiosErrorMessage } from "@app/utils/utils";
 import { Stakeholder } from "@app/api/models";
 import { NewStakeholderModal } from "./components/new-stakeholder-modal";
 import { UpdateStakeholderModal } from "./components/update-stakeholder-modal";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import {
   FilterCategory,
   FilterToolbar,
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
 import {
   useDeleteStakeholderMutation,
@@ -165,13 +165,13 @@ export const Stakeholders: React.FC = () => {
     "", // Action column
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const columns: ICell[] = [
     {

--- a/client/src/app/pages/controls/tags/tags.tsx
+++ b/client/src/app/pages/controls/tags/tags.tsx
@@ -35,14 +35,14 @@ import { UpdateTagCategoryModal } from "./components/update-tag-category-modal";
 import { NewTagModal } from "./components/new-tag-modal";
 import { UpdateTagModal } from "./components/update-tag-modal";
 import { TagTable } from "./components/tag-table";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import {
   FilterCategory,
   FilterToolbar,
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
 import {
   useDeleteTagMutation,
@@ -237,13 +237,13 @@ export const Tags: React.FC = () => {
     "", // Action column
   ];
 
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const deleteTagFromTable = (row: Tag) => {
     setTagIdToDelete(row.id);

--- a/client/src/app/pages/identities/identities.tsx
+++ b/client/src/app/pages/identities/identities.tsx
@@ -29,8 +29,8 @@ import {
 } from "@app/shared/components";
 import { Identity, ITypeOptions } from "@app/api/models";
 import { useFilterState } from "@app/shared/hooks/useFilterState";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { useEntityModal } from "@app/shared/hooks/useEntityModal";
 import { AxiosError, AxiosResponse } from "axios";
 import { NewIdentityModal } from "./components/new-identity-modal";
@@ -144,13 +144,13 @@ export const Identities: React.FC = () => {
     identity?.createUser || "",
     "", // Action column
   ];
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const columns: ICell[] = [
     {

--- a/client/src/app/pages/jira-trackers/jira-trackers.tsx
+++ b/client/src/app/pages/jira-trackers/jira-trackers.tsx
@@ -74,19 +74,16 @@ export const JiraTrackers: React.FC = () => {
   const {
     numRenderedColumns,
     selectionState: { selectedItems },
-    paginationState: {
-      paginationProps, // TODO maybe paginationProps should be in propHelpers and not part of the responsibility of usePaginationState
-      currentPageItems,
-    },
+    paginationState: { currentPageItems },
     propHelpers: {
       toolbarProps,
       toolbarBulkSelectorProps,
       filterToolbarProps,
       paginationToolbarItemProps,
+      paginationProps,
       tableProps,
       getThProps,
       getTdProps,
-      getSelectCheckboxTdProps,
     },
   } = tableControls;
 

--- a/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -31,8 +31,8 @@ import {
 import { getAssessmentConfidence } from "@app/api/rest";
 
 import { ApplicationSelectionContext } from "../../application-selection-context";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
-import { useSortState } from "@app/shared/hooks/useSortState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
+import { useLegacySortState } from "@app/shared/hooks/useLegacySortState";
 import { useSelectionState } from "@migtools/lib-ui";
 import {
   FilterCategory,
@@ -206,13 +206,13 @@ export const AdoptionCandidateTable: React.FC<IAdoptionCandidateTable> = () => {
     RISK_LIST[item?.risk].sortFactor || "",
     "",
   ];
-  const { sortBy, onSort, sortedItems } = useSortState(
+  const { sortBy, onSort, sortedItems } = useLegacySortState(
     filteredItems,
     getSortValues
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(sortedItems, 10);
+    useLegacyPaginationState(sortedItems, 10);
 
   const rows: IRow[] = [];
   currentPageItems.forEach((item) => {

--- a/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
+++ b/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
@@ -14,7 +14,7 @@ import { Application, AssessmentQuestionRisk } from "@app/api/models";
 import { getAssessmentIdentifiedRisks } from "@app/api/rest";
 
 import { ApplicationSelectionContext } from "../../application-selection-context";
-import { usePaginationState } from "@app/shared/hooks/usePaginationState";
+import { useLegacyPaginationState } from "@app/shared/hooks/useLegacyPaginationState";
 import {
   FilterCategory,
   FilterToolbar,
@@ -157,7 +157,7 @@ export const IdentifiedRisksTable: React.FC<
   );
 
   const { currentPageItems, setPageNumber, paginationProps } =
-    usePaginationState(filteredItems, 10);
+    useLegacyPaginationState(filteredItems, 10);
 
   const rows: IRow[] = [];
   currentPageItems.forEach((item) => {

--- a/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
+++ b/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
@@ -57,13 +57,11 @@ export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
   });
   const {
     numRenderedColumns,
-    paginationState: {
-      paginationProps, // TODO maybe paginationProps should be in propHelpers and not part of the responsibility of usePaginationState
-      currentPageItems,
-    },
+    paginationState: { currentPageItems },
     propHelpers: {
       toolbarProps,
       paginationToolbarItemProps,
+      paginationProps,
       tableProps,
       getThProps,
       getTdProps,

--- a/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
+++ b/client/src/app/pages/waves/wave-applications-table/wave-applications-table.tsx
@@ -47,7 +47,6 @@ export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
     hasActionsColumn: true,
     getSortValues: (app) => ({
       appName: app.name || "",
-      description: "", // TODO
       businessService: app.businessService?.name || "",
       owner: "", // TODO
     }),

--- a/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
+++ b/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
@@ -60,10 +60,11 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
   });
   const {
     numRenderedColumns,
-    paginationState: { paginationProps, currentPageItems },
+    paginationState: { currentPageItems },
     propHelpers: {
       toolbarProps,
       paginationToolbarItemProps,
+      paginationProps,
       tableProps,
       getThProps,
       getTdProps,

--- a/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
+++ b/client/src/app/pages/waves/wave-stakeholders-table/wave-stakeholders-table.tsx
@@ -52,7 +52,6 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
       jobFunction: stakeholder.jobFunction?.name || "",
       role: "", // TODO
       email: "", // TODO
-      groups: "", // TODO
     }),
     sortableColumns: ["name", "jobFunction", "role", "email"],
     hasPagination: true,

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -107,15 +107,13 @@ export const Waves: React.FC = () => {
     numRenderedColumns,
     expansionState: { isCellExpanded },
     selectionState: { selectedItems },
-    paginationState: {
-      paginationProps, // TODO maybe paginationProps should be in propHelpers and not part of the responsibility of usePaginationState
-      currentPageItems,
-    },
+    paginationState: { currentPageItems },
     propHelpers: {
       toolbarProps,
       toolbarBulkSelectorProps,
       filterToolbarProps,
       paginationToolbarItemProps,
+      paginationProps,
       tableProps,
       getThProps,
       getTdProps,

--- a/client/src/app/pages/waves/waves.tsx
+++ b/client/src/app/pages/waves/waves.tsx
@@ -91,15 +91,12 @@ export const Waves: React.FC = () => {
         },
       },
     ],
+    sortableColumns: ["name", "startDate", "endDate"],
     getSortValues: (wave) => ({
       name: wave.name || "",
       startDate: wave.startDate || "",
       endDate: wave.endDate || "",
-      applications: wave.applications.length,
-      stakeholders: wave.stakeholders.length,
-      status: "TODO: Status",
     }),
-    sortableColumns: ["name", "startDate", "endDate"],
     initialSort: { columnKey: "startDate", direction: "asc" },
     hasPagination: true,
   });

--- a/client/src/app/shared/components/app-table-with-controls/app-table-with-controls.tsx
+++ b/client/src/app/shared/components/app-table-with-controls/app-table-with-controls.tsx
@@ -9,7 +9,7 @@ import {
 } from "@patternfly/react-core";
 
 import { AppTable, IAppTableProps } from "../app-table/app-table";
-import { PaginationStateProps } from "@app/shared/hooks/usePaginationState";
+import { PaginationStateProps } from "@app/shared/hooks/useLegacyPaginationState";
 import { SimplePagination } from "../simple-pagination";
 
 export interface IAppTableWithControlsProps extends IAppTableProps {

--- a/client/src/app/shared/components/simple-pagination/simple-pagination.tsx
+++ b/client/src/app/shared/components/simple-pagination/simple-pagination.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Pagination, PaginationVariant } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { PaginationStateProps } from "@app/shared/hooks/usePaginationState";
+import { PaginationStateProps } from "@app/shared/hooks/useLegacyPaginationState";
 
 export interface SimplePaginationProps {
   paginationProps: PaginationStateProps;

--- a/client/src/app/shared/components/table-controls/TableHeaderContentWithControls.tsx
+++ b/client/src/app/shared/components/table-controls/TableHeaderContentWithControls.tsx
@@ -4,19 +4,27 @@ import { useTableControls } from "@app/shared/hooks/use-table-controls";
 
 export interface ITableHeaderContentWithControlsProps<
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
-> extends ReturnType<typeof useTableControls<TItem, TColumnNames>> {
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
+> extends ReturnType<
+    typeof useTableControls<TItem, TColumnKey, TSortableColumnKey>
+  > {
   children: React.ReactNode;
 }
 
 export const TableHeaderContentWithControls = <
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
 >({
   numColumnsBeforeData,
   numColumnsAfterData,
   children,
-}: ITableHeaderContentWithControlsProps<TItem, TColumnNames>) => (
+}: ITableHeaderContentWithControlsProps<
+  TItem,
+  TColumnKey,
+  TSortableColumnKey
+>) => (
   <>
     {Array(numColumnsBeforeData)
       .fill(null)

--- a/client/src/app/shared/components/table-controls/TableRowContentWithControls.tsx
+++ b/client/src/app/shared/components/table-controls/TableRowContentWithControls.tsx
@@ -4,8 +4,11 @@ import { useTableControls } from "@app/shared/hooks/use-table-controls";
 
 export interface ITableRowContentWithControlsProps<
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
-> extends ReturnType<typeof useTableControls<TItem, TColumnNames>> {
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
+> extends ReturnType<
+    typeof useTableControls<TItem, TColumnKey, TSortableColumnKey>
+  > {
   item: TItem;
   rowIndex: number;
   children: React.ReactNode;
@@ -15,7 +18,8 @@ export interface ITableRowContentWithControlsProps<
 
 export const TableRowContentWithControls = <
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
 >({
   isSelectable = false,
   propHelpers: { getSelectCheckboxTdProps },
@@ -23,7 +27,7 @@ export const TableRowContentWithControls = <
   rowIndex,
   children,
 }: React.PropsWithChildren<
-  ITableRowContentWithControlsProps<TItem, TColumnNames>
+  ITableRowContentWithControlsProps<TItem, TColumnKey, TSortableColumnKey>
 >) => (
   <>
     {/* TODO implement single-expandable toggle cell */}

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlProps.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlProps.ts
@@ -1,5 +1,9 @@
 import { useTranslation } from "react-i18next";
-import { ToolbarItemProps, ToolbarProps } from "@patternfly/react-core";
+import {
+  PaginationProps,
+  ToolbarItemProps,
+  ToolbarProps,
+} from "@patternfly/react-core";
 import {
   TableComposableProps,
   TdProps,
@@ -37,6 +41,7 @@ export const useTableControlProps = <
   const { t } = useTranslation();
 
   const {
+    totalItemCount,
     filterCategories,
     filterState: { filterValues, setFilterValues },
     expansionState: { isCellExpanded, setCellExpanded, expandedCells },
@@ -49,7 +54,13 @@ export const useTableControlProps = <
       isItemSelected,
     },
     sortState: { sortBy, onSort },
-    paginationState: { paginationProps, currentPageItems },
+    paginationState: {
+      currentPageItems,
+      pageNumber,
+      setPageNumber,
+      itemsPerPage,
+      setItemsPerPage,
+    },
     columnNames,
     sortableColumns = [],
     isSelectable = false,
@@ -75,6 +86,17 @@ export const useTableControlProps = <
     collapseListedFiltersBreakpoint: "xl",
     clearAllFilters: () => setFilterValues({}),
     clearFiltersButtonText: t("actions.clearAllFilters"),
+  };
+
+  const paginationProps: PaginationProps = {
+    itemCount: totalItemCount,
+    perPage: itemsPerPage,
+    page: pageNumber,
+    onSetPage: (event, pageNumber) => setPageNumber(pageNumber),
+    onPerPageSelect: (event, perPage) => {
+      setPageNumber(1);
+      setItemsPerPage(perPage);
+    },
   };
 
   const toolbarBulkSelectorProps: IToolbarBulkSelectorProps<TItem> = {
@@ -190,6 +212,7 @@ export const useTableControlProps = <
       toolbarProps,
       toolbarBulkSelectorProps,
       filterToolbarProps,
+      paginationProps,
       paginationToolbarItemProps,
       tableProps,
       getThProps,

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlProps.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlProps.ts
@@ -16,10 +16,7 @@ import { IToolbarBulkSelectorProps } from "@app/shared/components/toolbar-bulk-s
 import { IFilterToolbarProps } from "@app/shared/components/FilterToolbar";
 import { objectKeys } from "@app/utils/utils";
 
-export interface UseTableControlPropsAdditionalArgs<
-  TColumnNames extends Record<string, string>
-> {
-  sortableColumns?: (keyof TColumnNames)[];
+export interface UseTableControlPropsAdditionalArgs {
   isSelectable?: boolean;
   expandableVariant?: "single" | "compound" | null;
   hasActionsColumn?: boolean;
@@ -30,7 +27,7 @@ export type UseTableControlPropsArgs<
   TItem extends { name: string },
   TColumnNames extends Record<string, string>
 > = ReturnType<typeof useTableControlState<TItem, TColumnNames>> &
-  UseTableControlPropsAdditionalArgs<TColumnNames>;
+  UseTableControlPropsAdditionalArgs;
 
 export const useTableControlProps = <
   TItem extends { name: string },
@@ -53,7 +50,7 @@ export const useTableControlProps = <
       toggleItemSelected,
       isItemSelected,
     },
-    sortState: { sortBy, onSort },
+    sortState: { activeSort, setActiveSort },
     paginationState: {
       currentPageItems,
       pageNumber,
@@ -125,18 +122,27 @@ export const useTableControlProps = <
     columnKey,
   }: {
     columnKey: keyof TColumnNames;
-  }): Omit<ThProps, "ref"> => ({
-    ...(sortableColumns.includes(columnKey)
-      ? {
-          sort: {
-            columnIndex: objectKeys(columnNames).indexOf(columnKey),
-            sortBy,
-            onSort,
-          },
-        }
-      : {}),
-    children: columnNames[columnKey],
-  });
+  }): Omit<ThProps, "ref"> => {
+    const columnKeys = objectKeys(columnNames);
+    return {
+      ...(sortableColumns.includes(columnKey)
+        ? {
+            sort: {
+              columnIndex: columnKeys.indexOf(columnKey),
+              sortBy: {
+                index: activeSort
+                  ? columnKeys.indexOf(activeSort.columnKey)
+                  : undefined,
+              },
+              onSort: (event, index, direction) => {
+                setActiveSort({ columnKey: columnKeys[index], direction });
+              },
+            },
+          }
+        : {}),
+      children: columnNames[columnKey],
+    };
+  };
 
   const getTdProps = ({
     columnKey,

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlProps.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlProps.ts
@@ -133,6 +133,7 @@ export const useTableControlProps = <
                 index: activeSort
                   ? columnKeys.indexOf(activeSort.columnKey)
                   : undefined,
+                direction: activeSort?.direction,
               },
               onSort: (event, index, direction) => {
                 setActiveSort({ columnKey: columnKeys[index], direction });

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
@@ -3,7 +3,7 @@ import { useFilterState } from "../useFilterState";
 import { useCompoundExpansionState } from "../useCompoundExpansionState";
 import { useSelectionState } from "@migtools/lib-ui";
 import { useLegacySortState } from "../useLegacySortState";
-import { useLegacyPaginationState } from "../useLegacyPaginationState";
+import { usePaginationState } from "../usePaginationState";
 import { objectKeys } from "@app/utils/utils";
 
 export interface UseTableControlStateArgs<
@@ -69,13 +69,14 @@ export const useTableControlState = <
       : undefined
   );
 
-  const paginationState = useLegacyPaginationState(
+  const paginationState = usePaginationState(
     sortState.sortedItems,
     initialItemsPerPage
   );
 
   return {
     ...args,
+    totalItemCount: items.length,
     filterState,
     expansionState,
     selectionState,

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
@@ -7,24 +7,26 @@ import { useSortState } from "../useSortState";
 
 export interface UseTableControlStateArgs<
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey // A subset of column keys as a separate narrower type
 > {
   items: TItem[]; // The objects represented by rows in this table
-  columnNames: TColumnNames; // An ordered mapping of unique keys to human-readable column name strings
+  columnNames: Record<TColumnKey, string>; // An ordered mapping of unique keys to human-readable column name strings
   filterCategories?: FilterCategory<TItem>[];
   filterStorageKey?: string;
-  sortableColumns?: (keyof TColumnNames)[]; // TODO can we limit this to a subset of sortable keys and have that enforced?
-  getSortValues?: (item: TItem) => Record<keyof TColumnNames, string | number>;
-  initialSort?: { columnKey: keyof TColumnNames; direction: "asc" | "desc" };
+  sortableColumns?: TSortableColumnKey[];
+  getSortValues?: (item: TItem) => Record<TSortableColumnKey, string | number>;
+  initialSort?: { columnKey: TSortableColumnKey; direction: "asc" | "desc" };
   hasPagination?: boolean;
   initialItemsPerPage?: number;
 }
 
 export const useTableControlState = <
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
 >(
-  args: UseTableControlStateArgs<TItem, TColumnNames>
+  args: UseTableControlStateArgs<TItem, TColumnKey, TSortableColumnKey>
 ) => {
   const {
     items,
@@ -39,9 +41,9 @@ export const useTableControlState = <
 
   const filterState = useFilterState(items, filterCategories, filterStorageKey);
 
-  const expansionState = useCompoundExpansionState<TItem, TColumnNames>();
+  const expansionState = useCompoundExpansionState<TItem, TColumnKey>();
 
-  const selectionState = useSelectionState<TItem>({
+  const selectionState = useSelectionState({
     items: filterState.filteredItems,
     isEqual: (a, b) => a.name === b.name,
   });

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
@@ -2,8 +2,8 @@ import { FilterCategory } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "../useFilterState";
 import { useCompoundExpansionState } from "../useCompoundExpansionState";
 import { useSelectionState } from "@migtools/lib-ui";
-import { useSortState } from "../useSortState";
-import { usePaginationState } from "../usePaginationState";
+import { useLegacySortState } from "../useLegacySortState";
+import { useLegacyPaginationState } from "../useLegacyPaginationState";
 import { objectKeys } from "@app/utils/utils";
 
 export interface UseTableControlStateArgs<
@@ -46,7 +46,7 @@ export const useTableControlState = <
     isEqual: (a, b) => a.name === b.name,
   });
 
-  const sortState = useSortState(
+  const sortState = useLegacySortState(
     filterState.filteredItems,
     getSortValues
       ? (item) => {
@@ -69,7 +69,7 @@ export const useTableControlState = <
       : undefined
   );
 
-  const paginationState = usePaginationState(
+  const paginationState = useLegacyPaginationState(
     sortState.sortedItems,
     initialItemsPerPage
   );

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
@@ -2,9 +2,8 @@ import { FilterCategory } from "@app/shared/components/FilterToolbar";
 import { useFilterState } from "../useFilterState";
 import { useCompoundExpansionState } from "../useCompoundExpansionState";
 import { useSelectionState } from "@migtools/lib-ui";
-import { useLegacySortState } from "../useLegacySortState";
 import { usePaginationState } from "../usePaginationState";
-import { objectKeys } from "@app/utils/utils";
+import { useSortState } from "../useSortState";
 
 export interface UseTableControlStateArgs<
   TItem extends { name: string },
@@ -14,6 +13,7 @@ export interface UseTableControlStateArgs<
   columnNames: TColumnNames; // An ordered mapping of unique keys to human-readable column name strings
   filterCategories?: FilterCategory<TItem>[];
   filterStorageKey?: string;
+  sortableColumns?: (keyof TColumnNames)[]; // TODO can we limit this to a subset of sortable keys and have that enforced?
   getSortValues?: (item: TItem) => Record<keyof TColumnNames, string | number>;
   initialSort?: { columnKey: keyof TColumnNames; direction: "asc" | "desc" };
   hasPagination?: boolean;
@@ -28,11 +28,11 @@ export const useTableControlState = <
 ) => {
   const {
     items,
-    columnNames,
     filterCategories = [],
     filterStorageKey,
+    sortableColumns = [],
     getSortValues,
-    initialSort,
+    initialSort = null,
     hasPagination = true,
     initialItemsPerPage = 10,
   } = args;
@@ -42,32 +42,16 @@ export const useTableControlState = <
   const expansionState = useCompoundExpansionState<TItem, TColumnNames>();
 
   const selectionState = useSelectionState<TItem>({
-    items: filterState.filteredItems || [],
+    items: filterState.filteredItems,
     isEqual: (a, b) => a.name === b.name,
   });
 
-  const sortState = useLegacySortState(
-    filterState.filteredItems,
-    getSortValues
-      ? (item) => {
-          // Because useSortState is based on column indexes and we want to base everything on columnKey,
-          // we need to convert to an array of strings based on column index here.
-          // TODO rewrite or write an alternate useSortState to be based on columnKey instead.
-          const sortValuesByColumnKey = getSortValues(item);
-          return [
-            ...objectKeys(columnNames).map(
-              (columnKey) => sortValuesByColumnKey[columnKey] || ""
-            ),
-          ];
-        }
-      : undefined,
-    initialSort
-      ? {
-          index: objectKeys(columnNames).indexOf(initialSort.columnKey),
-          direction: initialSort.direction,
-        }
-      : undefined
-  );
+  const sortState = useSortState({
+    items: filterState.filteredItems,
+    sortableColumns,
+    getSortValues,
+    initialSort,
+  });
 
   const paginationState = usePaginationState(
     sortState.sortedItems,

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlState.ts
@@ -53,10 +53,10 @@ export const useTableControlState = <
     initialSort,
   });
 
-  const paginationState = usePaginationState(
-    sortState.sortedItems,
-    initialItemsPerPage
-  );
+  const paginationState = usePaginationState({
+    items: sortState.sortedItems,
+    initialItemsPerPage,
+  });
 
   return {
     ...args,

--- a/client/src/app/shared/hooks/use-table-controls/useTableControls.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControls.ts
@@ -9,15 +9,17 @@ import {
 
 export type UseTableControlsArgs<
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
-> = UseTableControlStateArgs<TItem, TColumnNames> &
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey // A subset of column keys as a separate narrower type
+> = UseTableControlStateArgs<TItem, TColumnKey, TSortableColumnKey> &
   UseTableControlPropsAdditionalArgs;
 
 export const useTableControls = <
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
 >(
-  args: UseTableControlsArgs<TItem, TColumnNames>
+  args: UseTableControlsArgs<TItem, TColumnKey, TSortableColumnKey>
 ) => {
   const stateReturnValues = useTableControlState(args);
   const propsReturnValues = useTableControlProps({

--- a/client/src/app/shared/hooks/use-table-controls/useTableControls.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControls.ts
@@ -11,7 +11,7 @@ export type UseTableControlsArgs<
   TItem extends { name: string },
   TColumnNames extends Record<string, string>
 > = UseTableControlStateArgs<TItem, TColumnNames> &
-  UseTableControlPropsAdditionalArgs<TColumnNames>;
+  UseTableControlPropsAdditionalArgs;
 
 export const useTableControls = <
   TItem extends { name: string },

--- a/client/src/app/shared/hooks/useCompoundExpansionState.ts
+++ b/client/src/app/shared/hooks/useCompoundExpansionState.ts
@@ -2,12 +2,12 @@ import React from "react";
 
 export const useCompoundExpansionState = <
   TItem extends { name: string },
-  TColumnNames extends Record<string, string>
+  TColumnKey extends string
 >() => {
   // TExpandedCells maps item names to either:
   //  - The key of an expanded column in that row, if the table is compound-expandable
   //  - The `true` literal value (the entire row is expanded), if non-compound-expandable
-  type TExpandedCells = Record<string, keyof TColumnNames | boolean>;
+  type TExpandedCells = Record<string, TColumnKey | boolean>;
 
   const [expandedCells, setExpandedCells] = React.useState<TExpandedCells>({});
   const setCellExpanded = ({
@@ -17,7 +17,7 @@ export const useCompoundExpansionState = <
   }: {
     item: TItem;
     isExpanding?: boolean;
-    columnKey?: keyof TColumnNames;
+    columnKey?: TColumnKey;
   }) => {
     const newExpandedCells = { ...expandedCells };
     if (isExpanding) {
@@ -31,7 +31,7 @@ export const useCompoundExpansionState = <
   // isCellExpanded:
   //  - If called with a columnKey, returns whether that specific cell is expanded
   //  - If called without a columnKey, returns whether the row is expanded at all
-  const isCellExpanded = (item: TItem, columnKey?: keyof TColumnNames) =>
+  const isCellExpanded = (item: TItem, columnKey?: TColumnKey) =>
     columnKey
       ? expandedCells[item.name] === columnKey
       : !!expandedCells[item.name];

--- a/client/src/app/shared/hooks/useFilterState.ts
+++ b/client/src/app/shared/hooks/useFilterState.ts
@@ -12,6 +12,8 @@ export interface IFilterStateHook<T> {
   filteredItems: T[];
 }
 
+// TODO refactor this to take an object of args for consistency with the other table state hooks
+
 export const useFilterState = <T>(
   items: T[],
   filterCategories: FilterCategory<T>[],

--- a/client/src/app/shared/hooks/useLegacyPaginationState.ts
+++ b/client/src/app/shared/hooks/useLegacyPaginationState.ts
@@ -1,23 +1,21 @@
 import * as React from "react";
 import { PaginationProps } from "@patternfly/react-core";
 
-// TODO these could be given generic types to avoid using `any` (https://www.typescriptlang.org/docs/handbook/generics.html)
-
 export type PaginationStateProps = Pick<
   PaginationProps,
   "itemCount" | "perPage" | "page" | "onSetPage" | "onPerPageSelect"
 >;
 
-export interface IPaginationStateHook<T> {
+export interface ILegacyPaginationStateHook<T> {
   currentPageItems: T[];
   setPageNumber: (pageNumber: number) => void;
   paginationProps: PaginationStateProps;
 }
 
-export const usePaginationState = <T>(
+export const useLegacyPaginationState = <T>(
   items: T[],
   initialItemsPerPage: number
-): IPaginationStateHook<T> => {
+): ILegacyPaginationStateHook<T> => {
   const [pageNumber, baseSetPageNumber] = React.useState(1);
   const setPageNumber = (num: number) => baseSetPageNumber(num >= 1 ? num : 1);
   const [itemsPerPage, setItemsPerPage] = React.useState(initialItemsPerPage);

--- a/client/src/app/shared/hooks/useLegacySortState.ts
+++ b/client/src/app/shared/hooks/useLegacySortState.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { ISortBy, SortByDirection } from "@patternfly/react-table";
 import i18n from "@app/i18n";
 
-export interface ISortStateHook<T> {
+export interface ILegacySortStateHook<T> {
   sortBy: ISortBy;
   onSort: (
     event: React.SyntheticEvent,
@@ -14,11 +14,11 @@ export interface ISortStateHook<T> {
 
 // TODO change this to work by columnKeys instead of column index?
 
-export const useSortState = <T>(
+export const useLegacySortState = <T>(
   items: T[],
   getSortValues?: (item: T) => (string | number | boolean)[],
   initialSort: ISortBy = { index: 0, direction: "asc" }
-): ISortStateHook<T> => {
+): ILegacySortStateHook<T> => {
   const [sortBy, setSortBy] = React.useState<ISortBy>(initialSort);
 
   const onSort = (

--- a/client/src/app/shared/hooks/usePaginationState.ts
+++ b/client/src/app/shared/hooks/usePaginationState.ts
@@ -1,23 +1,22 @@
 import * as React from "react";
-import { PaginationProps } from "@patternfly/react-core";
 
-export type PaginationStateProps = Pick<
-  PaginationProps,
-  "itemCount" | "perPage" | "page" | "onSetPage" | "onPerPageSelect"
->;
+export interface IPaginationStateArgs<TItem> {
+  items: TItem[];
+  initialItemsPerPage?: number;
+}
 
-export interface IPaginationStateHook<T> {
-  currentPageItems: T[];
+export interface IPaginationStateHook<TItem> {
+  currentPageItems: TItem[];
   pageNumber: number;
   setPageNumber: (pageNumber: number) => void;
   itemsPerPage: number;
   setItemsPerPage: (numItems: number) => void;
 }
 
-export const usePaginationState = <T>(
-  items: T[],
-  initialItemsPerPage: number
-): IPaginationStateHook<T> => {
+export const usePaginationState = <TItem>({
+  items,
+  initialItemsPerPage = 10,
+}: IPaginationStateArgs<TItem>): IPaginationStateHook<TItem> => {
   const [pageNumber, baseSetPageNumber] = React.useState(1);
   const setPageNumber = (num: number) => baseSetPageNumber(num >= 1 ? num : 1);
   const [itemsPerPage, setItemsPerPage] = React.useState(initialItemsPerPage);

--- a/client/src/app/shared/hooks/usePaginationState.ts
+++ b/client/src/app/shared/hooks/usePaginationState.ts
@@ -1,25 +1,25 @@
 import * as React from "react";
 import { PaginationProps } from "@patternfly/react-core";
 
-// NOTE: This was refactored to return generic state data and decouple the PF props piece to another helper function.
-//       See usePaginationState for the new version, which should probably be used instead of this everywhere eventually.
-//       See usePaginationProps for the pieces that were removed here.
+// TODO only return simple state
+// TODO separate the props stuff to a usePaginationProps or getPaginationProps
+// TODO integrate that into useTableControlProps
 
 export type PaginationStateProps = Pick<
   PaginationProps,
   "itemCount" | "perPage" | "page" | "onSetPage" | "onPerPageSelect"
 >;
 
-export interface ILegacyPaginationStateHook<T> {
+export interface IPaginationStateHook<T> {
   currentPageItems: T[];
   setPageNumber: (pageNumber: number) => void;
   paginationProps: PaginationStateProps;
 }
 
-export const useLegacyPaginationState = <T>(
+export const usePaginationState = <T>(
   items: T[],
   initialItemsPerPage: number
-): ILegacyPaginationStateHook<T> => {
+): IPaginationStateHook<T> => {
   const [pageNumber, baseSetPageNumber] = React.useState(1);
   const setPageNumber = (num: number) => baseSetPageNumber(num >= 1 ? num : 1);
   const [itemsPerPage, setItemsPerPage] = React.useState(initialItemsPerPage);

--- a/client/src/app/shared/hooks/usePaginationState.ts
+++ b/client/src/app/shared/hooks/usePaginationState.ts
@@ -1,10 +1,6 @@
 import * as React from "react";
 import { PaginationProps } from "@patternfly/react-core";
 
-// TODO only return simple state
-// TODO separate the props stuff to a usePaginationProps or getPaginationProps
-// TODO integrate that into useTableControlProps
-
 export type PaginationStateProps = Pick<
   PaginationProps,
   "itemCount" | "perPage" | "page" | "onSetPage" | "onPerPageSelect"
@@ -12,8 +8,10 @@ export type PaginationStateProps = Pick<
 
 export interface IPaginationStateHook<T> {
   currentPageItems: T[];
+  pageNumber: number;
   setPageNumber: (pageNumber: number) => void;
-  paginationProps: PaginationStateProps;
+  itemsPerPage: number;
+  setItemsPerPage: (numItems: number) => void;
 }
 
 export const usePaginationState = <T>(
@@ -38,20 +36,11 @@ export const usePaginationState = <T>(
     pageStartIndex + itemsPerPage
   );
 
-  const paginationProps: PaginationStateProps = {
-    itemCount: items.length,
-    perPage: itemsPerPage,
-    page: pageNumber,
-    onSetPage: (event, pageNumber) => setPageNumber(pageNumber),
-    onPerPageSelect: (event, perPage) => {
-      setPageNumber(1);
-      setItemsPerPage(perPage);
-    },
-  };
-
   return {
     currentPageItems,
+    pageNumber,
     setPageNumber,
-    paginationProps,
+    itemsPerPage,
+    setItemsPerPage,
   };
 };

--- a/client/src/app/shared/hooks/useSortState.ts
+++ b/client/src/app/shared/hooks/useSortState.ts
@@ -2,12 +2,12 @@ import * as React from "react";
 import { ISortBy, SortByDirection } from "@patternfly/react-table";
 import i18n from "@app/i18n";
 
-// NOTE: This was refactored to expose an API based on columnKey instead of column index,
-//       and to return generic state data and decouple the PF props piece to another helper function.
-//       See useSortState for the new version, which should probably be used instead of this everywhere eventually.
-//       See useSortProps for the prop parts that were removed here (TODO ?)
+// TODO refactor to use columnIndex
+// TODO only return simple state
+// TODO separate the props stuff into useSortProps or getSortProps
+// TODO integrate that into useTableControlProps
 
-export interface ILegacySortStateHook<T> {
+export interface ISortStateHook<T> {
   sortBy: ISortBy;
   onSort: (
     event: React.SyntheticEvent,
@@ -17,11 +17,13 @@ export interface ILegacySortStateHook<T> {
   sortedItems: T[];
 }
 
-export const useLegacySortState = <T>(
+// TODO change this to work by columnKeys instead of column index?
+
+export const useSortState = <T>(
   items: T[],
   getSortValues?: (item: T) => (string | number | boolean)[],
   initialSort: ISortBy = { index: 0, direction: "asc" }
-): ILegacySortStateHook<T> => {
+): ISortStateHook<T> => {
   const [sortBy, setSortBy] = React.useState<ISortBy>(initialSort);
 
   const onSort = (

--- a/client/src/app/shared/hooks/useSortState.ts
+++ b/client/src/app/shared/hooks/useSortState.ts
@@ -1,47 +1,36 @@
 import * as React from "react";
 import i18n from "@app/i18n";
 
-// TODO try to use TSortableColumnKey instead of TColumnNames, do that everywhere and try to enforce string keys
-
-export interface IActiveSort<TColumnNames extends Record<string, string>> {
-  columnKey: keyof TColumnNames;
+export interface IActiveSort<TSortableColumnKey extends string> {
+  columnKey: TSortableColumnKey;
   direction: "asc" | "desc";
 }
 
-export interface ISortStateArgs<
-  TItem,
-  TColumnNames extends Record<string, string>
-> {
+export interface ISortStateArgs<TItem, TSortableColumnKey extends string> {
   items: TItem[];
-  sortableColumns: (keyof TColumnNames)[];
+  sortableColumns: TSortableColumnKey[];
   getSortValues?: (
     item: TItem
-  ) => Record<keyof TColumnNames, string | number | boolean>;
-  initialSort: IActiveSort<TColumnNames> | null;
+  ) => Record<TSortableColumnKey, string | number | boolean>;
+  initialSort: IActiveSort<TSortableColumnKey> | null;
 }
 
-export interface ISortStateHook<
-  TItem,
-  TColumnNames extends Record<string, string>
-> {
-  activeSort: IActiveSort<TColumnNames> | null;
-  setActiveSort: (sort: IActiveSort<TColumnNames> | null) => void;
+export interface ISortStateHook<TItem, TSortableColumnKey extends string> {
+  activeSort: IActiveSort<TSortableColumnKey> | null;
+  setActiveSort: (sort: IActiveSort<TSortableColumnKey> | null) => void;
   sortedItems: TItem[];
 }
 
-export const useSortState = <
-  TItem,
-  TColumnNames extends Record<string, string>
->({
+export const useSortState = <TItem, TSortableColumnKey extends string>({
   items,
   sortableColumns,
   getSortValues,
   initialSort = sortableColumns[0]
     ? { columnKey: sortableColumns[0], direction: "asc" }
     : null,
-}: ISortStateArgs<TItem, TColumnNames>): ISortStateHook<
+}: ISortStateArgs<TItem, TSortableColumnKey>): ISortStateHook<
   TItem,
-  TColumnNames
+  TSortableColumnKey
 > => {
   const [activeSort, setActiveSort] = React.useState(initialSort);
 


### PR DESCRIPTION
As far as client-side table state goes, this completes the journey I started in #792 and continued in #808 and #809.

The `useSortState` and `usePaginationState` hooks we had included some presentational logic (they were coupled to returning PatternFly props), which made them hard to swap out with server-driven replacements without duplicating that logic. Also, `useSortState` based its logic on column indexes, and `useTableControls` attempts to expose only arguments concerned with columnKeys to insulate the consumer from that complexity, so `useTableControlState` had to wrap `useSortState` with extra logic to convert between the two.

This PR renames the existing `useSortState` and `usePaginationState` to `useLegacySortState` and `useLegacyPaginationState` respectively so that we don't have to refactor all the legacy tables in the UI to use the new implementations. It introduces replacement `useSortState` and `usePaginationState` hooks that address the above issues, and moves the presentational logic into some new `propHelpers` in `useTableControlProps`. The new versions of these two hooks now return only basic state that is similar to what we might use when working with server-side sorting and pagination, and they no longer depend on any types from PatternFly packages.

During this refactor, I noticed something strange about the way I had been using the `TColumnNames extends Record<string, string>` generic type. Apparently `keyof TColumnNames` was resolving to `string | number | symbol` in contexts where the specific column names are not in scope, which made it difficult to work with in useSortState (in reality the keys of the columnNames object will always be strings). To resolve this, I refactored all the generics of these new hooks and components so they take `TColumnKey extends string` as a type param, which can still be inferred from the `columnNames` object due to its type being `Record<TColumnKey, string>`.

This also presented the opportunity to have a third generic type `TSortableColumnKey extends TColumnKey`, so that the array passed in for `sortableColumns` is used as a narrower type to enforce what keys need to be returned from `getSortValues`. Now, you no longer need to return placeholder sort values for columns you don't intend to make sortable. Also, if you use an initialSort columnKey that is not one of your sortableColumns, this will cause a type error.

This should unblock the team from making further progress on tables like Migration Waves and Jira Trackers which have client-side pagination/sorting/filtering. Now that all the presentational logic is consolidated in `useTableControlProps`, `useTableControlState` is fairly trivial and we should be able to make a drop-in replacement that works with server-side state without having to refactor the existing tables further.