### PR TITLE
:sparkles: Issues: Add tabs for "All issues" (existing table) and "Single application" (stub), add syntax highlighting to the code snippet, clean up columns, parse source/target labels, general polish

### DIFF
--- a/client/config/monacoConstants.ts
+++ b/client/config/monacoConstants.ts
@@ -1,0 +1,22 @@
+import { EditorLanguage } from "monaco-editor/esm/metadata";
+
+export const LANGUAGES_BY_FILE_EXTENSION = {
+  java: "java",
+  go: "go",
+  xml: "xml",
+  js: "javascript",
+  ts: "typescript",
+  html: "html",
+  htm: "html",
+  css: "css",
+  yaml: "yaml",
+  yml: "yaml",
+  json: "json",
+  md: "markdown",
+  php: "php",
+  py: "python",
+  pl: "perl",
+  rb: "ruby",
+  sh: "shell",
+  bash: "shell",
+} as const satisfies Record<string, EditorLanguage>;

--- a/client/config/webpack.common.ts
+++ b/client/config/webpack.common.ts
@@ -4,6 +4,7 @@ import Dotenv from "dotenv-webpack";
 import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin";
 import { Configuration, WatchIgnorePlugin } from "webpack";
 import MonacoWebpackPlugin from "monaco-editor-webpack-plugin";
+import { LANGUAGES_BY_FILE_EXTENSION } from "./monacoConstants";
 
 const BG_IMAGES_DIRNAME = "images";
 
