### PR TITLE
:seedling: Enable CI on release branches

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "release-*"
   pull_request:
     branches:
       - main
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "release-*"
 
 jobs:
   unit-test:
@@ -28,7 +30,9 @@ jobs:
         run: npm run build
       - name: Test
         run: npm run test -- --coverage --watchAll=false
-      - uses: codecov/codecov-action@v1
+      - name: Code coverage (PR to main or push to main)
+        if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.base_ref == 'refs/heads/main'}}
+        uses: codecov/codecov-action@v1
         with:
           flags: unitests
           directory: ./*/coverage


### PR DESCRIPTION
  - enable CI on release branches
  - only do the code coverage check on PRs/pushes to the main branch
