### PR TITLE
:sparkles: Issues and Affected Apps: compatibility with new hub changes, carry app name filter between pages, use issues data as basis for table control hooks

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -184,6 +184,7 @@
     "add": "Add",
     "additionalNotesOrComments": "Additional notes or comments",
     "adoptionCandidateDistribution": "Adoption candidate distribution",
+    "affectedApplications": "Affected applications",
     "analysis": "Analysis",
     "answer": "Answer",
     "application": "Application",

--- a/client/src/app/Paths.ts
+++ b/client/src/app/Paths.ts
@@ -31,7 +31,7 @@ export enum Paths {
   migrationWaves = "/migration-waves",
   waves = "/waves",
   compositeIssues = "/composite/issues",
-  issuesRuleId = "/issues/:ruleidparam",
+  issuesForRule = "/issues/:ruleset/:rule",
 
   dependencies = "/dependencies",
 

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -95,7 +95,7 @@ export const devRoutes: IRoute[] = [
           exact: false,
         },
         {
-          path: Paths.issuesRuleId,
+          path: Paths.issuesForRule,
           comp: AffectedApplications,
           exact: false,
         },

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -566,7 +566,7 @@ export interface IssueTechnology {
   source: boolean;
 }
 
-export interface AnalysisCompositeIssue {
+export interface BaseAnalysisCompositeIssue {
   name: string;
   ruleSet: string;
   rule: string;
@@ -577,6 +577,10 @@ export interface AnalysisCompositeIssue {
   labels: string[];
   affected: number;
   createTime?: string;
+}
+
+export interface AnalysisCompositeIssue extends BaseAnalysisCompositeIssue {
+  _ui_unique_id: string;
 }
 
 export interface AnalysisIssue {

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -568,6 +568,8 @@ export interface IssueTechnology {
 
 export interface AnalysisCompositeIssue {
   name: string;
+  ruleSet: string;
+  rule: string;
   description: string;
   category: string;
   effort: number;

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -557,6 +557,7 @@ export interface AnalysisDependency {
   // applications: { id: number; name: string }[];
 }
 
+// TODO this has been replaced by labels, which we need to parse in order to display separately.
 export interface IssueTechnology {
   createUser: string;
   updateUser: string;
@@ -567,12 +568,11 @@ export interface IssueTechnology {
 
 export interface AnalysisCompositeIssue {
   name: string;
-  ruleID: string; // ruleset+rule
   description: string;
   category: string;
   effort: number;
-  technologies: Array<IssueTechnology>;
-  labels: Array<string>;
+  // technologies: Array<IssueTechnology>;
+  labels: string[];
   affected: number;
   createTime?: string;
 }

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -2,7 +2,7 @@ import axios, { AxiosPromise } from "axios";
 import { APIClient } from "@app/axios-config";
 
 import {
-  AnalysisCompositeIssue,
+  BaseAnalysisCompositeIssue,
   AnalysisDependency,
   AnalysisIssue,
   Application,
@@ -544,7 +544,7 @@ export const getDependencies = (params: HubRequestParams = {}) =>
   getHubPaginatedResult<AnalysisDependency>(ANALYSIS_DEPENDENCIES, params);
 
 export const getCompositeIssues = (params: HubRequestParams = {}) =>
-  getHubPaginatedResult<AnalysisCompositeIssue>(
+  getHubPaginatedResult<BaseAnalysisCompositeIssue>(
     ANALYSIS_COMPOSITE_ISSUES,
     params
   );

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -35,7 +35,10 @@ import { useFetchIssues } from "@app/queries/issues";
 import { useFetchApplications } from "@app/queries/applications";
 import { Link, useParams } from "react-router-dom";
 import { IssueFilterGroups } from "../issues";
-import { FilterType } from "@app/shared/components/FilterToolbar";
+import {
+  FilterToolbar,
+  FilterType,
+} from "@app/shared/components/FilterToolbar";
 import { useCompoundExpansionState } from "@app/shared/hooks/useCompoundExpansionState";
 import { useSelectionState } from "@migtools/lib-ui";
 interface IAffectedApplicationsRouteParams {
@@ -116,6 +119,7 @@ export const AffectedApplications: React.FC = () => {
     numRenderedColumns,
     propHelpers: {
       toolbarProps,
+      filterToolbarProps,
       paginationToolbarItemProps,
       paginationProps,
       tableProps,
@@ -129,6 +133,8 @@ export const AffectedApplications: React.FC = () => {
   const { data: applications } = useFetchApplications();
 
   // TODO get the breadcrumb bar to take you back to the exact view you left - put a backTo param in the URL here?
+  // When going back, if we cleared the app name filter here should we clear it there too?
+  // special logic to filter it out of the backTo param? that feels weird
 
   return (
     <>
@@ -157,6 +163,7 @@ export const AffectedApplications: React.FC = () => {
           >
             <Toolbar {...toolbarProps}>
               <ToolbarContent>
+                <FilterToolbar {...filterToolbarProps} />
                 <ToolbarItem {...paginationToolbarItemProps}>
                   <SimplePagination
                     idPrefix="affected-applications-table"

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -42,14 +42,16 @@ import {
 import { useCompoundExpansionState } from "@app/shared/hooks/useCompoundExpansionState";
 import { useSelectionState } from "@migtools/lib-ui";
 import { getBackToIssuesUrl } from "../helpers";
+
 interface IAffectedApplicationsRouteParams {
-  ruleidparam: string;
+  ruleset: string;
+  rule: string;
 }
 
 export const AffectedApplications: React.FC = () => {
   const { t } = useTranslation();
 
-  const { ruleidparam } = useParams<IAffectedApplicationsRouteParams>();
+  const routeParams = useParams<IAffectedApplicationsRouteParams>();
 
   const tableControlState = useTableControlUrlParams({
     columnNames: {
@@ -89,9 +91,14 @@ export const AffectedApplications: React.FC = () => {
       ...tableControlState,
       implicitFilters: [
         {
-          field: "name", // Composite issue name = issue name = rule name/id
+          field: "ruleset",
           operator: "=",
-          value: ruleidparam || "",
+          value: routeParams.ruleset || "",
+        },
+        {
+          field: "rule",
+          operator: "=",
+          value: routeParams.rule || "",
         },
       ],
       /*
@@ -159,7 +166,9 @@ export const AffectedApplications: React.FC = () => {
             </Link>
           </BreadcrumbItem>
           <BreadcrumbItem to="#" isActive>
-            {ruleidparam || "Active rule"}
+            {routeParams.ruleset && routeParams.rule
+              ? `${routeParams.ruleset}/${routeParams.rule}`
+              : "Active rule"}
           </BreadcrumbItem>
         </Breadcrumb>
       </PageSection>

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -141,13 +141,6 @@ export const AffectedApplications: React.FC = () => {
 
   const { data: applications } = useFetchApplications();
 
-  // TODO get the breadcrumb bar to take you back to the exact view you left - put a backTo param in the URL here?
-  // When going back, if we cleared the app name filter here should we clear it there too?
-  // special logic to filter it out of the backTo param? that feels weird
-
-  // using the location from Issues page, pass a full URL as "backTo" in the URL for affected apps.
-  // when clearing or applying the application.name filter, clear or apply it in the filters arg inside backTo as well?
-
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -88,7 +88,7 @@ export const AffectedApplications: React.FC = () => {
       ...tableControlState,
       implicitFilters: [
         {
-          field: "ruleid",
+          field: "name", // Composite issue name = issue name = rule name/id
           operator: "=",
           value: ruleidparam || "",
         },

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -128,6 +128,8 @@ export const AffectedApplications: React.FC = () => {
 
   const { data: applications } = useFetchApplications();
 
+  // TODO get the breadcrumb bar to take you back to the exact view you left - put a backTo param in the URL here?
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -33,7 +33,7 @@ import {
 } from "@app/shared/components/table-controls";
 import { useFetchIssues } from "@app/queries/issues";
 import { useFetchApplications } from "@app/queries/applications";
-import { Link, useParams } from "react-router-dom";
+import { Link, useLocation, useParams } from "react-router-dom";
 import { IssueFilterGroups } from "../issues";
 import {
   FilterToolbar,
@@ -41,6 +41,7 @@ import {
 } from "@app/shared/components/FilterToolbar";
 import { useCompoundExpansionState } from "@app/shared/hooks/useCompoundExpansionState";
 import { useSelectionState } from "@migtools/lib-ui";
+import { getBackToIssuesUrl } from "../helpers";
 interface IAffectedApplicationsRouteParams {
   ruleidparam: string;
 }
@@ -117,6 +118,7 @@ export const AffectedApplications: React.FC = () => {
 
   const {
     numRenderedColumns,
+    filterState: { filterValues },
     propHelpers: {
       toolbarProps,
       filterToolbarProps,
@@ -136,6 +138,9 @@ export const AffectedApplications: React.FC = () => {
   // When going back, if we cleared the app name filter here should we clear it there too?
   // special logic to filter it out of the backTo param? that feels weird
 
+  // using the location from Issues page, pass a full URL as "backTo" in the URL for affected apps.
+  // when clearing or applying the application.name filter, clear or apply it in the filters arg inside backTo as well?
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -144,7 +149,14 @@ export const AffectedApplications: React.FC = () => {
         </TextContent>
         <Breadcrumb>
           <BreadcrumbItem>
-            <Link to="/composite/issues">{t("terms.issues")}</Link>
+            <Link
+              to={getBackToIssuesUrl({
+                fromFilterValues: filterValues,
+                fromLocation: useLocation(),
+              })}
+            >
+              {t("terms.issues")}
+            </Link>
           </BreadcrumbItem>
           <BreadcrumbItem to="#" isActive>
             {ruleidparam || "Active rule"}

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -51,7 +51,7 @@ interface IAffectedApplicationsRouteParams {
 export const AffectedApplications: React.FC = () => {
   const { t } = useTranslation();
 
-  const routeParams = useParams<IAffectedApplicationsRouteParams>();
+  const { ruleset, rule } = useParams<IAffectedApplicationsRouteParams>();
   const compositeIssueName =
     new URLSearchParams(useLocation().search).get("compositeIssueName") ||
     "Active rule";
@@ -96,12 +96,12 @@ export const AffectedApplications: React.FC = () => {
         {
           field: "ruleset",
           operator: "=",
-          value: routeParams.ruleset || "",
+          value: ruleset || "",
         },
         {
           field: "rule",
           operator: "=",
-          value: routeParams.rule || "",
+          value: rule || "",
         },
       ],
       /*
@@ -162,7 +162,7 @@ export const AffectedApplications: React.FC = () => {
             </Link>
           </BreadcrumbItem>
           <BreadcrumbItem to="#" isActive>
-            {compositeIssueName}
+            {compositeIssueName} ({ruleset}, {rule})
           </BreadcrumbItem>
         </Breadcrumb>
       </PageSection>

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -35,6 +35,8 @@ import { useLocalTableControls } from "@app/shared/hooks/table-controls";
 import { useFetchApplications } from "@app/queries/applications";
 import { Application } from "@app/api/models";
 import { Link, useParams } from "react-router-dom";
+import { IssueFilterGroups } from "../issues";
+import { FilterType } from "@app/shared/components/FilterToolbar";
 interface IAffectedApplicationsRouteParams {
   ruleidparam: string;
 }
@@ -51,11 +53,25 @@ export const AffectedApplications: React.FC = () => {
       businessService: "Business serice",
       tags: "Tags",
     },
-    sortableColumns: ["name"],
-    initialSort: {
-      columnKey: "name",
-      direction: "asc",
-    },
+    // TODO this isn't working in the hub
+    // sortableColumns: ["name"],
+    // initialSort: {
+    //   columnKey: "name",
+    //   direction: "asc",
+    // },
+    filterCategories: [
+      //TODO: Should this be select filter type using apps available in memory?
+      {
+        key: "application.name",
+        title: t("terms.applicationName"),
+        filterGroup: IssueFilterGroups.ApplicationInventory,
+        type: FilterType.search,
+        placeholderText:
+          t("actions.filterBy", {
+            what: t("terms.applicationName").toLowerCase(),
+          }) + "...",
+      },
+    ],
     initialItemsPerPage: 10,
   });
 
@@ -65,12 +81,19 @@ export const AffectedApplications: React.FC = () => {
     fetchError,
   } = useFetchIssues(
     getHubRequestParams({
-      filterState: {
-        filterValues: {
-          ruleid: [ruleidparam || ""],
+      ...tableControlState,
+      implicitFilters: [
+        {
+          field: "ruleid",
+          operator: "=",
+          value: ruleidparam || "",
         },
-        setFilterValues: tableControlState.filterState.setFilterValues,
-      },
+      ],
+      /*
+      // TODO this isn't working in the hub
+      hubSortFieldKeys: {
+        name: "application.name",
+      },*/
     })
   );
 
@@ -116,11 +139,11 @@ export const AffectedApplications: React.FC = () => {
     <>
       <PageSection variant={PageSectionVariants.light}>
         <TextContent>
-          <Text component="h1">{t("terms.issues")}</Text>
+          <Text component="h1">{t("terms.affectedApplications")}</Text>
         </TextContent>
         <Breadcrumb>
           <BreadcrumbItem>
-            <Link to="/composite/issues">Issues</Link>
+            <Link to="/composite/issues">{t("terms.issues")}</Link>
           </BreadcrumbItem>
           <BreadcrumbItem to="#" isActive>
             {ruleidparam || "Active rule"}

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -52,6 +52,9 @@ export const AffectedApplications: React.FC = () => {
   const { t } = useTranslation();
 
   const routeParams = useParams<IAffectedApplicationsRouteParams>();
+  const compositeIssueName =
+    new URLSearchParams(useLocation().search).get("compositeIssueName") ||
+    "Active rule";
 
   const tableControlState = useTableControlUrlParams({
     columnNames: {
@@ -159,9 +162,7 @@ export const AffectedApplications: React.FC = () => {
             </Link>
           </BreadcrumbItem>
           <BreadcrumbItem to="#" isActive>
-            {routeParams.ruleset && routeParams.rule
-              ? `${routeParams.ruleset}/${routeParams.rule}`
-              : "Active rule"}
+            {compositeIssueName}
           </BreadcrumbItem>
         </Breadcrumb>
       </PageSection>

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -1,0 +1,22 @@
+import { AnalysisCompositeIssue } from "@app/api/models";
+import { FilterValue } from "@app/shared/components/FilterToolbar";
+import { serializeFilterUrlParams } from "@app/shared/hooks/table-controls";
+import { trimAndStringifyUrlParams } from "@app/shared/hooks/useUrlParams";
+
+const filterKeysToCarry = ["application.name"] as const;
+type FilterValuesToCarry = Partial<
+  Record<(typeof filterKeysToCarry)[number], FilterValue>
+>;
+
+export const getAffectedAppsUrl = (
+  issue: AnalysisCompositeIssue,
+  fromFilterValues: FilterValuesToCarry
+) => {
+  const toFilterValues: FilterValuesToCarry = {};
+  filterKeysToCarry.forEach((key) => {
+    if (fromFilterValues[key]) toFilterValues[key] = fromFilterValues[key];
+  });
+  return `/issues/${issue.ruleID}?${trimAndStringifyUrlParams({
+    params: serializeFilterUrlParams(toFilterValues),
+  })}`;
+};

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -9,14 +9,14 @@ type FilterValuesToCarry = Partial<
 >;
 
 export const getAffectedAppsUrl = (
-  issue: AnalysisCompositeIssue,
+  compositeIssue: AnalysisCompositeIssue,
   fromFilterValues: FilterValuesToCarry
 ) => {
   const toFilterValues: FilterValuesToCarry = {};
   filterKeysToCarry.forEach((key) => {
     if (fromFilterValues[key]) toFilterValues[key] = fromFilterValues[key];
   });
-  return `/issues/${issue.ruleID}?${trimAndStringifyUrlParams({
+  return `/issues/${compositeIssue.name}?${trimAndStringifyUrlParams({
     params: serializeFilterUrlParams(toFilterValues),
   })}`;
 };

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -35,7 +35,11 @@ export const getAffectedAppsUrl = ({
   return `/issues/${compositeIssue.ruleSet}/${
     compositeIssue.rule
   }?${trimAndStringifyUrlParams({
-    params: { ...serializeFilterUrlParams(toFilterValues), fromIssuesParams },
+    params: {
+      ...serializeFilterUrlParams(toFilterValues),
+      fromIssuesParams,
+      compositeIssueName: compositeIssue.name,
+    },
   })}`;
 };
 

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -1,22 +1,71 @@
+import { Location } from "history";
 import { AnalysisCompositeIssue } from "@app/api/models";
 import { FilterValue } from "@app/shared/components/FilterToolbar";
-import { serializeFilterUrlParams } from "@app/shared/hooks/table-controls";
+import {
+  deserializeFilterUrlParams,
+  serializeFilterUrlParams,
+} from "@app/shared/hooks/table-controls";
 import { trimAndStringifyUrlParams } from "@app/shared/hooks/useUrlParams";
+
+// Certain filters are shared between the Issues page and the Affected Applications Page.
+// We carry these filter values between the two pages when determining the URLs to navigate between them.
+// It is also important to restore any unrelated params when returning to the Issues page.
 
 const filterKeysToCarry = ["application.name"] as const;
 type FilterValuesToCarry = Partial<
   Record<(typeof filterKeysToCarry)[number], FilterValue>
 >;
 
-export const getAffectedAppsUrl = (
-  compositeIssue: AnalysisCompositeIssue,
-  fromFilterValues: FilterValuesToCarry
-) => {
+// URL for Affected Apps page that includes carried filters and a snapshot of original URL params from the Issues page
+export const getAffectedAppsUrl = ({
+  compositeIssue,
+  fromFilterValues,
+  fromLocation,
+}: {
+  compositeIssue: AnalysisCompositeIssue;
+  fromFilterValues: FilterValuesToCarry;
+  fromLocation: Location;
+}) => {
+  // The raw location.search string (already encoded) from the issues page is used as the fromIssuesParams param
+  const fromIssuesParams = fromLocation.search;
   const toFilterValues: FilterValuesToCarry = {};
   filterKeysToCarry.forEach((key) => {
     if (fromFilterValues[key]) toFilterValues[key] = fromFilterValues[key];
   });
   return `/issues/${compositeIssue.name}?${trimAndStringifyUrlParams({
-    params: serializeFilterUrlParams(toFilterValues),
+    params: { ...serializeFilterUrlParams(toFilterValues), fromIssuesParams },
+  })}`;
+};
+
+// URL for Issues page that restores original URL params and overrides them with any changes to the carried filters.
+export const getBackToIssuesUrl = ({
+  fromFilterValues,
+  fromLocation,
+}: {
+  fromFilterValues: FilterValuesToCarry;
+  fromLocation: Location;
+}) => {
+  // Pull the fromIssuesParams param out of the current location's URLSearchParams
+  const fromIssuesParams =
+    new URLSearchParams(fromLocation.search).get("fromIssuesParams") || "";
+  // Pull the params themselves out of fromIssuesParams
+  const paramsToRestore = Object.fromEntries(
+    new URLSearchParams(fromIssuesParams)
+  );
+  // Pull the filters param out of that
+  const filterValuesToRestore = deserializeFilterUrlParams(
+    paramsToRestore || {}
+  );
+  // For each of the filters we care about, override the original value with the one from the affected apps page.
+  // This will carry over changes including the filter having been cleared.
+  filterKeysToCarry.forEach((key) => {
+    filterValuesToRestore[key] = fromFilterValues[key] || null;
+  });
+  // Put it all back together
+  return `/composite/issues?${trimAndStringifyUrlParams({
+    params: {
+      ...paramsToRestore,
+      ...serializeFilterUrlParams(filterValuesToRestore),
+    },
   })}`;
 };

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -32,7 +32,9 @@ export const getAffectedAppsUrl = ({
   filterKeysToCarry.forEach((key) => {
     if (fromFilterValues[key]) toFilterValues[key] = fromFilterValues[key];
   });
-  return `/issues/${compositeIssue.name}?${trimAndStringifyUrlParams({
+  return `/issues/${compositeIssue.ruleSet}/${
+    compositeIssue.rule
+  }?${trimAndStringifyUrlParams({
     params: { ...serializeFilterUrlParams(toFilterValues), fromIssuesParams },
   })}`;
 };

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -206,7 +206,7 @@ export const Issues: React.FC = () => {
                 <FilterToolbar {...filterToolbarProps} />
                 <ToolbarItem {...paginationToolbarItemProps}>
                   <SimplePagination
-                    idPrefix="dependencies-table"
+                    idPrefix="issues-table"
                     isTop
                     paginationProps={paginationProps}
                   />
@@ -373,7 +373,7 @@ export const Issues: React.FC = () => {
               </ConditionalTableBody>
             </TableComposable>
             <SimplePagination
-              idPrefix="dependencies-table"
+              idPrefix="issues-table"
               isTop={false}
               paginationProps={paginationProps}
             />

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -58,11 +58,20 @@ export const Issues: React.FC = () => {
   const tableControlState = useTableControlUrlParams({
     columnNames: {
       name: "Name",
+      ruleset: "Rule set",
+      rule: "Rule",
       category: "Category",
       effort: "Effort",
       affected: "Affected applications",
     },
-    sortableColumns: ["name", "category"],
+    sortableColumns: [
+      "name",
+      "ruleset",
+      "rule",
+      "category",
+      "effort",
+      "affected",
+    ],
     initialSort: {
       columnKey: "name",
       direction: "asc",
@@ -148,7 +157,11 @@ export const Issues: React.FC = () => {
       ...tableControlState, // Includes filterState, sortState and paginationState
       hubSortFieldKeys: {
         name: "name",
+        ruleset: "ruleset",
+        rule: "rule",
         category: "category",
+        effort: "effort",
+        affected: "affected",
       },
     })
   );
@@ -226,6 +239,8 @@ export const Issues: React.FC = () => {
                 <Tr>
                   <TableHeaderContentWithControls {...tableControls}>
                     <Th {...getThProps({ columnKey: "name" })} />
+                    <Th {...getThProps({ columnKey: "ruleset" })} />
+                    <Th {...getThProps({ columnKey: "rule" })} />
                     <Th {...getThProps({ columnKey: "category" })} />
                     <Th {...getThProps({ columnKey: "effort" })} />
                     <Th {...getThProps({ columnKey: "affected" })} />
@@ -257,9 +272,17 @@ export const Issues: React.FC = () => {
                               rowIndex,
                             })}
                           />
-                          <Td width={25} {...getTdProps({ columnKey: "name" })}>
-                            {compositeIssue.name} ({compositeIssue.ruleSet},{" "}
-                            {compositeIssue.rule})
+                          <Td width={15} {...getTdProps({ columnKey: "name" })}>
+                            {compositeIssue.name}
+                          </Td>
+                          <Td
+                            width={15}
+                            {...getTdProps({ columnKey: "ruleset" })}
+                          >
+                            {compositeIssue.ruleSet}
+                          </Td>
+                          <Td width={15} {...getTdProps({ columnKey: "rule" })}>
+                            {compositeIssue.rule}
                           </Td>
                           <Td
                             width={10}
@@ -274,7 +297,7 @@ export const Issues: React.FC = () => {
                             {compositeIssue.effort}
                           </Td>
                           <Td
-                            width={10}
+                            width={15}
                             {...getTdProps({
                               columnKey: "affected",
                             })}

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -57,14 +57,14 @@ export const Issues: React.FC = () => {
 
   const tableControlState = useTableControlUrlParams({
     columnNames: {
-      ruleID: "Rule ID",
+      name: "Name",
       category: "Category",
       effort: "Effort",
       affected: "Affected applications",
     },
-    sortableColumns: ["ruleID", "category"],
+    sortableColumns: ["name", "category"],
     initialSort: {
-      columnKey: "ruleID",
+      columnKey: "name",
       direction: "asc",
     },
     filterCategories: [
@@ -147,7 +147,7 @@ export const Issues: React.FC = () => {
     getHubRequestParams({
       ...tableControlState, // Includes filterState, sortState and paginationState
       hubSortFieldKeys: {
-        ruleID: "ruleID",
+        name: "name",
         category: "category",
       },
     })
@@ -155,12 +155,12 @@ export const Issues: React.FC = () => {
 
   const tableControls = useTableControlProps({
     ...tableControlState, // Includes filterState, sortState and paginationState
-    idProperty: "ruleID",
+    idProperty: "name",
     currentPageItems,
     totalItemCount,
     isLoading: isFetching,
     expandableVariant: "single",
-    expansionState: useCompoundExpansionState("ruleID"),
+    expansionState: useCompoundExpansionState("name"),
     selectionState: useSelectionState({
       items: currentPageItems,
       isEqual: (a, b) => a.name === b.name,
@@ -236,21 +236,22 @@ export const Issues: React.FC = () => {
                 isNoData={totalItemCount === 0}
                 numRenderedColumns={numRenderedColumns}
               >
-                {currentPageItems?.map((issue, rowIndex) => {
+                {currentPageItems?.map((compositeIssue, rowIndex) => {
                   return (
                     <Tbody
-                      key={issue.ruleID}
-                      isExpanded={isCellExpanded(issue)}
+                      key={compositeIssue.name}
+                      isExpanded={isCellExpanded(compositeIssue)}
                     >
                       <Tr>
                         <TableRowContentWithControls
                           {...tableControls}
-                          item={issue}
+                          item={compositeIssue}
                           rowIndex={rowIndex}
                         >
                           <Td
+                            // TODO abstract this into TableRowContentWithControls for single-expand tables
                             {...getSingleExpandTdProps({
-                              item: issue,
+                              item: compositeIssue,
                               rowIndex,
                             })}
                           />
@@ -258,19 +259,19 @@ export const Issues: React.FC = () => {
                             width={25}
                             {...getTdProps({ columnKey: "ruleId" })}
                           >
-                            {issue.ruleID}
+                            {compositeIssue.name}
                           </Td>
                           <Td
                             width={10}
                             {...getTdProps({ columnKey: "category" })}
                           >
-                            {issue.category}
+                            {compositeIssue.category}
                           </Td>
                           <Td
                             width={10}
                             {...getTdProps({ columnKey: "effort" })}
                           >
-                            {issue.effort}
+                            {compositeIssue.effort}
                           </Td>
                           <Td
                             width={10}
@@ -278,16 +279,16 @@ export const Issues: React.FC = () => {
                               columnKey: "affected",
                             })}
                           >
-                            {issue.affected}
+                            {compositeIssue.affected}
                           </Td>
                         </TableRowContentWithControls>
                       </Tr>
-                      {isCellExpanded(issue) ? (
+                      {isCellExpanded(compositeIssue) ? (
                         <Tr isExpanded>
                           <Td />
                           <Td
                             {...getExpandedContentTdProps({
-                              item: issue,
+                              item: compositeIssue,
                             })}
                             className={spacing.pyLg}
                           >
@@ -305,12 +306,12 @@ export const Issues: React.FC = () => {
                                     <Button variant="link" isInline>
                                       <Link
                                         to={getAffectedAppsUrl(
-                                          issue,
+                                          compositeIssue,
                                           filterValues
                                         )}
                                       >
-                                        {issue.affected} - View affected
-                                        applications
+                                        {compositeIssue.affected} - View
+                                        affected applications
                                       </Link>
                                     </Button>
                                   </Tooltip>
@@ -321,6 +322,8 @@ export const Issues: React.FC = () => {
                                     Target technologies
                                   </Text>
                                   <div>
+                                    {/*
+                                    // TODO the technologies array is missing from latest data?
                                     {issue.technologies.map((tech) => {
                                       return (
                                         <Label className={spacing.mrSm}>
@@ -328,6 +331,7 @@ export const Issues: React.FC = () => {
                                         </Label>
                                       );
                                     })}
+                                    */}
                                   </div>
                                   <Text
                                     component="h4"
@@ -343,7 +347,8 @@ export const Issues: React.FC = () => {
                                     Level of effort
                                   </Text>
                                   <div>
-                                    {issue.effort} - what do we show here?
+                                    {compositeIssue.effort} - what do we show
+                                    here?
                                   </div>
                                   <Text
                                     component="h4"
@@ -352,7 +357,7 @@ export const Issues: React.FC = () => {
                                     Labels
                                   </Text>
                                   <div>
-                                    {issue.labels?.map((label) => {
+                                    {compositeIssue.labels.map((label) => {
                                       return (
                                         <Label className={spacing.mrSm}>
                                           {label}

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -347,7 +347,7 @@ export const Issues: React.FC = () => {
                                   </Text>
                                   <div>
                                     {/*
-                                    // TODO the technologies array is missing from latest data?
+                                    // TODO the technologies array was replaced by labels, we need to parse them
                                     {issue.technologies.map((tech) => {
                                       return (
                                         <Label className={spacing.mrSm}>

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -45,7 +45,7 @@ import { useSelectionState } from "@migtools/lib-ui";
 import { useFetchCompositeIssues } from "@app/queries/issues";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { getAffectedAppsUrl } from "./helpers";
 
 export enum IssueFilterGroups {
@@ -186,6 +186,8 @@ export const Issues: React.FC = () => {
   console.log("%c Current page items", "color: blue;");
   console.log({ currentPageItems, totalItemCount });
 
+  const location = useLocation();
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -218,12 +220,12 @@ export const Issues: React.FC = () => {
             <TableComposable
               {...tableProps}
               isExpandable
-              aria-label="Migration waves table"
+              aria-label="Issues table"
             >
               <Thead>
                 <Tr>
                   <TableHeaderContentWithControls {...tableControls}>
-                    <Th {...getThProps({ columnKey: "ruleID" })} />
+                    <Th {...getThProps({ columnKey: "name" })} />
                     <Th {...getThProps({ columnKey: "category" })} />
                     <Th {...getThProps({ columnKey: "effort" })} />
                     <Th {...getThProps({ columnKey: "affected" })} />
@@ -255,10 +257,7 @@ export const Issues: React.FC = () => {
                               rowIndex,
                             })}
                           />
-                          <Td
-                            width={25}
-                            {...getTdProps({ columnKey: "ruleId" })}
-                          >
+                          <Td width={25} {...getTdProps({ columnKey: "name" })}>
                             {compositeIssue.name}
                           </Td>
                           <Td
@@ -305,10 +304,11 @@ export const Issues: React.FC = () => {
                                   <Tooltip content="View Report">
                                     <Button variant="link" isInline>
                                       <Link
-                                        to={getAffectedAppsUrl(
+                                        to={getAffectedAppsUrl({
                                           compositeIssue,
-                                          filterValues
-                                        )}
+                                          fromFilterValues: filterValues,
+                                          fromLocation: location,
+                                        })}
                                       >
                                         {compositeIssue.affected} - View
                                         affected applications

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -155,12 +155,12 @@ export const Issues: React.FC = () => {
 
   const tableControls = useTableControlProps({
     ...tableControlState, // Includes filterState, sortState and paginationState
-    idProperty: "name",
+    idProperty: "_ui_unique_id",
     currentPageItems,
     totalItemCount,
     isLoading: isFetching,
     expandableVariant: "single",
-    expansionState: useCompoundExpansionState("name"),
+    expansionState: useCompoundExpansionState("_ui_unique_id"),
     selectionState: useSelectionState({
       items: currentPageItems,
       isEqual: (a, b) => a.name === b.name,
@@ -241,7 +241,7 @@ export const Issues: React.FC = () => {
                 {currentPageItems?.map((compositeIssue, rowIndex) => {
                   return (
                     <Tbody
-                      key={compositeIssue.name}
+                      key={compositeIssue._ui_unique_id}
                       isExpanded={isCellExpanded(compositeIssue)}
                     >
                       <Tr>
@@ -258,7 +258,8 @@ export const Issues: React.FC = () => {
                             })}
                           />
                           <Td width={25} {...getTdProps({ columnKey: "name" })}>
-                            {compositeIssue.name}
+                            {compositeIssue.name} ({compositeIssue.ruleSet},{" "}
+                            {compositeIssue.rule})
                           </Td>
                           <Td
                             width={10}

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -46,8 +46,9 @@ import { useFetchCompositeIssues } from "@app/queries/issues";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
 import { Link } from "react-router-dom";
+import { getAffectedAppsUrl } from "./helpers";
 
-enum IssueFilterGroups {
+export enum IssueFilterGroups {
   ApplicationInventory = "Application inventory",
   Issues = "Issues",
 }
@@ -168,6 +169,7 @@ export const Issues: React.FC = () => {
 
   const {
     numRenderedColumns,
+    filterState: { filterValues },
     expansionState: { isCellExpanded },
     propHelpers: {
       toolbarProps,
@@ -302,7 +304,10 @@ export const Issues: React.FC = () => {
                                   <Tooltip content="View Report">
                                     <Button variant="link" isInline>
                                       <Link
-                                        to={`/issues/${issue.ruleID}?filter=ruleid~*${issue.ruleID}*~&sort=asc:ruleID&limit=&offset=0`}
+                                        to={getAffectedAppsUrl(
+                                          issue,
+                                          filterValues
+                                        )}
                                       >
                                         {issue.affected} - View affected
                                         applications

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -347,7 +347,7 @@ export const Issues: React.FC = () => {
                                     Labels
                                   </Text>
                                   <div>
-                                    {issue.labels.map((label) => {
+                                    {issue.labels?.map((label) => {
                                       return (
                                         <Label className={spacing.mrSm}>
                                           {label}

--- a/client/src/app/shared/hooks/table-controls/active-row/getActiveRowDerivedState.ts
+++ b/client/src/app/shared/hooks/table-controls/active-row/getActiveRowDerivedState.ts
@@ -3,7 +3,7 @@ import { IActiveRowState } from "./useActiveRowState";
 
 export interface IActiveRowDerivedStateArgs<TItem> {
   currentPageItems: TItem[];
-  idProperty: KeyWithValueType<TItem, string>;
+  idProperty: KeyWithValueType<TItem, string | number>;
   activeRowState: IActiveRowState;
 }
 

--- a/client/src/app/shared/hooks/table-controls/filtering/useFilterState.ts
+++ b/client/src/app/shared/hooks/table-controls/filtering/useFilterState.ts
@@ -32,6 +32,27 @@ export const useFilterState = <TItem, TFilterCategoryKey extends string>({
   return { filterValues, setFilterValues };
 };
 
+export const serializeFilterUrlParams = <TFilterCategoryKey extends string>(
+  filterValues: IFilterValues<TFilterCategoryKey>
+): Partial<Record<"filters", string | null>> => {
+  // If a filter value is empty/cleared, don't put it in the object in URL params
+  const trimmedFilterValues = { ...filterValues };
+  objectKeys(trimmedFilterValues).forEach((filterCategoryKey) => {
+    if (
+      !trimmedFilterValues[filterCategoryKey] ||
+      trimmedFilterValues[filterCategoryKey]?.length === 0
+    ) {
+      delete trimmedFilterValues[filterCategoryKey];
+    }
+  });
+  return {
+    filters:
+      objectKeys(trimmedFilterValues).length > 0
+        ? JSON.stringify(trimmedFilterValues)
+        : null, // If there are no filters, remove the filters param from the URL entirely.
+  };
+};
+
 export const useFilterUrlParams = <
   TFilterCategoryKey extends string
 >(): IFilterState<TFilterCategoryKey> => {
@@ -41,24 +62,7 @@ export const useFilterUrlParams = <
   >({
     keys: ["filters"],
     defaultValue: {},
-    serialize: (filterValues) => {
-      // If a filter value is empty/cleared, don't put it in the object in URL params
-      const trimmedFilterValues = { ...filterValues };
-      objectKeys(trimmedFilterValues).forEach((filterCategoryKey) => {
-        if (
-          !trimmedFilterValues[filterCategoryKey] ||
-          trimmedFilterValues[filterCategoryKey]?.length === 0
-        ) {
-          delete trimmedFilterValues[filterCategoryKey];
-        }
-      });
-      return {
-        filters:
-          objectKeys(trimmedFilterValues).length > 0
-            ? JSON.stringify(trimmedFilterValues)
-            : null, // If there are no filters, remove the filters param from the URL entirely.
-      };
-    },
+    serialize: serializeFilterUrlParams,
     deserialize: (urlParams) => {
       try {
         return JSON.parse(urlParams.filters || "{}");

--- a/client/src/app/shared/hooks/table-controls/filtering/useFilterState.ts
+++ b/client/src/app/shared/hooks/table-controls/filtering/useFilterState.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useSessionStorage } from "@migtools/lib-ui";
 import {
   FilterCategory,
+  FilterValue,
   IFilterValues,
 } from "@app/shared/components/FilterToolbar";
 import { useUrlParams } from "../../useUrlParams";
@@ -34,7 +35,7 @@ export const useFilterState = <TItem, TFilterCategoryKey extends string>({
 
 export const serializeFilterUrlParams = <TFilterCategoryKey extends string>(
   filterValues: IFilterValues<TFilterCategoryKey>
-): Partial<Record<"filters", string | null>> => {
+): { filters?: string | null } => {
   // If a filter value is empty/cleared, don't put it in the object in URL params
   const trimmedFilterValues = { ...filterValues };
   objectKeys(trimmedFilterValues).forEach((filterCategoryKey) => {
@@ -53,6 +54,18 @@ export const serializeFilterUrlParams = <TFilterCategoryKey extends string>(
   };
 };
 
+export const deserializeFilterUrlParams = <
+  TFilterCategoryKey extends string
+>(urlParams: {
+  filters?: string;
+}): Partial<Record<TFilterCategoryKey, FilterValue>> => {
+  try {
+    return JSON.parse(urlParams.filters || "{}");
+  } catch (e) {
+    return {};
+  }
+};
+
 export const useFilterUrlParams = <
   TFilterCategoryKey extends string
 >(): IFilterState<TFilterCategoryKey> => {
@@ -63,13 +76,7 @@ export const useFilterUrlParams = <
     keys: ["filters"],
     defaultValue: {},
     serialize: serializeFilterUrlParams,
-    deserialize: (urlParams) => {
-      try {
-        return JSON.parse(urlParams.filters || "{}");
-      } catch (e) {
-        return {};
-      }
-    },
+    deserialize: deserializeFilterUrlParams,
   });
   return { filterValues, setFilterValues };
 };

--- a/client/src/app/shared/hooks/table-controls/sorting/useSortState.ts
+++ b/client/src/app/shared/hooks/table-controls/sorting/useSortState.ts
@@ -12,7 +12,7 @@ export interface ISortState<TSortableColumnKey extends string> {
 }
 
 export interface ISortStateArgs<TSortableColumnKey extends string> {
-  sortableColumns: TSortableColumnKey[];
+  sortableColumns?: TSortableColumnKey[];
   initialSort?: IActiveSort<TSortableColumnKey> | null;
 }
 
@@ -24,7 +24,7 @@ const getDefaultSort = <TSortableColumnKey extends string>(
     : null;
 
 export const useSortState = <TSortableColumnKey extends string>({
-  sortableColumns,
+  sortableColumns = [],
   initialSort = getDefaultSort(sortableColumns),
 }: ISortStateArgs<TSortableColumnKey>): ISortState<TSortableColumnKey> => {
   const [activeSort, setActiveSort] = React.useState(initialSort);
@@ -32,7 +32,7 @@ export const useSortState = <TSortableColumnKey extends string>({
 };
 
 export const useSortUrlParams = <TSortableColumnKey extends string>({
-  sortableColumns,
+  sortableColumns = [],
   initialSort = getDefaultSort(sortableColumns),
 }: ISortStateArgs<TSortableColumnKey>): ISortState<TSortableColumnKey> => {
   const [activeSort, setActiveSort] = useUrlParams({

--- a/client/src/app/shared/hooks/table-controls/types.ts
+++ b/client/src/app/shared/hooks/table-controls/types.ts
@@ -56,7 +56,7 @@ export interface ITableControlCommonArgs<
 // - Requires query values and defined TItem type in scope but not state values
 export interface ITableControlDataDependentArgs<TItem> {
   isLoading?: boolean;
-  idProperty: KeyWithValueType<TItem, string>;
+  idProperty: KeyWithValueType<TItem, string | number>;
 }
 
 // Derived state option args

--- a/client/src/app/shared/hooks/useCompoundExpansionState.ts
+++ b/client/src/app/shared/hooks/useCompoundExpansionState.ts
@@ -2,7 +2,7 @@ import { KeyWithValueType } from "@app/utils/type-utils";
 import React from "react";
 
 export const useCompoundExpansionState = <TItem, TColumnKey extends string>(
-  idProperty: KeyWithValueType<TItem, string>
+  idProperty: KeyWithValueType<TItem, string | number>
 ) => {
   // TExpandedCells maps item names to either:
   //  - The key of an expanded column in that row, if the table is compound-expandable
@@ -21,9 +21,9 @@ export const useCompoundExpansionState = <TItem, TColumnKey extends string>(
   }) => {
     const newExpandedCells = { ...expandedCells };
     if (isExpanding) {
-      newExpandedCells[item[idProperty] as string] = columnKey || true;
+      newExpandedCells[String(item[idProperty])] = columnKey || true;
     } else {
-      delete newExpandedCells[item[idProperty] as string];
+      delete newExpandedCells[String(item[idProperty])];
     }
     setExpandedCells(newExpandedCells);
   };
@@ -33,8 +33,8 @@ export const useCompoundExpansionState = <TItem, TColumnKey extends string>(
   //  - If called without a columnKey, returns whether the row is expanded at all
   const isCellExpanded = (item: TItem, columnKey?: TColumnKey) => {
     return columnKey
-      ? expandedCells[item[idProperty] as string] === columnKey
-      : !!expandedCells[item[idProperty] as string];
+      ? expandedCells[String(item[idProperty])] === columnKey
+      : !!expandedCells[String(item[idProperty])];
   };
 
   // TODO we will need to adapt this to regular-expandable and not just compound-expandable

--- a/client/src/app/shared/hooks/useUrlParams.ts
+++ b/client/src/app/shared/hooks/useUrlParams.ts
@@ -41,23 +41,12 @@ export const useUrlParams = <TUrlParamKey extends string, TDeserializedParams>({
       new URLSearchParams(search)
     );
     const newSerializedParams = serialize(newParams);
-    objectKeys(newSerializedParams).forEach((key) => {
-      // Returning undefined for a property from serialize should result in it being omitted from the partial update.
-      if (newSerializedParams[key] === undefined) {
-        delete newSerializedParams[key];
-      }
-      // Returning null for a property from serialize should result in it being removed from the URL.
-      if (newSerializedParams[key] === null) {
-        delete newSerializedParams[key];
-        delete existingSerializedParams[key];
-      }
-    });
     history.replace({
       pathname,
-      search: new URLSearchParams({
-        ...existingSerializedParams,
-        ...newSerializedParams,
-      }).toString(),
+      search: trimAndStringifyUrlParams({
+        existingParams: existingSerializedParams,
+        params: newSerializedParams,
+      }),
     });
   };
 
@@ -75,4 +64,25 @@ export const useUrlParams = <TUrlParamKey extends string, TDeserializedParams>({
   }, [allParamsEmpty]);
 
   return [params, setParams];
+};
+
+export const trimAndStringifyUrlParams = <TUrlParamKey extends string>({
+  existingParams = {},
+  params,
+}: {
+  existingParams?: Record<string, string>;
+  params: Partial<Record<TUrlParamKey, string | null>>;
+}) => {
+  objectKeys(params).forEach((key) => {
+    // Returning undefined for a property from serialize should result in it being omitted from the partial update.
+    if (params[key] === undefined) {
+      delete params[key];
+    }
+    // Returning null for a property from serialize should result in it being removed from the URL.
+    if (params[key] === null) {
+      delete params[key];
+      delete existingParams[key];
+    }
+  });
+  return new URLSearchParams({ ...existingParams, ...params }).toString();
 };


### PR DESCRIPTION
This gets us a little closer to a complete issues / affected apps flow. It's not complete, but I reached a decent stopping point.

Notes in order of appearance in the diff:

* Updates text and ids to match Issues and Affected Applications page titles correctly
* Updates route for Affected Apps page to `/issues/:ruleset/:rule` (the composite issue object no longer has a unique identifier (previously ruleID), it is now identified by a unique pair of ruleset and rule)
* Renames the type of `AnalysisCompositeIssue` as returned from the hub to `BaseAnalysisCompositeIssue`, so that we can have a type `AnalysisCompositeIssue` which extends that with a new property `_ui_unique_id`. This property is injected into these objects in the `select` function of `useFetchCompositeIssues`. This is because our table hooks expect an `idProperty` which can uniquely identify a row for the purposes of state management. `_ui_unique_id` is just a combination of ruleset and rule.
* Comments out code related to displaying source and target technologies, and leaves TODO comments for restoring them. Technologies have been moved into special labels in the hub, and we need to parse them in a future change. That seemed out of scope for this PR.
* Removes sorting the affected apps page by application name, as this is causing errors in the hub. TODO comments added to see if we can fix this, need to check with @jortel.
* Adds a filter on application name to the affected apps page. This filter is special: when moving from the Issues page to Affected Apps, if there is an app name filter on the issues page we include it in the URL and carry it over to the affected apps page. We also include a property `fromIssuesParams` which is an encoded string of all the URL params that were present on the issues page before we navigated away. Then when getting the URL for the breadcrumb bar that returns us to the issues page, we restore those params in `fromIssuesParams`, and if the user has modified or cleared the app name filter while on the affected apps page, we carry that change back over to the issues page. This filter-carrying behavior does not conflict with any other filters or params which may be present on either of these pages; everything will be retained and merged together.
  * This logic is defined in the `getAffectedAppsUrl` and `getBackToIssuesUrl` functions in `client/src/app/pages/issues/helpers.ts`. Note that the constant `filterKeysToCarry` at the top can be modified to include more filters in this carry-over behavior if we want to add more filters in the future that are present on both of these pages.
* Adds an `implicitFilters` argument to `getHubRequestParams`. This can be used to inject additional filters in the hub request that are not visible to the user. On the affected apps page, we use it to filter the hub's issues endpoint by the current ruleset and rule. Implicit filters and the user-exposed filters get merged together when making a hub request.
* Refactors the affected apps page so that all table control state is based on issue objects rather than application objects (removes the use of `useLocalTableControls`). Instead, the application ref on each issue is resolved in the render logic inside the table JSX. This way we don't need to worry about multiple sets of state for sorting/filtering/pagination etc, because we need to apply those things to the hub for issues and not apps anyway.
* Adds a TODO to return to about making `expansionState` and `selectionState` optional in `useTableControlProps`. We have to include a stub `selectionState` here even though it isn't being used. Fixing this felt out of scope for this PR.
* Passes the composite issue's name in an additional URL param down to the affected apps page. This is purely for rendering in the breadcrumb bar so we have a consistent information architecture (the user should see the name of the thing they drilled down from).
  * Also includes the ruleset and rule in the breadcrumb bar for now, since those are what make the view unique. This is not in the mockups: we should discuss this with Justin in a future design review.
* On the issues page:
  * Replaces the old Rule ID column with Name, and adds Rule set and Rule columns for now (so the rows are unique). We should also discuss this in a design review.
  * Switches everything that depended on `idProperty: "ruleID"` to use `_ui_unique_id`.
  * Renames `issue` to `compositeIssue` in the table rendering code for clarity.
* As mentioned above, adds a `select` option to `useQuery` in `useFetchCompositeIssues` in order to inject `_ui_unique_id` on the composite issue objects.
* For the `idProperty` field's type everywhere it is used (`KeyWithValueType`), allows either a string or a number value for that property. This change was made for accommodating the ruleID in certain places before that was removed, but I left it because it's a useful change.
* As mentioned above, adds the `implicitFilters` support to `getFilterHubRequestParams`.
* In `useFilterState.ts`, factors out and exports the `serialize` and `deserialize` functions from `useFilterUrlParams` so they can be used on their own in the filter-carrying behavior of `getAffectedAppsUrl` and `getBackToIssuesUrl` mentioned above. The new functions `serializeFilterUrlParams` and `deserializeFilterUrlParams` can now be used to manipulate filters in a URL string anywhere and retain the special behavior (it is mostly just a JSON serialization, but null/undefined/empty filters get automatically stripped out).
* In `useSortState`, makes `sortableColumns` optional because we may not want sorting in every table. Currently there are no sortable columns in the affected apps table due to the weirdness with querying issues but displaying applications.
* In `useCompoundExpansionState`, casts the `item[idProperty]` as a string wherever it is used in state in order to support the earlier change that allows numeric id properties without modifying a bunch of types that expect string keys in state.
* In `useUrlParams.ts`, factors out and exports a function `trimAndStringifyUrlParams` so the behavior of excluding params from the URL if they are null or undefined can be reused in `getAffectedAppsUrl` and `getBackToIssuesUrl` above.