### PR TITLE
:sparkles: Migration Waves:  name is not required, use start and end dates if needed

### DIFF
--- a/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
+++ b/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
@@ -223,7 +223,7 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
         <Text component={TextVariants.h5}>Selected wave</Text>
         <TextInput
           value={
-            migrationWave?.name === ""
+            !migrationWave?.name
               ? `${dayjs(migrationWave.startDate).format(
                   "MM/DD/YYYY"
                 )} - ${dayjs(migrationWave.endDate).format("MM/DD/YYYY")}`

--- a/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
+++ b/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
@@ -203,7 +203,7 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
       applications: selectedItems.map((application) => {
         return { id: application.id, name: application.name };
       }),
-      name: migrationWave?.name ? migrationWave.name.trim() : "",
+      name: migrationWave?.name?.trim() || "",
       startDate: migrationWave?.startDate || "",
       endDate: migrationWave?.endDate || "",
       stakeholders: migrationWave?.stakeholders || [],
@@ -216,8 +216,6 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
 
     onClose();
   };
-
-  console.log(migrationWave);
 
   return (
     <Form onSubmit={onSubmit}>

--- a/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
+++ b/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
@@ -13,6 +13,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
+import dayjs from "dayjs";
 
 import { Application, MigrationWave } from "@app/api/models";
 import { ToolbarBulkSelector } from "@app/shared/components";
@@ -202,7 +203,7 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
       applications: selectedItems.map((application) => {
         return { id: application.id, name: application.name };
       }),
-      name: migrationWave?.name.trim() || "",
+      name: migrationWave?.name ? migrationWave.name.trim() : "",
       startDate: migrationWave?.startDate || "",
       endDate: migrationWave?.endDate || "",
       stakeholders: migrationWave?.stakeholders || [],
@@ -216,12 +217,20 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
     onClose();
   };
 
+  console.log(migrationWave);
+
   return (
     <Form onSubmit={onSubmit}>
       <TextContent>
         <Text component={TextVariants.h5}>Selected wave</Text>
         <TextInput
-          value={migrationWave.name}
+          value={
+            migrationWave?.name === ""
+              ? `${dayjs(migrationWave.startDate).format(
+                  "MM/DD/YYYY"
+                )} - ${dayjs(migrationWave.endDate).format("MM/DD/YYYY")}`
+              : migrationWave.name
+          }
           type="text"
           aria-label="wave-name"
           isDisabled={true}

--- a/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
+++ b/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
@@ -58,7 +58,7 @@ const stakeholderToOption = (
 });
 
 interface WaveFormValues {
-  name: string | undefined;
+  name?: string;
   startDate: Date | null;
   endDate: Date | null;
   stakeholders: Stakeholder[];
@@ -190,8 +190,7 @@ export const WaveForm: React.FC<WaveFormProps> = ({
   const onSubmit = (formValues: WaveFormValues) => {
     const payload: New<MigrationWave> = {
       applications: migrationWave?.applications || [],
-      name:
-        formValues.name && formValues.name !== "" ? formValues.name.trim() : "",
+      name: formValues.name?.trim() || "",
       startDate: dayjs.utc(formValues.startDate).format(),
       endDate: dayjs.utc(formValues.endDate).format(),
       stakeholders: formValues.stakeholders,

--- a/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
+++ b/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
@@ -170,8 +170,7 @@ export const WaveForm: React.FC<WaveFormProps> = ({
   } = useForm<WaveFormValues>({
     mode: "onChange",
     defaultValues: {
-      name:
-        migrationWave && migrationWave.name !== null ? migrationWave.name : "",
+      name: migrationWave?.name || "",
       startDate: migrationWave?.startDate
         ? dayjs(migrationWave.startDate).toDate()
         : null,

--- a/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
+++ b/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
@@ -58,7 +58,7 @@ const stakeholderToOption = (
 });
 
 interface WaveFormValues {
-  name: string;
+  name: string | undefined;
   startDate: Date | null;
   endDate: Date | null;
   stakeholders: Stakeholder[];
@@ -135,15 +135,7 @@ export const WaveForm: React.FC<WaveFormProps> = ({
     name: yup
       .string()
       .trim()
-      .min(3, t("validation.minLength", { length: 3 }))
-      .max(120, t("validation.maxLength", { length: 120 }))
-      .test(
-        "Duplicate name",
-        "An identity with this name already exists. Use a different name.",
-        (value) =>
-          duplicateNameCheck(migrationWaves, migrationWave || null, value || "")
-      )
-      .required(t("validation.required")),
+      .max(120, t("validation.maxLength", { length: 120 })),
     startDate: yup
       .date()
       .when([], {
@@ -178,7 +170,8 @@ export const WaveForm: React.FC<WaveFormProps> = ({
   } = useForm<WaveFormValues>({
     mode: "onChange",
     defaultValues: {
-      name: migrationWave?.name || "",
+      name:
+        migrationWave && migrationWave.name !== null ? migrationWave.name : "",
       startDate: migrationWave?.startDate
         ? dayjs(migrationWave.startDate).toDate()
         : null,
@@ -197,7 +190,8 @@ export const WaveForm: React.FC<WaveFormProps> = ({
   const onSubmit = (formValues: WaveFormValues) => {
     const payload: New<MigrationWave> = {
       applications: migrationWave?.applications || [],
-      name: formValues.name.trim(),
+      name:
+        formValues.name && formValues.name !== "" ? formValues.name.trim() : "",
       startDate: dayjs.utc(formValues.startDate).format(),
       endDate: dayjs.utc(formValues.endDate).format(),
       stakeholders: formValues.stakeholders,
@@ -237,7 +231,6 @@ export const WaveForm: React.FC<WaveFormProps> = ({
             name="name"
             label="Name"
             fieldId="name"
-            isRequired
           />
         </GridItem>
         <Level>


### PR DESCRIPTION
The name of migration is optional, the start and end dates are used if needed to distinguish migration waves.
Also migration wave names are not unique.

Resolves https://github.com/konveyor/tackle2-ui/issues/865
