### PR TITLE
:sparkles: Add Jira bearer identity to issue manager form

### DIFF
--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -258,7 +258,11 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
             })}
             toggleAriaLabel="Credentials select dropdown toggle"
             aria-label={name}
-            value={value ? toOptionLike(value, identityOptions) : undefined}
+            value={
+              value
+                ? toOptionLike(value, identityOptions(values.kind))
+                : undefined
+            }
             options={identityOptions(values.kind)}
             onChange={(selection) => {
               const selectionValue = selection as OptionWithValue<string>;

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -13,7 +13,7 @@ import {
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 
-import { IssueManagerKind, Tracker } from "@app/api/models";
+import { IdentityKind, IssueManagerKind, Tracker } from "@app/api/models";
 import { IssueManagerOptions, toOptionLike } from "@app/utils/model-utils";
 import {
   useCreateTrackerMutation,
@@ -33,6 +33,14 @@ import {
 } from "@app/shared/components/hook-form-pf-fields";
 import { NotificationsContext } from "@app/shared/notifications-context";
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
+
+const supportedIdentityKindByIssueManagerKind: Record<
+  IssueManagerKind,
+  IdentityKind[]
+> = {
+  "jira-cloud": ["basic-auth"],
+  "jira-onprem": ["basic-auth", "bearer"],
+};
 
 interface FormValues {
   id: number;
@@ -170,14 +178,19 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
   const values = getValues();
   const watchAllFields = watch();
 
-  const identityOptions = identities
-    .filter((identity) => identity.kind === "basic-auth")
-    .map((identity) => {
-      return {
-        value: identity.name,
-        toString: () => identity.name,
-      };
-    });
+  const identityOptions = (kind: IssueManagerKind) => {
+    const identityKinds = supportedIdentityKindByIssueManagerKind[kind];
+    return identities
+      .filter((identity) =>
+        identity.kind ? identityKinds.includes(identity.kind) : false
+      )
+      .map((identity) => {
+        return {
+          value: identity.name,
+          toString: () => identity.name,
+        };
+      });
+  };
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
@@ -246,7 +259,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
             toggleAriaLabel="Credentials select dropdown toggle"
             aria-label={name}
             value={value ? toOptionLike(value, identityOptions) : undefined}
-            options={identityOptions}
+            options={identityOptions(values.kind)}
             onChange={(selection) => {
               const selectionValue = selection as OptionWithValue<string>;
               onChange(selectionValue.value);


### PR DESCRIPTION
Jira server/datacenter supports both `basic-auth` and `bearer` credential types.
So when user selects instance type `Jira-cloud` or `jira-onprem` (jira server/datacenter) then available identities to select from are filtered on either :
 `basic-auth`
 `basic-auth and bearer`.

Resolves https://issues.redhat.com/browse/MTA-772