### PR TITLE
:bug: Save button always enabled for custom-target edit

### DIFF
--- a/client/src/app/pages/migration-targets/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/custom-target-form.tsx
@@ -478,7 +478,13 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
                   <MultipleFileUploadStatusItem
                     file={file.fullFile}
                     key={file.fileName}
-                    customFileHandler={(file) => handleFile(file)}
+                    customFileHandler={(file) => {
+                      if (file.type === "placeholder") {
+                        return null;
+                      } else {
+                        return handleFile(file);
+                      }
+                    }}
                     onClearClick={() => removeFiles([file.fileName])}
                     progressValue={getloadPercentage(file.fileName)}
                     progressVariant={getloadResult(file.fileName)}


### PR DESCRIPTION
- Fixes an issue where the save button is always enabled for custom-target-update form. This is because the default handler calls setValue due to the file upload component form state being manually managed by the useRuleFiles component. This fix bypasses the setValue call for initially loaded placeholder files. 
Closes https://github.com/konveyor/tackle2-ui/issues/1073 