### PR TITLE
:seedling: Fix container build for old versions of docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # Builder image
-FROM registry.access.redhat.com/ubi9/nodejs-18 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-18:latest as builder
 
-COPY --chown=default . .
+USER 1001
+COPY --chown=1001 . .
 RUN npm clean-install && npm run build && npm run dist
 
 # Runner image
-FROM registry.access.redhat.com/ubi9/nodejs-18-minimal
+FROM registry.access.redhat.com/ubi9/nodejs-18-minimal:latest
 
 # Add ps package to allow liveness probe for k8s cluster
 # Add tar package to allow copying files with kubectl scp


### PR DESCRIPTION
With docker version `Docker version 20.10.22, build 3a2c30b`, the build fails not knowing how to map a username to a uid in the `COPY` command.

Do two things to prevent this error, and potentially others, going forward:

  - explicitly use the `:latest` tag on the FROM containers

  - explicitly use `USER 1001` and `COPY --chown:1001` to avoid any user name to uid lookup problems
