### PR TITLE
:bug: Fix broken axios get calls for fetching tags and tag categories by id

### DIFF
--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -651,7 +651,7 @@ export const getTags = (): Promise<Tag[]> =>
   axios.get(TAGS).then((response) => response.data);
 
 export const getTagById = (id: number | string): Promise<Tag> =>
-  axios.get(`${TAGS}/${id}`);
+  axios.get(`${TAGS}/${id}`).then((response) => response.data);
 
 export const createTag = (obj: New<Tag>): Promise<Tag> => axios.post(TAGS, obj);
 
@@ -667,7 +667,7 @@ export const getTagCategories = (): Promise<Array<TagCategory>> =>
   axios.get(TAG_CATEGORIES).then((response) => response.data);
 
 export const getTagCategoryById = (id: number): Promise<TagCategory> =>
-  axios.get(`${TAG_CATEGORIES}/${id}`);
+  axios.get(`${TAG_CATEGORIES}/${id}`).then((response) => response.data);
 
 export const deleteTagCategory = (id: number): Promise<TagCategory> =>
   axios.delete(`${TAG_CATEGORIES}/${id}`);

--- a/client/src/app/pages/applications/components/application-tags/application-tags.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tags.tsx
@@ -59,7 +59,6 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
 
   useEffect(() => {
     if (application.tags) {
-      console.log({ application, tags });
       setIsFetching(true);
 
       Promise.all(
@@ -69,7 +68,6 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
       )
         .then((tags) => {
           const tagsWithSources = tags.reduce((prev, current, index) => {
-            console.log({ prev, current });
             if (current) {
               const currentTagWithSource: TagWithSource = {
                 ...current,

--- a/client/src/app/pages/applications/components/application-tags/application-tags.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tags.tsx
@@ -59,6 +59,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
 
   useEffect(() => {
     if (application.tags) {
+      console.log({ application, tags });
       setIsFetching(true);
 
       Promise.all(
@@ -68,6 +69,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
       )
         .then((tags) => {
           const tagsWithSources = tags.reduce((prev, current, index) => {
+            console.log({ prev, current });
             if (current) {
               const currentTagWithSource: TagWithSource = {
                 ...current,


### PR DESCRIPTION
In https://github.com/konveyor/tackle2-ui/pull/889, the `getTagById` and `getTagCategoryById` functions were changed to use axios, but the `.then` callback was left out. That means a Promise is being returned instead of a Tag or TagCategory, and TypeScript isn't catching it because axios doesn't know what type it is fetching. This led to tags not being displayed in the app details drawer on the app inventory page.