### PR TITLE
:bug: Update konveyor doc URL

### DIFF
--- a/client/src/app/layout/AppAboutModal/AppAboutModal.tsx
+++ b/client/src/app/layout/AppAboutModal/AppAboutModal.tsx
@@ -65,7 +65,7 @@ export const AppAboutModal: React.FC<AppAboutModalProps> = ({
             component={TextVariants.a}
             href={
               APP_BRAND === BrandType.Konveyor
-                ? "https://konveyor-docs.konveyor.io/"
+                ? "https://konveyor.github.io/konveyor/"
                 : "https://access.redhat.com/documentation/en-us/migration_toolkit_for_applications"
             }
             target="_blank"

--- a/client/src/app/layout/AppAboutModal/tests/__snapshots__/AppAboutModal.test.tsx.snap
+++ b/client/src/app/layout/AppAboutModal/tests/__snapshots__/AppAboutModal.test.tsx.snap
@@ -149,7 +149,7 @@ Object {
                         data-ouia-component-type="PF4/Text"
                         data-ouia-safe="true"
                         data-pf-content="true"
-                        href="https://konveyor-docs.konveyor.io/"
+                        href="https://konveyor.github.io/konveyor/"
                         target="_blank"
                       >
                         Konveyor


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->

Fixes #945
