### PR TITLE
:bug: [Backport release-0.2] Credential modal, reset value and revalidate form for password onFocus

### DIFF
--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -355,6 +355,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
     setValue,
     control,
     watch,
+    resetField,
   } = useForm<IdentityFormValues>({
     defaultValues: {
       description: identity?.description || "",
@@ -457,8 +458,8 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
               const selectionValue = selection as OptionWithValue<IdentityKind>;
               setValue(name, selectionValue.value);
               // So we don't retain the values from the wrong type of credential
-              setValue("user", "");
-              setValue("password", "");
+              resetField("user");
+              resetField("password");
             }}
           />
         )}
@@ -489,8 +490,8 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                     selection as OptionWithValue<UserCredentials>;
                   setValue(name, selectionValue.value);
                   // So we don't retain the values from the wrong type of credential
-                  setValue("user", "");
-                  setValue("password", "");
+                  resetField("user");
+                  resetField("password");
                 }}
               />
             )}
@@ -520,7 +521,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                   ) : undefined,
                 }}
                 type={isPasswordHidden ? "password" : "text"}
-                onFocus={() => setValue("password", "")}
+                onFocus={() => resetField("password")}
               />
             </>
           )}
@@ -563,7 +564,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                     filenamePlaceholder="Drag and drop a file or upload one"
                     onClearClick={() => {
                       onChange("");
-                      setValue("keyFilename", "");
+                      resetField("keyFilename");
                       setIsKeyFileRejected(false);
                     }}
                     allowEditingUploadedText
@@ -586,12 +587,13 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                     />
                   ) : undefined,
                 }}
-                onFocus={() => setValue("password", "")}
+                onFocus={() => resetField("password")}
               />
             </>
           )}
         </>
       )}
+
       {values?.kind === "maven" && (
         <HookFormPFGroupController
           control={control}
@@ -627,7 +629,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
               filenamePlaceholder="Drag and drop a file or upload one"
               onClearClick={() => {
                 onChange("");
-                setValue("settingsFilename", "");
+                resetField("settingsFilename");
                 setIsSettingsFileRejected(false);
               }}
               onReadStarted={() => setIsLoading(true)}
@@ -667,7 +669,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
                 />
               ) : undefined,
             }}
-            onFocus={() => setValue("password", "")}
+            onFocus={() => resetField("password")}
           />
         </>
       )}

--- a/client/src/app/pages/identities/identities.tsx
+++ b/client/src/app/pages/identities/identities.tsx
@@ -288,6 +288,7 @@ export const Identities: React.FC = () => {
         </ConditionalRender>
 
         <Modal
+          id="credential.modal"
           title={
             identityToUpdate
               ? t("dialog.title.update", {
@@ -316,7 +317,7 @@ export const Identities: React.FC = () => {
           titleIconVariant={"warning"}
           message={
             dependentApplications?.length
-              ? `${`The credentials are being used by ${dependentApplications.length} application(s). Deleting these credentials will also remove them from the associated applications.`} 
+              ? `${`The credentials are being used by ${dependentApplications.length} application(s). Deleting these credentials will also remove them from the associated applications.`}
           ${t("dialog.message.delete")}`
               : `${t("dialog.message.delete")}`
           }


### PR DESCRIPTION
When `onFocus` to a password or token input field, reset the value back to default and have the form revalidate. Use `resetField()` instead of `setValue("password", "")` to achieve this behavior.

The field reset and form invalidation causes the Create button to be disabled and the old password removed when focus enters the password field.

Bug-Url: https://issues.redhat.com/browse/MTA-474

Backport of #989
