### PR TITLE
:bug: Stakeholder JobFunction name and address API request

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -45,7 +45,7 @@ export interface Stakeholder {
   id: number;
   name: string;
   email: string;
-  jobFunction?: JobFunction;
+  jobFunction: Ref | null;
   stakeholderGroups?: Ref[];
   businessServices?: Ref[];
   migrationWaves?: Ref[];
@@ -70,7 +70,7 @@ export interface Ref {
 }
 
 export interface JobFunction {
-  id?: number;
+  id: number;
   name: string;
   stakeholders?: Array<Ref>;
 }

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -170,7 +170,7 @@ export const getJobFunctions = (): AxiosPromise<JobFunction[]> => {
 };
 
 export const createJobFunction = (
-  obj: JobFunction
+  obj: New<JobFunction>
 ): AxiosPromise<JobFunction> => {
   return APIClient.post(`${JOB_FUNCTIONS}`, obj);
 };

--- a/client/src/app/pages/controls/job-functions/components/job-function-form/job-function-form.tsx
+++ b/client/src/app/pages/controls/job-functions/components/job-function-form/job-function-form.tsx
@@ -12,7 +12,7 @@ import {
 } from "@patternfly/react-core";
 
 import { createJobFunction, updateJobFunction } from "@app/api/rest";
-import { JobFunction } from "@app/api/models";
+import { JobFunction, New } from "@app/api/models";
 import { duplicateNameCheck, getAxiosErrorMessage } from "@app/utils/utils";
 import { useFetchJobFunctions } from "@app/queries/jobfunctions";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -70,14 +70,14 @@ export const JobFunctionForm: React.FC<JobFunctionFormProps> = ({
   });
 
   const onSubmit = (formValues: FormValues) => {
-    const payload: JobFunction = {
+    const payload: New<JobFunction> = {
       name: formValues.name.trim(),
     };
 
     let promise: AxiosPromise<JobFunction>;
     if (jobFunction) {
       promise = updateJobFunction({
-        ...jobFunction,
+        id: jobFunction.id,
         ...payload,
       });
     } else {

--- a/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
+++ b/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
@@ -178,7 +178,7 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
       name: formValues.name.trim(),
       jobFunction: matchingJobFunction
         ? { id: matchingJobFunction.id, name: matchingJobFunction.name }
-        : undefined,
+        : null,
       stakeholderGroups: matchingStakeholderGroupRefs,
     };
 

--- a/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
+++ b/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
@@ -169,12 +169,16 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
         };
       });
 
+    const matchingJobFunction = jobFunctions.find(
+      (jobFunction) => jobFunction.name === formValues.jobFunctionName
+    );
+
     const payload: New<Stakeholder> = {
       email: formValues.email.trim(),
       name: formValues.name.trim(),
-      jobFunction: jobFunctions.find(
-        (jobFunction) => jobFunction.name === formValues.jobFunctionName
-      ),
+      jobFunction: matchingJobFunction
+        ? { id: matchingJobFunction.id, name: matchingJobFunction.name }
+        : undefined,
       stakeholderGroups: matchingStakeholderGroupRefs,
     };
 


### PR DESCRIPTION
With hub fixed, the JobFunction name is displayed
Resolves https://github.com/konveyor/tackle2-ui/issues/1033 

Although it doesn't break backend API, when creating or updating a stakeholder only `id` and `name` fields are necessary when a Job Function is selected.


