### PR TITLE
:sparkles: Jira authentication for Jira Cloud and Jira Server/Datacenter combo 

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -174,7 +174,12 @@ export interface BulkCopyReview {
   completed?: boolean;
 }
 
-export type IdentityKind = "source" | "maven" | "proxy" | "jira";
+export type IdentityKind =
+  | "source"
+  | "maven"
+  | "proxy"
+  | "basic-auth"
+  | "bearer";
 
 export interface Identity {
   id: number;

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -543,7 +543,7 @@ export interface IssueType {
   name: string;
 }
 
-export type IssueManagerKind = "jira-cloud" | "jira-server" | "jira-datacenter";
+export type IssueManagerKind = "jira-cloud" | "jira-onprem";
 
 export interface Tracker {
   connected: boolean;

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -26,7 +26,6 @@ import {
   duplicateNameCheck,
   getAxiosErrorMessage,
   standardStrictURLRegex,
-  standardURLRegex,
 } from "@app/utils/utils";
 import {
   HookFormPFGroupController,
@@ -172,7 +171,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
   const watchAllFields = watch();
 
   const identityOptions = identities
-    .filter((identity) => identity.kind === "jira")
+    .filter((identity) => identity.kind === "basic-auth")
     .map((identity) => {
       return {
         value: identity.name,

--- a/client/src/app/utils/model-utils.tsx
+++ b/client/src/app/utils/model-utils.tsx
@@ -206,11 +206,7 @@ export const IssueManagerOptions: OptionWithValue<IssueManagerKind>[] = [
     toString: () => "Jira Cloud",
   },
   {
-    value: "jira-server",
-    toString: () => "Jira Server",
-  },
-  {
-    value: "jira-datacenter",
-    toString: () => "Jira Datacenter",
+    value: "jira-onprem",
+    toString: () => "Jira Server/Datacenter",
   },
 ];


### PR DESCRIPTION
Identities has two new kinds (see https://github.com/konveyor/tackle2-hub/pull/374) :
- basic-auth : username(email) and password(token) fields are used for Jira Cloud and Jira Server/Datacenter use cases
- bearer: key field (containing bearer token) used only for Server/Datacenter

Resolves https://github.com/konveyor/tackle2-ui/issues/1011