### PR TITLE
:sparkles: [Backport release-0.2] Forms: use isDirty instead of isTouched for immediate feed…

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -13,7 +13,7 @@ import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 
-import { getValidatedFromErrorTouched } from "@app/utils/utils";
+import { getValidatedFromErrors } from "@app/utils/utils";
 import { defaultTargets } from "../../../data/targets";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { AnalysisWizardFormValues } from "./schema";
@@ -74,7 +74,7 @@ export const SetOptions: React.FC = () => {
         fieldId="targets"
         renderInput={({
           field: { onChange, onBlur, value: selectedFormTargets },
-          fieldState: { isTouched, error },
+          fieldState: { isDirty, error },
         }) => (
           <Select
             id="rulesets"
@@ -120,7 +120,7 @@ export const SetOptions: React.FC = () => {
             onClear={() => {
               onChange([]);
             }}
-            validated={getValidatedFromErrorTouched(error, isTouched)}
+            validated={getValidatedFromErrors(error, isDirty)}
           >
             {defaultTargetsAndRulesetTargets.map((targetName, index) => (
               <SelectOption
@@ -139,7 +139,7 @@ export const SetOptions: React.FC = () => {
         fieldId="sources"
         renderInput={({
           field: { onChange, onBlur, value },
-          fieldState: { isTouched, error },
+          fieldState: { isDirty, error },
         }) => (
           <Select
             id="formSources-id"
@@ -169,7 +169,7 @@ export const SetOptions: React.FC = () => {
             onClear={() => {
               onChange([]);
             }}
-            validated={getValidatedFromErrorTouched(error, isTouched)}
+            validated={getValidatedFromErrors(error, isDirty)}
           >
             {formSources.map((source, index) => (
               <SelectOption

--- a/client/src/app/pages/proxies/proxy-form.tsx
+++ b/client/src/app/pages/proxies/proxy-form.tsx
@@ -8,10 +8,7 @@ import {
   Switch,
 } from "@patternfly/react-core";
 import { OptionWithValue, SimpleSelect } from "@app/shared/components";
-import {
-  getAxiosErrorMessage,
-  getValidatedFromErrorTouched,
-} from "@app/utils/utils";
+import { getAxiosErrorMessage, getValidatedFromErrors } from "@app/utils/utils";
 import { useProxyFormValidationSchema } from "./proxies-validation-schema";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { Proxy } from "@app/api/models";
@@ -263,7 +260,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
               isRequired
               renderInput={({
                 field: { onChange, value },
-                fieldState: { isTouched, error },
+                fieldState: { isDirty, error },
               }) => (
                 <SimpleSelect
                   id="httpIdentity"
@@ -276,7 +273,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                     const selectionValue = selection as OptionWithValue<string>;
                     onChange(selectionValue.value);
                   }}
-                  validated={getValidatedFromErrorTouched(error, isTouched)}
+                  validated={getValidatedFromErrors(error, isDirty)}
                 />
               )}
             />
@@ -349,7 +346,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
               className={spacing.mMd}
               renderInput={({
                 field: { onChange, value },
-                fieldState: { isTouched, error },
+                fieldState: { isDirty, error },
               }) => (
                 <SimpleSelect
                   toggleId="https-proxy-credentials-select-toggle"
@@ -361,7 +358,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                     const selectionValue = selection as OptionWithValue<string>;
                     onChange(selectionValue.value);
                   }}
-                  validated={getValidatedFromErrorTouched(error, isTouched)}
+                  validated={getValidatedFromErrors(error, isDirty)}
                 />
               )}
             />

--- a/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-group-controller.tsx
+++ b/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-group-controller.tsx
@@ -7,7 +7,7 @@ import {
   FieldValues,
   Path,
 } from "react-hook-form";
-import { getValidatedFromErrorTouched } from "@app/utils/utils";
+import { getValidatedFromErrors } from "@app/utils/utils";
 
 // We have separate interfaces for these props with and without `renderInput` for convenience.
 // Generic type params here are the same as the ones used by react-hook-form's <Controller>.
@@ -54,7 +54,7 @@ export const HookFormPFGroupController = <
     control={control}
     name={name}
     render={({ field, fieldState, formState }) => {
-      const { isTouched, error } = fieldState;
+      const { isDirty, error } = fieldState;
       return (
         <FormGroup
           labelIcon={labelIcon}
@@ -66,7 +66,7 @@ export const HookFormPFGroupController = <
           validated={
             errorsSuppressed
               ? "default"
-              : getValidatedFromErrorTouched(error, isTouched)
+              : getValidatedFromErrors(error, isDirty)
           }
           helperText={helperText}
           helperTextInvalid={errorsSuppressed ? null : error?.message}

--- a/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-text-area.tsx
+++ b/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-text-area.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { FieldValues, Path } from "react-hook-form";
 import { TextArea, TextAreaProps } from "@patternfly/react-core";
-import { getValidatedFromErrorTouched } from "@app/utils/utils";
+import { getValidatedFromErrors } from "@app/utils/utils";
 import {
   HookFormPFGroupController,
   BaseHookFormPFGroupControllerProps,
@@ -30,7 +30,7 @@ export const HookFormPFTextArea = <
       {...extractedProps}
       renderInput={({
         field: { onChange, onBlur, value, name, ref },
-        fieldState: { isTouched, error },
+        fieldState: { isDirty, error },
       }) => (
         <TextArea
           ref={ref}
@@ -44,7 +44,7 @@ export const HookFormPFTextArea = <
           validated={
             errorsSuppressed
               ? "default"
-              : getValidatedFromErrorTouched(error, isTouched)
+              : getValidatedFromErrors(error, isDirty)
           }
           {...remainingProps}
         />

--- a/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-text-input.tsx
+++ b/client/src/app/shared/components/hook-form-pf-fields/hook-form-pf-text-input.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { FieldValues, Path } from "react-hook-form";
 import { TextInput, TextInputProps } from "@patternfly/react-core";
-import { getValidatedFromErrorTouched } from "@app/utils/utils";
+import { getValidatedFromErrors } from "@app/utils/utils";
 import {
   extractGroupControllerProps,
   HookFormPFGroupController,
@@ -31,7 +31,7 @@ export const HookFormPFTextInput = <
       {...extractedProps}
       renderInput={({
         field: { onChange, onBlur, value, name, ref },
-        fieldState: { isTouched, error },
+        fieldState: { isDirty, error },
       }) => (
         <TextInput
           ref={ref}
@@ -51,7 +51,7 @@ export const HookFormPFTextInput = <
           validated={
             errorsSuppressed
               ? "default"
-              : getValidatedFromErrorTouched(error, isTouched)
+              : getValidatedFromErrors(error, isDirty)
           }
           {...remainingProps}
         />

--- a/client/src/app/shared/components/string-list-field/string-list-field.tsx
+++ b/client/src/app/shared/components/string-list-field/string-list-field.tsx
@@ -6,7 +6,7 @@ import * as yup from "yup";
 import { InputGroup, TextInput, Button } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import TimesCircleIcon from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
-import { getValidatedFromErrorTouched } from "@app/utils/utils";
+import { getValidatedFromErrors } from "@app/utils/utils";
 import { HookFormPFGroupController } from "../hook-form-pf-fields";
 
 import { TableComposable, Tbody, Td, Tr } from "@patternfly/react-table";
@@ -62,7 +62,7 @@ export const StringListField: React.FC<StringListFieldProps> = ({
         label={itemToAddLabel}
         renderInput={({
           field: { onChange, onBlur, value, ref },
-          fieldState: { isTouched, error },
+          fieldState: { isDirty, error },
         }) => {
           const isValid = !!value && !error;
           const addItem = () => {
@@ -75,7 +75,7 @@ export const StringListField: React.FC<StringListFieldProps> = ({
                 ref={ref}
                 id={itemToAddFieldId}
                 aria-label={itemToAddAriaLabel}
-                validated={getValidatedFromErrorTouched(error, isTouched)}
+                validated={getValidatedFromErrors(error, isDirty)}
                 value={value}
                 onChange={onChange}
                 onBlur={onBlur}

--- a/client/src/app/utils/utils.test.ts
+++ b/client/src/app/utils/utils.test.ts
@@ -2,7 +2,7 @@ import { AxiosError } from "axios";
 import {
   getAxiosErrorMessage,
   getValidatedFromError,
-  getValidatedFromErrorTouched,
+  getValidatedFromErrors,
   getToolbarChipKey,
 } from "./utils";
 
@@ -62,19 +62,19 @@ describe("utils", () => {
     expect(status).toBe("default");
   });
 
-  it("getValidatedFromErrorTouched: given 'error' and 'touched' return 'error'", () => {
+  it("getValidatedFromErrors: given 'error' and 'touched' return 'error'", () => {
     const error = "Any value";
-    const touched = true;
+    const dirty = true;
 
-    const status = getValidatedFromErrorTouched(error, touched);
+    const status = getValidatedFromErrors(error, dirty);
     expect(status).toBe("error");
   });
 
-  it("getValidatedFromErrorTouched: given 'error' but not 'touched' return 'default'", () => {
+  it("getValidatedFromErrors: given 'error' but not 'touched' return 'default'", () => {
     const error = "Any value";
-    const touched = false;
+    const dirty = false;
 
-    const status = getValidatedFromErrorTouched(error, touched);
+    const status = getValidatedFromErrors(error, dirty);
     expect(status).toBe("default");
   });
 

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -81,11 +81,11 @@ export const numStr = (num: number | undefined): string => {
 export const objectKeys = <T extends Object>(obj: T) =>
   Object.keys(obj) as (keyof T)[];
 
-export const getValidatedFromErrorTouched = (
+export const getValidatedFromErrors = (
   error: unknown | undefined,
-  touched: boolean | undefined
+  dirty: boolean | undefined
 ): FormGroupProps["validated"] => {
-  return error && touched ? "error" : "default";
+  return error && dirty ? "error" : "default";
 };
 
 export const getValidatedFromError = (


### PR DESCRIPTION
…back to user (#1000)

Make `getValidatedFromErrorErrors()` to use `isDirty` instead of `isTouched`

Resolves https://issues.redhat.com/browse/MTA-658

(cherry picked from commit b8e31e9b50a577e15949a4ed41fb8805d395f081)
