### PR TITLE
:ghost: Change references of "instance" to "tracker"

### DIFF
--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -43,13 +43,13 @@ interface FormValues {
   insecure: boolean;
 }
 
-export interface InstanceFormProps {
-  instance?: Tracker;
+export interface TrackerFormProps {
+  tracker?: Tracker;
   onClose: () => void;
 }
 
-export const InstanceForm: React.FC<InstanceFormProps> = ({
-  instance,
+export const TrackerForm: React.FC<TrackerFormProps> = ({
+  tracker,
   onClose,
 }) => {
   const { t } = useTranslation();
@@ -57,12 +57,12 @@ export const InstanceForm: React.FC<InstanceFormProps> = ({
   const [axiosError, setAxiosError] = useState<AxiosError>();
   const [isLoading, setIsLoading] = useState(false);
 
-  const { trackers: instances } = useFetchTrackers();
+  const { trackers: trackers } = useFetchTrackers();
   const { identities } = useFetchIdentities();
 
   const { pushNotification } = React.useContext(NotificationsContext);
 
-  const onCreateInstanceSuccess = (_: AxiosResponse<Tracker>) =>
+  const onCreateTrackerSuccess = (_: AxiosResponse<Tracker>) =>
     pushNotification({
       title: t("toastr.success.save", {
         type: t("terms.instance").toLocaleLowerCase(),
@@ -70,16 +70,16 @@ export const InstanceForm: React.FC<InstanceFormProps> = ({
       variant: "success",
     });
 
-  const onCreateUpdateInstanceError = (error: AxiosError) => {
+  const onCreateUpdatetrackerError = (error: AxiosError) => {
     setAxiosError(error);
   };
 
-  const { mutate: createInstance } = useCreateTrackerMutation(
-    onCreateInstanceSuccess,
-    onCreateUpdateInstanceError
+  const { mutate: createTracker } = useCreateTrackerMutation(
+    onCreateTrackerSuccess,
+    onCreateUpdatetrackerError
   );
 
-  const onUpdateInstanceSuccess = (_: AxiosResponse<Tracker>) =>
+  const onUpdateTrackerSuccess = (_: AxiosResponse<Tracker>) =>
     pushNotification({
       title: t("toastr.success.save", {
         type: t("terms.instance").toLocaleLowerCase(),
@@ -87,9 +87,9 @@ export const InstanceForm: React.FC<InstanceFormProps> = ({
       variant: "success",
     });
 
-  const { mutate: updateInstance } = useUpdateTrackerMutation(
-    onUpdateInstanceSuccess,
-    onCreateUpdateInstanceError
+  const { mutate: updateTracker } = useUpdateTrackerMutation(
+    onUpdateTrackerSuccess,
+    onCreateUpdatetrackerError
   );
 
   const onSubmit = (formValues: FormValues) => {
@@ -110,12 +110,12 @@ export const InstanceForm: React.FC<InstanceFormProps> = ({
         : undefined,
       insecure: formValues.insecure,
     };
-    if (instance) {
-      updateInstance({
+    if (tracker) {
+      updateTracker({
         ...payload,
       });
     } else {
-      createInstance(payload);
+      createTracker(payload);
     }
     onClose();
   };
@@ -132,7 +132,7 @@ export const InstanceForm: React.FC<InstanceFormProps> = ({
       .test(
         "Duplicate name",
         "An identity with this name already exists. Use a different name.",
-        (value) => duplicateNameCheck(instances, instance || null, value || "")
+        (value) => duplicateNameCheck(trackers, tracker || null, value || "")
       )
       .required(t("validation.required")),
     url: yup
@@ -154,12 +154,12 @@ export const InstanceForm: React.FC<InstanceFormProps> = ({
     watch,
   } = useForm<FormValues>({
     defaultValues: {
-      name: instance?.name || "",
-      url: instance?.url || "",
-      id: instance?.id || 0,
-      kind: instance?.kind,
-      credentialName: instance?.identity?.name || "",
-      insecure: instance?.insecure || false,
+      name: tracker?.name || "",
+      url: tracker?.url || "",
+      id: tracker?.id || 0,
+      kind: tracker?.kind,
+      credentialName: tracker?.identity?.name || "",
+      insecure: tracker?.insecure || false,
     },
     resolver: yupResolver(validationSchema),
     mode: "onChange",
@@ -277,7 +277,7 @@ export const InstanceForm: React.FC<InstanceFormProps> = ({
             !isValid || isSubmitting || isValidating || isLoading || !isDirty
           }
         >
-          {!instance ? "Create" : "Save"}
+          {!tracker ? "Create" : "Save"}
         </Button>
         <Button
           type="button"

--- a/client/src/app/pages/external/jira/trackers.tsx
+++ b/client/src/app/pages/external/jira/trackers.tsx
@@ -44,7 +44,7 @@ import {
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/shared/components/table-controls";
-import { InstanceForm } from "./instance-form";
+import { TrackerForm } from "./tracker-form";
 import { Tracker, Ref } from "@app/api/models";
 import { NotificationsContext } from "@app/shared/notifications-context";
 import { getAxiosErrorMessage } from "@app/utils/utils";
@@ -56,16 +56,17 @@ export const JiraTrackers: React.FC = () => {
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
 
-  const [instanceModalState, setInstanceModalState] = React.useState<
+  const [trackerModalState, setTrackerModalState] = React.useState<
     "create" | Tracker | null
   >(null);
-  const isInstanceModalOpen = instanceModalState !== null;
-  const instanceToUpdate =
-    instanceModalState !== "create" ? instanceModalState : null;
+  const isTrackerModalOpen = trackerModalState !== null;
+  const trackerToUpdate =
+    trackerModalState !== "create" ? trackerModalState : null;
 
-  const [instanceToDeleteState, setInstanceToDeleteState] =
-    React.useState<Ref | null>(null);
-  const isConfirmDialogOpen = instanceToDeleteState !== null;
+  const [trackerToDeleteState, setTrackerToDeleteState] =
+    React.useState<Tracker | null>(null);
+
+  const isConfirmDialogOpen = trackerToDeleteState !== null;
 
   const { trackers, isFetching, fetchError, refetch } = useFetchTrackers();
 
@@ -74,7 +75,7 @@ export const JiraTrackers: React.FC = () => {
   const includesTracker = (id: number) =>
     tickets.map((ticket) => ticket.tracker.id).includes(id);
 
-  const onDeleteInstanceSuccess = (name: string) => {
+  const onDeleteTrackerSuccess = (name: string) => {
     pushNotification({
       title: t("toastr.success.deleted", {
         what: name,
@@ -84,7 +85,7 @@ export const JiraTrackers: React.FC = () => {
     });
   };
 
-  const onDeleteInstanceError = (error: AxiosError) => {
+  const onDeleteTrackerError = (error: AxiosError) => {
     pushNotification({
       title: getAxiosErrorMessage(error),
       variant: "danger",
@@ -92,18 +93,18 @@ export const JiraTrackers: React.FC = () => {
     refetch();
   };
 
-  const { mutate: deleteInstance } = useDeleteTrackerMutation(
-    onDeleteInstanceSuccess,
-    onDeleteInstanceError
+  const { mutate: deleteTracker } = useDeleteTrackerMutation(
+    onDeleteTrackerSuccess,
+    onDeleteTrackerError
   );
 
   const tableControls = useLocalTableControls({
     idProperty: "name",
     items: trackers,
     columnNames: {
-      name: "Instance name",
+      name: `${t("terms.instance")} name`,
       url: "URL",
-      kind: "Instance type",
+      kind: `${t("terms.instance")} type`,
       connection: "Connection",
     },
     isSelectable: true,
@@ -174,10 +175,10 @@ export const JiraTrackers: React.FC = () => {
                   <ToolbarItem>
                     <Button
                       type="button"
-                      id="create-instance"
-                      aria-label="Create new instance"
+                      id="create-Tracker"
+                      aria-label="Create new tracker"
                       variant={ButtonVariant.primary}
-                      onClick={() => setInstanceModalState("create")}
+                      onClick={() => setTrackerModalState("create")}
                     >
                       {t("actions.createNew")}
                     </Button>
@@ -195,7 +196,7 @@ export const JiraTrackers: React.FC = () => {
                 </ToolbarGroup>
                 <ToolbarItem {...paginationToolbarItemProps}>
                   <SimplePagination
-                    idPrefix="jira-instance-table"
+                    idPrefix="jira-Tracker-table"
                     isTop
                     paginationProps={paginationProps}
                   />
@@ -241,7 +242,7 @@ export const JiraTrackers: React.FC = () => {
                         </Td>
                         <Td width={20}>
                           <AppTableActionButtons
-                            onEdit={() => setInstanceModalState(tracker)}
+                            onEdit={() => setTrackerModalState(tracker)}
                             onDelete={() => {
                               includesTracker(tracker.id)
                                 ? pushNotification({
@@ -250,10 +251,7 @@ export const JiraTrackers: React.FC = () => {
                                     ),
                                     variant: "danger",
                                   })
-                                : setInstanceToDeleteState({
-                                    id: tracker.id,
-                                    name: tracker.name,
-                                  });
+                                : setTrackerToDeleteState(tracker);
                             }}
                           />
                         </Td>
@@ -268,7 +266,7 @@ export const JiraTrackers: React.FC = () => {
       </PageSection>
       <Modal
         title={
-          instanceToUpdate
+          trackerToUpdate
             ? t("dialog.title.update", {
                 what: t("terms.instance").toLowerCase(),
               })
@@ -277,16 +275,14 @@ export const JiraTrackers: React.FC = () => {
               })
         }
         variant="medium"
-        isOpen={isInstanceModalOpen}
+        isOpen={isTrackerModalOpen}
         onClose={() => {
-          setInstanceModalState(null);
+          setTrackerModalState(null);
         }}
       >
-        <InstanceForm
-          instance={instanceToUpdate ? instanceToUpdate : undefined}
-          onClose={() => {
-            setInstanceModalState(null);
-          }}
+        <TrackerForm
+          tracker={trackerToUpdate ? trackerToUpdate : undefined}
+          onClose={() => setTrackerModalState(null)}
         />
       </Modal>
       <ConfirmDialog
@@ -299,15 +295,13 @@ export const JiraTrackers: React.FC = () => {
         confirmBtnVariant={ButtonVariant.danger}
         confirmBtnLabel={t("actions.delete")}
         cancelBtnLabel={t("actions.cancel")}
-        onCancel={() => setInstanceToDeleteState(null)}
-        onClose={() => setInstanceToDeleteState(null)}
+        onCancel={() => setTrackerToDeleteState(null)}
+        onClose={() => setTrackerToDeleteState(null)}
         onConfirm={() => {
-          if (instanceToDeleteState) {
-            deleteInstance(
-              instanceToDeleteState as { id: number; name: string }
-            );
+          if (trackerToDeleteState) {
+            deleteTracker({ tracker: trackerToDeleteState });
           }
-          setInstanceToDeleteState(null);
+          setTrackerToDeleteState(null);
         }}
       />
     </>

--- a/client/src/app/pages/migration-waves/components/status-table.tsx
+++ b/client/src/app/pages/migration-waves/components/status-table.tsx
@@ -30,7 +30,7 @@ import { getTrackerTypesByProjectId } from "@app/queries/trackers";
 export interface IWaveStatusTableProps {
   migrationWave: MigrationWave;
   applications: Application[];
-  instances: Tracker[];
+  trackers: Tracker[];
   tickets: Ticket[];
   getTicket: (tickets: Ticket[], id: number) => Ticket | undefined;
   removeApplication: (migrationWave: MigrationWave, id: number) => void;
@@ -39,7 +39,7 @@ export interface IWaveStatusTableProps {
 export const WaveStatusTable: React.FC<IWaveStatusTableProps> = ({
   migrationWave,
   applications,
-  instances,
+  trackers,
   tickets,
   getTicket,
   removeApplication,
@@ -87,7 +87,7 @@ export const WaveStatusTable: React.FC<IWaveStatusTableProps> = ({
       const ticket = getTicket(tickets, appId);
       if (ticket) {
         const types = getTrackerTypesByProjectId(
-          instances,
+          trackers,
           ticket.tracker.name,
           ticket.parent
         );

--- a/client/src/app/pages/migration-waves/migration-waves.tsx
+++ b/client/src/app/pages/migration-waves/migration-waves.tsx
@@ -92,7 +92,7 @@ export const MigrationWaves: React.FC = () => {
   const { migrationWaves, isFetching, fetchError, refetch } =
     useFetchMigrationWaves();
 
-  const { trackers: instances } = useFetchTrackers();
+  const { trackers: trackers } = useFetchTrackers();
   const { data: applications } = useFetchApplications();
   const { tickets } = useFetchTickets();
   const { stakeholders } = useFetchStakeholders();
@@ -620,14 +620,14 @@ export const MigrationWaves: React.FC = () => {
                                   )}
                                 />
                               ) : isCellExpanded(migrationWave, "status") &&
-                                instances.length > 0 &&
+                                trackers.length > 0 &&
                                 migrationWave.applications.length > 0 ? (
                                 <WaveStatusTable
                                   migrationWave={migrationWave}
                                   applications={getApplications(
                                     migrationWave.applications
                                   )}
-                                  instances={instances}
+                                  trackers={trackers}
                                   tickets={tickets}
                                   getTicket={getTicketByApplication}
                                   removeApplication={removeApplication}
@@ -679,7 +679,7 @@ export const MigrationWaves: React.FC = () => {
         >
           <ExportForm
             applications={applicationsToExport}
-            instances={instances}
+            trackers={trackers}
             onClose={() => setApplicationsToExport(null)}
           />
         </Modal>

--- a/client/src/app/queries/trackers.ts
+++ b/client/src/app/queries/trackers.ts
@@ -57,49 +57,50 @@ export const useUpdateTrackerMutation = (
 };
 
 export const useDeleteTrackerMutation = (
-  onSuccess: (instanceName: string) => void,
+  onSuccess: (trackerName: string) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id }: { id: number; name: string }) => deleteTracker(id),
+    mutationFn: ({ tracker }: { tracker: Tracker }) =>
+      deleteTracker(tracker.id),
     onSuccess: (_, vars) => {
-      onSuccess(vars.name);
+      onSuccess(vars.tracker.name);
       queryClient.invalidateQueries([TrackersQueryKey]);
     },
     onError: onError,
   });
 };
 
-export const getTrackersByKind = (instances: Tracker[], kind: string) =>
-  instances.filter((instance) => instance.kind === kind && instance.connected);
+export const getTrackersByKind = (trackers: Tracker[], kind: string) =>
+  trackers.filter((tracker) => tracker.kind === kind && tracker.connected);
 
-export const getTrackerProjectsByInstance = (
-  instances: Tracker[],
-  instanceName: string
+export const getTrackerProjectsByTracker = (
+  trackers: Tracker[],
+  trackerName: string
 ) =>
-  instances
-    .filter((instance) => instance.name === instanceName)
-    .map((instance) => instance.metadata?.projects.map((project) => project))
+  trackers
+    .filter((tracker) => tracker.name === trackerName)
+    .map((tracker) => tracker.metadata?.projects.map((project) => project))
     .flat();
 
 export const getTrackerTypesByProjectName = (
-  instances: Tracker[],
-  instanceName: string,
+  trackers: Tracker[],
+  trackerName: string,
   projectName: string
 ) =>
-  getTrackerProjectsByInstance(instances, instanceName)
+  getTrackerProjectsByTracker(trackers, trackerName)
     .filter((project) => project.name === projectName)
     .map((project) => project.issueTypes)
     .flat();
 
 export const getTrackerTypesByProjectId = (
-  instances: Tracker[],
-  instanceName: string,
+  trackers: Tracker[],
+  trackerName: string,
   projectId: string
 ) =>
-  getTrackerProjectsByInstance(instances, instanceName)
+  getTrackerProjectsByTracker(trackers, trackerName)
     .filter((project) => project.id === projectId)
     .map((project) => project.issueTypes)
     .flat();


### PR DESCRIPTION
- Use the same name ("trackers") for all of the UI components (forms/tables) & underlying architecture (hooks, queries/ etc) dealing with JIRA trackers. 
- Keeps usage of instance in form fields displayed to user and other "copy".
