### PR TITLE
:sparkles: Add support for clickable/active rows with URL param + example usage with Drawer on Dependencies table

### DIFF
--- a/client/src/app/pages/dependencies/dependencies.tsx
+++ b/client/src/app/pages/dependencies/dependencies.tsx
@@ -9,7 +9,6 @@ import {
   ToolbarItem,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import { AppPlaceholder, ConditionalRender } from "@app/shared/components";
 import {
   FilterToolbar,
   FilterType,
@@ -36,7 +35,6 @@ import {
 import { useFetchDependencies } from "@app/queries/dependencies";
 import { useSelectionState } from "@migtools/lib-ui";
 import { getHubRequestParams } from "@app/shared/hooks/table-controls";
-import { AnalysisDependency } from "@app/api/models";
 import { PageDrawerContent } from "@app/shared/page-drawer-context";
 
 export const Dependencies: React.FC = () => {
@@ -104,14 +102,8 @@ export const Dependencies: React.FC = () => {
       getTdProps,
       getClickableTrProps,
     },
+    activeRowDerivedState: { activeRowItem, clearActiveRow },
   } = tableControls;
-
-  // TODO lift this into URL params / managed state?
-  const [activeDependencyInDetailDrawer, openDetailDrawer] =
-    React.useState<AnalysisDependency | null>(null);
-  const closeDetailDrawer = () => openDetailDrawer(null);
-
-  console.log({ currentPageItems, totalItemCount });
 
   return (
     <>
@@ -157,24 +149,7 @@ export const Dependencies: React.FC = () => {
               {currentPageItems?.map((dependency, rowIndex) => {
                 return (
                   <Tbody key={dependency.name}>
-                    <Tr
-                      // When this is lifted to managed state, do we take only the item/dependency as an arg here? should we still allow overriding with custom onRowClick?
-                      {...getClickableTrProps({
-                        isRowSelected:
-                          activeDependencyInDetailDrawer?.name ===
-                          dependency.name,
-                        onRowClick: () => {
-                          if (
-                            activeDependencyInDetailDrawer?.name ===
-                            dependency.name
-                          ) {
-                            closeDetailDrawer();
-                          } else {
-                            openDetailDrawer(dependency);
-                          }
-                        },
-                      })}
-                    >
+                    <Tr {...getClickableTrProps({ item: dependency })}>
                       <TableRowContentWithControls
                         {...tableControls}
                         item={dependency}
@@ -212,13 +187,12 @@ export const Dependencies: React.FC = () => {
         </div>
       </PageSection>
       <PageDrawerContent
-        isExpanded={!!activeDependencyInDetailDrawer}
-        onCloseClick={closeDetailDrawer}
-        focusKey={activeDependencyInDetailDrawer?.name}
+        isExpanded={!!activeRowItem}
+        onCloseClick={clearActiveRow}
+        focusKey={activeRowItem?.name}
         pageKey="analysis-dependencies"
       >
-        TODO details about dependency {activeDependencyInDetailDrawer?.name}{" "}
-        here!
+        TODO details about dependency {activeRowItem?.name} here!
       </PageDrawerContent>
     </>
   );

--- a/client/src/app/pages/dependencies/dependencies.tsx
+++ b/client/src/app/pages/dependencies/dependencies.tsx
@@ -215,6 +215,7 @@ export const Dependencies: React.FC = () => {
         isExpanded={!!activeDependencyInDetailDrawer}
         onCloseClick={closeDetailDrawer}
         focusKey={activeDependencyInDetailDrawer?.name}
+        pageKey="analysis-dependencies"
       >
         TODO details about dependency {activeDependencyInDetailDrawer?.name}{" "}
         here!

--- a/client/src/app/pages/dependencies/dependencies.tsx
+++ b/client/src/app/pages/dependencies/dependencies.tsx
@@ -60,6 +60,7 @@ export const Dependencies: React.FC = () => {
       },
     ],
     initialItemsPerPage: 10,
+    hasClickableRows: true,
   });
 
   const {
@@ -99,6 +100,7 @@ export const Dependencies: React.FC = () => {
       tableProps,
       getThProps,
       getTdProps,
+      getClickableTrProps,
     },
   } = tableControls;
 
@@ -152,7 +154,14 @@ export const Dependencies: React.FC = () => {
                 {currentPageItems?.map((dependency, rowIndex) => {
                   return (
                     <Tbody key={dependency.name}>
-                      <Tr>
+                      <Tr
+                        {...getClickableTrProps({
+                          isRowSelected: false,
+                          onRowClick: () => {
+                            alert("TODO");
+                          },
+                        })}
+                      >
                         <TableRowContentWithControls
                           {...tableControls}
                           item={dependency}

--- a/client/src/app/shared/components/app-table/app-table.tsx
+++ b/client/src/app/shared/components/app-table/app-table.tsx
@@ -13,6 +13,7 @@ import { StateNoResults } from "./state-no-results";
 import { StateError } from "./state-error";
 import "./app-table.css";
 import { Application } from "@app/api/models";
+import { handlePropagatedRowClick } from "@app/shared/hooks/table-controls";
 
 const ENTITY_FIELD = "entity";
 
@@ -142,30 +143,9 @@ export const AppTable: React.FC<IAppTableProps> = ({
       <TableHeader />
       <TableBody
         onRowClick={(event, row) => {
-          // Check if there is a clickable element between the event target and the row such as a
-          // checkbox, button or link. Don't trigger the row click if those are clicked.
-          // This recursive parent check is necessary because the event target could be,
-          // for example, the SVG icon inside a button rather than the button itself.
-          const isClickableElementInTheWay = (element: Element): boolean => {
-            if (
-              ["input", "button", "a"].includes(element.tagName.toLowerCase())
-            ) {
-              return true;
-            }
-            if (
-              !element.parentElement ||
-              element.parentElement?.tagName.toLowerCase() === "tr"
-            ) {
-              return false;
-            }
-            return isClickableElementInTheWay(element.parentElement);
-          };
-          if (
-            event.target instanceof Element &&
-            !isClickableElementInTheWay(event.target)
-          ) {
+          handlePropagatedRowClick(event, () => {
             onAppClick?.(row[ENTITY_FIELD] || null);
-          }
+          });
         }}
       />
     </Table>

--- a/client/src/app/shared/hooks/table-controls/active-row/getActiveRowDerivedState.ts
+++ b/client/src/app/shared/hooks/table-controls/active-row/getActiveRowDerivedState.ts
@@ -1,0 +1,22 @@
+import { KeyWithValueType } from "@app/utils/type-utils";
+import { IActiveRowState } from "./useActiveRowState";
+
+export interface IActiveRowDerivedStateArgs<TItem> {
+  currentPageItems: TItem[];
+  idProperty: KeyWithValueType<TItem, string>;
+  activeRowState: IActiveRowState;
+}
+
+// Note: This is not named `getLocalActiveRowDerivedState` because it is always local,
+//       and it is still used when working with server-managed tables.
+export const getActiveRowDerivedState = <TItem>({
+  currentPageItems,
+  idProperty,
+  activeRowState: { activeRowId, setActiveRowId },
+}: IActiveRowDerivedStateArgs<TItem>) => ({
+  activeRowItem:
+    currentPageItems.find((item) => item[idProperty] === activeRowId) || null,
+  setActiveRowItem: (item: TItem | null) =>
+    setActiveRowId((item?.[idProperty] as string) || null),
+  clearActiveRow: () => setActiveRowId(null),
+});

--- a/client/src/app/shared/hooks/table-controls/active-row/index.ts
+++ b/client/src/app/shared/hooks/table-controls/active-row/index.ts
@@ -1,2 +1,3 @@
 export * from "./useActiveRowState";
 export * from "./getActiveRowDerivedState";
+export * from "./useActiveRowEffects";

--- a/client/src/app/shared/hooks/table-controls/active-row/index.ts
+++ b/client/src/app/shared/hooks/table-controls/active-row/index.ts
@@ -1,0 +1,2 @@
+export * from "./useActiveRowState";
+export * from "./getActiveRowDerivedState";

--- a/client/src/app/shared/hooks/table-controls/active-row/useActiveRowEffects.ts
+++ b/client/src/app/shared/hooks/table-controls/active-row/useActiveRowEffects.ts
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { getActiveRowDerivedState } from "./getActiveRowDerivedState";
+import { IActiveRowState } from "./useActiveRowState";
+
+interface IUseActiveRowEffectsArgs<TItem> {
+  isLoading?: boolean;
+  activeRowState: IActiveRowState;
+  activeRowDerivedState: ReturnType<typeof getActiveRowDerivedState<TItem>>;
+}
+
+export const useActiveRowEffects = <TItem>({
+  isLoading,
+  activeRowState: { activeRowId },
+  activeRowDerivedState: { activeRowItem, clearActiveRow },
+}: IUseActiveRowEffectsArgs<TItem>) => {
+  React.useEffect(() => {
+    // If some state change (e.g. refetch, pagination) causes the active row to disappear,
+    // remove its id from state so the drawer won't automatically reopen if the row comes back.
+    if (!isLoading && activeRowId && !activeRowItem) {
+      clearActiveRow();
+    }
+  }, [isLoading, activeRowId, activeRowItem]);
+};

--- a/client/src/app/shared/hooks/table-controls/active-row/useActiveRowState.ts
+++ b/client/src/app/shared/hooks/table-controls/active-row/useActiveRowState.ts
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { useUrlParams } from "../../useUrlParams";
+
+export interface IActiveRowState {
+  activeRowId: string | null;
+  setActiveRowId: (id: string | null) => void;
+}
+
+export const useActiveRowState = (): IActiveRowState => {
+  const [activeRowId, setActiveRowId] = React.useState<string | null>(null);
+  return { activeRowId, setActiveRowId };
+};
+
+export const useActiveRowUrlParams = (): IActiveRowState => {
+  const [activeRowId, setActiveRowId] = useUrlParams({
+    keys: ["activeRow"],
+    defaultValue: null as string | null,
+    serialize: (activeRowId) => ({ activeRow: activeRowId || null }),
+    deserialize: ({ activeRow }) => activeRow || null,
+  });
+  return { activeRowId, setActiveRowId };
+};

--- a/client/src/app/shared/hooks/table-controls/index.ts
+++ b/client/src/app/shared/hooks/table-controls/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./utils";
 export * from "./useLocalTableControlState";
 export * from "./useTableControlProps";
 export * from "./useLocalTableControls";

--- a/client/src/app/shared/hooks/table-controls/types.ts
+++ b/client/src/app/shared/hooks/table-controls/types.ts
@@ -1,4 +1,6 @@
 import { TableComposableProps } from "@patternfly/react-table";
+import { useSelectionState } from "@migtools/lib-ui";
+import { KeyWithValueType } from "@app/utils/type-utils";
 import {
   IFilterStateArgs,
   ILocalFilterDerivedStateArgs,
@@ -14,9 +16,8 @@ import {
   ILocalPaginationDerivedStateArgs,
   IPaginationPropsArgs,
 } from "./pagination";
+import { IActiveRowDerivedStateArgs } from "./active-row";
 import { useCompoundExpansionState } from "../useCompoundExpansionState";
-import { useSelectionState } from "@migtools/lib-ui";
-import { KeyWithValueType } from "@app/utils/type-utils";
 
 // Generic type params used here:
 //   TItem - The actual API objects represented by rows in the table. Can be any object.
@@ -98,7 +99,8 @@ export interface IUseTableControlPropsArgs<
     ITableControlDataDependentArgs<TItem>,
     IFilterPropsArgs<TItem, TFilterCategoryKey>,
     ISortPropsArgs<TColumnKey, TSortableColumnKey>,
-    IPaginationPropsArgs {
+    IPaginationPropsArgs,
+    IActiveRowDerivedStateArgs<TItem> {
   currentPageItems: TItem[];
   expansionState: ReturnType<
     typeof useCompoundExpansionState<TItem, TColumnKey>

--- a/client/src/app/shared/hooks/table-controls/types.ts
+++ b/client/src/app/shared/hooks/table-controls/types.ts
@@ -47,6 +47,7 @@ export interface ITableControlCommonArgs<
   expandableVariant?: "single" | "compound" | null;
   hasActionsColumn?: boolean;
   variant?: TableComposableProps["variant"];
+  hasClickableRows?: boolean;
 }
 
 // Data-dependent args

--- a/client/src/app/shared/hooks/table-controls/useLocalTableControlState.ts
+++ b/client/src/app/shared/hooks/table-controls/useLocalTableControlState.ts
@@ -10,6 +10,7 @@ import {
   IUseTableControlPropsArgs,
 } from "./types";
 import { getLocalFilterDerivedState, useFilterState } from "./filtering";
+import { useActiveRowState } from "./active-row";
 
 export const useLocalTableControlState = <
   TItem,
@@ -59,6 +60,7 @@ export const useLocalTableControlState = <
     paginationState,
     items: sortedItems,
   });
+  const activeRowState = useActiveRowState();
 
   return {
     ...args,
@@ -67,6 +69,7 @@ export const useLocalTableControlState = <
     selectionState,
     sortState,
     paginationState,
+    activeRowState,
     totalItemCount: items.length,
     currentPageItems: hasPagination ? currentPageItems : sortedItems,
   };

--- a/client/src/app/shared/hooks/table-controls/useTableControlProps.ts
+++ b/client/src/app/shared/hooks/table-controls/useTableControlProps.ts
@@ -4,6 +4,7 @@ import {
   TableComposableProps,
   TdProps,
   ThProps,
+  TrProps,
 } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
@@ -13,6 +14,8 @@ import { IUseTableControlPropsArgs } from "./types";
 import { getFilterProps } from "./filtering";
 import { getSortProps } from "./sorting";
 import { getPaginationProps, usePaginationEffects } from "./pagination";
+import React from "react";
+import { handlePropagatedRowClick } from "./utils";
 
 export const useTableControlProps = <
   TItem,
@@ -49,6 +52,7 @@ export const useTableControlProps = <
     isSelectable = false,
     expandableVariant = null,
     hasActionsColumn = false,
+    hasClickableRows = false,
     variant,
     idProperty,
   } = args;
@@ -91,7 +95,10 @@ export const useTableControlProps = <
     onSelectMultiple: selectMultiple,
   };
 
-  const tableProps: Omit<TableComposableProps, "ref"> = { variant };
+  const tableProps: Omit<TableComposableProps, "ref"> = {
+    variant,
+    hasSelectableRowCaption: hasClickableRows,
+  };
 
   const getThProps = ({
     columnKey,
@@ -106,6 +113,19 @@ export const useTableControlProps = <
         })
       : {}),
     children: columnNames[columnKey],
+  });
+
+  const getClickableTrProps = ({
+    isRowSelected = false,
+    onRowClick,
+  }: {
+    isRowSelected: boolean;
+    onRowClick: (event: React.MouseEvent | React.KeyboardEvent) => void;
+  }): Omit<TrProps, "ref"> => ({
+    isSelectable: true,
+    isHoverable: true,
+    isRowSelected,
+    onRowClick: (event) => handlePropagatedRowClick(event, onRowClick),
   });
 
   const getTdProps = ({
@@ -205,6 +225,7 @@ export const useTableControlProps = <
       paginationToolbarItemProps,
       tableProps,
       getThProps,
+      getClickableTrProps,
       getTdProps,
       getSelectCheckboxTdProps,
       getCompoundExpandTdProps,

--- a/client/src/app/shared/hooks/table-controls/useTableControlProps.ts
+++ b/client/src/app/shared/hooks/table-controls/useTableControlProps.ts
@@ -14,7 +14,7 @@ import { IUseTableControlPropsArgs } from "./types";
 import { getFilterProps } from "./filtering";
 import { getSortProps } from "./sorting";
 import { getPaginationProps, usePaginationEffects } from "./pagination";
-import { getActiveRowDerivedState } from "./active-row";
+import { getActiveRowDerivedState, useActiveRowEffects } from "./active-row";
 import { handlePropagatedRowClick } from "./utils";
 
 export const useTableControlProps = <
@@ -53,7 +53,6 @@ export const useTableControlProps = <
     expandableVariant = null,
     hasActionsColumn = false,
     hasClickableRows = false,
-    activeRowState: { activeRowId, setActiveRowId },
     variant,
     idProperty,
   } = args;
@@ -71,6 +70,7 @@ export const useTableControlProps = <
     columnKeys.length + numColumnsBeforeData + numColumnsAfterData;
 
   const activeRowDerivedState = getActiveRowDerivedState(args);
+  useActiveRowEffects({ ...args, activeRowDerivedState });
   const { activeRowItem, setActiveRowItem, clearActiveRow } =
     activeRowDerivedState;
 
@@ -129,10 +129,10 @@ export const useTableControlProps = <
   }): Omit<TrProps, "ref"> => ({
     isSelectable: true,
     isHoverable: true,
-    isRowSelected: item && item[idProperty] === activeRowId,
+    isRowSelected: item && item[idProperty] === activeRowItem?.[idProperty],
     onRowClick: (event) =>
       handlePropagatedRowClick(event, () => {
-        if (item && activeRowId !== item[idProperty]) {
+        if (item && activeRowItem?.[idProperty] !== item[idProperty]) {
           setActiveRowItem(item);
         } else {
           clearActiveRow();

--- a/client/src/app/shared/hooks/table-controls/useTableControlUrlParams.ts
+++ b/client/src/app/shared/hooks/table-controls/useTableControlUrlParams.ts
@@ -1,7 +1,8 @@
-import { useSortUrlParams } from "./sorting";
-import { usePaginationUrlParams } from "./pagination";
 import { ITableControlCommonArgs } from "./types";
 import { useFilterUrlParams } from "./filtering";
+import { useSortUrlParams } from "./sorting";
+import { usePaginationUrlParams } from "./pagination";
+import { useActiveRowUrlParams } from "./active-row";
 
 export const useTableControlUrlParams = <
   TItem,
@@ -19,5 +20,6 @@ export const useTableControlUrlParams = <
   const filterState = useFilterUrlParams<TFilterCategoryKey>();
   const sortState = useSortUrlParams(args);
   const paginationState = usePaginationUrlParams(args);
-  return { ...args, filterState, sortState, paginationState };
+  const activeRowState = useActiveRowUrlParams();
+  return { ...args, filterState, sortState, paginationState, activeRowState };
 };

--- a/client/src/app/shared/hooks/table-controls/utils.ts
+++ b/client/src/app/shared/hooks/table-controls/utils.ts
@@ -1,0 +1,31 @@
+import React from "react";
+
+export const handlePropagatedRowClick = <
+  E extends React.KeyboardEvent | React.MouseEvent
+>(
+  event: E | undefined,
+  onRowClick: (event: E) => void
+) => {
+  // Check if there is a clickable element between the event target and the row such as a
+  // checkbox, button or link. Don't trigger the row click if those are clicked.
+  // This recursive parent check is necessary because the event target could be,
+  // for example, the SVG icon inside a button rather than the button itself.
+  const isClickableElementInTheWay = (element: Element): boolean => {
+    if (["input", "button", "a"].includes(element.tagName.toLowerCase())) {
+      return true;
+    }
+    if (
+      !element.parentElement ||
+      element.parentElement?.tagName.toLowerCase() === "tr"
+    ) {
+      return false;
+    }
+    return isClickableElementInTheWay(element.parentElement);
+  };
+  if (
+    event?.target instanceof Element &&
+    !isClickableElementInTheWay(event.target)
+  ) {
+    onRowClick(event);
+  }
+};


### PR DESCRIPTION
Implements clickable rows and a drawer on the Dependencies table (with placeholder content) via new reusable features in the table-control hooks. The drawer on these new tables can now be trivially driven by a URL param (thanks to `idProperty` being a thing) so when you navigate away from a page with a drawer open and click Back, the open drawer is restored :slightly_smiling_face:

* Adds `@app/shared/hooks/table-controls/utils.ts` for general table-related utils that can be used either with or without the table control hooks.
  * Currently only contains `handlePropagatedRowClick`, which is factored out from the clickable row / drawer changes in the applications table introduced in https://github.com/konveyor/tackle2-ui/pull/654. This is the handler that makes sure that when the user clicks interactable elements within a row (buttons, checkboxes, etc) we don't trigger the row click / drawer. It is now used both in the legacy tables and the new tables.
* Adds an `active-row` folder to `@app/shared/hooks/table-controls`, with:
  * `useActiveRowState.ts` - similar to other table control concerns, contains hooks for tracking the active row ID string in either React state or a URL param
  * `getActiveRowDerivedState.ts` - given the state and the `currentPageItems` derived from existing hooks / query data, returns the active row's actual `TItem` object (or null) for convenience. Also returns simplified functions for setting/clearing the active row by item rather than by id so the page level components don't have to do any id comparisons.
    * Note: this is different from the other `getLocal*DerivedState` hooks (note the lack of "local" in the name), because it is used in `useTableControlProps` no matter whether the table uses local or server-side filtering/pagination/sorting logic. We store this state in a URL param on the client, but it is not passed to the hub; deriving the active row's item can always be done locally.
  * `useActiveRowEffects.ts` - provides a `useEffect` that watches for a corner case where the `activeRowId` in state no longer matches anything present in `currentPageItems`, and clears the state.
    * This avoids a weird quirk where you could click a row and open its drawer, use pagination/filtering to make that row disappear (closing the drawer), then go back to a view which includes the row and the drawer would spontaneously reopen. Worse, if the row never reappeared at all (e.g. it was deleted and the data was refetched), the stale `activeRowId` would remain in state indefinitely.
    * With this effect in place in `useTableControlProps`, once the drawer closes for any reason it stays closed until the user clicks another row, and the `activeRowId` in state always matches an item in `currentPageItems`.
    * There is an exception: If `isLoading` is true, we let the stale `activeRowId` stick around until loading finishes so we can restore an open drawer via URL (e.g. clicking the Back button) if the first data we fetch includes a matching row.
* Adds `activeRowState` to the object returned by both `useTableControlState` and `useTableControlUrlParams`, so it is automatically consumed via the `args` object in `useTableControlProps` for both styles of table.
* Adds a boolean `hasClickableRows` property to the `ITableControlCommonArgs` so it can be used for whatever logic necessary (currently only adds the `hasSelectableRowCaption` prop to TableComposable in `useTableControlProps`).
* In `useTableControlProps`:
  * Adds calls to `getActiveRowDerivedState` and `useActiveRowEffects`
  * Adds a new propHelper `getClickableTrProps`
    * This can be used either for clickable rows that set an active row, or to make clickable rows for any reason (e.g. direct route navigation). You can pass only an `item` to it to have it handle all the active row state for you, or you can pass only an `onRowClick` to it for it to handle and it won't touch the active row state. The benefit of this over directly passing `onRowClick` to the `Tr` yourself is that you'll get the `handlePropagatedRowClick` behavior.
* In the Dependencies table:
  * Adds `hasClickableRows: true`
  * Calls `getClickableTrProps` on each `Tr`
  * Pulls `activeRowItem` and `clearActiveRow` out from `activeRowDerivedState` and uses them to render the PageDrawerContent
    * Drawer content is a placeholder for now and will be filled out in a followup PR.
  * Removes the `ConditionalRender` wrapping the table: after some discussion on Slack with @gildub, it appears we don't really need this anymore if the tables can handle loading states gracefully. We should probably remove it elsewhere.