### PR TITLE
:bug: Fix unnecessary page remounts: don't attempt to render less boilerplate on pages without a drawer

### DIFF
--- a/client/src/app/layout/DefaultLayout/tests/__snapshots__/DefaultLayout.test.tsx.snap
+++ b/client/src/app/layout/DefaultLayout/tests/__snapshots__/DefaultLayout.test.tsx.snap
@@ -238,7 +238,33 @@ Object {
           class="pf-c-page__main"
           id="main-content-page-layout-horizontal-nav"
           tabindex="-1"
-        />
+        >
+          <div
+            class="pf-c-page__drawer"
+          >
+            <div
+              class="pf-c-drawer"
+            >
+              <div
+                class="pf-c-drawer__main"
+              >
+                <div
+                  class="pf-c-drawer__content"
+                >
+                  <div
+                    class="pf-c-drawer__body"
+                  />
+                </div>
+                <div
+                  class="pf-c-drawer__panel pf-m-resizable"
+                  hidden=""
+                  id="page-drawer-content"
+                  style="--pf-c-drawer__panel--md--FlexBasis: 500px; --pf-c-drawer__panel--md--FlexBasis--min: 150px;"
+                />
+              </div>
+            </div>
+          </div>
+        </main>
       </div>
     </div>
     <div />
@@ -484,7 +510,33 @@ Object {
         class="pf-c-page__main"
         id="main-content-page-layout-horizontal-nav"
         tabindex="-1"
-      />
+      >
+        <div
+          class="pf-c-page__drawer"
+        >
+          <div
+            class="pf-c-drawer"
+          >
+            <div
+              class="pf-c-drawer__main"
+            >
+              <div
+                class="pf-c-drawer__content"
+              >
+                <div
+                  class="pf-c-drawer__body"
+                />
+              </div>
+              <div
+                class="pf-c-drawer__panel pf-m-resizable"
+                hidden=""
+                id="page-drawer-content"
+                style="--pf-c-drawer__panel--md--FlexBasis: 500px; --pf-c-drawer__panel--md--FlexBasis--min: 150px;"
+              />
+            </div>
+          </div>
+        </div>
+      </main>
     </div>
   </div>,
   "debug": [Function],

--- a/client/src/app/shared/page-drawer-context.tsx
+++ b/client/src/app/shared/page-drawer-context.tsx
@@ -110,6 +110,7 @@ export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
     setIsDrawerExpanded(localIsExpandedProp);
     return () => {
       setIsDrawerExpanded(false);
+      setDrawerChildren(null);
     };
   }, [localIsExpandedProp]);
 

--- a/client/src/app/shared/page-drawer-context.tsx
+++ b/client/src/app/shared/page-drawer-context.tsx
@@ -11,14 +11,11 @@ import {
 import pageStyles from "@patternfly/react-styles/css/components/Page/page";
 
 const usePageDrawerState = () => {
-  const [isDrawerMounted, setIsDrawerMounted] = React.useState(false);
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState(false);
   const [drawerChildren, setDrawerChildren] =
     React.useState<React.ReactNode>(null);
   const drawerFocusRef = React.useRef(document.createElement("span"));
   return {
-    isDrawerMounted,
-    setIsDrawerMounted,
     isDrawerExpanded,
     setIsDrawerExpanded,
     drawerChildren,
@@ -30,8 +27,6 @@ const usePageDrawerState = () => {
 type PageDrawerState = ReturnType<typeof usePageDrawerState>;
 
 const PageDrawerContext = React.createContext<PageDrawerState>({
-  isDrawerMounted: false,
-  setIsDrawerMounted: () => {},
   isDrawerExpanded: false,
   setIsDrawerExpanded: () => {},
   drawerChildren: null,
@@ -47,36 +42,31 @@ export const PageContentWithDrawerProvider: React.FC<
   IPageContentWithDrawerProviderProps
 > = ({ children }) => {
   const pageDrawerState = usePageDrawerState();
-  const { isDrawerMounted, isDrawerExpanded, drawerFocusRef, drawerChildren } =
-    pageDrawerState;
+  const { isDrawerExpanded, drawerFocusRef, drawerChildren } = pageDrawerState;
   return (
     <PageDrawerContext.Provider value={pageDrawerState}>
-      {isDrawerMounted ? (
-        <div className={pageStyles.pageDrawer}>
-          <Drawer
-            isExpanded={isDrawerExpanded}
-            onExpand={() => drawerFocusRef?.current?.focus()}
-            position="right"
+      <div className={pageStyles.pageDrawer}>
+        <Drawer
+          isExpanded={isDrawerExpanded}
+          onExpand={() => drawerFocusRef?.current?.focus()}
+          position="right"
+        >
+          <DrawerContent
+            panelContent={
+              <DrawerPanelContent
+                isResizable
+                id="page-drawer-content"
+                defaultSize="500px"
+                minSize="150px"
+              >
+                {drawerChildren}
+              </DrawerPanelContent>
+            }
           >
-            <DrawerContent
-              panelContent={
-                <DrawerPanelContent
-                  isResizable
-                  id="page-drawer-content"
-                  defaultSize="500px"
-                  minSize="150px"
-                >
-                  {drawerChildren}
-                </DrawerPanelContent>
-              }
-            >
-              <DrawerContentBody>{children}</DrawerContentBody>
-            </DrawerContent>
-          </Drawer>
-        </div>
-      ) : (
-        children
-      )}
+            <DrawerContentBody>{children}</DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </div>
     </PageDrawerContext.Provider>
   );
 };
@@ -97,21 +87,14 @@ export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
   children,
   focusKey,
 }) => {
-  const {
-    setIsDrawerMounted,
-    setIsDrawerExpanded,
-    drawerFocusRef,
-    setDrawerChildren,
-  } = React.useContext(PageDrawerContext);
+  const { setIsDrawerExpanded, drawerFocusRef, setDrawerChildren } =
+    React.useContext(PageDrawerContext);
 
-  // Prevent Drawer boilerplate from being rendered in PageContentWithDrawerProvider if no PageDrawerContent exists.
-  // Also, warn if we are trying to render more than one PageDrawerContent (they'll fight over the same state).
+  // Warn if we are trying to render more than one PageDrawerContent (they'll fight over the same state).
   React.useEffect(() => {
     numPageDrawerContentInstances++;
-    setIsDrawerMounted(true);
     return () => {
       numPageDrawerContentInstances--;
-      setIsDrawerMounted(false);
     };
   }, []);
   if (numPageDrawerContentInstances > 1) {


### PR DESCRIPTION
Fixes the entire app re-rendering when PageDrawerContent renders for the first time, which was causing all our applications table queries to fetch twice and the initial fetch updating state on an older unmounted instance of the page (resulting in React warnings).