### PR TITLE
:seedling: Adopt `react-refesh` in dev mode to allow hot component replacement

### DIFF
--- a/client/config/webpack.common.ts
+++ b/client/config/webpack.common.ts
@@ -25,12 +25,13 @@ const config: Configuration = {
   module: {
     rules: [
       {
-        test: /\.tsx?$/,
-        loader: "ts-loader",
+        test: /\.[jt]sx?$/,
         exclude: /node_modules/,
-        options: {
-          // disable type checker for fork-ts-checker-webpack-plugin
-          transpileOnly: true,
+        use: {
+          loader: "ts-loader",
+          options: {
+            transpileOnly: true,
+          },
         },
       },
       {

--- a/client/config/webpack.common.ts
+++ b/client/config/webpack.common.ts
@@ -13,7 +13,7 @@ const pathTo = (relativePath: string) => path.resolve(__dirname, relativePath);
 
 const config: Configuration = {
   entry: {
-    app: ["react-hot-loader/patch", pathTo("../src/index.tsx")],
+    app: [pathTo("../src/index.tsx")],
   },
 
   output: {

--- a/client/config/webpack.dev.ts
+++ b/client/config/webpack.dev.ts
@@ -1,9 +1,11 @@
 import path from "path";
-import merge from "webpack-merge";
-import { Configuration } from "webpack";
+import { mergeWithRules } from "webpack-merge";
 import HtmlWebpackPlugin from "html-webpack-plugin";
-import "webpack-dev-server";
+import ReactRefreshTypeScript from "react-refresh-typescript";
+import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
+import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 
+import "webpack-dev-server";
 import { getEncodedEnv } from "./envLookup";
 import { stylePaths } from "./stylePaths";
 import commonWebpackConfiguration from "./webpack.common";
@@ -11,7 +13,17 @@ import commonWebpackConfiguration from "./webpack.common";
 const brandType = process.env["PROFILE"] || "konveyor";
 const pathTo = (relativePath: string) => path.resolve(__dirname, relativePath);
 
-const config = merge<Configuration>(commonWebpackConfiguration, {
+const config = mergeWithRules({
+  module: {
+    rules: {
+      test: "match",
+      use: {
+        loader: "match",
+        options: "replace",
+      },
+    },
+  },
+})(commonWebpackConfiguration, {
   mode: "development",
   devtool: "eval-source-map",
   output: {
@@ -30,9 +42,39 @@ const config = merge<Configuration>(commonWebpackConfiguration, {
     historyApiFallback: {
       disableDotRule: true,
     },
+    hot: true,
+  },
+
+  module: {
+    rules: [
+      {
+        test: /\.[jt]sx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "ts-loader",
+          options: {
+            transpileOnly: true, // HMR in webpack-dev-server requires transpileOnly
+            getCustomTransformers: () => ({
+              before: [ReactRefreshTypeScript()],
+            }),
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        include: [...stylePaths],
+        use: ["style-loader", "css-loader"],
+      },
+    ],
   },
 
   plugins: [
+    new ReactRefreshWebpackPlugin(),
+    new ForkTsCheckerWebpackPlugin({
+      typescript: {
+        mode: "readonly",
+      },
+    }),
     new HtmlWebpackPlugin({
       // In dev mode, populate window._env at build time
       filename: "index.html",
@@ -45,14 +87,8 @@ const config = merge<Configuration>(commonWebpackConfiguration, {
     }),
   ],
 
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        include: [...stylePaths],
-        use: ["style-loader", "css-loader"],
-      },
-    ],
+  watchOptions: {
+    ignored: /node_modules/, // adjust this pattern if using monorepo linked packages
   },
 });
 export default config;

--- a/client/config/webpack.prod.ts
+++ b/client/config/webpack.prod.ts
@@ -28,6 +28,16 @@ const config = merge<Configuration>(commonWebpackConfiguration, {
     ],
   },
 
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        include: [...stylePaths],
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
+      },
+    ],
+  },
+
   plugins: [
     new MiniCssExtractPlugin({
       filename: "[name].[contenthash:8].css",
@@ -48,16 +58,6 @@ const config = merge<Configuration>(commonWebpackConfiguration, {
       NODE_ENV: "production",
     }),
   ],
-
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        include: [...stylePaths],
-        use: [MiniCssExtractPlugin.loader, "css-loader"],
-      },
-    ],
-  },
 });
 
 export default config;

--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.43.1",
-    "react-hot-loader": "^4.13.1",
     "react-i18next": "^11.8.5",
     "react-image-file-resizer": "^0.4.8",
     "react-markdown": "^8.0.7",

--- a/client/package.json
+++ b/client/package.json
@@ -56,6 +56,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@testing-library/dom": "^8.14.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
@@ -84,7 +85,7 @@
     "eslint-webpack-plugin": "^3.1.1",
     "exports-loader": "^3.1.0",
     "file-loader": "^6.2.0",
-    "fork-ts-checker-webpack-plugin": "^7.2.1",
+    "fork-ts-checker-webpack-plugin": "^8.0.0",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^8.0.3",
     "i18next-parser": "^0.13.0",
@@ -96,6 +97,8 @@
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.3",
     "raw-loader": "^4.0.2",
+    "react-refresh": "^0.14.0",
+    "react-refresh-typescript": "^2.0.9",
     "sass-loader": "^12.4.0",
     "source-map-explorer": "^2.5.2",
     "style-loader": "^3.3.1",
@@ -105,12 +108,13 @@
     "ts-loader": "^9.4.1",
     "ts-node": "^10.9.1",
     "tsconfig-paths-webpack-plugin": "^4.0.0",
+    "type-fest": "^3.13.0",
     "typescript": "^4.8.4",
     "url-loader": "^4.1.1",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1",
-    "webpack-merge": "^5.8.0"
+    "webpack-merge": "^5.9.0"
   },
   "eslintConfig": {
     "extends": [

--- a/client/src/app/pages/reports/application-selection-context.tsx
+++ b/client/src/app/pages/reports/application-selection-context.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useSelectionState, ISelectionState } from "@migtools/lib-ui";
 import { Application } from "@app/api/models";
-import { AppContainer } from "react-hot-loader";
 
 interface IApplicationSelectionContext extends ISelectionState<Application> {
   allItems: Application[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.43.1",
-        "react-hot-loader": "^4.13.1",
         "react-i18next": "^11.8.5",
         "react-image-file-resizer": "^0.4.8",
         "react-markdown": "^8.0.7",
@@ -3353,6 +3352,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -5019,11 +5019,6 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -5203,6 +5198,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5790,7 +5786,8 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "node_modules/fast-printf": {
       "version": "1.6.9",
@@ -6314,15 +6311,6 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
-    },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
     },
     "node_modules/globals": {
       "version": "13.20.0",
@@ -8876,6 +8864,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -8991,6 +8980,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
       "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -9843,14 +9833,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
-      "dependencies": {
-        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/min-indent": {
@@ -11372,14 +11354,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -11645,42 +11619,6 @@
         "react": "^16.8.0 || ^17 || ^18"
       }
     },
-    "node_modules/react-hot-loader": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.1.tgz",
-      "integrity": "sha512-ZlqCfVRqDJmMXTulUGic4lN7Ic1SXgHAFw7y/Jb7t25GBgTR0fYAJ8uY4mrpxjRyWGWmqw77qJQGnYbzCvBU7g==",
-      "dependencies": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^2.0.3",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "@types/react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-hot-loader/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/react-i18next": {
       "version": "11.18.6",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
@@ -11711,11 +11649,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-markdown": {
       "version": "8.0.7",
@@ -12572,11 +12505,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "yup": "^0.32.11"
       },
       "devDependencies": {
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
         "@testing-library/dom": "^8.14.0",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
@@ -90,7 +91,7 @@
         "eslint-webpack-plugin": "^3.1.1",
         "exports-loader": "^3.1.0",
         "file-loader": "^6.2.0",
-        "fork-ts-checker-webpack-plugin": "^7.2.1",
+        "fork-ts-checker-webpack-plugin": "^8.0.0",
         "html-webpack-plugin": "^5.5.0",
         "husky": "^8.0.3",
         "i18next-parser": "^0.13.0",
@@ -102,6 +103,8 @@
         "prettier": "^2.2.1",
         "pretty-quick": "^3.1.3",
         "raw-loader": "^4.0.2",
+        "react-refresh": "^0.14.0",
+        "react-refresh-typescript": "^2.0.9",
         "sass-loader": "^12.4.0",
         "source-map-explorer": "^2.5.2",
         "style-loader": "^3.3.1",
@@ -111,12 +114,13 @@
         "ts-loader": "^9.4.1",
         "ts-node": "^10.9.1",
         "tsconfig-paths-webpack-plugin": "^4.0.0",
+        "type-fest": "^3.13.0",
         "typescript": "^4.8.4",
         "url-loader": "^4.1.1",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1",
-        "webpack-merge": "^5.8.0"
+        "webpack-merge": "^5.9.0"
       }
     },
     "client/node_modules/@patternfly/react-core": {
@@ -140,6 +144,18 @@
       "version": "5.0.0-prerelease.6",
       "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.0-prerelease.6.tgz",
       "integrity": "sha512-QZ/eEK0/MvjWlctzGxCUcWGYhgd5xZMSQ3wux7YFjk8YCYeClXnlZ9BZtQ7u6Y1FxyeqpwQbACgQyUXdfZaXwg=="
+    },
+    "client/node_modules/type-fest": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.0.tgz",
+      "integrity": "sha512-Gur3yQGM9qiLNs0KPP7LPgeRbio2QTt4xXouobMCarR0/wyW3F+F/+OWwshg3NG0Adon7uQfSZBpB46NfhoF1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -1636,6 +1652,83 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.0-prerelease.5.tgz",
       "integrity": "sha512-36iQ7CuYh3OKf+TEZNSfU5Mpgi+aLJoFFA2V4YDaOL8+7RC8sFqh/dW3S9ThkjQrtc0fF7OK7mrPJzK+nQB9UQ==",
       "peer": true
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz",
+      "integrity": "sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-html-community": "^0.0.8",
+        "common-path-prefix": "^3.0.0",
+        "core-js-pure": "^3.23.3",
+        "error-stack-parser": "^2.0.6",
+        "find-up": "^5.0.0",
+        "html-entities": "^2.1.0",
+        "loader-utils": "^2.0.4",
+        "schema-utils": "^3.0.0",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "@types/webpack": "4.x || 5.x",
+        "react-refresh": ">=0.10.0 <1.0.0",
+        "sockjs-client": "^1.4.0",
+        "type-fest": ">=0.17.0 <4.0.0",
+        "webpack": ">=4.43.0 <6.0.0",
+        "webpack-dev-server": "3.x || 4.x",
+        "webpack-hot-middleware": "2.x",
+        "webpack-plugin-serve": "0.x || 1.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        },
+        "sockjs-client": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        },
+        "webpack-hot-middleware": {
+          "optional": true
+        },
+        "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/@react-keycloak/core": {
       "version": "3.2.0",
@@ -3946,6 +4039,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+      "dev": true
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4254,6 +4353,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.31.1.tgz",
+      "integrity": "sha512-w+C62kvWti0EPs4KPMCMVv9DriHSXfQOCQ94bGGBiEW5rrbtt/Rz8n5Krhfw9cpFyzXBjf3DB3QnPdEzGDY4Fw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -5263,6 +5373,15 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/es-get-iterator": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
@@ -6081,9 +6200,9 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.3.0.tgz",
-      "integrity": "sha512-IN+XTzusCjR5VgntYFgxbxVx3WraPRnKehBFrf00cMSrtUuW9MsG9dhL6MWpY6MkjC3wVwoujfCDgZZCQwbswA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
+      "integrity": "sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
@@ -6105,13 +6224,7 @@
       },
       "peerDependencies": {
         "typescript": ">3.6.0",
-        "vue-template-compiler": "*",
         "webpack": "^5.11.0"
-      },
-      "peerDependenciesMeta": {
-        "vue-template-compiler": {
-          "optional": true
-        }
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
@@ -11713,6 +11826,25 @@
         "react": ">=17 <= 18"
       }
     },
+    "node_modules/react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-refresh-typescript": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.9.tgz",
+      "integrity": "sha512-chAnOO4vpxm/3WkgOVmti+eN8yUtkJzeGkOigV6UA9eDFz12W34e/SsYe2H5+RwYJ3+sfSZkVbiXcG1chEBxlg==",
+      "dev": true,
+      "peerDependencies": {
+        "react-refresh": "0.10.x || 0.11.x || 0.12.x || 0.13.x || 0.14.x",
+        "typescript": "^4.8 || ^5.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -12832,6 +12964,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true
     },
     "node_modules/statuses": {
       "version": "2.0.1",


### PR DESCRIPTION
By adopting react-refresh in webpack dev configurations, via `ReactRefreshWebpackPlugin` and `ReactRefreshTypeScript`, developers can now live edit react components without loosing state.  This means components are replaced on change without forcing a page reload.

The `webpack-dev.ts` configuration is using `mergeWithRules()` to both merge the common configuration, and to replace the `ts-loader` options.  The dev options enable react-refresh.

Add `ForkTsCheckerWebpackPlugin` to dev configuration to do async typescript type checking.  It isn't needed on the prod config since the build runs full `tsc` before running webpack.  Any type errors will stop the build before progressing to webpack.

In all webpack configs, `module/rules` now come before `plugins` to maintain visual consistency.
