### PR TITLE
:sparkles: Add Dependencies page & drawer 

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -270,6 +270,8 @@
     "jobFunction": "Job function",
     "jobFunctionDeleted": "Job function deleted",
     "jobFunctions": "Job functions",
+    "language": "Language",
+    "label": "Label",
     "loading": "Loading",
     "lowRisk": "Low risk",
     "mavenConfig": "Maven configuration",

--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -241,4 +241,5 @@ export enum TableURLParamKeyPrefix {
   issuesAffectedApps = "ia",
   issuesAffectedFiles = "if",
   issuesRemainingIncidents = "ii",
+  dependencyApplications = "da",
 }

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -557,10 +557,27 @@ export interface TrackerProjectIssuetype {
 export interface AnalysisDependency {
   createTime: string;
   name: string;
+  provider: string;
   version: string;
-  // TODO where did these properties go?
-  // indirect?: boolean;
-  // applications: { id: number; name: string }[];
+  sha: string;
+  applications: number;
+  labels: string[];
+}
+
+export interface AnalysisAppDependency {
+  id: number;
+  name: string;
+  description: string;
+  businessService: string;
+  dependency: {
+    id: number;
+    name: string;
+    version: string;
+    provider: string;
+    indirect: boolean;
+    //TODO: Glean from labels somehow
+    // management?: string;
+  };
 }
 
 interface AnalysisIssuesCommonFields {

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -6,7 +6,6 @@ import {
   BaseAnalysisRuleReport,
   BaseAnalysisIssueReport,
   AnalysisIssue,
-  AnalysisAppReport,
   AnalysisFileReport,
   AnalysisIncident,
   Application,
@@ -47,6 +46,8 @@ import {
   TrackerProjectIssuetype,
   Fact,
   UnstructuredFact,
+  AnalysisAppDependency,
+  AnalysisAppReport,
 } from "./models";
 import { QueryKey } from "@tanstack/react-query";
 import { serializeRequestParamsForHub } from "@app/shared/hooks/table-controls";
@@ -86,7 +87,7 @@ export const RULESETS = HUB + "/rulesets";
 export const FILES = HUB + "/files";
 export const CACHE = HUB + "/cache/m2";
 
-export const ANALYSIS_DEPENDENCIES = HUB + "/analyses/dependencies";
+export const ANALYSIS_DEPENDENCIES = HUB + "/analyses/report/dependencies";
 export const ANALYSIS_REPORT_RULES = HUB + "/analyses/report/rules";
 export const ANALYSIS_REPORT_ISSUES_APPS =
   HUB + "/analyses/report/issues/applications";
@@ -94,6 +95,11 @@ export const ANALYSIS_REPORT_APP_ISSUES =
   HUB + "/analyses/report/applications/:applicationId/issues";
 export const ANALYSIS_REPORT_ISSUE_FILES =
   HUB + "/analyses/report/issues/:issueId/files";
+
+export const ANALYSIS_REPORT_APP_DEPENDENCIES =
+  HUB + "/analyses/report/dependencies/applications";
+
+export const ANALYSIS_REPORT_FILES = HUB + "/analyses/report/issues/:id/files";
 export const ANALYSIS_ISSUES = HUB + "/analyses/issues";
 export const ANALYSIS_ISSUE_INCIDENTS =
   HUB + "/analyses/issues/:issueId/incidents";
@@ -616,8 +622,7 @@ export const getIssueReports = (
     ANALYSIS_REPORT_APP_ISSUES.replace(
       "/:applicationId/",
       `/${String(applicationId)}/`
-    ),
-    params
+    )
   );
 
 export const getIssues = (params: HubRequestParams = {}) =>
@@ -652,6 +657,12 @@ export const getIncidents = (issueId?: number, params: HubRequestParams = {}) =>
 
 export const getDependencies = (params: HubRequestParams = {}) =>
   getHubPaginatedResult<AnalysisDependency>(ANALYSIS_DEPENDENCIES, params);
+
+export const getAppDependencies = (params: HubRequestParams = {}) =>
+  getHubPaginatedResult<AnalysisAppDependency>(
+    ANALYSIS_REPORT_APP_DEPENDENCIES,
+    params
+  );
 
 // Tickets
 export const createTickets = (payload: New<Ticket>, applications: Ref[]) => {

--- a/client/src/app/pages/dependencies/dependency-apps-detail-drawer.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-detail-drawer.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import {
+  IPageDrawerContentProps,
+  PageDrawerContent,
+} from "@app/shared/page-drawer-context";
+import {
+  TextContent,
+  Text,
+  Title,
+  Tabs,
+  TabTitleText,
+  Tab,
+} from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { AnalysisDependency } from "@app/api/models";
+import { StateNoData } from "@app/shared/components/app-table/state-no-data";
+import { DependencyAppsTable } from "./dependency-apps-table";
+
+export interface IDependencyAppsDetailDrawerProps
+  extends Pick<IPageDrawerContentProps, "onCloseClick"> {
+  dependency: AnalysisDependency | null;
+}
+
+enum TabKey {
+  Applications = 0,
+}
+
+export const DependencyAppsDetailDrawer: React.FC<
+  IDependencyAppsDetailDrawerProps
+> = ({ dependency, onCloseClick }) => {
+  const [activeTabKey, setActiveTabKey] = React.useState<TabKey>(
+    TabKey.Applications
+  );
+
+  return (
+    <PageDrawerContent
+      isExpanded={!!dependency}
+      onCloseClick={onCloseClick}
+      focusKey={dependency?.name}
+      pageKey="analysis-app-dependencies"
+      drawerPanelContentProps={{ defaultSize: "600px" }}
+    >
+      {!dependency ? (
+        <StateNoData />
+      ) : (
+        <>
+          <TextContent>
+            <Text component="small" className={spacing.mb_0}>
+              Dependencies
+            </Text>
+            <Title headingLevel="h2" size="lg" className={spacing.mtXs}>
+              {dependency?.name || ""}
+            </Title>
+          </TextContent>
+          <Tabs
+            activeKey={activeTabKey}
+            onSelect={(_event, tabKey) => setActiveTabKey(tabKey as TabKey)}
+            className={spacing.mtLg}
+          >
+            <Tab
+              eventKey={TabKey.Applications}
+              title={<TabTitleText>Applications</TabTitleText>}
+            >
+              {dependency ? (
+                <DependencyAppsTable dependency={dependency} />
+              ) : null}
+            </Tab>
+          </Tabs>
+        </>
+      )}
+    </PageDrawerContent>
+  );
+};

--- a/client/src/app/pages/dependencies/dependency-apps-table.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-table.tsx
@@ -1,14 +1,7 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
-import {
-  TableComposable,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-} from "@patternfly/react-table";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { useSelectionState } from "@migtools/lib-ui";
 import { AnalysisDependency } from "@app/api/models";
@@ -52,7 +45,6 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
       relationship: "Relationship",
     },
     sortableColumns: ["name", "version"],
-    // sortableColumns: ["application", "version", "relationship"],
     initialSort: { columnKey: "name", direction: "asc" },
     filterCategories: [
       {
@@ -153,7 +145,7 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
           </ToolbarItem>
         </ToolbarContent>
       </Toolbar>
-      <TableComposable {...tableProps} aria-label="Affected files table">
+      <Table {...tableProps} aria-label="Dependency applications table">
         <Thead>
           <Tr>
             <TableHeaderContentWithControls {...tableControls}>
@@ -215,9 +207,9 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
             ))}
           </Tbody>
         </ConditionalTableBody>
-      </TableComposable>
+      </Table>
       <SimplePagination
-        idPrefix="affected-files-table"
+        idPrefix="dependency-apps-table"
         isTop={false}
         isCompact
         paginationProps={paginationProps}

--- a/client/src/app/pages/dependencies/dependency-apps-table.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-table.tsx
@@ -1,0 +1,227 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
+import {
+  TableComposable,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { useSelectionState } from "@migtools/lib-ui";
+import { AnalysisDependency } from "@app/api/models";
+import {
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlUrlParams,
+} from "@app/shared/hooks/table-controls";
+import { TableURLParamKeyPrefix } from "@app/Constants";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/shared/components/table-controls";
+import { SimplePagination } from "@app/shared/components/simple-pagination";
+import {
+  FilterToolbar,
+  FilterType,
+} from "@app/shared/components/FilterToolbar";
+import { useFetchAppDependencies } from "@app/queries/dependencies";
+import { useFetchBusinessServices } from "@app/queries/businessservices";
+import { useFetchTags } from "@app/queries/tags";
+
+export interface IDependencyAppsTableProps {
+  dependency: AnalysisDependency;
+}
+
+export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
+  dependency,
+}) => {
+  const { t } = useTranslation();
+  const { businessServices } = useFetchBusinessServices();
+  const { tags } = useFetchTags();
+
+  const tableControlState = useTableControlUrlParams({
+    urlParamKeyPrefix: TableURLParamKeyPrefix.dependencyApplications,
+    columnNames: {
+      name: "Application",
+      version: "Version",
+      //   management (3rd party or not boolean... parsed from labels)
+      relationship: "Relationship",
+    },
+    sortableColumns: ["name", "version"],
+    // sortableColumns: ["application", "version", "relationship"],
+    initialSort: { columnKey: "name", direction: "asc" },
+    filterCategories: [
+      {
+        key: "name",
+        title: "Application Name",
+        type: FilterType.search,
+        placeholderText:
+          t("actions.filterBy", {
+            what: "name", // TODO i18n
+          }) + "...",
+        getServerFilterValue: (value) => (value ? [`*${value[0]}*`] : []),
+      },
+      {
+        key: "businessService",
+        title: t("terms.businessService"),
+        placeholderText:
+          t("actions.filterBy", {
+            what: t("terms.businessService").toLowerCase(),
+          }) + "...",
+        type: FilterType.select,
+        selectOptions: businessServices
+          .map((businessService) => businessService.name)
+          .map((name) => ({ key: name, value: name })),
+      },
+      {
+        key: "tag.id",
+        title: t("terms.tags"),
+        type: FilterType.multiselect,
+        placeholderText:
+          t("actions.filterBy", {
+            what: t("terms.tagName").toLowerCase(),
+          }) + "...",
+        selectOptions: [...new Set(tags.map((tag) => tag.name))].map(
+          (tagName) => ({ key: tagName, value: tagName })
+        ),
+      },
+    ],
+    initialItemsPerPage: 10,
+  });
+
+  const {
+    result: { data: currentPageAppDependencies, total: totalItemCount },
+    isFetching,
+    fetchError,
+  } = useFetchAppDependencies(
+    getHubRequestParams({
+      ...tableControlState,
+      hubSortFieldKeys: {
+        name: "name",
+        version: "version",
+      },
+      implicitFilters: [
+        { field: "dep.name", operator: "=", value: dependency.name },
+        { field: "dep.version", operator: "=", value: dependency.version },
+        { field: "dep.sha", operator: "=", value: dependency.sha },
+      ],
+    })
+  );
+
+  const tableControls = useTableControlProps({
+    ...tableControlState,
+    idProperty: "name",
+    currentPageItems: currentPageAppDependencies,
+    totalItemCount,
+    isLoading: isFetching,
+    // TODO FIXME - we don't need selectionState but it's required by this hook?
+    selectionState: useSelectionState({
+      items: currentPageAppDependencies,
+      isEqual: (a, b) => a.name === b.name,
+    }),
+  });
+
+  const {
+    numRenderedColumns,
+    propHelpers: {
+      toolbarProps,
+      filterToolbarProps,
+      paginationToolbarItemProps,
+      paginationProps,
+      tableProps,
+      getThProps,
+      getTdProps,
+    },
+  } = tableControls;
+
+  return (
+    <>
+      <Toolbar {...toolbarProps} className={spacing.mtSm}>
+        <ToolbarContent>
+          <FilterToolbar {...filterToolbarProps} />
+          <ToolbarItem {...paginationToolbarItemProps}>
+            <SimplePagination
+              idPrefix="dependency-apps-table"
+              isTop
+              isCompact
+              paginationProps={paginationProps}
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+      <TableComposable {...tableProps} aria-label="Affected files table">
+        <Thead>
+          <Tr>
+            <TableHeaderContentWithControls {...tableControls}>
+              <Th {...getThProps({ columnKey: "name" })} />
+              <Th {...getThProps({ columnKey: "version" })} modifier="nowrap" />
+              {/* <Th
+                {...getThProps({ columnKey: "management" })}
+                modifier="nowrap"
+              /> */}
+              <Th
+                {...getThProps({ columnKey: "relationship" })}
+                modifier="nowrap"
+              />
+            </TableHeaderContentWithControls>
+          </Tr>
+        </Thead>
+        <ConditionalTableBody
+          isLoading={isFetching}
+          isError={!!fetchError}
+          isNoData={totalItemCount === 0}
+          numRenderedColumns={numRenderedColumns}
+        >
+          <Tbody>
+            {currentPageAppDependencies?.map((appDependency, rowIndex) => (
+              <Tr key={appDependency.name}>
+                <TableRowContentWithControls
+                  {...tableControls}
+                  item={appDependency}
+                  rowIndex={rowIndex}
+                >
+                  <Td width={70} {...getTdProps({ columnKey: "name" })}>
+                    {appDependency.name}
+                  </Td>
+                  <Td
+                    width={10}
+                    modifier="nowrap"
+                    {...getTdProps({ columnKey: "version" })}
+                  >
+                    {appDependency.dependency.version}
+                  </Td>
+                  {/* <Td
+                    width={20}
+                    modifier="nowrap"
+                    {...getTdProps({ columnKey: "management" })}
+                  >
+                    {appDependency.management}
+                  </Td> */}
+                  <Td
+                    width={20}
+                    modifier="nowrap"
+                    {...getTdProps({ columnKey: "relationship" })}
+                  >
+                    {appDependency.dependency.indirect
+                      ? "Transitive"
+                      : "Direct"}
+                  </Td>
+                </TableRowContentWithControls>
+              </Tr>
+            ))}
+          </Tbody>
+        </ConditionalTableBody>
+      </TableComposable>
+      <SimplePagination
+        idPrefix="affected-files-table"
+        isTop={false}
+        isCompact
+        paginationProps={paginationProps}
+      />
+    </>
+  );
+};

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -30,7 +30,7 @@ import { FilterToolbar } from "@app/shared/components/FilterToolbar";
 import { useSelectionState } from "@migtools/lib-ui";
 import {
   getBackToAllIssuesUrl,
-  useSharedFilterCategoriesForIssuesAndAffectedApps,
+  useSharedAffectedApplicationFilterCategories,
 } from "../helpers";
 import { IssueDetailDrawer } from "../issue-detail-drawer";
 import { TableURLParamKeyPrefix } from "@app/Constants";
