### PR TITLE
:bug: Restore deprecated `Dropdown` in `KebabDropdown`, use matching deprecated `DropdownItems`, use `isAriaDisabled` prop for items with tooltips

### DIFF
--- a/client/src/app/components/target-card.tsx
+++ b/client/src/app/components/target-card.tsx
@@ -7,13 +7,13 @@ import {
   Card,
   CardBody,
   Text,
-  DropdownItem,
   Flex,
   FlexItem,
   Button,
   ButtonVariant,
   Label,
 } from "@patternfly/react-core";
+import { DropdownItem } from "@patternfly/react-core/deprecated";
 import {
   Select,
   SelectOption,

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -6,12 +6,12 @@ import WarningTriangleIcon from "@patternfly/react-icons/dist/esm/icons/warning-
 import {
   Button,
   ButtonVariant,
-  DropdownItem,
   Modal,
   ToolbarGroup,
   ToolbarItem,
   TooltipPosition,
 } from "@patternfly/react-core";
+import { DropdownItem } from "@patternfly/react-core/deprecated";
 import {
   cellWidth,
   IAction,

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -464,7 +464,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
         >
           <DropdownItem
             key="applications-bulk-delete"
-            isDisabled={selectedRows.some(
+            isAriaDisabled={selectedRows.some(
               (application) => application.migrationWave !== null
             )}
             onClick={() => {

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -640,7 +640,7 @@ export const ApplicationsTable: React.FC = () => {
         >
           <DropdownItem
             key="applications-bulk-delete"
-            isDisabled={selectedRows.some(
+            isAriaDisabled={selectedRows.some(
               (application) => application.migrationWave !== null
             )}
             onClick={() => {

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -6,12 +6,12 @@ import { useTranslation, Trans } from "react-i18next";
 import {
   Button,
   ButtonVariant,
-  DropdownItem,
   Modal,
   ToolbarGroup,
   ToolbarItem,
   TooltipPosition,
 } from "@patternfly/react-core";
+import { DropdownItem } from "@patternfly/react-core/deprecated";
 import {
   cellWidth,
   IAction,

--- a/client/src/app/pages/migration-waves/migration-waves.tsx
+++ b/client/src/app/pages/migration-waves/migration-waves.tsx
@@ -434,7 +434,9 @@ export const MigrationWaves: React.FC = () => {
                                       >
                                         <DropdownItem
                                           key="manage-app"
-                                          isDisabled={applications.length === 0}
+                                          isAriaDisabled={
+                                            applications.length === 0
+                                          }
                                           onClick={() => {
                                             setWaveToManageModalState(
                                               migrationWave

--- a/client/src/app/pages/migration-waves/migration-waves.tsx
+++ b/client/src/app/pages/migration-waves/migration-waves.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {
   Button,
   ButtonVariant,
-  DropdownItem,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -18,6 +17,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { DropdownItem } from "@patternfly/react-core/deprecated";
 import { useTranslation } from "react-i18next";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";

--- a/client/src/app/shared/components/kebab-dropdown/kebab-dropdown.tsx
+++ b/client/src/app/shared/components/kebab-dropdown/kebab-dropdown.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { Dropdown, KebabToggle } from "@patternfly/react-core/deprecated";
 
 export interface IKebabDropdownProps {
-  dropdownItems?: any[];
+  dropdownItems?: React.ReactNode[];
 }
 
 export const KebabDropdown: React.FC<IKebabDropdownProps> = ({

--- a/client/src/app/shared/components/kebab-dropdown/kebab-dropdown.tsx
+++ b/client/src/app/shared/components/kebab-dropdown/kebab-dropdown.tsx
@@ -1,14 +1,9 @@
 import React, { useState } from "react";
-import {
-  Dropdown,
-  DropdownList,
-  MenuToggle,
-  MenuToggleElement,
-} from "@patternfly/react-core";
-import EllipsisVIcon from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
+
+import { Dropdown, KebabToggle } from "@patternfly/react-core/deprecated";
 
 export interface IKebabDropdownProps {
-  dropdownItems?: React.ReactNode[];
+  dropdownItems?: any[];
 }
 
 export const KebabDropdown: React.FC<IKebabDropdownProps> = ({
@@ -16,25 +11,17 @@ export const KebabDropdown: React.FC<IKebabDropdownProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
+  const onKebabToggle = (isOpen: boolean) => {
+    setIsOpen(isOpen);
+  };
+
   return (
     <Dropdown
-      popperProps={{ position: "right" }}
+      toggle={<KebabToggle onToggle={(_, isOpen) => onKebabToggle(isOpen)} />}
       isOpen={isOpen}
-      onOpenChange={(isOpen) => setIsOpen(isOpen)}
-      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle
-          ref={toggleRef}
-          isExpanded={isOpen}
-          onClick={() => setIsOpen(!isOpen)}
-          variant="plain"
-          aria-label="Table toolbar actions kebab toggle"
-          isDisabled={!dropdownItems || dropdownItems.length === 0}
-        >
-          <EllipsisVIcon aria-hidden="true" />
-        </MenuToggle>
-      )}
-    >
-      <DropdownList>{dropdownItems}</DropdownList>
-    </Dropdown>
+      isPlain
+      position="right"
+      dropdownItems={dropdownItems}
+    />
   );
 };


### PR DESCRIPTION
Fixes a regression caused by #1126 where dropdown items that are disabled with tooltips could not trigger the tooltips. Discovered by @gildub when working on #1149.

It appears the `isAriaDisabled` prop which we need for retaining the mouse hover event on a disabled DropdownItem is not present in the new PF5 DropdownItem. This is due to missing styles in PF core that are still being addressed (see https://github.com/patternfly/patternfly/issues/5528, https://github.com/patternfly/patternfly/pull/5692, and related comment here: https://github.com/patternfly/patternfly-react/pull/8992#issuecomment-1530234144)

Until `isAriaDisabled` is supported in the new PF5 DropdownItem we must restore the usage of the deprecated component for these tooltips to work.