### PR TITLE
:seedling: Enable webpack to do code splitting

### DIFF
--- a/client/config/webpack.common.ts
+++ b/client/config/webpack.common.ts
@@ -1,26 +1,27 @@
 import path from "path";
+import { Configuration, WatchIgnorePlugin } from "webpack";
+import CaseSensitivePathsPlugin from "case-sensitive-paths-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
 import Dotenv from "dotenv-webpack";
 import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin";
-import { Configuration, WatchIgnorePlugin } from "webpack";
 import MonacoWebpackPlugin from "monaco-editor-webpack-plugin";
+
 import { LANGUAGES_BY_FILE_EXTENSION } from "./monacoConstants";
 
 const BG_IMAGES_DIRNAME = "images";
+const pathTo = (relativePath: string) => path.resolve(__dirname, relativePath);
 
 const config: Configuration = {
   entry: {
-    app: [
-      "react-hot-loader/patch",
-      path.resolve(__dirname, "../src/index.tsx"),
-    ],
+    app: ["react-hot-loader/patch", pathTo("../src/index.tsx")],
   },
+
   output: {
-    filename: "[name].bundle.js",
-    path: path.resolve(__dirname, "../dist"),
+    path: pathTo("../dist"),
     publicPath: "auto",
     clean: true,
   },
+
   module: {
     rules: [
       {
@@ -37,23 +38,15 @@ const config: Configuration = {
         // only process modules with this loader
         // if they live under a 'fonts' or 'pficon' directory
         include: [
-          path.resolve(__dirname, "../../node_modules/patternfly/dist/fonts"),
-          path.resolve(
-            __dirname,
+          pathTo("../../node_modules/patternfly/dist/fonts"),
+          pathTo(
             "../../node_modules/@patternfly/react-core/dist/styles/assets/fonts"
           ),
-          path.resolve(
-            __dirname,
+          pathTo(
             "../../node_modules/@patternfly/react-core/dist/styles/assets/pficon"
           ),
-          path.resolve(
-            __dirname,
-            "../../node_modules/@patternfly/patternfly/assets/fonts"
-          ),
-          path.resolve(
-            __dirname,
-            "../../node_modules/@patternfly/patternfly/assets/pficon"
-          ),
+          pathTo("../../node_modules/@patternfly/patternfly/assets/fonts"),
+          pathTo("../../node_modules/@patternfly/patternfly/assets/pficon"),
         ],
         use: {
           loader: "file-loader",
@@ -67,7 +60,7 @@ const config: Configuration = {
       },
       {
         test: /\.(xsd)$/,
-        include: [path.resolve(__dirname, "../src")],
+        include: [pathTo("../src")],
         use: {
           loader: "raw-loader",
           options: {
@@ -118,30 +111,22 @@ const config: Configuration = {
       {
         test: /\.(jpg|jpeg|png|gif)$/i,
         include: [
-          path.resolve(__dirname, "../src"),
-          path.resolve(__dirname, "../../node_modules/patternfly"),
-          path.resolve(
-            __dirname,
-            "../../node_modules/@patternfly/patternfly/assets/images"
-          ),
-          path.resolve(
-            __dirname,
+          pathTo("../src"),
+          pathTo("../../node_modules/patternfly"),
+          pathTo("../../node_modules/@patternfly/patternfly/assets/images"),
+          pathTo(
             "../../node_modules/@patternfly/react-styles/css/assets/images"
           ),
-          path.resolve(
-            __dirname,
+          pathTo(
             "../../node_modules/@patternfly/react-core/dist/styles/assets/images"
           ),
-          path.resolve(
-            __dirname,
+          pathTo(
             "../../node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles/css/assets/images"
           ),
-          path.resolve(
-            __dirname,
+          pathTo(
             "../../node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles/css/assets/images"
           ),
-          path.resolve(
-            __dirname,
+          pathTo(
             "../../node_modules/@patternfly/react-inline-edit-extension/node_modules/@patternfly/react-styles/css/assets/images"
           ),
         ],
@@ -158,7 +143,7 @@ const config: Configuration = {
         type: "javascript/auto",
       },
       {
-        test: path.resolve(__dirname, "../../node_modules/xmllint/xmllint.js"),
+        test: pathTo("../../node_modules/xmllint/xmllint.js"),
         loader: "exports-loader",
         options: {
           exports: "xmllint",
@@ -167,7 +152,7 @@ const config: Configuration = {
       // For monaco-editor-webpack-plugin
       {
         test: /\.css$/,
-        include: [path.resolve(__dirname, "../../node_modules/monaco-editor")],
+        include: [pathTo("../../node_modules/monaco-editor")],
         use: ["style-loader", "css-loader"],
       },
       // For monaco-editor-webpack-plugin
@@ -177,7 +162,9 @@ const config: Configuration = {
       },
     ],
   },
+
   plugins: [
+    new CaseSensitivePathsPlugin(),
     new Dotenv({
       systemvars: true,
       silent: true,
@@ -185,23 +172,16 @@ const config: Configuration = {
     new CopyPlugin({
       patterns: [
         {
-          from: path.resolve(__dirname, "../public/locales"),
-          to: path.resolve(__dirname, "../dist/locales"),
-        },
-        // TODO revisit to optimize ?
-        {
-          from: path.resolve(__dirname, "../public/manifest.json"),
-          to: path.resolve(__dirname, "../dist/manifest.json"),
+          from: pathTo("../public/locales"),
+          to: pathTo("../dist/locales"),
         },
         {
-          from: path.resolve(
-            __dirname,
-            "../public/template_application_import.csv"
-          ),
-          to: path.resolve(
-            __dirname,
-            "../dist/template_application_import.csv"
-          ),
+          from: pathTo("../public/manifest.json"),
+          to: pathTo("../dist/manifest.json"),
+        },
+        {
+          from: pathTo("../public/template_application_import.csv"),
+          to: pathTo("../dist/template_application_import.csv"),
         },
       ],
     }),
@@ -209,9 +189,11 @@ const config: Configuration = {
       paths: [/\.js$/, /\.d\.ts$/],
     }),
     new MonacoWebpackPlugin({
+      filename: "monaco/[name].worker.js",
       languages: Object.values(LANGUAGES_BY_FILE_EXTENSION),
     }),
   ],
+
   resolve: {
     alias: {
       "react-dom": "@hot-loader/react-dom",
@@ -219,13 +201,14 @@ const config: Configuration = {
     extensions: [".js", ".ts", ".tsx", ".jsx"],
     plugins: [
       new TsconfigPathsPlugin({
-        configFile: path.resolve(__dirname, "../tsconfig.json"),
+        configFile: pathTo("../tsconfig.json"),
       }),
     ],
     symlinks: false,
     cacheWithContext: false,
     fallback: { crypto: false, fs: false, path: false },
   },
+
   externals: {
     // required by xmllint (but not really used in the browser)
     ws: "{}",

--- a/client/config/webpack.dev.ts
+++ b/client/config/webpack.dev.ts
@@ -1,17 +1,25 @@
 import path from "path";
 import merge from "webpack-merge";
-import commonWebpackConfiguration from "./webpack.common";
-import { stylePaths } from "./stylePaths";
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import { getEncodedEnv } from "./envLookup";
 import { Configuration } from "webpack";
+import HtmlWebpackPlugin from "html-webpack-plugin";
 import "webpack-dev-server";
 
+import { getEncodedEnv } from "./envLookup";
+import { stylePaths } from "./stylePaths";
+import commonWebpackConfiguration from "./webpack.common";
+
 const brandType = process.env["PROFILE"] || "konveyor";
+const pathTo = (relativePath: string) => path.resolve(__dirname, relativePath);
 
 const config = merge<Configuration>(commonWebpackConfiguration, {
   mode: "development",
   devtool: "eval-source-map",
+  output: {
+    filename: "[name].js",
+    chunkFilename: "js/[name].js",
+    assetModuleFilename: "assets/[name][ext]",
+  },
+
   devServer: {
     port: 9000,
     proxy: {
@@ -23,15 +31,13 @@ const config = merge<Configuration>(commonWebpackConfiguration, {
       disableDotRule: true,
     },
   },
-  optimization: {
-    runtimeChunk: "single",
-  },
+
   plugins: [
     new HtmlWebpackPlugin({
       // In dev mode, populate window._env at build time
       filename: "index.html",
-      template: path.resolve(__dirname, "../public/index.html.ejs"),
-      favicon: path.resolve(__dirname, `../public/${brandType}-favicon.ico`),
+      template: pathTo("../public/index.html.ejs"),
+      favicon: pathTo(`../public/${brandType}-favicon.ico`),
       templateParameters: {
         _env: getEncodedEnv(),
         brandType,

--- a/client/config/webpack.prod.ts
+++ b/client/config/webpack.prod.ts
@@ -1,26 +1,37 @@
 import path from "path";
 import merge from "webpack-merge";
 import webpack, { Configuration } from "webpack";
-import commonWebpackConfiguration from "./webpack.common";
-import { stylePaths } from "./stylePaths";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import CssMinimizerPlugin from "css-minimizer-webpack-plugin";
-import TerserJSPlugin from "terser-webpack-plugin";
+
+import { stylePaths } from "./stylePaths";
+import commonWebpackConfiguration from "./webpack.common";
 
 const brandType = process.env["PROFILE"] || "konveyor";
+const pathTo = (relativePath: string) => path.resolve(__dirname, relativePath);
 
 const config = merge<Configuration>(commonWebpackConfiguration, {
   mode: "production",
-  devtool: "nosources-source-map",
-  optimization: {
-    minimizer: [new TerserJSPlugin({}), `...`, new CssMinimizerPlugin()],
-    sideEffects: true,
+  devtool: "nosources-source-map", // used to map stack traces on the client without exposing all of the source code
+  output: {
+    filename: "[name].[contenthash:8].min.js",
+    chunkFilename: "js/[name].[chunkhash:8].min.js",
+    assetModuleFilename: "assets/[name].[contenthash:8][ext]",
   },
+
+  optimization: {
+    minimize: true,
+    minimizer: [
+      "...", // The '...' string represents the webpack default TerserPlugin instance
+      new CssMinimizerPlugin(),
+    ],
+  },
+
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "[name].css",
-      chunkFilename: "[name].bundle.css",
+      filename: "[name].[contenthash:8].css",
+      chunkFilename: "css/[name].[chunkhash:8].min.css",
     }),
     new CssMinimizerPlugin({
       minimizerOptions: {
@@ -30,16 +41,14 @@ const config = merge<Configuration>(commonWebpackConfiguration, {
     new HtmlWebpackPlugin({
       // In real prod mode, populate window._env at run time with express
       filename: "index.html.ejs",
-      template: `!!raw-loader!${path.resolve(
-        __dirname,
-        "../public/index.html.ejs"
-      )}`,
-      favicon: path.resolve(__dirname, `../public/${brandType}-favicon.ico`),
+      template: `!!raw-loader!${pathTo("../public/index.html.ejs")}`,
+      favicon: pathTo(`../public/${brandType}-favicon.ico`),
     }),
     new webpack.EnvironmentPlugin({
       NODE_ENV: "production",
     }),
   ],
+
   module: {
     rules: [
       {

--- a/client/package.json
+++ b/client/package.json
@@ -4,15 +4,16 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
+    "prepare": "cd .. && husky install client/.husky",
     "analyze": "source-map-explorer 'dist/static/js/*.js'",
     "clean": "rimraf ./dist",
-    "prebuild": "npm run tsc && npm run clean",
-    "build": "NODE_ENV=production webpack --config ./config/webpack.prod.ts",
     "extract": "i18next --config i18next-parser.config.js",
-    "start:dev": "GENERATE_SOURCEMAP=true webpack serve --config ./config/webpack.dev.ts",
+    "prebuild": "npm run clean && npm run tsc -- --noEmit",
+    "build": "NODE_ENV=production webpack --config ./config/webpack.prod.ts",
+    "build:dev": "webpack --config ./config/webpack.dev.ts",
+    "start:dev": "webpack serve --config ./config/webpack.dev.ts",
     "test": "jest --rootDir=. --config=./config/jest.config.js",
-    "tsc": "tsc -p ./tsconfig.json",
-    "prepare": "cd .. && husky install client/.husky"
+    "tsc": "tsc -p ./tsconfig.json"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.0.7",
@@ -96,8 +97,6 @@
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.3",
     "raw-loader": "^4.0.2",
-    "react-dev-utils": "^12.0.0",
-    "react-refresh": "^0.11.0",
     "sass-loader": "^12.4.0",
     "source-map-explorer": "^2.5.2",
     "style-loader": "^3.3.1",
@@ -112,7 +111,6 @@
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1",
-    "webpack-manifest-plugin": "^4.1.1",
     "webpack-merge": "^5.8.0"
   },
   "eslintConfig": {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,37 +1,43 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+
   "include": ["src/**/*"],
+
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
     "outDir": "dist",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "sourceMap": true,
-    "allowJs": true,
-    "checkJs": true,
-    "downlevelIteration": true,
-    "importHelpers": true,
-    "noEmitHelpers": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "jsx": "react",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noImplicitAny": true,
-    "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
       "@app/*": ["src/app/*"],
-      "@assets/*": ["../node_modules/@patternfly/react-core/dist/styles/assets/*"]
+      "@assets/*": [
+        "../node_modules/@patternfly/react-core/dist/styles/assets/*"
+      ]
     },
+
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true, // Includes alwaysStrict and noImplicitAny
-    "noUnusedParameters": false, // TODO: activate when fixed
+    "sourceMap": true,
+    "strict": true,
+
     "noUnusedLocals": false, // TODO: activate when fixed
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
+    "noUnusedParameters": false, // TODO: activate when fixed
+
     "noEmit": true
   },
+
+  "ts-node": {
+    "files": true,
+    "transpileOnly": true,
+    "compilerOptions": {
+      "module": "commonjs" // allow webpack config to be typescript
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,8 +103,6 @@
         "prettier": "^2.2.1",
         "pretty-quick": "^3.1.3",
         "raw-loader": "^4.0.2",
-        "react-dev-utils": "^12.0.0",
-        "react-refresh": "^0.11.0",
         "sass-loader": "^12.4.0",
         "source-map-explorer": "^2.5.2",
         "style-loader": "^3.3.1",
@@ -119,7 +117,6 @@
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1",
-        "webpack-manifest-plugin": "^4.1.1",
         "webpack-merge": "^5.8.0"
       }
     },
@@ -2906,15 +2903,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/address": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -3170,15 +3158,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/attr-accept": {
       "version": "2.2.2",
@@ -4951,38 +4930,6 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
-    "node_modules/detect-port-alt": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-      "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
-      "dev": true,
-      "dependencies": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
-      },
-      "bin": {
-        "detect": "bin/detect-port",
-        "detect-port": "bin/detect-port"
-      },
-      "engines": {
-        "node": ">= 4.2.1"
-      }
-    },
-    "node_modules/detect-port-alt/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/detect-port-alt/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -6009,15 +5956,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/filesize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
-      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6384,44 +6322,6 @@
       "dependencies": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
-      }
-    },
-    "node_modules/global-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-      "dev": true,
-      "dependencies": {
-        "global-prefix": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-      "dev": true,
-      "dependencies": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/global-prefix/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/globals": {
@@ -7244,16 +7144,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -7321,12 +7211,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
     },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
@@ -7675,15 +7559,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-root": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
-      "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-set": {
@@ -10773,79 +10648,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-up/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.4.25",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
@@ -11778,176 +11580,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-dev-utils": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
-      "integrity": "sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "address": "^1.1.2",
-        "browserslist": "^4.18.1",
-        "chalk": "^4.1.2",
-        "cross-spawn": "^7.0.3",
-        "detect-port-alt": "^1.1.6",
-        "escape-string-regexp": "^4.0.0",
-        "filesize": "^8.0.6",
-        "find-up": "^5.0.0",
-        "fork-ts-checker-webpack-plugin": "^6.5.0",
-        "global-modules": "^2.0.0",
-        "globby": "^11.0.4",
-        "gzip-size": "^6.0.0",
-        "immer": "^9.0.7",
-        "is-root": "^2.1.0",
-        "loader-utils": "^3.2.0",
-        "open": "^8.4.0",
-        "pkg-up": "^3.1.0",
-        "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.11",
-        "recursive-readdir": "^2.2.2",
-        "shell-quote": "^1.7.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz",
-      "integrity": "sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "@types/json-schema": "^7.0.5",
-        "chalk": "^4.1.0",
-        "chokidar": "^3.4.2",
-        "cosmiconfig": "^6.0.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^9.0.0",
-        "glob": "^7.1.6",
-        "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
-        "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "yarn": ">=1.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">= 6",
-        "typescript": ">= 2.7",
-        "vue-template-compiler": "*",
-        "webpack": ">= 4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        },
-        "vue-template-compiler": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
-      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/schema-utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-      "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.12.2",
-        "ajv-keywords": "^3.4.1"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -11992,12 +11624,6 @@
       "peerDependencies": {
         "react": ">=16.13.1"
       }
-    },
-    "node_modules/react-error-overlay": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
-      "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
-      "dev": true
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -12154,15 +11780,6 @@
         "react": ">=17 <= 18"
       }
     },
-    "node_modules/react-refresh": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -12241,18 +11858,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/recursive-readdir": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
-      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/redent": {
@@ -13050,12 +12655,6 @@
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
       }
-    },
-    "node_modules/source-list-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -15183,35 +14782,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-manifest-plugin": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-4.1.1.tgz",
-      "integrity": "sha512-YXUAwxtfKIJIKkhg03MKuiFAD72PlrqCiwdwO4VEXdRO5V0ORCNwaOwAZawPZalCbmH9kBDmXnNeQOw+BIEiow==",
-      "dev": true,
-      "dependencies": {
-        "tapable": "^2.0.0",
-        "webpack-sources": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.44.2 || ^5.47.0"
-      }
-    },
-    "node_modules/webpack-manifest-plugin/node_modules/webpack-sources": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
-      "integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
-      "dev": true,
-      "dependencies": {
-        "source-list-map": "^2.0.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/webpack-merge": {


### PR DESCRIPTION
## Summary
By updating `tsconfig.json` and making a few changes in webpack configuration, code splitting is now working.

For developers, this means that the previous 100MB+ app bundle that could frequently crash my browser when trying to debug code has been replaced by a small initial bundle with dynamic loading of each React.lazy() component.  Code debugging and source viewing works much better now.

For end users, this means the app can start up faster.  Less network traffic is great, but really only has an effect if the network latency is high (e.g. if the app is located on a different continent from the user).

Resolves: #1074 

## Change Details

### Refactor the client `tsconfig.json`
  - By updating the `tsconfig.json` to use `module: es2020`, this allows
    webpack to do actual code splitting based on `React.lazy()`.

  - Many of the previous settings that were removed are now redundant
    with either the `strict: true` or with the current `target`, `module`,
    and `moduleResolution` settings.

  - The `ts-node` section has been added to allow the webpack configuration
    files to be written in typescript.

### webpack config refactoring
  - Use `pathTo()` instead of `path.resolve(__dirname)`.  This
    will help any migration to use ESM modules in future.

  - Setup `output` file names for dev and prod builds

  - Have monaco workers generate to `monaco/...`

  - Use `CaseSensitivePathsPlugin` since it is a devDep but
    currently unused

  - Use consistent ordering for imports

### updates to `client/package.json`
  - Add script `build:dev`

  - Remove `GENERATE_SOURCEMAP=true` from the `start:dev` script since
    it does not impact the build at all

  - Rearrange the `prebuild` script, and force `--noEmit`

  - Drop dependencies that are not being used:
    - `webpack-manifest-plugin`
    - `react-dev-utils`
    - `react-refresh`