### PR TITLE
:bug: Fix PageSidebar structure and spacing of perpective selector above nav

### DIFF
--- a/client/src/app/layout/SidebarApp/SidebarApp.css
+++ b/client/src/app/layout/SidebarApp/SidebarApp.css
@@ -1,5 +1,5 @@
 .perspective {
-  padding: var(--pf-v5-c-nav__link--PaddingTop)
+  padding: var(--pf-v5-global--spacer--lg)
     var(--pf-v5-c-nav__link--PaddingRight) var(--pf-v5-global--spacer--lg)
     var(--pf-v5-c-nav__link--PaddingLeft);
   border-bottom: 1px solid var(--pf-v5-c-nav__link--before--BorderColor);
@@ -26,4 +26,8 @@
   border-bottom-width: var(
     --pf-v5-c-select__toggle--m-expanded--before--BorderBottomWidth
   );
+}
+
+.perspective + .pf-v5-c-nav__list {
+  padding-top: 0;
 }

--- a/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -7,6 +7,7 @@ import {
   PageSidebar,
   NavList,
   NavExpandable,
+  PageSidebarBody,
 } from "@patternfly/react-core";
 import { SelectOption, SelectVariant } from "@patternfly/react-core/deprecated";
 
@@ -80,154 +81,156 @@ export const SidebarApp: React.FC = () => {
 
   return (
     <PageSidebar theme={LayoutTheme}>
-      <Nav id="nav-primary" aria-label="Nav" theme={LayoutTheme}>
-        <div className="perspective">
-          <SimpleSelect
-            toggleId="sidebar-perspective-toggle"
-            variant={SelectVariant.single}
-            aria-label="Select user perspective"
-            id="sidebar-perspective"
-            value={
-              selectedPersona
-                ? toOptionLike(selectedPersona, personaOptions)
-                : undefined
-            }
-            options={personaOptions}
-            onChange={(selection) => {
-              const selectionValue = selection as OptionWithValue<PersonaKey>;
-              setSelectedPersona(selectionValue.value);
-              if (selectionValue.value === PersonaKey.ADMINISTRATION) {
-                history.push(Paths.general);
-              } else {
-                history.push(Paths.applications);
+      <PageSidebarBody>
+        <Nav id="nav-primary" aria-label="Nav" theme={LayoutTheme}>
+          <div className="perspective">
+            <SimpleSelect
+              toggleId="sidebar-perspective-toggle"
+              variant={SelectVariant.single}
+              aria-label="Select user perspective"
+              id="sidebar-perspective"
+              value={
+                selectedPersona
+                  ? toOptionLike(selectedPersona, personaOptions)
+                  : undefined
               }
-            }}
-          />
-        </div>
-        {selectedPersona === PersonaKey.MIGRATION ? (
-          <NavList title="Global">
-            <NavItem>
-              <NavLink
-                to={Paths.applications + search}
-                activeClassName="pf-m-current"
-              >
-                {t("sidebar.applicationInventory")}
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink
-                to={Paths.reports + search}
-                activeClassName="pf-m-current"
-              >
-                {t("sidebar.reports")}
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink to={Paths.controls} activeClassName="pf-m-current">
-                {t("sidebar.controls")}
-              </NavLink>
-            </NavItem>
-            {FEATURES_ENABLED.migrationWaves ? (
+              options={personaOptions}
+              onChange={(selection) => {
+                const selectionValue = selection as OptionWithValue<PersonaKey>;
+                setSelectedPersona(selectionValue.value);
+                if (selectionValue.value === PersonaKey.ADMINISTRATION) {
+                  history.push(Paths.general);
+                } else {
+                  history.push(Paths.applications);
+                }
+              }}
+            />
+          </div>
+          {selectedPersona === PersonaKey.MIGRATION ? (
+            <NavList title="Global">
               <NavItem>
                 <NavLink
-                  to={Paths.migrationWaves}
+                  to={Paths.applications + search}
                   activeClassName="pf-m-current"
                 >
-                  {t("sidebar.migrationWaves")}
+                  {t("sidebar.applicationInventory")}
                 </NavLink>
               </NavItem>
-            ) : null}
-            {FEATURES_ENABLED.dynamicReports ? (
-              <>
+              <NavItem>
+                <NavLink
+                  to={Paths.reports + search}
+                  activeClassName="pf-m-current"
+                >
+                  {t("sidebar.reports")}
+                </NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink to={Paths.controls} activeClassName="pf-m-current">
+                  {t("sidebar.controls")}
+                </NavLink>
+              </NavItem>
+              {FEATURES_ENABLED.migrationWaves ? (
                 <NavItem>
-                  <NavLink to={Paths.issues} activeClassName="pf-m-current">
-                    {t("sidebar.issues")}
+                  <NavLink
+                    to={Paths.migrationWaves}
+                    activeClassName="pf-m-current"
+                  >
+                    {t("sidebar.migrationWaves")}
+                  </NavLink>
+                </NavItem>
+              ) : null}
+              {FEATURES_ENABLED.dynamicReports ? (
+                <>
+                  <NavItem>
+                    <NavLink to={Paths.issues} activeClassName="pf-m-current">
+                      {t("sidebar.issues")}
+                    </NavLink>
+                  </NavItem>
+                  <NavItem>
+                    <NavLink
+                      to={Paths.dependencies}
+                      activeClassName="pf-m-current"
+                    >
+                      {t("sidebar.dependencies")}
+                    </NavLink>
+                  </NavItem>
+                </>
+              ) : null}
+            </NavList>
+          ) : (
+            <NavList title="Admin">
+              <NavItem>
+                <NavLink to={Paths.general} activeClassName="pf-m-current">
+                  {t("terms.general")}
+                </NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink to={Paths.identities} activeClassName="pf-m-current">
+                  {t("terms.credentials")}
+                </NavLink>
+              </NavItem>
+              <NavExpandable
+                title="Repositories"
+                srText="SR Link"
+                groupId="admin-repos"
+                isExpanded
+              >
+                <NavItem>
+                  <NavLink
+                    to={Paths.repositoriesGit}
+                    activeClassName="pf-m-current"
+                  >
+                    Git
                   </NavLink>
                 </NavItem>
                 <NavItem>
                   <NavLink
-                    to={Paths.dependencies}
+                    to={Paths.repositoriesSvn}
                     activeClassName="pf-m-current"
                   >
-                    {t("sidebar.dependencies")}
+                    Subversion
                   </NavLink>
                 </NavItem>
-              </>
-            ) : null}
-          </NavList>
-        ) : (
-          <NavList title="Admin">
-            <NavItem>
-              <NavLink to={Paths.general} activeClassName="pf-m-current">
-                {t("terms.general")}
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink to={Paths.identities} activeClassName="pf-m-current">
-                {t("terms.credentials")}
-              </NavLink>
-            </NavItem>
-            <NavExpandable
-              title="Repositories"
-              srText="SR Link"
-              groupId="admin-repos"
-              isExpanded
-            >
-              <NavItem>
-                <NavLink
-                  to={Paths.repositoriesGit}
-                  activeClassName="pf-m-current"
-                >
-                  Git
-                </NavLink>
-              </NavItem>
-              <NavItem>
-                <NavLink
-                  to={Paths.repositoriesSvn}
-                  activeClassName="pf-m-current"
-                >
-                  Subversion
-                </NavLink>
-              </NavItem>
-              <NavItem>
-                <NavLink
-                  to={Paths.repositoriesMvn}
-                  activeClassName="pf-m-current"
-                >
-                  Maven
-                </NavLink>
-              </NavItem>
-            </NavExpandable>
-            <NavItem>
-              <NavLink to={Paths.proxies} activeClassName="pf-m-current">
-                Proxy
-              </NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink
-                to={Paths.migrationTargets}
-                activeClassName="pf-m-current"
-              >
-                Custom migration targets
-              </NavLink>
-            </NavItem>
-            {FEATURES_ENABLED.migrationWaves ? (
-              <NavExpandable
-                title="Issue management"
-                srText="SR Link"
-                groupId="admin-issue-management"
-                isExpanded
-              >
                 <NavItem>
-                  <NavLink to={Paths.jira} activeClassName="pf-m-current">
-                    Jira
+                  <NavLink
+                    to={Paths.repositoriesMvn}
+                    activeClassName="pf-m-current"
+                  >
+                    Maven
                   </NavLink>
                 </NavItem>
               </NavExpandable>
-            ) : null}
-          </NavList>
-        )}
-      </Nav>
+              <NavItem>
+                <NavLink to={Paths.proxies} activeClassName="pf-m-current">
+                  Proxy
+                </NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink
+                  to={Paths.migrationTargets}
+                  activeClassName="pf-m-current"
+                >
+                  Custom migration targets
+                </NavLink>
+              </NavItem>
+              {FEATURES_ENABLED.migrationWaves ? (
+                <NavExpandable
+                  title="Issue management"
+                  srText="SR Link"
+                  groupId="admin-issue-management"
+                  isExpanded
+                >
+                  <NavItem>
+                    <NavLink to={Paths.jira} activeClassName="pf-m-current">
+                      Jira
+                    </NavLink>
+                  </NavItem>
+                </NavExpandable>
+              ) : null}
+            </NavList>
+          )}
+        </Nav>
+      </PageSidebarBody>
     </PageSidebar>
   );
 };


### PR DESCRIPTION
Fixes #1163 

As part of the PF5 upgrade we failed to wrap the children of `<PageSidebar>` in `<PageSidebarBody>` as mentioned [in the release notes](https://staging.patternfly.org/get-started/upgrade/release-notes/):

> PageSidebar API has been updated. The nav property has been renamed to children. Any content passed to the property should be wrapped in PageSidebarBody.

Also, the padding at the top of the page sidebar body element has been moved to the top of the nav element in PF5, so our custom styles for the perspective selector broke. This fixes that CSS to restore the styles established in https://github.com/konveyor/tackle2-ui/pull/251 (based on [design guidelines here](https://www.patternfly.org/v4/components/context-selector/design-guidelines#recommended-placement-0)).

Note that we may still want to follow up and check if these design guidelines are still the best practice, since the context selector component is deprecated and I can't find equivalent guidelines in the new menu docs for a menu at the top of the nav like ours. It would be nice to find a solution that is supported by the PF components without these custom styles.

It's the little things 😄 ✨ 

![Screenshot 2023-07-21 at 12 07 14 PM](https://github.com/konveyor/tackle2-ui/assets/811963/2f0e852b-dd41-45cf-9143-8b115862589f)

Note: the diff is best viewed with "hide whitespace" checked in the diff viewer settings. The only change to the JSX was nesting things under `<PageSidebarBody>`.
