### PR TITLE
:bug: Fix double tab pane in issue incidents detail modal from PF upgrade

### DIFF
--- a/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -94,7 +94,7 @@ export const FileIncidentsDetailModal: React.FC<
           }
         >
           {[
-            ...firstFiveIncidents.map((incident, index) => (
+            firstFiveIncidents.map((incident, index) => (
               <Tab
                 key={incident.id}
                 eventKey={incident.id}
@@ -124,24 +124,24 @@ export const FileIncidentsDetailModal: React.FC<
                 ) : null}
               </Tab>
             )),
-            ...(totalNumIncidents > 5
-              ? [
-                  <Tab
-                    key="all"
-                    eventKey="all"
-                    title={`All incidents (${totalNumIncidents})`} // TODO i18n
-                  >
-                    <Alert
-                      isInline
-                      variant="info"
-                      className={spacing.mtMd}
-                      title="TODO"
-                    />
-                    <FileAllIncidentsTable fileReport={fileReport} />
-                  </Tab>,
-                ]
-              : []),
-          ]}
+            totalNumIncidents > 5 && [
+              <Tab
+                key="all"
+                eventKey="all"
+                title={`All incidents (${totalNumIncidents})`} // TODO i18n
+              >
+                <Alert
+                  isInline
+                  variant="info"
+                  className={spacing.mtMd}
+                  title="TODO"
+                />
+                <FileAllIncidentsTable fileReport={fileReport} />
+              </Tab>,
+            ],
+          ]
+            .flat(1)
+            .filter(Boolean)}
         </Tabs>
       )}
     </Modal>

--- a/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -62,6 +62,8 @@ export const FileIncidentsDetailModal: React.FC<
   // TODO render incident facts?
   // TODO render documentation links? are those part of the markdown? where do we get them from the hub?
 
+  console.log({ activeTabIncidentId });
+
   return (
     <Modal
       title={fileReport.file}
@@ -85,14 +87,14 @@ export const FileIncidentsDetailModal: React.FC<
           })}
         />
       ) : (
-        <>
-          <Tabs
-            activeKey={activeTabIncidentId}
-            onSelect={(_event, tabKey) =>
-              setActiveTabIncidentId(tabKey as IncidentIdOrAll)
-            }
-          >
-            {firstFiveIncidents.map((incident, index) => (
+        <Tabs
+          activeKey={activeTabIncidentId}
+          onSelect={(_event, tabKey) =>
+            setActiveTabIncidentId(tabKey as IncidentIdOrAll)
+          }
+        >
+          {[
+            ...firstFiveIncidents.map((incident, index) => (
               <Tab
                 key={incident.id}
                 eventKey={incident.id}
@@ -121,30 +123,26 @@ export const FileIncidentsDetailModal: React.FC<
                   </Grid>
                 ) : null}
               </Tab>
-            ))}
-          </Tabs>
-          {totalNumIncidents > 5 ? (
-            <Tabs
-              activeKey="all"
-              onSelect={(_event, tabKey) =>
-                setActiveTabIncidentId(tabKey as IncidentIdOrAll)
-              }
-            >
-              <Tab
-                eventKey="all"
-                title={`All incidents (${totalNumIncidents})`} // TODO i18n
-              >
-                <Alert
-                  isInline
-                  variant="info"
-                  className={spacing.mtMd}
-                  title="TODO"
-                />
-                <FileAllIncidentsTable fileReport={fileReport} />
-              </Tab>
-            </Tabs>
-          ) : null}
-        </>
+            )),
+            ...(totalNumIncidents > 5
+              ? [
+                  <Tab
+                    key="all"
+                    eventKey="all"
+                    title={`All incidents (${totalNumIncidents})`} // TODO i18n
+                  >
+                    <Alert
+                      isInline
+                      variant="info"
+                      className={spacing.mtMd}
+                      title="TODO"
+                    />
+                    <FileAllIncidentsTable fileReport={fileReport} />
+                  </Tab>,
+                ]
+              : []),
+          ]}
+        </Tabs>
       )}
     </Modal>
   );


### PR DESCRIPTION
I missed this when reviewing #1078. cc @gildub

I noticed that when clicking an affected file in the drawer on the Issues pages to open the incident details modal, the last tab ("All incidents" table) was split out into its own tab bar and rendered below the contents of the selected tab. This is because of this change: https://github.com/konveyor/tackle2-ui/pull/1078/files#diff-e40974378de11be89b5b1ca02db26b8fed80482f468154ebb84807af7f0e7273L125-R147 (link takes a while to scroll the diff after loading)

When I reversed the change, I saw the reason for it: the new Tabs component doesn't like to have its children expressed as a combination of an array and extra nodes (like we had been doing when mapping over the first 5 incidents and conditionally including a 6th tab). It gave this error:

![Screenshot 2023-07-10 at 3 38 00 PM](https://github.com/konveyor/tackle2-ui/assets/811963/6d10427c-15c5-47bb-973d-2110b2f2b48f)

It appears to be due to this type change in PF: https://github.com/patternfly/patternfly-react/pull/8217

The solution was to make sure the children of `<Tabs>` is always a single array of `<Tab>` elements.