### PR TITLE
:seedling: Convert stakeholder table to new table abstraction

### DIFF
--- a/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
+++ b/client/src/app/pages/controls/stakeholders/components/stakeholder-form/stakeholder-form.tsx
@@ -120,8 +120,6 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
     mode: "onChange",
   });
 
-  const values = getValues();
-
   const onSubmit = (formValues: FormValues) => {
     const matchingStakeholderGroupRefs: Ref[] = stakeholderGroups
       .filter((stakeholderGroup) =>

--- a/client/src/app/shared/hooks/use-table-controls/useTableControlProps.ts
+++ b/client/src/app/shared/hooks/use-table-controls/useTableControlProps.ts
@@ -173,6 +173,25 @@ export const useTableControlProps = <
     },
   });
 
+  const getSingleExpandTdProps = ({
+    item,
+    rowIndex,
+  }: {
+    item: TItem;
+    rowIndex: number;
+  }): Omit<TdProps, "ref"> => ({
+    expand: {
+      rowIndex,
+      isExpanded: isCellExpanded(item),
+      onToggle: () =>
+        setCellExpanded({
+          item,
+          isExpanding: !isCellExpanded(item),
+        }),
+      expandId: `expandable-row-${item.name}`,
+    },
+  });
+
   const getCompoundExpandTdProps = ({
     item,
     rowIndex,
@@ -230,6 +249,7 @@ export const useTableControlProps = <
       getTdProps,
       getSelectCheckboxTdProps,
       getCompoundExpandTdProps,
+      getSingleExpandTdProps,
       getExpandedContentTdProps,
     },
   };


### PR DESCRIPTION
- useTableControls implementation for Stakeholders expandable form 
@mturley Nice work! We don't have to necessarily merge this as I know it is still under construction a bit. Just wanted to explore the changes. Works flawlessly. Only thing I did notice - we might need a way to make individual rows expandable. If I have a stakeholder with no groups assigned, I wonder if there is a way to make only that row not have an expandable icon displayed without shifting the columns/table rows. 