### PR TITLE
:sparkles: [Backport release-0.2] Applications assigned to migration waves cannot be deleted…

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -118,7 +118,7 @@ export interface Application {
   identities?: Ref[];
   repository?: Repository;
   binary?: string;
-  migrationWave?: Ref;
+  migrationWave: Ref | null;
 }
 
 export interface Review {

--- a/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -9,11 +9,13 @@ import userEvent from "@testing-library/user-event";
 const applicationData1 = {
   id: 1,
   name: "App1",
+  migrationWave: null,
 };
 
 const applicationData2 = {
   id: 2,
   name: "App2",
+  migrationWave: null,
 };
 
 const taskgroupData = {

--- a/client/src/app/pages/applications/application-review/components/application-details/tests/application-details.test.tsx
+++ b/client/src/app/pages/applications/application-review/components/application-details/tests/application-details.test.tsx
@@ -10,6 +10,7 @@ describe("AppTable", () => {
       id: 1,
       name: "myApp",
       description: "myDescription",
+      migrationWave: null,
     };
 
     const assessment: Assessment = {

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -346,6 +346,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
         },
         {
           title: t("actions.delete"),
+          isDisabled: row.migrationWave !== null,
           onClick: () => deleteRow(row),
         }
       );
@@ -439,7 +440,12 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     ? [
         <DropdownItem
           key="manage-applications-bulk-delete"
-          isDisabled={selectedRows.length < 1}
+          isDisabled={
+            selectedRows.length < 1 ||
+            selectedRows.filter(
+              (application) => application.migrationWave !== null
+            ).length > 0
+          }
           onClick={() => {
             openBulkDeleteModal(selectedRows);
           }}

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -463,6 +463,7 @@ export const ApplicationsTable: React.FC = () => {
     if (applicationWriteAccess) {
       actions.push({
         title: t("actions.delete"),
+        isDisabled: row.migrationWave !== null,
         onClick: (
           event: React.MouseEvent,
           rowIndex: number,
@@ -656,7 +657,12 @@ export const ApplicationsTable: React.FC = () => {
     ? [
         <DropdownItem
           key="manage-applications-bulk-delete"
-          isDisabled={selectedRows.length < 1}
+          isDisabled={
+            selectedRows.length < 1 ||
+            selectedRows.filter(
+              (application) => application.migrationWave !== null
+            ).length > 0
+          }
           onClick={() => {
             openBulkDeleteModal(selectedRows);
           }}

--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -356,7 +356,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
       ),
       review: undefined, // The review should not updated through this form
       id: formValues.id,
-      migrationWave: application?.migrationWave,
+      migrationWave: application ? application.migrationWave : null,
     };
 
     if (application) {

--- a/client/src/app/pages/applications/components/application-identity-form/application-identity-form.tsx
+++ b/client/src/app/pages/applications/components/application-identity-form/application-identity-form.tsx
@@ -12,7 +12,7 @@ import {
 } from "@patternfly/react-core";
 import WarningTriangleIcon from "@patternfly/react-icons/dist/esm/icons/warning-triangle-icon";
 import { getAxiosErrorMessage } from "@app/utils/utils";
-import { Application, Identity, Ref } from "@app/api/models";
+import { Application, Ref } from "@app/api/models";
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { getKindIDByRef, toOptionLike } from "@app/utils/model-utils";
@@ -116,6 +116,7 @@ export const ApplicationIdentityForm: React.FC<
           identities: updatedIdentities,
           id: application.id,
           businessService: application.businessService,
+          migrationWave: application.migrationWave,
         };
         let promise: Promise<Application>;
         promise = updateApplication({

--- a/client/src/app/shared/hooks/useAssessApplication/useAssessApplication.test.tsx
+++ b/client/src/app/shared/hooks/useAssessApplication/useAssessApplication.test.tsx
@@ -18,6 +18,7 @@ describe("useAssessApplication", () => {
     const application: Application = {
       id: 1,
       name: "some",
+      migrationWave: null,
     };
 
     new MockAdapter(axios)
@@ -49,6 +50,7 @@ describe("useAssessApplication", () => {
     const application: Application = {
       id: 1,
       name: "some",
+      migrationWave: null,
     };
 
     // Mock REST API
@@ -82,6 +84,7 @@ describe("useAssessApplication", () => {
     const application: Application = {
       id: 1,
       name: "some",
+      migrationWave: null,
     };
 
     const response = { id: 123 };
@@ -116,6 +119,7 @@ describe("useAssessApplication", () => {
     const application: Application = {
       id: 1,
       name: "some",
+      migrationWave: null,
     };
 
     new MockAdapter(axios)
@@ -147,6 +151,7 @@ describe("useAssessApplication", () => {
     const application: Application = {
       id: 1,
       name: "some",
+      migrationWave: null,
     };
 
     new MockAdapter(axios)
@@ -178,6 +183,7 @@ describe("useAssessApplication", () => {
     const application: Application = {
       id: 1,
       name: "some",
+      migrationWave: null,
     };
 
     // Mock REST API
@@ -212,6 +218,7 @@ describe("useAssessApplication", () => {
     const application: Application = {
       id: 1,
       name: "some",
+      migrationWave: null,
     };
 
     // Mock REST API


### PR DESCRIPTION
… (#923)

Todo: add a pop over the delete action.

Resolves https://github.com/konveyor/tackle2-ui/issues/921

(cherry picked from commit 10bced25170edc0166c505705db9ea4379b1dd1b)