### PR TITLE
:seedling: Add `npm run test` and update github action `ci-actions.yml` to use it

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -23,14 +23,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install
-        working-directory: client
-        run: npm install
+        run: npm clean-install
       - name: Build
-        working-directory: client
         run: npm run build
       - name: Test
-        working-directory: client
-        run: npm run test --coverage --watchAll=false
+        run: npm run test -- --coverage --watchAll=false
       - uses: codecov/codecov-action@v1
         with:
           flags: unitests
+          directory: ./*/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules/
 /client/public/locales/**/translation_old.json
 /.pnp
 .pnp.js
 
 # testing
-/coverage
+coverage/
 
 # production
-/client/dist
+dist/
 /qa/build
-/dist
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm run build -w client",
     "start:dev": "npm run start:dev -w client",
     "start": "npm run start -w client",
+    "test": "npm run test -ws --if-present --",
     "port-forward": "npm run port-forward -w client"
   },
   "workspaces": [


### PR DESCRIPTION
Add a `npm run test` script to the root package and adjust the Github Action to run from the root directory.  This allows for proper installation of any shared dependencies in the root `package.json`, and for test scripts to be run in each workspace.

**Note**: The cli options given in `ci-actions.yml` for the test script were not actually being passed to the jest command.  An extra `--` is needed to send those options.  Those adjustments have also been made.

**Note 2**: Using `npm clean-install` in the `ci-actions.yml` will cause ci tests to fail if `package-lock.json` has not been updated in a PR. This version of install prevents npm from updating the lock file.

**Note 3**: `.gitignore` updated for non-root test, build and dist paths

Extracted from #895