### PR TITLE
:seedling: [Backport release-0.2] Add password blur test to identity form

### DIFF
--- a/client/src/app/pages/identities/components/identity-form/__tests__/identity-form.test.tsx
+++ b/client/src/app/pages/identities/components/identity-form/__tests__/identity-form.test.tsx
@@ -164,7 +164,17 @@ describe("Component: identity-form", () => {
       }
     );
 
+    expect(passwordInput).toHaveValue("password");
     expect(createButton).toBeEnabled();
+
+    // focus off password then focus back on should 1. clear the password and 2. disable the create button
+    await waitFor(() => {
+      fireEvent.focus(createButton);
+      fireEvent.focus(passwordInput);
+    });
+
+    expect(passwordInput).toHaveValue("");
+    expect(createButton).toBeDisabled();
   });
 
   it("Identity form validation test - source - key upload", async () => {
@@ -316,5 +326,14 @@ describe("Component: identity-form", () => {
     const createButton = screen.getByRole("button", { name: /submit/i });
 
     expect(createButton).toBeEnabled();
+
+    // focus off password then focus back on should 1. clear the password and 2. disable the create button
+    await waitFor(() => {
+      fireEvent.focus(createButton);
+      fireEvent.focus(proxyPasswordInput);
+    });
+
+    expect(proxyPasswordInput).toHaveValue("");
+    expect(createButton).toBeDisabled();
   });
 });


### PR DESCRIPTION
Followup PR #989 and extend the `identity-form.test.tsx` test "Identity form validation test - source - username/password" to include blur of the password field and refocus to make sure the password is cleared and the submit button is disabled.

Backport of #996