### PR TITLE
:bug: Don't show empty {{what}} value in success notifications

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -346,7 +346,8 @@
   },
   "toastr": {
     "success": {
-      "save": "{{type}} {{what}} was successfully saved.",
+      "saveWhat": "{{type}} {{what}} was successfully saved.",
+      "save": "{{type}} was successfully saved.",
       "applicationDeleted": "{{appIDCount}} application(s) successfully deleted.",
       "assessmentAndReviewCopied": "Success! Assessment and review copied to selected applications",
       "assessmentCopied": "Success! Assessment copied to selected applications",
@@ -355,8 +356,7 @@
       "deleted": "{{type}} {{what}} was successfully deleted.",
       "deletedAll": "{{type}} {{what}} were successfully deleted.",
       "fileSavedToBeProcessed": "Success! file saved to be processed.",
-      "reviewDiscarded": "Success! Review discarded for {{application}}.",
-      "waveSaved": "Migration wave was successfully saved."
+      "reviewDiscarded": "Success! Review discarded for {{application}}."
     },
     "fail": {
       "create": "Failed to create {{type}}.",

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -176,9 +176,9 @@ export const ApplicationsTableAnalyze: React.FC = () => {
   const onApplicationModalSaved = (response: AxiosResponse<Application>) => {
     if (!applicationToUpdate) {
       pushNotification({
-        title: t("toastr.success.save", {
+        title: t("toastr.success.saveWhat", {
           what: response.data.name,
-          type: t("terms.application"),
+          type: t("terms.application").toLowerCase(),
         }),
         variant: "success",
       });

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -180,7 +180,7 @@ export const ApplicationsTable: React.FC = () => {
   const onApplicationModalSaved = (response: AxiosResponse<Application>) => {
     if (!applicationToUpdate) {
       pushNotification({
-        title: t("toastr.success.save", {
+        title: t("toastr.success.saveWhat", {
           what: response.data.name,
           type: t("terms.application").toLowerCase(),
         }),

--- a/client/src/app/pages/controls/business-services/business-services.tsx
+++ b/client/src/app/pages/controls/business-services/business-services.tsx
@@ -221,7 +221,7 @@ export const BusinessServices: React.FC = () => {
     setIsNewModalOpen(false);
     refetch();
     pushNotification({
-      title: t("toastr.success.save", {
+      title: t("toastr.success.saveWhat", {
         what: response.data.name,
         type: "business service",
       }),

--- a/client/src/app/pages/controls/job-functions/job-functions.tsx
+++ b/client/src/app/pages/controls/job-functions/job-functions.tsx
@@ -173,7 +173,7 @@ export const JobFunctions: React.FC = () => {
     refetch();
 
     pushNotification({
-      title: t("toastr.success.save", {
+      title: t("toastr.success.saveWhat", {
         what: response.data.name,
         type: "job function",
       }),

--- a/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
@@ -137,7 +137,7 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
     res: AxiosResponse<StakeholderGroup>
   ) =>
     pushNotification({
-      title: t("toastr.success.save", {
+      title: t("toastr.success.saveWhat", {
         what: res.data.name,
         type: t("terms.stakeholderGroup"),
       }),

--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -102,7 +102,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
 
   const onCreateUpdateIdentitySuccess = (response: AxiosResponse<Identity>) => {
     pushNotification({
-      title: t("toastr.success.save", {
+      title: t("toastr.success.saveWhat", {
         what: response.data.name,
         type: t("terms.credential"),
       }),

--- a/client/src/app/pages/migration-targets/migration-targets.tsx
+++ b/client/src/app/pages/migration-targets/migration-targets.tsx
@@ -91,7 +91,7 @@ export const MigrationTargets: React.FC = () => {
   const onCustomTargetModalSaved = (response: AxiosResponse<Ruleset>) => {
     if (!rulesetToUpdate) {
       pushNotification({
-        title: t("toastr.success.save", {
+        title: t("toastr.success.saveWhat", {
           what: response.data.name,
           type: "custom target",
         }),

--- a/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
+++ b/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
@@ -86,7 +86,7 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
     response: AxiosResponse<MigrationWave>
   ) => {
     pushNotification({
-      title: t("toastr.success.save", {
+      title: t("toastr.success.saveWhat", {
         what: response.data.name,
         type: t("terms.migrationWave"),
       }),

--- a/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
+++ b/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
@@ -108,11 +108,11 @@ export const WaveForm: React.FC<WaveFormProps> = ({
     onCreateMigrationWaveError
   );
 
-  const onUpdateMigrationWaveSuccess = (
-    response: AxiosResponse<MigrationWave>
-  ) => {
+  const onUpdateMigrationWaveSuccess = () => {
     pushNotification({
-      title: t("toastr.success.waveSaved"),
+      title: t("toastr.success.save", {
+        type: t("terms.migrationWave"),
+      }),
       variant: "success",
     });
   };


### PR DESCRIPTION
- Fixes empty string issue which is breaking QE tests
[Update notifications include two spaces](https://issues.redhat.com/browse/MTA-753)