### PR TITLE
:seedling: Add environment varable to override feature flags

### DIFF
--- a/client/src/app/FeatureFlags.ts
+++ b/client/src/app/FeatureFlags.ts
@@ -2,3 +2,11 @@ export const FEATURES_ENABLED = {
   migrationWaves: false,
   dynamicReports: false,
 };
+
+if (process.env?.FEATURES_ENABLED) {
+  const featureTuples = process.env?.FEATURES_ENABLED.split(",");
+  featureTuples.forEach((tuple) => {
+    const [key, val] = tuple.split(":");
+    FEATURES_ENABLED[key as keyof typeof FEATURES_ENABLED] = val === "true";
+  });
+}


### PR DESCRIPTION
Feature flags can be overridden in development by setting the `FEATURES_ENABLED` environment variable in the following format:
```
FEATURES_ENABLED=featureKey:boolean[,featureKey:boolean,...]
```
For example:
```
FEATURES_ENABLED=migrationWaves:true,dynamicReports:true npm run start:dev
FEATURES_ENABLED=migrationWaves:true npm run start:dev
```

The values in the `FEATURES_ENABLED` constant in the code will be used for any feature keys not included in the env var.