### PR TITLE
:sparkles: Add expandable issues table content & affected applications page

### DIFF
--- a/client/config/webpack.dev.ts
+++ b/client/config/webpack.dev.ts
@@ -19,7 +19,9 @@ const config = merge<Configuration>(commonWebpackConfiguration, {
       "/auth": "http://localhost:8080",
       "/hub": "http://localhost:8080",
     },
-    historyApiFallback: true,
+    historyApiFallback: {
+      disableDotRule: true,
+    },
   },
   optimization: {
     runtimeChunk: "single",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -327,6 +327,7 @@
     "tagDeleted": "Tag deleted",
     "tagName": "Tag name",
     "tags": "Tags",
+    "target": "Target",
     "tagCategory": "Tag category",
     "tagCategoryDeleted": "Tag category deleted",
     "tagCategories": "Tag categories",

--- a/client/src/app/Paths.ts
+++ b/client/src/app/Paths.ts
@@ -29,7 +29,10 @@ export enum Paths {
   controlsTags = "/controls/tags",
   reports = "/reports",
   migrationWaves = "/migration-waves",
-  issues = "/issues",
+  waves = "/waves",
+  compositeIssues = "/composite/issues",
+  issuesRuleId = "/issues/:ruleidparam",
+
   dependencies = "/dependencies",
 
   // Administrator perspective

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -30,6 +30,9 @@ const General = lazy(() => import("./pages/general"));
 const MigrationWaves = lazy(() => import("./pages/migration-waves"));
 const Jira = lazy(() => import("./pages/external/jira"));
 const Issues = lazy(() => import("./pages/issues"));
+const AffectedApplications = lazy(
+  () => import("./pages/issues/affected-applications")
+);
 const Dependencies = lazy(() => import("./pages/dependencies"));
 
 export interface IRoute {
@@ -87,8 +90,13 @@ export const devRoutes: IRoute[] = [
   ...(FEATURES_ENABLED.dynamicReports
     ? [
         {
-          path: Paths.issues,
+          path: Paths.compositeIssues,
           comp: Issues,
+          exact: false,
+        },
+        {
+          path: Paths.issuesRuleId,
+          comp: AffectedApplications,
           exact: false,
         },
         {

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -3,6 +3,7 @@ export interface HubFilter {
   operator?: "=" | "!=" | "~" | ">" | ">=" | "<" | "<=";
   value:
     | string
+    | number
     | {
         list: string[];
         operator?: "AND" | "OR";
@@ -563,6 +564,21 @@ export interface AnalysisCompositeIssue {
   technologies: Array<IssueTechnology>;
   labels: Array<string>;
   affected: number;
+  createTime?: string;
+}
+
+export interface AnalysisIssue {
+  id: number;
+  ruleID: string; // ruleset+rule
+  application: number;
+  name: string;
+  description: string;
+  category: string;
+  effort: number;
+  incidents: Array<any>;
+  labels: Array<string>;
+  affected: number;
+  createTime?: string;
 }
 
 export interface Ticket {

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -4,6 +4,7 @@ import { APIClient } from "@app/axios-config";
 import {
   AnalysisCompositeIssue,
   AnalysisDependency,
+  AnalysisIssue,
   Application,
   ApplicationAdoptionPlan,
   ApplicationDependency,
@@ -73,7 +74,8 @@ export const FILES = HUB + "/files";
 export const CACHE = HUB + "/cache/m2";
 
 export const ANALYSIS_DEPENDENCIES = HUB + "/analyses/dependencies";
-export const ANALYSIS_ISSUES = HUB + "/analyses/composite/issues";
+export const ANALYSIS_COMPOSITE_ISSUES = HUB + "/analyses/composite/issues";
+export const ANALYSIS_ISSUES = HUB + "/analyses/issues";
 
 // PATHFINDER
 export const PATHFINDER = "/hub/pathfinder";
@@ -639,7 +641,13 @@ export const getDependencies = (params: HubRequestParams = {}) =>
   getHubPaginatedResult<AnalysisDependency>(ANALYSIS_DEPENDENCIES, params);
 
 export const getCompositeIssues = (params: HubRequestParams = {}) =>
-  getHubPaginatedResult<AnalysisCompositeIssue>(ANALYSIS_ISSUES, params);
+  getHubPaginatedResult<AnalysisCompositeIssue>(
+    ANALYSIS_COMPOSITE_ISSUES,
+    params
+  );
+
+export const getIssues = (params: HubRequestParams = {}) =>
+  getHubPaginatedResult<AnalysisIssue>(ANALYSIS_ISSUES, params);
 
 export const createTicket = (obj: Ticket): Promise<Ticket> =>
   axios.post(TICKETS, obj);

--- a/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -135,7 +135,10 @@ export const SidebarApp: React.FC = () => {
           {FEATURES_ENABLED.dynamicReports ? (
             <>
               <NavItem>
-                <NavLink to={Paths.issues} activeClassName="pf-m-current">
+                <NavLink
+                  to={Paths.compositeIssues}
+                  activeClassName="pf-m-current"
+                >
                   {t("sidebar.issues")}
                 </NavLink>
               </NavItem>

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -1,0 +1,217 @@
+import * as React from "react";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import { AppPlaceholder, ConditionalRender } from "@app/shared/components";
+import {
+  TableComposable,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
+import {
+  useTableControlUrlParams,
+  getHubRequestParams,
+} from "@app/shared/hooks/table-controls";
+import { SimplePagination } from "@app/shared/components/simple-pagination";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/shared/components/table-controls";
+import { useFetchIssues } from "@app/queries/issues";
+import { useLocalTableControls } from "@app/shared/hooks/table-controls";
+import { useFetchApplications } from "@app/queries/applications";
+import { Application } from "@app/api/models";
+import { Link, useParams } from "react-router-dom";
+interface IAffectedApplicationsRouteParams {
+  ruleidparam: string;
+}
+
+export const AffectedApplications: React.FC = () => {
+  const { t } = useTranslation();
+
+  const { ruleidparam } = useParams<IAffectedApplicationsRouteParams>();
+
+  const tableControlState = useTableControlUrlParams({
+    columnNames: {
+      name: "Name",
+      description: "Description",
+      businessService: "Business serice",
+      tags: "Tags",
+    },
+    sortableColumns: ["name"],
+    initialSort: {
+      columnKey: "name",
+      direction: "asc",
+    },
+    initialItemsPerPage: 10,
+  });
+
+  const {
+    result: { data: issues, total: totalItemCount },
+    isFetching,
+    fetchError,
+  } = useFetchIssues(
+    getHubRequestParams({
+      filterState: {
+        filterValues: {
+          ruleid: [ruleidparam || ""],
+        },
+        setFilterValues: tableControlState.filterState.setFilterValues,
+      },
+    })
+  );
+
+  const { data: applications } = useFetchApplications();
+  const issueAppIds = issues.map((issue) => issue.application);
+  const affectedApplications: Application[] = applications.filter(
+    (app) => app.id && issueAppIds.includes(app.id)
+  );
+
+  const tableControls = useLocalTableControls({
+    idProperty: "name",
+    items: applications,
+    columnNames: {
+      name: "Name",
+      description: "Description",
+      businessService: "Business serice",
+      tags: "Tags",
+    },
+    sortableColumns: ["name"],
+    getSortValues: (item) => ({
+      name: item?.name || "",
+    }),
+    initialSort: { columnKey: "name", direction: "asc" },
+    hasPagination: true,
+    isLoading: isFetching,
+  });
+
+  const {
+    currentPageItems,
+    numRenderedColumns,
+    propHelpers: {
+      toolbarProps,
+      paginationToolbarItemProps,
+      paginationProps,
+      tableProps,
+      getThProps,
+      getTdProps,
+    },
+  } = tableControls;
+  console.log({ currentPageItems, totalItemCount });
+
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <TextContent>
+          <Text component="h1">{t("terms.issues")}</Text>
+        </TextContent>
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to="/composite/issues">Issues</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem to="#" isActive>
+            {ruleidparam || "Active rule"}
+          </BreadcrumbItem>
+        </Breadcrumb>
+      </PageSection>
+      <PageSection>
+        <ConditionalRender
+          when={isFetching && !(currentPageItems || fetchError)}
+          then={<AppPlaceholder />}
+        >
+          <div
+            style={{
+              backgroundColor: "var(--pf-global--BackgroundColor--100)",
+            }}
+          >
+            <Toolbar {...toolbarProps}>
+              <ToolbarContent>
+                <ToolbarItem {...paginationToolbarItemProps}>
+                  <SimplePagination
+                    idPrefix="affected-applications-table"
+                    isTop
+                    paginationProps={paginationProps}
+                  />
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
+            <TableComposable {...tableProps} aria-label="Migration waves table">
+              <Thead>
+                <Tr>
+                  <TableHeaderContentWithControls {...tableControls}>
+                    <Th {...getThProps({ columnKey: "name" })} />
+                    <Th {...getThProps({ columnKey: "description" })} />
+                    <Th {...getThProps({ columnKey: "businessService" })} />
+                    <Th {...getThProps({ columnKey: "tags" })} />
+                  </TableHeaderContentWithControls>
+                </Tr>
+              </Thead>
+              <ConditionalTableBody
+                isLoading={isFetching}
+                isError={!!fetchError}
+                isNoData={totalItemCount === 0}
+                numRenderedColumns={numRenderedColumns}
+              >
+                {affectedApplications?.map((application, rowIndex) => {
+                  return (
+                    <Tbody key={application.name}>
+                      <Tr>
+                        <TableRowContentWithControls
+                          {...tableControls}
+                          item={application}
+                          rowIndex={rowIndex}
+                        >
+                          <Td width={25} {...getTdProps({ columnKey: "name" })}>
+                            {application.name}
+                          </Td>
+                          <Td
+                            width={10}
+                            {...getTdProps({ columnKey: "description" })}
+                          >
+                            {application.description}
+                          </Td>
+                          <Td
+                            width={10}
+                            {...getTdProps({ columnKey: "businessService" })}
+                          >
+                            {application.businessService?.name}
+                          </Td>
+                          <Td
+                            width={10}
+                            {...getTdProps({
+                              columnKey: "tags",
+                            })}
+                          >
+                            {application?.tags?.length}
+                          </Td>
+                        </TableRowContentWithControls>
+                      </Tr>
+                    </Tbody>
+                  );
+                })}
+              </ConditionalTableBody>
+            </TableComposable>
+            <SimplePagination
+              idPrefix="dependencies-table"
+              isTop={false}
+              paginationProps={paginationProps}
+            />
+          </div>
+        </ConditionalRender>
+      </PageSection>
+    </>
+  );
+};

--- a/client/src/app/pages/issues/affected-applications/index.ts
+++ b/client/src/app/pages/issues/affected-applications/index.ts
@@ -1,0 +1,1 @@
+export { AffectedApplications as default } from "./affected-applications";

--- a/client/src/app/queries/applications.ts
+++ b/client/src/app/queries/applications.ts
@@ -26,6 +26,7 @@ export const ApplicationsQueryKey = "applications";
 export const useFetchApplications = () => {
   const queryClient = useQueryClient();
   const { isLoading, error, refetch, data } = useQuery({
+    initialData: [],
     queryKey: [ApplicationsQueryKey],
     queryFn: getApplications,
     onSuccess: () => {

--- a/client/src/app/queries/issues.ts
+++ b/client/src/app/queries/issues.ts
@@ -1,27 +1,33 @@
 import { useQuery } from "@tanstack/react-query";
-import {
-  AnalysisCompositeIssue,
-  HubPaginatedResult,
-  HubRequestParams,
-} from "@app/api/models";
-import { getCompositeIssues } from "@app/api/rest";
+import { HubRequestParams } from "@app/api/models";
+import { getCompositeIssues, getIssues } from "@app/api/rest";
 import { serializeRequestParamsForHub } from "@app/shared/hooks/table-controls";
 
-export interface IIssuesFetchState {
-  result: HubPaginatedResult<AnalysisCompositeIssue>;
-  isFetching: boolean;
-  fetchError: unknown;
-  refetch: () => void;
-}
-
+export const CompositeIssuesQueryKey = "compositeissues";
 export const IssuesQueryKey = "issues";
 
-export const useFetchIssues = (
-  params: HubRequestParams = {}
-): IIssuesFetchState => {
+export const useFetchCompositeIssues = (params: HubRequestParams = {}) => {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: [
+      CompositeIssuesQueryKey,
+      serializeRequestParamsForHub(params).toString(),
+    ],
+    queryFn: async () => await getCompositeIssues(params),
+    onError: (error) => console.log("error, ", error),
+    keepPreviousData: true,
+  });
+  return {
+    result: data || { data: [], total: 0, params },
+    isFetching: isLoading,
+    fetchError: error,
+    refetch,
+  };
+};
+
+export const useFetchIssues = (params: HubRequestParams = {}) => {
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: [IssuesQueryKey, serializeRequestParamsForHub(params).toString()],
-    queryFn: async () => await getCompositeIssues(params),
+    queryFn: async () => await getIssues(params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,
   });

--- a/client/src/app/shared/components/FilterToolbar/FilterControl.tsx
+++ b/client/src/app/shared/components/FilterToolbar/FilterControl.tsx
@@ -33,10 +33,14 @@ export const FilterControl = <TItem, TFilterCategoryKey extends string>({
       />
     );
   }
-  if (category.type === FilterType.search) {
+  if (
+    category.type === FilterType.search ||
+    category.type === FilterType.numsearch
+  ) {
     return (
       <SearchFilterControl
         category={category as ISearchFilterCategory<TItem, TFilterCategoryKey>}
+        isNumeric={category.type === FilterType.numsearch}
         {...props}
       />
     );

--- a/client/src/app/shared/components/FilterToolbar/SearchFilterControl.tsx
+++ b/client/src/app/shared/components/FilterToolbar/SearchFilterControl.tsx
@@ -9,12 +9,14 @@ import {
 import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
 import { IFilterControlProps } from "./FilterControl";
 import { ISearchFilterCategory } from "./FilterToolbar";
+import { inflateSync } from "zlib";
 
 export interface ISearchFilterControlProps<
   TItem,
   TFilterCategoryKey extends string
 > extends IFilterControlProps<TItem, TFilterCategoryKey> {
   category: ISearchFilterCategory<TItem, TFilterCategoryKey>;
+  isNumeric: boolean;
 }
 
 export const SearchFilterControl = <TItem, TFilterCategoryKey extends string>({
@@ -22,6 +24,7 @@ export const SearchFilterControl = <TItem, TFilterCategoryKey extends string>({
   filterValue,
   setFilterValue,
   showToolbarItem,
+  isNumeric,
 }: React.PropsWithChildren<
   ISearchFilterControlProps<TItem, TFilterCategoryKey>
 >): JSX.Element | null => {
@@ -48,9 +51,9 @@ export const SearchFilterControl = <TItem, TFilterCategoryKey extends string>({
         <TextInput
           name={id}
           id={id}
-          type="search"
-          aria-label={`${category.title} filter`}
+          type={isNumeric ? "number" : "search"}
           onChange={setInputValue}
+          aria-label={`${category.title} filter`}
           value={inputValue}
           placeholder={category.placeholderText}
           onKeyDown={(event: React.KeyboardEvent) => {

--- a/client/src/app/shared/hooks/table-controls/filtering/getFilterHubRequestParams.ts
+++ b/client/src/app/shared/hooks/table-controls/filtering/getFilterHubRequestParams.ts
@@ -42,6 +42,13 @@ export const getFilterHubRequestParams = <
     // Note: If we need to support more of the logic operators in HubFilter in the future,
     //       we'll need to figure out how to express those on the FilterCategory objects
     //       and translate them here.
+    if (filterCategory.type === "numsearch") {
+      params.filters?.push({
+        field: categoryKey,
+        operator: "=",
+        value: Number(filterValue[0]),
+      });
+    }
     if (filterCategory.type === "search") {
       params.filters?.push({
         field: categoryKey,
@@ -78,6 +85,8 @@ export const serializeFilterForHub = (filter: HubFilter): string => {
   const joinedValue =
     typeof value === "string"
       ? wrapInQuotesAndEscape(value)
+      : typeof value === "number"
+      ? `"${value}"`
       : `(${value.list
           .map(wrapInQuotesAndEscape)
           .join(value.operator === "OR" ? "|" : ",")})`;


### PR DESCRIPTION
- Adds initial issues table expandable area content
- Adds numsearch filter type for handling filtering by number if the need arises. I have commented out the effort filter until more info surfaces on the needs.
- Adds affected applications view with apps viewed by associated issue ruleid. Uses react-router route params approach. 
- https://stackoverflow.com/a/38576357 - disable dot rule to allow routing to rule urls with dot notation.

TODO: 
- convert search filters to select where needed for applications
- Improve grouped categories implementation to dynamically hide empty groups
- Add validation description to composite issue expanded area
- Use new hub api label changes 