### PR TITLE
:bug: Do not require .git extention for git urls

### DIFF
--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -137,7 +137,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
 
   const customURLValidation = (schema: StringSchema) => {
     const gitUrlRegex =
-      /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$/;
+      /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\/?|\#[-\d\w._]+?)$/;
     const containsURL = (string: string) =>
       gitUrlRegex.test(string) || standardURLRegex.test(string);
 


### PR DESCRIPTION
- Reinstate fix for git url validation
