### PR TITLE
:bug: [backport release-0.2] Migration wave name is min 3/max 20 chars only when provided (1156)

### DIFF
--- a/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
+++ b/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
@@ -138,9 +138,21 @@ export const WaveForm: React.FC<WaveFormProps> = ({
   const validationSchema: yup.SchemaOf<WaveFormValues> = yup.object().shape({
     name: yup
       .string()
-      .trim()
-      .min(3, t("validation.minLength", { length: 3 }))
-      .max(120, t("validation.maxLength", { length: 120 })),
+      .defined()
+      .test(
+        "min-char-check",
+        "Name is invalid. The name must be between 3 and 120 characters ",
+        (value) => {
+          if (!!value) {
+            const schema = yup
+              .string()
+              .min(3, t("validation.minLength", { length: 3 }))
+              .max(120, t("validation.maxLength", { length: 120 }));
+            return schema.isValidSync(value);
+          }
+          return true;
+        }
+      ),
     startDateStr: yup
       .string()
       .required(t("validation.required"))


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-906

(cherry picked from commit 34e68b7419a9a910be00fee4cce19472d0aa0831)
