### PR TITLE
:sparkles: Add support for additional useSelectionState args in useLocalTableControls

### DIFF
--- a/client/src/app/shared/hooks/table-controls/types.ts
+++ b/client/src/app/shared/hooks/table-controls/types.ts
@@ -1,5 +1,5 @@
 import { TableComposableProps } from "@patternfly/react-table";
-import { useSelectionState } from "@migtools/lib-ui";
+import { ISelectionStateArgs, useSelectionState } from "@migtools/lib-ui";
 import { KeyWithValueType } from "@app/utils/type-utils";
 import {
   IFilterStateArgs,
@@ -77,7 +77,8 @@ export type IUseLocalTableControlStateArgs<
   ILocalFilterDerivedStateArgs<TItem, TFilterCategoryKey> &
   IFilterStateArgs<TItem, TFilterCategoryKey> &
   ILocalSortDerivedStateArgs<TItem, TSortableColumnKey> &
-  ILocalPaginationDerivedStateArgs<TItem>;
+  ILocalPaginationDerivedStateArgs<TItem> &
+  Pick<ISelectionStateArgs<TItem>, "initialSelected" | "isItemSelectable">;
 
 // Rendering args
 // - Used by only useTableControlProps

--- a/client/src/app/shared/hooks/table-controls/useLocalTableControlState.ts
+++ b/client/src/app/shared/hooks/table-controls/useLocalTableControlState.ts
@@ -28,6 +28,8 @@ export const useLocalTableControlState = <
     hasPagination = true,
     initialItemsPerPage = 10,
     idProperty,
+    initialSelected,
+    isItemSelectable,
   } = args;
 
   const filterState = useFilterState(args);
@@ -44,6 +46,8 @@ export const useLocalTableControlState = <
   const selectionState = useSelectionState({
     items: filteredItems,
     isEqual: (a, b) => a[idProperty] === b[idProperty],
+    initialSelected,
+    isItemSelectable,
   });
 
   const sortState = useSortState({ sortableColumns, initialSort });


### PR DESCRIPTION
Currently `useLocalTableControlState` (and by extension `useLocalTableControls`) uses `useSelectionState` internally and only passes the required arguments to it. This PR exposes the optional `initialSelected` and `isItemSelectable` arguments for `useSelectionState` on the table args object.

Note: This is to unblock @gildub for now, but eventually we probably want to refactor these to get rid of the usage of `useSelectionState` in its current form, so that we can drive the state from string keys via `idProperty` instead of references to row data in memory. This will make it possible to lift selection state into the URL bar and to set items as initially selected before the data is loaded.