@@ -59,7 +59,7 @@ export const AffectedApplications: React.FC = () => {
     },
     sortableColumns: ["name", "businessService", "effort", "incidents"],
     initialSort: { columnKey: "name", direction: "asc" },
-    filterCategories: useSharedFilterCategoriesForIssuesAndAffectedApps(),
+    filterCategories: useSharedAffectedApplicationFilterCategories(),
     initialItemsPerPage: 10,
     // TODO PF V5 obsolete
     // hasClickableRows: true,

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -31,62 +31,64 @@ export type IssuesFilterValuesToCarry = Partial<
   Record<IssuesFilterKeyToCarry, FilterValue>
 >;
 
-export const useSharedFilterCategoriesForIssuesAndAffectedApps =
-  (): FilterCategory<unknown, IssuesFilterKeyToCarry>[] => {
-    const { t } = useTranslation();
-    const { tags } = useFetchTags();
-    const { businessServices } = useFetchBusinessServices();
+export const useSharedAffectedApplicationFilterCategories = (): FilterCategory<
+  unknown,
+  IssuesFilterKeyToCarry
+>[] => {
+  const { t } = useTranslation();
+  const { tags } = useFetchTags();
+  const { businessServices } = useFetchBusinessServices();
 
-    return [
-      {
-        key: "application.name",
-        title: t("terms.applicationName"),
-        filterGroup: IssueFilterGroups.ApplicationInventory,
-        type: FilterType.search,
-        placeholderText:
-          t("actions.filterBy", {
-            what: t("terms.applicationName").toLowerCase(),
-          }) + "...",
-        getServerFilterValue: (value) => (value ? [`*${value[0]}*`] : []),
-      },
-      {
-        key: "businessService.name",
-        title: t("terms.businessService"),
-        filterGroup: IssueFilterGroups.ApplicationInventory,
-        placeholderText:
-          t("actions.filterBy", {
-            what: t("terms.businessService").toLowerCase(),
-          }) + "...",
-        type: FilterType.select,
-        selectOptions: businessServices
-          .map((businessService) => businessService.name)
-          .map((name) => ({ key: name, value: name })),
-      },
-      {
-        key: "tag.id",
-        title: t("terms.tags"),
-        filterGroup: IssueFilterGroups.ApplicationInventory,
-        type: FilterType.multiselect,
-        placeholderText:
-          t("actions.filterBy", {
-            what: t("terms.tagName").toLowerCase(),
-          }) + "...",
-        selectOptions: [...new Set(tags.map((tag) => tag.name))].map(
-          (tagName) => ({ key: tagName, value: tagName })
+  return [
+    {
+      key: "application.name",
+      title: t("terms.applicationName"),
+      filterGroup: IssueFilterGroups.ApplicationInventory,
+      type: FilterType.search,
+      placeholderText:
+        t("actions.filterBy", {
+          what: t("terms.applicationName").toLowerCase(),
+        }) + "...",
+      getServerFilterValue: (value) => (value ? [`*${value[0]}*`] : []),
+    },
+    {
+      key: "businessService.name",
+      title: t("terms.businessService"),
+      filterGroup: IssueFilterGroups.ApplicationInventory,
+      placeholderText:
+        t("actions.filterBy", {
+          what: t("terms.businessService").toLowerCase(),
+        }) + "...",
+      type: FilterType.select,
+      selectOptions: businessServices
+        .map((businessService) => businessService.name)
+        .map((name) => ({ key: name, value: name })),
+    },
+    {
+      key: "tag.id",
+      title: t("terms.tags"),
+      filterGroup: IssueFilterGroups.ApplicationInventory,
+      type: FilterType.multiselect,
+      placeholderText:
+        t("actions.filterBy", {
+          what: t("terms.tagName").toLowerCase(),
+        }) + "...",
+      selectOptions: [...new Set(tags.map((tag) => tag.name))].map(
+        (tagName) => ({ key: tagName, value: tagName })
+      ),
+      // NOTE: The same tag name can appear in multiple tag categories.
+      //       To replicate the behavior of the app inventory page, selecting a tag name
+      //       will perform an OR filter matching all tags with that name across tag categories.
+      //       In the future we may instead want to present the tag select options to the user in category sections.
+      getServerFilterValue: (tagNames) =>
+        tagNames?.flatMap((tagName) =>
+          tags
+            .filter((tag) => tag.name === tagName)
+            .map((tag) => String(tag.id))
         ),
-        // NOTE: The same tag name can appear in multiple tag categories.
-        //       To replicate the behavior of the app inventory page, selecting a tag name
-        //       will perform an OR filter matching all tags with that name across tag categories.
-        //       In the future we may instead want to present the tag select options to the user in category sections.
-        getServerFilterValue: (tagNames) =>
-          tagNames?.flatMap((tagName) =>
-            tags
-              .filter((tag) => tag.name === tagName)
-              .map((tag) => String(tag.id))
-          ),
-      },
-    ];
-  };
+    },
+  ];
+};
 
 const FROM_ISSUES_PARAMS_KEY = "~fromIssuesParams"; // ~ prefix sorts it at the end of the URL for readability
 

--- a/client/src/app/pages/issues/issues-table.tsx
+++ b/client/src/app/pages/issues/issues-table.tsx
@@ -56,9 +56,9 @@ import {
 } from "@app/shared/hooks/table-controls";
 
 import {
-  useSharedFilterCategoriesForIssuesAndAffectedApps,
   parseReportLabels,
   getIssuesSingleAppSelectedLocation,
+  useSharedAffectedApplicationFilterCategories,
 } from "./helpers";
 import { IssueFilterGroups } from "./issues";
 import {
@@ -94,7 +94,7 @@ export const IssuesTable: React.FC<IIssuesTableProps> = ({ mode }) => {
   };
 
   const allIssuesSpecificFilterCategories =
-    useSharedFilterCategoriesForIssuesAndAffectedApps();
+    useSharedAffectedApplicationFilterCategories();
 
   const tableControlState = useTableControlUrlParams({
     urlParamKeyPrefix: TableURLParamKeyPrefix.issues,

--- a/client/src/app/queries/dependencies.ts
+++ b/client/src/app/queries/dependencies.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import {
+  AnalysisAppDependency,
   AnalysisDependency,
   HubPaginatedResult,
   HubRequestParams,
 } from "@app/api/models";
-import { getDependencies } from "@app/api/rest";
+import { getAppDependencies, getDependencies } from "@app/api/rest";
 import { serializeRequestParamsForHub } from "@app/shared/hooks/table-controls/getHubRequestParams";
 
 export interface IDependenciesFetchState {
@@ -13,8 +14,15 @@ export interface IDependenciesFetchState {
   fetchError: unknown;
   refetch: () => void;
 }
+export interface IAppDependenciesFetchState {
+  result: HubPaginatedResult<AnalysisAppDependency>;
+  isFetching: boolean;
+  fetchError: unknown;
+  refetch: () => void;
+}
 
 export const DependenciesQueryKey = "dependencies";
+export const AppDependenciesQueryKey = "appdependencies";
 
 export const useFetchDependencies = (
   params: HubRequestParams = {}
@@ -25,6 +33,26 @@ export const useFetchDependencies = (
       serializeRequestParamsForHub(params).toString(),
     ],
     queryFn: async () => await getDependencies(params),
+    onError: (error) => console.log("error, ", error),
+    keepPreviousData: true,
+  });
+  return {
+    result: data || { data: [], total: 0, params },
+    isFetching: isLoading,
+    fetchError: error,
+    refetch,
+  };
+};
+
+export const useFetchAppDependencies = (
+  params: HubRequestParams = {}
+): IAppDependenciesFetchState => {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: [
+      AppDependenciesQueryKey,
+      serializeRequestParamsForHub(params).toString(),
+    ],
+    queryFn: async () => await getAppDependencies(params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,
   });


### PR DESCRIPTION
- Adds the dependencies page & dependencies drawer from [these](https://www.sketch.com/s/af50e991-8061-4b69-84c1-c11241e274f2/a/elkkKkq) mockups
- Uses the existing server side filter/sort method for both the dependencies and dependencies applications components