### PR TITLE
:bug: Prevent infinite render loop when `drawerPanelContentProps` is omitted in PageDrawerContent

### DIFF
--- a/client/src/app/shared/page-drawer-context.tsx
+++ b/client/src/app/shared/page-drawer-context.tsx
@@ -108,7 +108,7 @@ export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
   isExpanded: localIsExpandedProp,
   onCloseClick,
   children,
-  drawerPanelContentProps = {},
+  drawerPanelContentProps: localDrawerPanelContentProps,
   focusKey,
   pageKey: localPageKeyProp,
 }) => {
@@ -144,13 +144,17 @@ export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
     };
   }, [localIsExpandedProp]);
 
-  // Same deal with the page key, keep it in sync with the local prop on PageDrawerContent.
+  // Same with pageKey and drawerPanelContentProps, keep them in sync with the local prop on PageDrawerContent.
   React.useEffect(() => {
     setDrawerPageKey(localPageKeyProp);
     return () => {
       setDrawerPageKey("");
     };
   }, [localPageKeyProp]);
+
+  React.useEffect(() => {
+    setDrawerPanelContentProps(localDrawerPanelContentProps || {});
+  }, [localDrawerPanelContentProps]);
 
   // If the drawer is already expanded describing app A, then the user clicks app B, we want to send focus back to the drawer.
   React.useEffect(() => {
@@ -173,10 +177,6 @@ export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
       </DrawerHead>
     );
   }, [children]);
-
-  React.useEffect(() => {
-    setDrawerPanelContentProps(drawerPanelContentProps);
-  }, [drawerPanelContentProps]);
 
   return null;
 };


### PR DESCRIPTION
Fixes https://github.com/konveyor/tackle2-ui/issues/984

In `PageDrawerContent`, there are a few props the consumer can pass in locally to the component that we sync up to the Context using useEffects. The existing ones `isExpanded` and `pageKey` are primitives (boolean and string) and so they were safe to use as dependencies in `useEffect` since an unchanged value is referentially equal to the previous value (`"foo" === "foo"`, `true === true`). However, in https://github.com/konveyor/tackle2-ui/pull/904 I introduced `drawerPanelContentProps`, which is an object with a default value of `{}` when omitted. Because `{} !== {}`, when this prop was omitted the useEffect to sync it to context was causing an infinite loop (React thinks every render has a new value for it and updates context with that new `{}` value, which triggers another render, etc).

The solution is not to default it to an object literal in the component function's definition, but instead let it be undefined if the consumer omits it and use `{}` as a fallback value when setting it in context (will happen only once if the prop is omitted).