### PR TITLE
:ghost: [backport] Improve status for migration waves (#950)

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -53,6 +53,10 @@ export interface Stakeholder {
   contributes?: Ref[];
 }
 
+export interface StakeholderWithRole extends Stakeholder {
+  role: Role;
+}
+
 export interface StakeholderGroup {
   id: number;
   name: string;
@@ -607,17 +611,26 @@ export type AggregateTicketStatus =
   | "In Progress"
   | "Completed"
   | "Error"
-  | "No Issues";
+  | "No Issues"
+  | "Not Started";
 
 export interface Ticket {
   id: number;
-  application: Ref | null;
+  application?: Ref | null;
   tracker: Ref;
   kind: string;
-  parent: string;
-  fields: Ref | null;
-  message: string | null;
-  reference: string | null;
-  status: string | null;
+  parent?: string;
+  fields?: Ref | null;
+  readonly message?: string | null;
+  reference?: string | null;
+  readonly status?: TicketStatus | null;
   error?: boolean;
+}
+
+export type Role = "Owner" | "Contributor" | null;
+export interface WaveWithStatus extends MigrationWave {
+  ticketStatus: TicketStatus[];
+  status: string;
+  fullApplications: Application[];
+  allStakeholders: StakeholderWithRole[];
 }

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -38,6 +38,7 @@ import {
   MigrationWave,
   Ticket,
   New,
+  Ref,
 } from "./models";
 import { QueryKey } from "@tanstack/react-query";
 import { serializeRequestParamsForHub } from "@app/shared/hooks/table-controls";
@@ -561,9 +562,18 @@ export const getIssues = (params: HubRequestParams = {}) =>
   getHubPaginatedResult<AnalysisIssue>(ANALYSIS_ISSUES, params);
 
 // Tickets
+export const createTickets = (payload: New<Ticket>, applications: Ref[]) => {
+  const promises: AxiosPromise[] = [];
 
-export const createTicket = (obj: New<Ticket>): Promise<Ticket> =>
-  axios.post(TICKETS, obj);
+  applications.map((app) => {
+    const appPayload: New<Ticket> = {
+      ...payload,
+      application: { id: app.id, name: app.name },
+    };
+    return [...promises, axios.post(TICKETS, appPayload)];
+  });
+  return Promise.all<AxiosPromise<Ticket>>(promises);
+};
 
 export const getTickets = (): Promise<Ticket[]> =>
   axios.get(TICKETS).then((response) => response.data);

--- a/client/src/app/pages/migration-waves/components/applications-table.tsx
+++ b/client/src/app/pages/migration-waves/components/applications-table.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Application, MigrationWave } from "@app/api/models";
+import { Application, MigrationWave, WaveWithStatus } from "@app/api/models";
 import { useTranslation } from "react-i18next";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import {
@@ -26,21 +26,17 @@ import {
 import { SimplePagination } from "@app/shared/components/simple-pagination";
 
 export interface IWaveApplicationsTableProps {
-  migrationWave: MigrationWave;
-  applications: Application[];
+  migrationWave: WaveWithStatus;
   removeApplication: (migrationWave: MigrationWave, id: number) => void;
 }
 
 export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
   migrationWave,
-  applications,
   removeApplication,
 }) => {
-  const { t } = useTranslation();
-
   const tableControls = useLocalTableControls({
     idProperty: "name",
-    items: applications,
+    items: migrationWave.fullApplications,
     columnNames: {
       appName: "Name",
       description: "Description",
@@ -98,7 +94,7 @@ export const WaveApplicationsTable: React.FC<IWaveApplicationsTableProps> = ({
           </Tr>
         </Thead>
         <ConditionalTableBody
-          isNoData={applications.length === 0}
+          isNoData={migrationWave.applications.length === 0}
           numRenderedColumns={numRenderedColumns}
         >
           <Tbody>

--- a/client/src/app/pages/migration-waves/components/export-form.tsx
+++ b/client/src/app/pages/migration-waves/components/export-form.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 import * as yup from "yup";
 import {
   ActionGroup,
@@ -23,7 +23,7 @@ import { getAxiosErrorMessage } from "@app/utils/utils";
 import { HookFormPFGroupController } from "@app/shared/components/hook-form-pf-fields";
 import { NotificationsContext } from "@app/shared/notifications-context";
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
-import { useCreateTicketMutation } from "@app/queries/tickets";
+import { useCreateTicketsMutation } from "@app/queries/tickets";
 
 interface FormValues {
   issueManager: IssueManagerKind | undefined;
@@ -46,7 +46,7 @@ export const ExportForm: React.FC<ExportFormProps> = ({
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
 
-  const onExportSuccess = (_: AxiosResponse<Tracker>) =>
+  const onExportSuccess = () =>
     pushNotification({
       title: t("toastr.success.create", {
         type: t("terms.exportToIssue"),
@@ -60,7 +60,7 @@ export const ExportForm: React.FC<ExportFormProps> = ({
       variant: "danger",
     });
 
-  const { mutate: createTicket } = useCreateTicketMutation(
+  const { mutate: createTickets } = useCreateTicketsMutation(
     onExportSuccess,
     onExportError
   );
@@ -113,23 +113,8 @@ export const ExportForm: React.FC<ExportFormProps> = ({
         tracker: { id: matchingtracker.id, name: matchingtracker.name },
         parent: matchingProject?.id || "",
         kind: matchingKind?.id || "",
-        // Hub managed fields
-        application: null,
-        reference: null,
-        message: null,
-        fields: null,
-        status: null,
       };
-
-      applications?.forEach((application) =>
-        createTicket({
-          ...payload,
-          application: {
-            id: application.id,
-            name: application.name,
-          },
-        })
-      );
+      createTickets({ payload, applications });
     }
     onClose();
   };

--- a/client/src/app/pages/migration-waves/components/stakeholders-table.tsx
+++ b/client/src/app/pages/migration-waves/components/stakeholders-table.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { Stakeholder, MigrationWave } from "@app/api/models";
-import { useTranslation } from "react-i18next";
+import { WaveWithStatus, Role } from "@app/api/models";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import {
   TableComposable,
@@ -19,28 +18,15 @@ import {
 } from "@app/shared/components/table-controls";
 
 export interface IWaveStakeholdersTableProps {
-  migrationWave: MigrationWave;
-  stakeholders: Stakeholder[];
+  migrationWave: WaveWithStatus;
 }
-
-type Role = "Owner" | "Contributor" | null;
 
 export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
   migrationWave,
-  stakeholders,
 }) => {
-  const { t } = useTranslation();
-
-  const getRole = (stakeholder: Stakeholder): Role => {
-    if (stakeholder.owns && stakeholder.owns.length > 0) return "Owner";
-    if (stakeholder.contributes && stakeholder.contributes.length > 0)
-      return "Contributor";
-    return null;
-  };
-
   const tableControls = useLocalTableControls({
     idProperty: "name",
-    items: stakeholders,
+    items: migrationWave.allStakeholders,
     columnNames: {
       name: "Name",
       jobFunction: "Job Function",
@@ -52,7 +38,7 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
     getSortValues: (stakeholder) => ({
       name: stakeholder.name || "",
       jobFunction: stakeholder.jobFunction?.name || "",
-      role: getRole(stakeholder) as string,
+      role: stakeholder.role || "",
       email: stakeholder.email,
     }),
     sortableColumns: ["name", "jobFunction", "role", "email"],
@@ -101,7 +87,7 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
           </Tr>
         </Thead>
         <ConditionalTableBody
-          isNoData={stakeholders.length === 0}
+          isNoData={migrationWave.stakeholders.length === 0}
           numRenderedColumns={numRenderedColumns}
         >
           <Tbody>
@@ -119,7 +105,7 @@ export const WaveStakeholdersTable: React.FC<IWaveStakeholdersTableProps> = ({
                     {stakeholder.jobFunction?.name}
                   </Td>
                   <Td width={10} {...getTdProps({ columnKey: "role" })}>
-                    {getRole(stakeholder)}
+                    {stakeholder.role}
                   </Td>
                   <Td width={10} {...getTdProps({ columnKey: "email" })}>
                     {stakeholder.email}

--- a/client/src/app/queries/migration-waves.ts
+++ b/client/src/app/queries/migration-waves.ts
@@ -7,6 +7,8 @@ import {
   updateMigrationWave,
   deleteAllMigrationWaves,
 } from "@app/api/rest";
+import { getWavesWithStatus } from "@app/utils/waves-selector";
+import { TicketsQueryKey } from "./tickets";
 
 export const MigrationWavesQueryKey = "migration-waves";
 
@@ -27,11 +29,14 @@ export const useCreateMigrationWaveMutation = (
 };
 
 export const useFetchMigrationWaves = () => {
+  const queryClient = useQueryClient();
   const { isLoading, error, refetch, data } = useQuery({
     queryKey: [MigrationWavesQueryKey],
     queryFn: getMigrationWaves,
     refetchInterval: 5000,
     onError: (error) => console.log("error, ", error),
+    onSuccess: () => queryClient.invalidateQueries([TicketsQueryKey]),
+    select: (waves) => getWavesWithStatus(queryClient, waves),
   });
   return {
     migrationWaves: data || [],

--- a/client/src/app/queries/stakeholders.ts
+++ b/client/src/app/queries/stakeholders.ts
@@ -6,6 +6,7 @@ import {
   updateStakeholder,
 } from "@app/api/rest";
 import { AxiosError } from "axios";
+import { Role, Stakeholder, StakeholderWithRole } from "@app/api/models";
 
 export const StakeholdersQueryKey = "stakeholders";
 
@@ -14,6 +15,18 @@ export const useFetchStakeholders = () => {
     queryKey: [StakeholdersQueryKey],
     queryFn: getStakeholders,
     onError: (error: AxiosError) => console.log("error, ", error),
+    select: (stakeholders): StakeholderWithRole[] => {
+      const getRole = (stakeholder: Stakeholder): Role => {
+        if (stakeholder.owns && stakeholder.owns.length > 0) return "Owner";
+        if (stakeholder.contributes && stakeholder.contributes.length > 0)
+          return "Contributor";
+        return null;
+      };
+      const stakeholdersWithRole = stakeholders.map((stakeholder) => {
+        return { ...stakeholder, role: getRole(stakeholder) };
+      });
+      return stakeholdersWithRole;
+    },
   });
   return {
     stakeholders: data || [],

--- a/client/src/app/queries/tickets.ts
+++ b/client/src/app/queries/tickets.ts
@@ -1,19 +1,23 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
-import { createTicket, deleteTicket, getTickets } from "@app/api/rest";
+import { createTickets, getTickets } from "@app/api/rest";
 import { AxiosError } from "axios";
-import { Ticket } from "@app/api/models";
-import React from "react";
+import { New, Ref, Ticket } from "@app/api/models";
 
 export const TicketsQueryKey = "tickets";
 
-export const useCreateTicketMutation = (
-  onSuccess: (res: any) => void,
+export const useCreateTicketsMutation = (
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
-  const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: createTicket,
+    mutationFn: ({
+      payload,
+      applications,
+    }: {
+      payload: New<Ticket>;
+      applications: Ref[];
+    }) => createTickets(payload, applications),
     onSuccess: onSuccess,
     onError: onError,
   });

--- a/client/src/app/queries/trackers.ts
+++ b/client/src/app/queries/trackers.ts
@@ -8,14 +8,17 @@ import {
   updateTracker,
 } from "@app/api/rest";
 import { Tracker } from "@app/api/models";
+import { TicketsQueryKey } from "./tickets";
 
 export const TrackersQueryKey = "trackers";
 
 export const useFetchTrackers = () => {
+  const queryClient = useQueryClient();
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: [TrackersQueryKey],
     queryFn: getTrackers,
     onError: (error: AxiosError) => console.log("error, ", error),
+    onSuccess: () => queryClient.invalidateQueries([TicketsQueryKey]),
   });
   return {
     trackers: data || [],
@@ -98,7 +101,7 @@ export const getTrackerTypesByProjectName = (
 export const getTrackerTypesByProjectId = (
   trackers: Tracker[],
   trackerName: string,
-  projectId: string
+  projectId?: string
 ) =>
   getTrackerProjectsByTracker(trackers, trackerName)
     .filter((project) => project.id === projectId)

--- a/client/src/app/utils/waves-selector.ts
+++ b/client/src/app/utils/waves-selector.ts
@@ -1,0 +1,156 @@
+import {
+  AggregateTicketStatus,
+  Application,
+  MigrationWave,
+  Ref,
+  StakeholderWithRole,
+  Ticket,
+  TicketStatus,
+  WaveWithStatus,
+} from "@app/api/models";
+import { ApplicationsQueryKey } from "@app/queries/applications";
+import { StakeholdersQueryKey } from "@app/queries/stakeholders";
+import { TicketsQueryKey } from "@app/queries/tickets";
+import { QueryClient, useQueryClient } from "@tanstack/react-query";
+import dayjs from "dayjs";
+
+export const getWavesWithStatus = (
+  queryClient: QueryClient,
+  waves: MigrationWave[]
+) => {
+  const tickets = queryClient.getQueryData<Ticket[]>([TicketsQueryKey]) || [];
+
+  const stakeholders =
+    queryClient.getQueryData<StakeholderWithRole[]>([StakeholdersQueryKey]) ||
+    [];
+
+  const applications =
+    queryClient.getQueryData<Application[]>([ApplicationsQueryKey]) || [];
+
+  const aggregatedTicketStatus = (
+    wave: MigrationWave,
+    tickets: Ticket[]
+  ): AggregateTicketStatus => {
+    const statuses = getTicketStatus(wave, tickets);
+    if (statuses.includes("Error")) {
+      return "Error";
+    } else if (statuses.includes("")) {
+      const now = dayjs.utc();
+      const start = dayjs.utc(wave.startDate);
+      var duration = now.diff(start);
+      if (duration > 0) {
+        return "In Progress";
+      } else {
+        return "Not Started";
+      }
+    } else if (statuses.includes("New")) {
+      return "Issues Created";
+    } else {
+      return "Not Started";
+    }
+  };
+  const getTicketByApplication = (tickets: Ticket[], id: number = 0) =>
+    tickets.find((ticket) => ticket.application?.id === id);
+
+  const getTicketStatus = (
+    wave: MigrationWave,
+    tickets: Ticket[]
+  ): TicketStatus[] =>
+    wave.applications.map((application): TicketStatus => {
+      const matchingTicket = getTicketByApplication(tickets, application.id);
+      if (matchingTicket?.error) {
+        return "Error";
+      } else if (matchingTicket?.status) {
+        return matchingTicket.status;
+      } else return "";
+    });
+
+  const getApplicationsOwners = (id: number) => {
+    const applicationOwnerIds = applications
+      .filter((application) => application.migrationWave?.id === id)
+      .map((application) => application.owner?.id);
+
+    return stakeholders.filter((stakeholder) =>
+      applicationOwnerIds.includes(stakeholder.id)
+    );
+  };
+
+  const getApplicationsContributors = (id: number) => {
+    const applicationContributorsIds = applications
+      .filter((application) => application.migrationWave?.id === id)
+      .map((application) =>
+        application.contributors?.map((contributor) => contributor.id)
+      )
+      .flat();
+
+    return stakeholders.filter((stakeholder) =>
+      applicationContributorsIds.includes(stakeholder.id)
+    );
+  };
+
+  const getStakeholdersByMigrationWave = (migrationWave: MigrationWave) => {
+    const holderIds = migrationWave.stakeholders.map(
+      (stakeholder) => stakeholder.id
+    );
+    return stakeholders.filter((stakeholder) =>
+      holderIds.includes(stakeholder.id)
+    );
+  };
+
+  const getStakeholderFromGroupsByMigrationWave = (
+    migrationWave: MigrationWave
+  ) => {
+    const groupIds = migrationWave.stakeholderGroups.map(
+      (stakeholderGroup) => stakeholderGroup.id
+    );
+
+    return stakeholders.filter((stakeholder) =>
+      stakeholder.stakeholderGroups?.find((stakeholderGroup) =>
+        groupIds.includes(stakeholderGroup.id)
+      )
+    );
+  };
+
+  const getAllStakeholders = (migrationWave: MigrationWave) => {
+    const allStakeholders: StakeholderWithRole[] = getApplicationsOwners(
+      migrationWave.id
+    );
+
+    getApplicationsContributors(migrationWave.id).forEach((stakeholder) => {
+      if (!allStakeholders.includes(stakeholder))
+        allStakeholders.push(stakeholder);
+    });
+
+    getStakeholdersByMigrationWave(migrationWave).forEach((stakeholder) => {
+      if (!allStakeholders.includes(stakeholder))
+        allStakeholders.push(stakeholder);
+    });
+
+    getStakeholderFromGroupsByMigrationWave(migrationWave).forEach(
+      (stakeholder) => {
+        if (!allStakeholders.includes(stakeholder))
+          allStakeholders.push(stakeholder);
+      }
+    );
+
+    return allStakeholders;
+  };
+  const getApplications = (refs: Ref[]) => {
+    const ids = refs.map((ref) => ref.id);
+    return applications.filter((application: any) =>
+      ids.includes(application.id)
+    );
+  };
+  const wavesWithStatus: WaveWithStatus[] = waves.map(
+    (wave): WaveWithStatus => {
+      return {
+        ...wave,
+        ticketStatus: getTicketStatus(wave, tickets),
+        status: aggregatedTicketStatus(wave, tickets),
+        fullApplications: getApplications(wave.applications),
+        allStakeholders: getAllStakeholders(wave),
+      };
+    }
+  );
+  return wavesWithStatus;
+};


### PR DESCRIPTION
- Currently migration status is clickable/hoverable when the value is null / applications assigned to wave are empty. This fixes that. Closes https://github.com/konveyor/tackle2-ui/issues/961

- Fixes No Issues status being "clickable / expandable" when no data is available in the table / migration wave
- Remove impure functions deriving state & introduce a selector pattern. Usage is MigrationWaveWithStatus which includes ticket status & derived migration wave status on the UI wave resource. Also, this moves away from prop drilling and moves all derived state to selectors for migration waves page and child component tables. Closes https://github.com/konveyor/tackle2-ui/issues/963
- Surface error to aggregate migration wave status Closes #964
- Refactor createTicket -> createTickets to allow for better handling of async code. This allows batch tickets to be created using Promise.all.
- Add a constraint for ticket export. Prevents export of an application that is already assigned to a ticket. Partially addresses https://github.com/konveyor/tackle2-ui/issues/952

---------

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
