### PR TITLE
:bug: Add forwarding headers to reverse proxy for keycloak

### DIFF
--- a/server/setupProxy.js
+++ b/server/setupProxy.js
@@ -7,6 +7,22 @@ module.exports = function (app) {
       target: process.env.KEYCLOAK_SERVER_URL || "http://localhost:9001",
       changeOrigin: true,
       logLevel: process.env.DEBUG ? "debug" : "info",
+      onProxyReq: (proxyReq, req, res) => {
+        // Keycloak needs these header set so we can function in Kubernetes (non-OpenShift)
+        // https://www.keycloak.org/server/reverseproxy
+        //
+        // Note, on OpenShift, this works as the haproxy implementation
+        // for the OpenShift route is setting these for us automatically
+        proxyReq.setHeader("X-Forwarded-For", req.socket.remoteAddress);
+        proxyReq.setHeader("X-Forwarded-Proto", req.protocol);
+        proxyReq.setHeader("X-Forwarded-Port", req.socket.localPort);
+        proxyReq.setHeader("X-Real-IP", req.socket.remoteAddress);
+        proxyReq.setHeader("X-Forwarded-Host", req.headers.host);
+        proxyReq.setHeader(
+          "Forwarded",
+          `for=${req.socket.remoteAddress};proto=${req.protocol};host=${req.headers.host}`
+        );
+      },
     })
   );
   app.use(


### PR DESCRIPTION
With this, I can run the below and login correctly with auth enabled

`kubectl port-forward svc/tackle-ui 7080:8080 -n konveyor-tackle`

Fixes https://github.com/konveyor/tackle2-ui/issues/821

For more info on debugging this, I captured some rough notes here: https://gist.github.com/jwmatthews/25ad0f2814d8bb6796649dcd22be4ed1