@@ -207,7 +208,9 @@ const config: Configuration = {
     new WatchIgnorePlugin({
       paths: [/\.js$/, /\.d\.ts$/],
     }),
-    new MonacoWebpackPlugin(),
+    new MonacoWebpackPlugin({
+      languages: Object.values(LANGUAGES_BY_FILE_EXTENSION),
+    }),
   ],
   resolve: {
     alias: {

--- a/client/src/app/Paths.ts
+++ b/client/src/app/Paths.ts
@@ -31,7 +31,9 @@ export enum Paths {
   migrationWaves = "/migration-waves",
   waves = "/waves",
   issues = "/issues",
-  issuesRuleAffectedApplications = "/issues/:ruleset/:rule/affected-applications",
+  issuesAllTab = "/issues/all",
+  issuesAllAffectedApplications = "/issues/all/:ruleset/:rule/affected-applications",
+  issuesSingleAppTab = "/issues/single-app",
 
   dependencies = "/dependencies",
 

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -90,13 +90,13 @@ export const devRoutes: IRoute[] = [
   ...(FEATURES_ENABLED.dynamicReports
     ? [
         {
-          path: Paths.issues,
-          comp: Issues,
-          exact: true,
+          path: Paths.issuesAllAffectedApplications,
+          comp: AffectedApplications,
+          exact: false,
         },
         {
-          path: Paths.issuesRuleAffectedApplications,
-          comp: AffectedApplications,
+          path: Paths.issues,
+          comp: Issues,
           exact: false,
         },
         {

--- a/client/src/app/components/markdown-pf-components.tsx
+++ b/client/src/app/components/markdown-pf-components.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Components } from "react-markdown";
-import { Text } from "@patternfly/react-core";
+import { CodeBlock, CodeBlockCode, Text } from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 export const markdownPFComponents: Components = {
   h1: (props) => <Text component="h1" {...props} />,
@@ -13,5 +14,9 @@ export const markdownPFComponents: Components = {
   a: (props) => <Text component="a" {...props} />,
   small: (props) => <Text component="small" {...props} />,
   blockquote: (props) => <Text component="blockquote" {...props} />,
-  pre: (props) => <Text component="pre" {...props} />,
+  pre: (props) => (
+    <CodeBlock className={spacing.mbMd}>
+      <CodeBlockCode {...props} />
+    </CodeBlock>
+  ),
 };

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -62,10 +62,10 @@ export const AffectedApplications: React.FC = () => {
       name: "Name",
       description: "Description",
       businessService: "Business serice",
-      incidents: "Incidents",
       effort: "Effort",
+      incidents: "Incidents",
     },
-    sortableColumns: ["name", "businessService", "incidents", "effort"],
+    sortableColumns: ["name", "businessService", "effort", "incidents"],
     initialSort: { columnKey: "name", direction: "asc" },
     filterCategories: [
       //TODO: Should this be select filter type using apps available in memory?
@@ -106,8 +106,8 @@ export const AffectedApplications: React.FC = () => {
       hubSortFieldKeys: {
         name: "name",
         businessService: "businessService",
-        incidents: "incidents",
         effort: "effort",
+        incidents: "incidents",
       },
     })
   );
@@ -192,8 +192,8 @@ export const AffectedApplications: React.FC = () => {
                     <Th {...getThProps({ columnKey: "name" })} />
                     <Th {...getThProps({ columnKey: "description" })} />
                     <Th {...getThProps({ columnKey: "businessService" })} />
-                    <Th {...getThProps({ columnKey: "incidents" })} />
                     <Th {...getThProps({ columnKey: "effort" })} />
+                    <Th {...getThProps({ columnKey: "incidents" })} />
                   </TableHeaderContentWithControls>
                 </Tr>
               </Thead>
@@ -229,14 +229,14 @@ export const AffectedApplications: React.FC = () => {
                         >
                           {appReport.businessService}
                         </Td>
+                        <Td width={15} {...getTdProps({ columnKey: "effort" })}>
+                          {appReport.effort}
+                        </Td>
                         <Td
                           width={15}
                           {...getTdProps({ columnKey: "incidents" })}
                         >
                           {appReport.incidents}
-                        </Td>
-                        <Td width={15} {...getTdProps({ columnKey: "effort" })}>
-                          {appReport.effort}
                         </Td>
                       </TableRowContentWithControls>
                     </Tr>

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -159,7 +159,7 @@ export const AffectedApplications: React.FC = () => {
             </Link>
           </BreadcrumbItem>
           <BreadcrumbItem to="#" isActive>
-            {ruleReportName} ({ruleset}, {rule})
+            {ruleReportName}
           </BreadcrumbItem>
         </Breadcrumb>
       </PageSection>

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -39,7 +39,7 @@ import {
   FilterType,
 } from "@app/shared/components/FilterToolbar";
 import { useSelectionState } from "@migtools/lib-ui";
-import { getBackToIssuesUrl } from "../helpers";
+import { getBackToAllIssuesUrl } from "../helpers";
 import { IssueDetailDrawer } from "./issue-detail-drawer";
 import { TableURLParamKeyPrefix } from "@app/Constants";
 
@@ -150,7 +150,7 @@ export const AffectedApplications: React.FC = () => {
         <Breadcrumb>
           <BreadcrumbItem>
             <Link
-              to={getBackToIssuesUrl({
+              to={getBackToAllIssuesUrl({
                 fromFilterValues: filterValues,
                 fromLocation: useLocation(),
               })}

--- a/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-all-incidents-table.tsx
+++ b/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-all-incidents-table.tsx
@@ -22,6 +22,8 @@ import {
   useTableControlProps,
   useTableControlUrlParams,
 } from "@app/shared/hooks/table-controls";
+import ReactMarkdown from "react-markdown";
+import { markdownPFComponents } from "@app/components/markdown-pf-components";
 
 export interface IFileRemainingIncidentsTableProps {
   fileReport: AnalysisFileReport;
@@ -118,7 +120,9 @@ export const FileAllIncidentsTable: React.FC<
                     colSpan={2}
                     {...getTdProps({ columnKey: "message" })}
                   >
-                    {incident.message}
+                    <ReactMarkdown components={markdownPFComponents}>
+                      {`${incident.message.split("\n")[0]} ...`}
+                    </ReactMarkdown>
                   </Td>
                 </TableRowContentWithControls>
               </Tr>

--- a/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -63,8 +63,6 @@ export const FileIncidentsDetailModal: React.FC<
   // TODO render incident facts?
   // TODO render documentation links? are those part of the markdown? where do we get them from the hub?
 
-  // TODO syntax highlighting based on filename extension? what are the languages? see Pranav's slack message
-
   return (
     <Modal
       title={fileReport.file}

--- a/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -108,9 +108,7 @@ export const FileIncidentsDetailModal: React.FC<
                   <GridItem span={6} className={spacing.plSm}>
                     <TextContent>
                       <Text component="h2">{appReport.issue.name}</Text>
-                      <Text className={`${textStyles.fontSizeMd}`}>
-                        Line {incident.line}
-                      </Text>
+                      <Text component="small">Line {incident.line}</Text>
                     </TextContent>
                     <TextContent className={spacing.mtLg}>
                       <ReactMarkdown components={markdownPFComponents}>

--- a/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -56,6 +56,10 @@ export const FileIncidentsDetailModal: React.FC<
     }
   }, [activeTabIncidentId, isFetching, firstFiveIncidents]);
 
+  const isLoadingState =
+    isFetching ||
+    (firstFiveIncidents.length > 0 && activeTabIncidentId === undefined);
+
   // TODO render incident facts?
   // TODO render documentation links? are those part of the markdown? where do we get them from the hub?
 
@@ -73,7 +77,7 @@ export const FileIncidentsDetailModal: React.FC<
         </Button>,
       ]}
     >
-      {isFetching ? (
+      {isLoadingState ? (
         <AppPlaceholder />
       ) : fetchError ? (
         <StateError />

--- a/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -63,7 +63,7 @@ export const FileIncidentsDetailModal: React.FC<
   // TODO render incident facts?
   // TODO render documentation links? are those part of the markdown? where do we get them from the hub?
 
-  console.log({ firstFiveIncidents });
+  // TODO syntax highlighting based on filename extension? what are the languages? see Pranav's slack message
 
   return (
     <Modal

--- a/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/incident-code-snip-viewer.tsx
+++ b/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/incident-code-snip-viewer.tsx
@@ -3,6 +3,7 @@ import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { AnalysisAppReport, AnalysisIncident } from "@app/api/models";
 
 import "./incident-code-snip-viewer.css";
+import { LANGUAGES_BY_FILE_EXTENSION } from "config/monacoConstants";
 
 export interface IIncidentCodeSnipViewerProps {
   appReport: AnalysisAppReport;
@@ -21,6 +22,13 @@ export const IncidentCodeSnipViewer: React.FC<IIncidentCodeSnipViewerProps> = ({
   const relativeToAbsoluteLineNum = (lineNum: number) =>
     lineNum + (codeSnipStartLine - 1);
 
+  const extension = incident.file.toLowerCase().split(".").slice(-1)[0];
+  const language = Object.keys(LANGUAGES_BY_FILE_EXTENSION).includes(extension)
+    ? (LANGUAGES_BY_FILE_EXTENSION[
+        extension as keyof typeof LANGUAGES_BY_FILE_EXTENSION
+      ] as Language)
+    : undefined;
+
   return (
     <CodeEditor
       isReadOnly
@@ -28,7 +36,7 @@ export const IncidentCodeSnipViewer: React.FC<IIncidentCodeSnipViewerProps> = ({
       isLineNumbersVisible
       height="450px"
       code={incident.codeSnip} // TODO replace this with line numbers stripped out
-      // language={Language.java} // TODO can we determine the language from the hub?
+      language={language}
       // TODO Configure monaco-editor-webpack-plugin to only include resources for supported languages in the build
       //      (See https://github.com/microsoft/monaco-editor/tree/main/webpack-plugin#options)
       options={{

--- a/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/incident-code-snip-viewer.tsx
+++ b/client/src/app/pages/issues/affected-applications/issue-detail-drawer/file-incidents-detail-modal/incident-code-snip-viewer.tsx
@@ -37,8 +37,6 @@ export const IncidentCodeSnipViewer: React.FC<IIncidentCodeSnipViewerProps> = ({
       height="450px"
       code={incident.codeSnip} // TODO replace this with line numbers stripped out
       language={language}
-      // TODO Configure monaco-editor-webpack-plugin to only include resources for supported languages in the build
-      //      (See https://github.com/microsoft/monaco-editor/tree/main/webpack-plugin#options)
       options={{
         renderValidationDecorations: "on", // See https://github.com/microsoft/monaco-editor/issues/311#issuecomment-578026465
         lineNumbers: (lineNumber) =>

--- a/client/src/app/pages/issues/affected-applications/issue-detail-drawer/issue-detail-drawer.tsx
+++ b/client/src/app/pages/issues/affected-applications/issue-detail-drawer/issue-detail-drawer.tsx
@@ -32,7 +32,6 @@ export const IssueDetailDrawer: React.FC<IIssueDetailDrawerProps> = ({
     TabKey.AffectedFiles
   );
 
-  // TODO should we also show the application name at the top?
   return (
     <PageDrawerContent
       isExpanded={!!appReport}

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -36,7 +36,7 @@ export const getAffectedAppsUrl = ({
   filterKeysToCarry.forEach((key) => {
     if (fromFilterValues[key]) toFilterValues[key] = fromFilterValues[key];
   });
-  const baseUrl = Paths.issuesRuleAffectedApplications
+  const baseUrl = Paths.issuesAllAffectedApplications
     .replace("/:ruleset/", `/${ruleReport.ruleset}/`)
     .replace("/:rule/", `/${ruleReport.rule}/`);
   const prefix = (key: string) =>
@@ -51,7 +51,7 @@ export const getAffectedAppsUrl = ({
 };
 
 // URL for Issues page that restores original URL params and overrides them with any changes to the carried filters.
-export const getBackToIssuesUrl = ({
+export const getBackToAllIssuesUrl = ({
   fromFilterValues,
   fromLocation,
 }: {
@@ -76,7 +76,7 @@ export const getBackToIssuesUrl = ({
   });
   // Put it all back together
   const prefix = (key: string) => `${TableURLParamKeyPrefix.issues}:${key}`;
-  return `${Paths.issues}?${trimAndStringifyUrlParams({
+  return `${Paths.issuesAllTab}?${trimAndStringifyUrlParams({
     newPrefixedSerializedParams: {
       ...prefixedParamsToRestore,
       [prefix("filters")]: serializeFilterUrlParams(filterValuesToRestore)

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -84,3 +84,19 @@ export const getBackToAllIssuesUrl = ({
     },
   })}`;
 };
+
+export const parseRuleReportLabels = (ruleReport: AnalysisRuleReport) => {
+  const sources: string[] = [];
+  const targets: string[] = [];
+  const otherLabels: string[] = [];
+  ruleReport.labels.forEach((label) => {
+    if (label.startsWith("konveyor.io/source=")) {
+      sources.push(label.split("konveyor.io/source=")[1]);
+    } else if (label.startsWith("konveyor.io/target=")) {
+      targets.push(label.split("konveyor.io/target=")[1]);
+    } else {
+      otherLabels.push(label);
+    }
+  });
+  return { sources, targets, otherLabels };
+};

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -423,6 +423,20 @@ export const Issues: React.FC = () => {
                                       component="h4"
                                       className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
                                     >
+                                      Rule set
+                                    </Text>
+                                    <div>{ruleReport.ruleset}</div>
+                                    <Text
+                                      component="h4"
+                                      className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
+                                    >
+                                      Rule
+                                    </Text>
+                                    <div>{ruleReport.rule}</div>
+                                    <Text
+                                      component="h4"
+                                      className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
+                                    >
                                       Labels
                                     </Text>
                                     <div>

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -50,8 +50,9 @@ import { useFetchRuleReports } from "@app/queries/issues";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
 import { Link, useHistory, useLocation } from "react-router-dom";
-import { getAffectedAppsUrl } from "./helpers";
+import { getAffectedAppsUrl, parseRuleReportLabels } from "./helpers";
 import { TableURLParamKeyPrefix } from "@app/Constants";
+import { SingleLabelWithOverflow } from "@app/shared/components/SingleLabelWithOverflow";
 
 export enum IssueFilterGroups {
   ApplicationInventory = "Application inventory",
@@ -273,6 +274,8 @@ export const Issues: React.FC = () => {
                   numRenderedColumns={numRenderedColumns}
                 >
                   {currentPageRuleReports?.map((ruleReport, rowIndex) => {
+                    const { sources, targets, otherLabels } =
+                      parseRuleReportLabels(ruleReport);
                     return (
                       <Tbody
                         key={ruleReport._ui_unique_id}
@@ -297,16 +300,26 @@ export const Issues: React.FC = () => {
                               {ruleReport.category}
                             </Td>
                             <Td
-                              width={15}
+                              width={10}
+                              modifier="nowrap"
+                              noPadding
                               {...getTdProps({ columnKey: "source" })}
                             >
-                              TODO
+                              <SingleLabelWithOverflow
+                                labels={sources}
+                                popoverAriaLabel="More sources"
+                              />
                             </Td>
                             <Td
-                              width={15}
+                              width={20}
+                              modifier="nowrap"
+                              noPadding
                               {...getTdProps({ columnKey: "target" })}
                             >
-                              TODO
+                              <SingleLabelWithOverflow
+                                labels={targets}
+                                popoverAriaLabel="More sources"
+                              />
                             </Td>
                             <Td
                               width={10}
@@ -376,16 +389,16 @@ export const Issues: React.FC = () => {
                                       Target technologies
                                     </Text>
                                     <div>
-                                      {/*
-                                    // TODO the technologies array was replaced by labels, we need to parse them
-                                    {issue.technologies.map((tech) => {
-                                      return (
-                                        <Label className={spacing.mrSm}>
-                                          {tech?.name}
-                                        </Label>
-                                      );
-                                    })}
-                                    */}
+                                      {targets.length > 0
+                                        ? targets.map((target) => (
+                                            <Label
+                                              key={target}
+                                              className={spacing.mrSm}
+                                            >
+                                              {target}
+                                            </Label>
+                                          ))
+                                        : "None"}
                                     </div>
                                     <Text
                                       component="h4"
@@ -393,17 +406,25 @@ export const Issues: React.FC = () => {
                                     >
                                       Source technologies
                                     </Text>
-                                    <div>None</div>
+                                    <div>
+                                      {sources.length > 0
+                                        ? sources.map((source) => (
+                                            <Label
+                                              key={source}
+                                              className={spacing.mrSm}
+                                            >
+                                              {source}
+                                            </Label>
+                                          ))
+                                        : "None"}
+                                    </div>
                                     <Text
                                       component="h4"
                                       className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
                                     >
                                       Level of effort
                                     </Text>
-                                    <div>
-                                      {ruleReport.effort} - what do we show
-                                      here?
-                                    </div>
+                                    <div>{ruleReport.effort}</div>
                                     <Text
                                       component="h4"
                                       className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
@@ -411,13 +432,16 @@ export const Issues: React.FC = () => {
                                       Labels
                                     </Text>
                                     <div>
-                                      {ruleReport.labels.map((label) => {
-                                        return (
-                                          <Label className={spacing.mrSm}>
-                                            {label}
-                                          </Label>
-                                        );
-                                      })}
+                                      {otherLabels.length > 0
+                                        ? otherLabels.map((label) => (
+                                            <Label
+                                              key={label}
+                                              className={spacing.mrSm}
+                                            >
+                                              {label}
+                                            </Label>
+                                          ))
+                                        : "None"}
                                     </div>
                                   </FlexItem>
                                   <FlexItem flex={{ default: "flex_1" }}>

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -446,8 +446,7 @@ export const Issues: React.FC = () => {
                                   </FlexItem>
                                   <FlexItem flex={{ default: "flex_1" }}>
                                     <Text component={TextVariants.h4}>
-                                      TODO: Render validation rule description
-                                      here when available
+                                      {ruleReport.description}
                                     </Text>
                                   </FlexItem>
                                 </Flex>

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -423,13 +423,6 @@ export const Issues: React.FC = () => {
                                       component="h4"
                                       className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
                                     >
-                                      Level of effort
-                                    </Text>
-                                    <div>{ruleReport.effort}</div>
-                                    <Text
-                                      component="h4"
-                                      className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
-                                    >
                                       Labels
                                     </Text>
                                     <div>

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -19,6 +19,7 @@ import {
   Tooltip,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
+import { Paths } from "@app/Paths";
 import { AppPlaceholder, ConditionalRender } from "@app/shared/components";
 import {
   FilterToolbar,
@@ -48,7 +49,7 @@ import { useSelectionState } from "@migtools/lib-ui";
 import { useFetchRuleReports } from "@app/queries/issues";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useHistory, useLocation } from "react-router-dom";
 import { getAffectedAppsUrl } from "./helpers";
 import { TableURLParamKeyPrefix } from "@app/Constants";
 
@@ -57,17 +58,17 @@ export enum IssueFilterGroups {
   Issues = "Issues",
 }
 
-enum TabKey {
-  allIssues = 0,
-  singleApp,
-}
+const TAB_PATHS = [Paths.issuesAllTab, Paths.issuesSingleAppTab] as const;
 
 export const Issues: React.FC = () => {
   const { t } = useTranslation();
+  const location = useLocation();
+  const history = useHistory();
 
-  const [activeTabKey, setActiveTabKey] = React.useState<TabKey>(
-    TabKey.allIssues
-  );
+  const activeTabPath = TAB_PATHS.find((path) => location.pathname === path);
+  React.useEffect(() => {
+    if (!activeTabPath) history.push(Paths.issuesAllTab);
+  }, [activeTabPath]);
 
   const tableControlState = useTableControlUrlParams({
     urlParamKeyPrefix: TableURLParamKeyPrefix.issues,
@@ -199,8 +200,6 @@ export const Issues: React.FC = () => {
     expansionDerivedState: { isCellExpanded },
   } = tableControls;
 
-  const location = useLocation();
-
   // TODO move the contents of each tab to their own components
 
   return (
@@ -214,21 +213,21 @@ export const Issues: React.FC = () => {
         </TextContent>
         <Tabs
           className={spacing.mtSm}
-          activeKey={activeTabKey}
-          onSelect={(_event, tabKey) => setActiveTabKey(tabKey as TabKey)}
+          activeKey={activeTabPath}
+          onSelect={(_event, tabPath) => history.push(tabPath as string)}
         >
           <Tab
-            eventKey={TabKey.allIssues}
+            eventKey={Paths.issuesAllTab}
             title={<TabTitleText>All issues</TabTitleText>}
           />
           <Tab
-            eventKey={TabKey.singleApp}
+            eventKey={Paths.issuesSingleAppTab}
             title={<TabTitleText>Single application</TabTitleText>}
           />
         </Tabs>
       </PageSection>
       <PageSection>
-        {activeTabKey === TabKey.allIssues ? (
+        {activeTabPath === Paths.issuesAllTab ? (
           <ConditionalRender
             when={isFetching && !(currentPageRuleReports || fetchError)}
             then={<AppPlaceholder />}
@@ -444,7 +443,7 @@ export const Issues: React.FC = () => {
               />
             </div>
           </ConditionalRender>
-        ) : activeTabKey === TabKey.singleApp ? (
+        ) : activeTabPath === Paths.issuesSingleAppTab ? (
           <>TODO</>
         ) : null}
       </PageSection>

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -6,9 +6,13 @@ import {
   Label,
   PageSection,
   PageSectionVariants,
+  Tab,
+  TabTitleText,
+  Tabs,
   Text,
   TextContent,
   TextVariants,
+  Title,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -52,8 +56,18 @@ export enum IssueFilterGroups {
   ApplicationInventory = "Application inventory",
   Issues = "Issues",
 }
+
+enum TabKey {
+  allIssues = 0,
+  singleApp,
+}
+
 export const Issues: React.FC = () => {
   const { t } = useTranslation();
+
+  const [activeTabKey, setActiveTabKey] = React.useState<TabKey>(
+    TabKey.allIssues
+  );
 
   const tableControlState = useTableControlUrlParams({
     urlParamKeyPrefix: TableURLParamKeyPrefix.issues,
@@ -184,165 +198,186 @@ export const Issues: React.FC = () => {
     },
     expansionDerivedState: { isCellExpanded },
   } = tableControls;
-  console.log("%c Current page items", "color: blue;");
-  console.log({ currentPageRuleReports, totalItemCount });
 
   const location = useLocation();
 
+  // TODO move the contents of each tab to their own components
+
   return (
     <>
-      <PageSection variant={PageSectionVariants.light}>
+      <PageSection variant={PageSectionVariants.light} className={spacing.pb_0}>
         <TextContent>
-          <Text component="h1">{t("terms.issues")}</Text>
+          <Title headingLevel="h1">{t("terms.issues")}</Title>
+          <Text component="small">
+            This report provides a concise summary of all issues identified.
+          </Text>
         </TextContent>
+        <Tabs
+          className={spacing.mtSm}
+          activeKey={activeTabKey}
+          onSelect={(_event, tabKey) => setActiveTabKey(tabKey as TabKey)}
+        >
+          <Tab
+            eventKey={TabKey.allIssues}
+            title={<TabTitleText>All issues</TabTitleText>}
+          />
+          <Tab
+            eventKey={TabKey.singleApp}
+            title={<TabTitleText>Single application</TabTitleText>}
+          />
+        </Tabs>
       </PageSection>
       <PageSection>
-        <ConditionalRender
-          when={isFetching && !(currentPageRuleReports || fetchError)}
-          then={<AppPlaceholder />}
-        >
-          <div
-            style={{
-              backgroundColor: "var(--pf-global--BackgroundColor--100)",
-            }}
+        {activeTabKey === TabKey.allIssues ? (
+          <ConditionalRender
+            when={isFetching && !(currentPageRuleReports || fetchError)}
+            then={<AppPlaceholder />}
           >
-            <Toolbar {...toolbarProps}>
-              <ToolbarContent>
-                <FilterToolbar {...filterToolbarProps} />
-                <ToolbarItem {...paginationToolbarItemProps}>
-                  <SimplePagination
-                    idPrefix="issues-table"
-                    isTop
-                    paginationProps={paginationProps}
-                  />
-                </ToolbarItem>
-              </ToolbarContent>
-            </Toolbar>
-            <TableComposable
-              {...tableProps}
-              isExpandable
-              aria-label="Issues table"
+            <div
+              style={{
+                backgroundColor: "var(--pf-global--BackgroundColor--100)",
+              }}
             >
-              <Thead>
-                <Tr>
-                  <TableHeaderContentWithControls {...tableControls}>
-                    <Th {...getThProps({ columnKey: "name" })} />
-                    <Th {...getThProps({ columnKey: "category" })} />
-                    <Th {...getThProps({ columnKey: "source" })} />
-                    <Th {...getThProps({ columnKey: "target" })} />
-                    <Th {...getThProps({ columnKey: "effort" })} />
-                    <Th {...getThProps({ columnKey: "applications" })} />
-                  </TableHeaderContentWithControls>
-                </Tr>
-              </Thead>
-              <ConditionalTableBody
-                isLoading={isFetching}
-                isError={!!fetchError}
-                isNoData={totalItemCount === 0}
-                numRenderedColumns={numRenderedColumns}
+              <Toolbar {...toolbarProps}>
+                <ToolbarContent>
+                  <FilterToolbar {...filterToolbarProps} />
+                  <ToolbarItem {...paginationToolbarItemProps}>
+                    <SimplePagination
+                      idPrefix="issues-table"
+                      isTop
+                      paginationProps={paginationProps}
+                    />
+                  </ToolbarItem>
+                </ToolbarContent>
+              </Toolbar>
+              <TableComposable
+                {...tableProps}
+                isExpandable
+                aria-label="Issues table"
               >
-                {currentPageRuleReports?.map((ruleReport, rowIndex) => {
-                  return (
-                    <Tbody
-                      key={ruleReport._ui_unique_id}
-                      isExpanded={isCellExpanded(ruleReport)}
-                    >
-                      <Tr>
-                        <TableRowContentWithControls
-                          {...tableControls}
-                          item={ruleReport}
-                          rowIndex={rowIndex}
-                        >
-                          <Td width={25} {...getTdProps({ columnKey: "name" })}>
-                            {ruleReport.name}
-                          </Td>
-                          <Td
-                            width={15}
-                            {...getTdProps({ columnKey: "category" })}
+                <Thead>
+                  <Tr>
+                    <TableHeaderContentWithControls {...tableControls}>
+                      <Th {...getThProps({ columnKey: "name" })} />
+                      <Th {...getThProps({ columnKey: "category" })} />
+                      <Th {...getThProps({ columnKey: "source" })} />
+                      <Th {...getThProps({ columnKey: "target" })} />
+                      <Th {...getThProps({ columnKey: "effort" })} />
+                      <Th {...getThProps({ columnKey: "applications" })} />
+                    </TableHeaderContentWithControls>
+                  </Tr>
+                </Thead>
+                <ConditionalTableBody
+                  isLoading={isFetching}
+                  isError={!!fetchError}
+                  isNoData={totalItemCount === 0}
+                  numRenderedColumns={numRenderedColumns}
+                >
+                  {currentPageRuleReports?.map((ruleReport, rowIndex) => {
+                    return (
+                      <Tbody
+                        key={ruleReport._ui_unique_id}
+                        isExpanded={isCellExpanded(ruleReport)}
+                      >
+                        <Tr>
+                          <TableRowContentWithControls
+                            {...tableControls}
+                            item={ruleReport}
+                            rowIndex={rowIndex}
                           >
-                            {ruleReport.category}
-                          </Td>
-                          <Td
-                            width={15}
-                            {...getTdProps({ columnKey: "source" })}
-                          >
-                            TODO
-                          </Td>
-                          <Td
-                            width={15}
-                            {...getTdProps({ columnKey: "target" })}
-                          >
-                            TODO
-                          </Td>
-                          <Td
-                            width={10}
-                            {...getTdProps({ columnKey: "effort" })}
-                          >
-                            {ruleReport.effort}
-                          </Td>
-                          <Td
-                            width={20}
-                            {...getTdProps({
-                              columnKey: "applications",
-                            })}
-                          >
-                            <Tooltip content="View Report">
-                              <Button variant="link" isInline>
-                                <Link
-                                  to={getAffectedAppsUrl({
-                                    ruleReport,
-                                    fromFilterValues: filterValues,
-                                    fromLocation: location,
-                                  })}
-                                >
-                                  {ruleReport.applications}
-                                </Link>
-                              </Button>
-                            </Tooltip>
-                          </Td>
-                        </TableRowContentWithControls>
-                      </Tr>
-                      {isCellExpanded(ruleReport) ? (
-                        <Tr isExpanded>
-                          <Td />
-                          <Td
-                            {...getExpandedContentTdProps({
-                              item: ruleReport,
-                            })}
-                            className={spacing.pyLg}
-                          >
-                            <ExpandableRowContent>
-                              <Flex>
-                                <FlexItem flex={{ default: "flex_1" }}>
-                                  <Text
-                                    component="h4"
-                                    className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
+                            <Td
+                              width={25}
+                              {...getTdProps({ columnKey: "name" })}
+                            >
+                              {ruleReport.name}
+                            </Td>
+                            <Td
+                              width={15}
+                              {...getTdProps({ columnKey: "category" })}
+                            >
+                              {ruleReport.category}
+                            </Td>
+                            <Td
+                              width={15}
+                              {...getTdProps({ columnKey: "source" })}
+                            >
+                              TODO
+                            </Td>
+                            <Td
+                              width={15}
+                              {...getTdProps({ columnKey: "target" })}
+                            >
+                              TODO
+                            </Td>
+                            <Td
+                              width={10}
+                              {...getTdProps({ columnKey: "effort" })}
+                            >
+                              {ruleReport.effort}
+                            </Td>
+                            <Td
+                              width={20}
+                              {...getTdProps({
+                                columnKey: "applications",
+                              })}
+                            >
+                              <Tooltip content="View Report">
+                                <Button variant="link" isInline>
+                                  <Link
+                                    to={getAffectedAppsUrl({
+                                      ruleReport,
+                                      fromFilterValues: filterValues,
+                                      fromLocation: location,
+                                    })}
                                   >
-                                    Total affected applications
-                                  </Text>
+                                    {ruleReport.applications}
+                                  </Link>
+                                </Button>
+                              </Tooltip>
+                            </Td>
+                          </TableRowContentWithControls>
+                        </Tr>
+                        {isCellExpanded(ruleReport) ? (
+                          <Tr isExpanded>
+                            <Td />
+                            <Td
+                              {...getExpandedContentTdProps({
+                                item: ruleReport,
+                              })}
+                              className={spacing.pyLg}
+                            >
+                              <ExpandableRowContent>
+                                <Flex>
+                                  <FlexItem flex={{ default: "flex_1" }}>
+                                    <Text
+                                      component="h4"
+                                      className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
+                                    >
+                                      Total affected applications
+                                    </Text>
 
-                                  <Tooltip content="View Report">
-                                    <Button variant="link" isInline>
-                                      <Link
-                                        to={getAffectedAppsUrl({
-                                          ruleReport,
-                                          fromFilterValues: filterValues,
-                                          fromLocation: location,
-                                        })}
-                                      >
-                                        {ruleReport.applications} - View
-                                        affected applications
-                                      </Link>
-                                    </Button>
-                                  </Tooltip>
-                                  <Text
-                                    component="h4"
-                                    className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
-                                  >
-                                    Target technologies
-                                  </Text>
-                                  <div>
-                                    {/*
+                                    <Tooltip content="View Report">
+                                      <Button variant="link" isInline>
+                                        <Link
+                                          to={getAffectedAppsUrl({
+                                            ruleReport,
+                                            fromFilterValues: filterValues,
+                                            fromLocation: location,
+                                          })}
+                                        >
+                                          {ruleReport.applications} - View
+                                          affected applications
+                                        </Link>
+                                      </Button>
+                                    </Tooltip>
+                                    <Text
+                                      component="h4"
+                                      className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
+                                    >
+                                      Target technologies
+                                    </Text>
+                                    <div>
+                                      {/*
                                     // TODO the technologies array was replaced by labels, we need to parse them
                                     {issue.technologies.map((tech) => {
                                       return (
@@ -352,62 +387,66 @@ export const Issues: React.FC = () => {
                                       );
                                     })}
                                     */}
-                                  </div>
-                                  <Text
-                                    component="h4"
-                                    className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
-                                  >
-                                    Source technologies
-                                  </Text>
-                                  <div>None</div>
-                                  <Text
-                                    component="h4"
-                                    className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
-                                  >
-                                    Level of effort
-                                  </Text>
-                                  <div>
-                                    {ruleReport.effort} - what do we show here?
-                                  </div>
-                                  <Text
-                                    component="h4"
-                                    className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
-                                  >
-                                    Labels
-                                  </Text>
-                                  <div>
-                                    {ruleReport.labels.map((label) => {
-                                      return (
-                                        <Label className={spacing.mrSm}>
-                                          {label}
-                                        </Label>
-                                      );
-                                    })}
-                                  </div>
-                                </FlexItem>
-                                <FlexItem flex={{ default: "flex_1" }}>
-                                  <Text component={TextVariants.h4}>
-                                    TODO: Render validation rule description
-                                    here when available
-                                  </Text>
-                                </FlexItem>
-                              </Flex>
-                            </ExpandableRowContent>
-                          </Td>
-                        </Tr>
-                      ) : null}
-                    </Tbody>
-                  );
-                })}
-              </ConditionalTableBody>
-            </TableComposable>
-            <SimplePagination
-              idPrefix="issues-table"
-              isTop={false}
-              paginationProps={paginationProps}
-            />
-          </div>
-        </ConditionalRender>
+                                    </div>
+                                    <Text
+                                      component="h4"
+                                      className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
+                                    >
+                                      Source technologies
+                                    </Text>
+                                    <div>None</div>
+                                    <Text
+                                      component="h4"
+                                      className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
+                                    >
+                                      Level of effort
+                                    </Text>
+                                    <div>
+                                      {ruleReport.effort} - what do we show
+                                      here?
+                                    </div>
+                                    <Text
+                                      component="h4"
+                                      className={`${spacing.mtSm} ${spacing.mbSm} ${textStyles.fontSizeSm} ${textStyles.fontWeightBold}`}
+                                    >
+                                      Labels
+                                    </Text>
+                                    <div>
+                                      {ruleReport.labels.map((label) => {
+                                        return (
+                                          <Label className={spacing.mrSm}>
+                                            {label}
+                                          </Label>
+                                        );
+                                      })}
+                                    </div>
+                                  </FlexItem>
+                                  <FlexItem flex={{ default: "flex_1" }}>
+                                    <Text component={TextVariants.h4}>
+                                      TODO: Render validation rule description
+                                      here when available
+                                    </Text>
+                                  </FlexItem>
+                                </Flex>
+                              </ExpandableRowContent>
+                            </Td>
+                          </Tr>
+                        ) : null}
+                      </Tbody>
+                    );
+                  })}
+                </ConditionalTableBody>
+              </TableComposable>
+              <SimplePagination
+                idPrefix="issues-table"
+                isTop={false}
+                paginationProps={paginationProps}
+              />
+            </div>
+          </ConditionalRender>
+        ) : activeTabKey === TabKey.singleApp ? (
+          <>TODO</>
+        ) : null}
       </PageSection>
     </>
   );

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -58,21 +58,14 @@ export const Issues: React.FC = () => {
   const tableControlState = useTableControlUrlParams({
     urlParamKeyPrefix: TableURLParamKeyPrefix.issues,
     columnNames: {
-      name: "Name",
-      ruleset: "Rule set",
-      rule: "Rule",
+      name: "Issue",
       category: "Category",
+      source: "Source",
+      target: "Target(s)",
       effort: "Effort",
       applications: "Affected applications",
     },
-    sortableColumns: [
-      "name",
-      "ruleset",
-      "rule",
-      "category",
-      "effort",
-      "applications",
-    ],
+    sortableColumns: ["name", "category", "effort", "applications"],
     initialSort: { columnKey: "name", direction: "asc" },
     filterCategories: [
       //TODO: Should this be select filter type using apps available in memory?
@@ -155,8 +148,6 @@ export const Issues: React.FC = () => {
       ...tableControlState, // Includes filterState, sortState and paginationState
       hubSortFieldKeys: {
         name: "name",
-        ruleset: "ruleset",
-        rule: "rule",
         category: "category",
         effort: "effort",
         applications: "applications",
@@ -236,9 +227,9 @@ export const Issues: React.FC = () => {
                 <Tr>
                   <TableHeaderContentWithControls {...tableControls}>
                     <Th {...getThProps({ columnKey: "name" })} />
-                    <Th {...getThProps({ columnKey: "ruleset" })} />
-                    <Th {...getThProps({ columnKey: "rule" })} />
                     <Th {...getThProps({ columnKey: "category" })} />
+                    <Th {...getThProps({ columnKey: "source" })} />
+                    <Th {...getThProps({ columnKey: "target" })} />
                     <Th {...getThProps({ columnKey: "effort" })} />
                     <Th {...getThProps({ columnKey: "applications" })} />
                   </TableHeaderContentWithControls>
@@ -262,23 +253,26 @@ export const Issues: React.FC = () => {
                           item={ruleReport}
                           rowIndex={rowIndex}
                         >
-                          <Td width={15} {...getTdProps({ columnKey: "name" })}>
+                          <Td width={25} {...getTdProps({ columnKey: "name" })}>
                             {ruleReport.name}
                           </Td>
                           <Td
                             width={15}
-                            {...getTdProps({ columnKey: "ruleset" })}
-                          >
-                            {ruleReport.ruleset}
-                          </Td>
-                          <Td width={15} {...getTdProps({ columnKey: "rule" })}>
-                            {ruleReport.rule}
-                          </Td>
-                          <Td
-                            width={10}
                             {...getTdProps({ columnKey: "category" })}
                           >
                             {ruleReport.category}
+                          </Td>
+                          <Td
+                            width={15}
+                            {...getTdProps({ columnKey: "source" })}
+                          >
+                            TODO
+                          </Td>
+                          <Td
+                            width={15}
+                            {...getTdProps({ columnKey: "target" })}
+                          >
+                            TODO
                           </Td>
                           <Td
                             width={10}
@@ -287,7 +281,7 @@ export const Issues: React.FC = () => {
                             {ruleReport.effort}
                           </Td>
                           <Td
-                            width={15}
+                            width={20}
                             {...getTdProps({
                               columnKey: "applications",
                             })}

--- a/client/src/app/pages/issues/issues.tsx
+++ b/client/src/app/pages/issues/issues.tsx
@@ -4,6 +4,7 @@ import {
   Flex,
   FlexItem,
   Label,
+  LabelGroup,
   PageSection,
   PageSectionVariants,
   Tab,
@@ -432,16 +433,20 @@ export const Issues: React.FC = () => {
                                       Labels
                                     </Text>
                                     <div>
-                                      {otherLabels.length > 0
-                                        ? otherLabels.map((label) => (
+                                      {otherLabels.length > 0 ? (
+                                        <LabelGroup>
+                                          {otherLabels.map((label) => (
                                             <Label
                                               key={label}
                                               className={spacing.mrSm}
                                             >
                                               {label}
                                             </Label>
-                                          ))
-                                        : "None"}
+                                          ))}
+                                        </LabelGroup>
+                                      ) : (
+                                        "None"
+                                      )}
                                     </div>
                                   </FlexItem>
                                   <FlexItem flex={{ default: "flex_1" }}>

--- a/client/src/app/shared/components/SingleLabelWithOverflow.tsx
+++ b/client/src/app/shared/components/SingleLabelWithOverflow.tsx
@@ -1,0 +1,54 @@
+import { Label, LabelGroup, LabelProps, Popover } from "@patternfly/react-core";
+import * as React from "react";
+
+export interface ISingleLabelWithOverflowProps
+  extends Omit<LabelProps, "children"> {
+  labels: string[];
+  popoverAriaLabel: string;
+}
+
+// TODO i18n
+
+export const SingleLabelWithOverflow: React.FC<
+  ISingleLabelWithOverflowProps
+> = ({ labels, popoverAriaLabel, ...props }) => {
+  if (labels.length === 0) {
+    return <>None</>;
+  }
+  return (
+    <LabelGroup>
+      <Label {...props}>{labels[0]}</Label>
+      {labels.length > 1 ? (
+        <Popover
+          position="top"
+          hasAutoWidth
+          aria-label={popoverAriaLabel}
+          bodyContent={
+            <LabelGroup isVertical>
+              {labels.slice(1).map((label) => (
+                <Label key={label} {...props}>
+                  {label}
+                </Label>
+              ))}
+            </LabelGroup>
+          }
+        >
+          <Label
+            variant="outline"
+            render={({ className, content }) => (
+              <a
+                href="#"
+                onClick={(event) => event.preventDefault()}
+                className={className}
+              >
+                {content}
+              </a>
+            )}
+          >
+            {labels.length - 1} more
+          </Label>
+        </Popover>
+      ) : null}
+    </LabelGroup>
+  );
+};


### PR DESCRIPTION
Note: This diff is best viewed with "Hide whitespace" enabled in GitHub's diff viewer, since the indentation of most of `issues.tsx` has changed.

![Screenshot 2023-06-14 at 5 41 23 PM](https://github.com/konveyor/tackle2-ui/assets/811963/d7484669-af6d-467d-8704-7287bee8abe7)

* Refactors the Issues page into two tabs with separate routes `/issues/all` and `/issues/single-app`. The single app tab is a stub for now and its content will come in a future PR.
  * I plan to move the contents of the "all issues" tab into their own component in a future PR to be separate from the "single application" contents. However, I left that stuff in `issues.tsx` for this PR so that the changes to that content are still readable in this diff.
* Changes the columns we're showing on the Issues page to match latest mockups
* Adds parsing for the `konveyor.io/source=` and `konveyor.io/target=` labels on RuleReports and displays them separately as source/target technologies.
  * Per design discussion with Justin, adds a new shared component `SingleLabelWithOverflow` for displaying these in the table cells. If there is one source/target it will be displayed in a regular PF Label, and if there are more than 1 there will be an overflow Label saying e.g. "3 more" that opens a popup containing the rest of the sources/targets. These parsed labels are filtered out of the existing Labels view.
  * Adds language detection to the `IncidentCodeSnipViewer` in order to enable syntax highlighting.
    * Based on discussion from @pranavgaikwad, the language is detected from the filename extension. This may be a temporary workaround until https://github.com/konveyor/enhancements/issues/125 is implemented, but we may decide it is sufficient and close that issue.
    * Configures the monaco-editor-webpack-plugin so it only bundles resources necessary for syntax highlighting of a subset of supported languages. Any languages not on this list will simply render as plain text in one color.
* Tweaks some ways we display things for polish:
  * In the incident message (markdown field), code blocks were being rendered as inline monospace with no background or indentation. This updates the `markdownPfComponents` to use the PF `CodeBlock` component for `pre` elements. (We added a markdown example with code blocks to the hub's hack scripts to test this, see https://github.com/konveyor/tackle2-hub/pull/400)
  * In the "all incidents" overflow table, the markdown message was being shown in plain text on one line. Rendering it with react-markdown would split it to multiple lines and break the table. This simply truncates it to the first line and renders that.
  * Fixes a weird flash of empty modal content when incident data is done loading but the effect has not run yet to auto-select the first tab.
  * Changes text style of the line number to distinguish it from the incident message.
  * Adds the RuleReport description, which was missing from the Issues page.

![Screenshot 2023-06-14 at 5 56 17 PM](https://github.com/konveyor/tackle2-ui/assets/811963/d10a79ef-2467-4ed7-b91c-f720ee43f684)

![Screenshot 2023-06-14 at 5 56 27 PM](https://github.com/konveyor/tackle2-ui/assets/811963/55a5d850-559f-4361-90cf-cffd3f3a7a6a)

![Screenshot 2023-06-14 at 5 56 34 PM](https://github.com/konveyor/tackle2-ui/assets/811963/f65c921a-1e9c-4fac-9856-18cfbf39b48c)

![Screenshot 2023-06-14 at 5 56 40 PM](https://github.com/konveyor/tackle2-ui/assets/811963/75e068a1-9537-4e19-864e-7f21fcfebed3)
