### PR TITLE
:bug: Use a React key prop to remount the drawer contents when changing routes

### DIFF
--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -51,6 +51,7 @@ export const ApplicationDetailDrawer: React.FC<
       isExpanded={!!application}
       onCloseClick={onCloseClick}
       focusKey={application?.id}
+      pageKey="app-inventory"
     >
       <TextContent>
         <Text component="small" className={spacing.mb_0}>

--- a/client/src/app/shared/page-drawer-context.tsx
+++ b/client/src/app/shared/page-drawer-context.tsx
@@ -14,12 +14,15 @@ const usePageDrawerState = () => {
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState(false);
   const [drawerChildren, setDrawerChildren] =
     React.useState<React.ReactNode>(null);
+  const [drawerPageKey, setDrawerPageKey] = React.useState<string>("");
   const drawerFocusRef = React.useRef(document.createElement("span"));
   return {
     isDrawerExpanded,
     setIsDrawerExpanded,
     drawerChildren,
     setDrawerChildren,
+    drawerPageKey,
+    setDrawerPageKey,
     drawerFocusRef: drawerFocusRef as typeof drawerFocusRef | null,
   };
 };
@@ -31,6 +34,8 @@ const PageDrawerContext = React.createContext<PageDrawerState>({
   setIsDrawerExpanded: () => {},
   drawerChildren: null,
   setDrawerChildren: () => {},
+  drawerPageKey: "",
+  setDrawerPageKey: () => {},
   drawerFocusRef: null,
 });
 
@@ -42,7 +47,8 @@ export const PageContentWithDrawerProvider: React.FC<
   IPageContentWithDrawerProviderProps
 > = ({ children }) => {
   const pageDrawerState = usePageDrawerState();
-  const { isDrawerExpanded, drawerFocusRef, drawerChildren } = pageDrawerState;
+  const { isDrawerExpanded, drawerFocusRef, drawerChildren, drawerPageKey } =
+    pageDrawerState;
   return (
     <PageDrawerContext.Provider value={pageDrawerState}>
       <div className={pageStyles.pageDrawer}>
@@ -58,6 +64,7 @@ export const PageContentWithDrawerProvider: React.FC<
                 id="page-drawer-content"
                 defaultSize="500px"
                 minSize="150px"
+                key={drawerPageKey}
               >
                 {drawerChildren}
               </DrawerPanelContent>
@@ -79,6 +86,7 @@ export interface IPageDrawerContentProps {
   onCloseClick: () => void; // Should be used to update local state such that `isExpanded` becomes false.
   children: React.ReactNode; // The content to show in the drawer when `isExpanded` is true.
   focusKey?: string | number; // A unique key representing the object being described in the drawer. When this changes, the drawer will regain focus.
+  pageKey: string; // A unique key representing the page where the drawer is used. Causes the drawer to remount when changing pages.
 }
 
 export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
@@ -86,9 +94,14 @@ export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
   onCloseClick,
   children,
   focusKey,
+  pageKey: localPageKeyProp,
 }) => {
-  const { setIsDrawerExpanded, drawerFocusRef, setDrawerChildren } =
-    React.useContext(PageDrawerContext);
+  const {
+    setIsDrawerExpanded,
+    drawerFocusRef,
+    setDrawerChildren,
+    setDrawerPageKey,
+  } = React.useContext(PageDrawerContext);
 
   // Warn if we are trying to render more than one PageDrawerContent (they'll fight over the same state).
   React.useEffect(() => {
@@ -113,6 +126,14 @@ export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
       setDrawerChildren(null);
     };
   }, [localIsExpandedProp]);
+
+  // Same deal with the page key, keep it in sync with the local prop on PageDrawerContent.
+  React.useEffect(() => {
+    setDrawerPageKey(localPageKeyProp);
+    return () => {
+      setDrawerPageKey("");
+    };
+  }, [localPageKeyProp]);
 
   // If the drawer is already expanded describing app A, then the user clicks app B, we want to send focus back to the drawer.
   React.useEffect(() => {


### PR DESCRIPTION
Followup to #848.

This solves the weird behavior where navigating away from a page of the app that has a drawer will cause the drawer to slide closed after navigating rather than disappear immediately with the rest of the page. This fixes an additional quirk I encountered while introducing a drawer to the Dependencies page: I would open the drawer for a Dependency, switch to the apps page, and right as the drawer started closing it would swap its contents for the app table's drawer contents.

A `key` prop on any React component will cause the component to fully unmount and remount when the key changes. This PR adds a `pageKey` prop to the `PageDrawerContent` component, to be a string literal describing the page where a drawer is used. This key is passed to the `DrawerPanelContent` component, which is what has the CSS animation for sliding the drawer open and closed. Remounting this component snaps the drawer closed with no animation, but does not remount the entire page contents (like we used to before #848).