### PR TITLE
:sparkles: [Backport release-0.2] StakeholderGroupForm: Stakeholders not mandatory (#939)

### DIFF
--- a/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
@@ -204,7 +204,6 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
         name="stakeholderNames"
         label={t("terms.member(s)")}
         fieldId="stakeholders"
-        isRequired
         renderInput={({ field: { value, name, onChange } }) => (
           <SimpleSelect
             variant="typeaheadmulti"


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-647

(cherry picked from commit 5e8f6c77525ef8d23c8feaa6386d8c8591d12aa6)
