### PR TITLE
:bug: Handle uploaded yaml with a single parsed value

### DIFF
--- a/client/src/app/common/CustomRules/rules-utils.tsx
+++ b/client/src/app/common/CustomRules/rules-utils.tsx
@@ -11,15 +11,21 @@ export const checkRuleFileType = (filename: string): RuleFileType => {
     return "XML";
   } else return null;
 };
+type ParsedYamlElement = { labels?: string[] };
+type ParsedYaml = ParsedYamlElement[] | {};
 
 export const parseRules = (file: IReadFile): ParsedRule => {
   if (file.data) {
     if (checkRuleFileType(file.fileName) === "YAML") {
-      const yamlDoc = yaml.load(file.data) as any[];
-      const yamlLabels = yamlDoc?.reduce((acc, parsedLine) => {
-        const newLabels = parsedLine?.labels ? parsedLine?.labels : [];
-        return [...acc, ...newLabels];
-      }, []);
+      const yamlDoc: ParsedYaml = yaml.load(file.data) as ParsedYaml;
+      const yamlList = Array.isArray(yamlDoc) ? yamlDoc : [yamlDoc];
+      const yamlLabels = Array.from(
+        new Set(
+          yamlList?.flatMap((parsedLine) => {
+            return parsedLine?.labels ? parsedLine?.labels : [];
+          }) || []
+        )
+      );
       const allLabels = getLabels(yamlLabels);
       return {
         source: allLabels?.sourceLabel,

--- a/client/src/app/pages/migration-targets/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/custom-target-form.tsx
@@ -113,13 +113,6 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
       };
     });
 
-  const toOptionWithValue = (
-    value: IdentityDropdown
-  ): OptionWithValue<IdentityDropdown> => ({
-    value,
-    toString: () => value?.name || "",
-  });
-
   const { rulesets } = useFetchRulesets();
 
   const validationSchema: yup.SchemaOf<CustomTargetFormValues> = yup
@@ -175,12 +168,12 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
     });
 
   const getInitialCustomRulesFilesData = () =>
-    ruleset?.rules?.map((ruleset): IReadFile => {
-      const emptyFile = new File(["empty"], ruleset.name, {
+    ruleset?.rules?.map((rule): IReadFile => {
+      const emptyFile = new File(["empty"], rule.name, {
         type: "placeholder",
       });
       return {
-        fileName: ruleset.name,
+        fileName: rule.name,
         fullFile: emptyFile,
         loadResult: "success",
         loadPercentage: 100,

--- a/client/src/app/queries/rulesets.ts
+++ b/client/src/app/queries/rulesets.ts
@@ -31,7 +31,7 @@ export const useFetchRulesets = () => {
               target: labels.targetLabel,
             };
             return {
-              ...ruleset,
+              ...rule,
               metadata: transformedMetadata,
             };
           });


### PR DESCRIPTION
- Fixes a bug with the rules selector that was writing ruleset data to each rule in the map. This caused all uploaded rules to show the ruleset name rather than the rule name. 
- Fixes an issue with yaml parsing. yaml.load returns an object when only one value is found rather than an array when multiple values are found from an uploaded rule file. This caused the app to blow up & freeze when trying to iterate through the single object. 
- TODO: Fix the enabled save button on edit with no dirty fields for the custom-target-form #1073 