### PR TITLE
:seedling: [Backport release-0.2] Enable CI on release branches

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "release-*"
   pull_request:
     branches:
       - main
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "release-*"
 
 jobs:
   unit-test:
@@ -28,7 +30,9 @@ jobs:
         run: npm run build
       - name: Test
         run: npm run test -- --coverage --watchAll=false
-      - uses: codecov/codecov-action@v1
+      - name: Code coverage (PR to main or push to main)
+        if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.base_ref == 'refs/heads/main'}}
+        uses: codecov/codecov-action@v1
         with:
           flags: unitests
           directory: ./*/coverage

--- a/client/src/app/layout/DefaultLayout/tests/__snapshots__/DefaultLayout.test.tsx.snap
+++ b/client/src/app/layout/DefaultLayout/tests/__snapshots__/DefaultLayout.test.tsx.snap
@@ -230,6 +230,20 @@ Object {
                     sidebar.controls
                   </a>
                 </li>
+                <li
+                  class="pf-c-nav__item"
+                  data-ouia-component-id="OUIA-Generated-NavItem-6"
+                  data-ouia-component-type="PF4/NavItem"
+                  data-ouia-safe="true"
+                >
+                  <a
+                    class="pf-c-nav__link"
+                    href="/migration-waves"
+                    tabindex="-1"
+                  >
+                    sidebar.migrationWaves
+                  </a>
+                </li>
               </ul>
             </nav>
           </div>
@@ -500,6 +514,20 @@ Object {
                   tabindex="-1"
                 >
                   sidebar.controls
+                </a>
+              </li>
+              <li
+                class="pf-c-nav__item"
+                data-ouia-component-id="OUIA-Generated-NavItem-6"
+                data-ouia-component-type="PF4/NavItem"
+                data-ouia-safe="true"
+              >
+                <a
+                  class="pf-c-nav__link"
+                  href="/migration-waves"
+                  tabindex="-1"
+                >
+                  sidebar.migrationWaves
                 </a>
               </li>
             </ul>

--- a/client/src/app/layout/SidebarApp/tests/__snapshots__/SidebarApp.test.tsx.snap
+++ b/client/src/app/layout/SidebarApp/tests/__snapshots__/SidebarApp.test.tsx.snap
@@ -111,6 +111,19 @@ Object {
                   sidebar.controls
                 </a>
               </li>
+              <li
+                class="pf-c-nav__item"
+                data-ouia-component-id="OUIA-Generated-NavItem-6"
+                data-ouia-component-type="PF4/NavItem"
+                data-ouia-safe="true"
+              >
+                <a
+                  class="pf-c-nav__link"
+                  href="/migration-waves"
+                >
+                  sidebar.migrationWaves
+                </a>
+              </li>
             </ul>
           </nav>
         </div>
@@ -222,6 +235,19 @@ Object {
                 href="/controls"
               >
                 sidebar.controls
+              </a>
+            </li>
+            <li
+              class="pf-c-nav__item"
+              data-ouia-component-id="OUIA-Generated-NavItem-6"
+              data-ouia-component-type="PF4/NavItem"
+              data-ouia-safe="true"
+            >
+              <a
+                class="pf-c-nav__link"
+                href="/migration-waves"
+              >
+                sidebar.migrationWaves
               </a>
             </li>
           </ul>


### PR DESCRIPTION
 - enable CI on release branches
 - only do the code coverage check on PRs/pushes to the main branch

 - After updating the CI workflow to run on the "release-*" branches,
found that some test snapshot were out of sync.  Update the snapshots
here to pass the tests.

Backport of #999