### PR TITLE
:bug: [Backport release-0.2] MTA-479: Use tag category fallback colors in tags table and tag category edit form (#1006)

### DIFF
--- a/client/src/app/pages/applications/components/application-tags/application-tag-label.tsx
+++ b/client/src/app/pages/applications/components/application-tags/application-tag-label.tsx
@@ -3,7 +3,7 @@ import { Tag, TagCategory } from "@app/api/models";
 import { LabelCustomColor } from "@migtools/lib-ui";
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
 
-const getCategoryFallbackColor = (category?: TagCategory) => {
+export const getTagCategoryFallbackColor = (category?: TagCategory) => {
   if (!category?.id) return COLOR_HEX_VALUES_BY_NAME.gray;
   const colorValues = Object.values(COLOR_HEX_VALUES_BY_NAME);
   return colorValues[category?.id % colorValues.length];
@@ -21,7 +21,7 @@ export const ApplicationTagLabel: React.FC<ApplicationTagLabelProps> = ({
   className,
 }) => (
   <LabelCustomColor
-    color={category?.colour || getCategoryFallbackColor(category)}
+    color={category?.colour || getTagCategoryFallbackColor(category)}
     className={className}
   >
     {tag.name}

--- a/client/src/app/pages/controls/tags/components/tag-category-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-category-form.tsx
@@ -31,6 +31,7 @@ import {
 } from "@app/shared/components/hook-form-pf-fields";
 import { Color, OptionWithValue, SimpleSelect } from "@app/shared/components";
 import { NotificationsContext } from "@app/shared/notifications-context";
+import { getTagCategoryFallbackColor } from "@app/pages/applications/components/application-tags/application-tag-label";
 export interface FormValues {
   name: string;
   rank?: number;
@@ -85,7 +86,9 @@ export const TagCategoryForm: React.FC<TagCategoryFormProps> = ({
     defaultValues: {
       name: tagCategory?.name || "",
       rank: tagCategory?.rank || 1,
-      color: tagCategory?.colour || null,
+      color: tagCategory
+        ? tagCategory.colour || getTagCategoryFallbackColor(tagCategory)
+        : null,
     },
     resolver: yupResolver(validationSchema),
     mode: "onChange",

--- a/client/src/app/pages/controls/tags/tags.tsx
+++ b/client/src/app/pages/controls/tags/tags.tsx
@@ -50,6 +50,7 @@ import { NotificationsContext } from "@app/shared/notifications-context";
 import { COLOR_NAMES_BY_HEX_VALUE } from "@app/Constants";
 import { TagForm } from "./components/tag-form";
 import { TagCategoryForm } from "./components/tag-category-form";
+import { getTagCategoryFallbackColor } from "@app/pages/applications/components/application-tags/application-tag-label";
 
 const ENTITY_FIELD = "entity";
 
@@ -297,6 +298,7 @@ export const Tags: React.FC = () => {
   const rows: IRow[] = [];
   currentPageItems.forEach((item) => {
     const isExpanded = isItemExpanded(item) && !!item?.tags?.length;
+    const categoryColor = item.colour || getTagCategoryFallbackColor(item);
     rows.push({
       [ENTITY_FIELD]: item,
       isOpen: (item.tags || []).length > 0 ? isExpanded : undefined,
@@ -308,7 +310,7 @@ export const Tags: React.FC = () => {
           title: item.rank,
         },
         {
-          title: <>{item.colour && <Color hex={item.colour} />}</>,
+          title: <Color hex={categoryColor} />,
         },
         {
           title: item.tags ? item.tags.length : 0,


### PR DESCRIPTION
Backports #1006 (fixes https://issues.redhat.com/browse/MTA-479)
