### PR TITLE
:bug: Identities: Fix editing Jira basic-auth

### DIFF
--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -317,12 +317,21 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
         .string()
         .defined()
         .when("kind", {
-          is: (value: string) => value === "proxy" || value === "basic-auth",
+          is: (value: string) => value === "proxy",
           then: yup
             .string()
             .required("This value is required")
             .min(3, t("validation.minLength", { length: 3 }))
             .max(220, t("validation.maxLength", { length: 220 })),
+          otherwise: (schema) => schema.trim(),
+        })
+        .when("kind", {
+          is: (value: string) => value === "basic-auth",
+          then: yup
+            .string()
+            .required("This value is required")
+            .min(3, t("validation.minLength", { length: 3 }))
+            .max(281, t("validation.maxLength", { length: 281 })),
           otherwise: (schema) => schema.trim(),
         })
         .when(["kind", "userCredentials"], {


### PR DESCRIPTION
The jira `basic-auth` token is stored in password field which returns encrypted from the hub with a bigger size.
The maximum size of the password has to be augmented so validation works when editing the creds.

Resolves https://issues.redhat.com/browse/MTA-717