### PR TITLE
:bug: Use truncated first line of issue description everywhere we were using issue name

### DIFF
--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -9,6 +9,7 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  Truncate,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { AppPlaceholder, ConditionalRender } from "@app/shared/components";
@@ -44,8 +45,8 @@ export const AffectedApplications: React.FC = () => {
   const { t } = useTranslation();
 
   const { ruleset, rule } = useParams<IAffectedApplicationsRouteParams>();
-  const ruleReportName =
-    new URLSearchParams(useLocation().search).get("ruleReportName") ||
+  const issueTitle =
+    new URLSearchParams(useLocation().search).get("issueTitle") ||
     "Active rule";
 
   const tableControlState = useTableControlUrlParams({
@@ -140,7 +141,7 @@ export const AffectedApplications: React.FC = () => {
             </Link>
           </BreadcrumbItem>
           <BreadcrumbItem to="#" isActive>
-            {ruleReportName}
+            {issueTitle}
           </BreadcrumbItem>
         </Breadcrumb>
       </PageSection>

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -167,7 +167,7 @@ export const AffectedApplications: React.FC = () => {
                 </ToolbarItem>
               </ToolbarContent>
             </Toolbar>
-            <Table {...tableProps} aria-label="Migration waves table">
+            <Table {...tableProps} aria-label="Affected applications table">
               <Thead>
                 <Tr>
                   <TableHeaderContentWithControls {...tableControls}>

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -117,7 +117,7 @@ export const getAffectedAppsUrl = ({
     newPrefixedSerializedParams: {
       [prefix("filters")]: serializeFilterUrlParams(toFilterValues).filters,
       [FROM_ISSUES_PARAMS_KEY]: fromIssuesParams,
-      ruleReportName: ruleReport.name,
+      issueTitle: ruleReport.description.split("\n")[0],
     },
   })}`;
 };

--- a/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -10,6 +10,7 @@ import {
   TextContent,
   Text,
   Alert,
+  Truncate,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { AnalysisFileReport, AnalysisIssue } from "@app/api/models";
@@ -58,6 +59,8 @@ export const FileIncidentsDetailModal: React.FC<
     isFetching ||
     (firstFiveIncidents.length > 0 && activeTabIncidentId === undefined);
 
+  const issueTitle = issue.description.split("\n")[0];
+
   return (
     <Modal
       title={fileReport.file}
@@ -99,13 +102,15 @@ export const FileIncidentsDetailModal: React.FC<
                   <Grid hasGutter className={spacing.mtLg}>
                     <GridItem span={6}>
                       <IncidentCodeSnipViewer
-                        issueName={issue.name}
+                        issueTitle={issueTitle}
                         incident={incident}
                       />
                     </GridItem>
                     <GridItem span={6} className={spacing.plSm}>
                       <TextContent>
-                        <Text component="h2">{issue.name}</Text>
+                        <Text component="h2">
+                          <Truncate content={issueTitle} />
+                        </Text>
                         <Text component="small">Line {incident.line}</Text>
                       </TextContent>
                       <IssueDescriptionAndLinks

--- a/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/incident-code-snip-viewer.tsx
+++ b/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/incident-code-snip-viewer.tsx
@@ -8,12 +8,12 @@ import { LANGUAGES_BY_FILE_EXTENSION } from "config/monacoConstants";
 const codeLineRegex = /^\s*([0-9]+)( {2})?(.*)$/; // Pattern: leading whitespace (line number) (2 spaces)? (code)
 
 export interface IIncidentCodeSnipViewerProps {
-  issueName: string;
+  issueTitle: string;
   incident: AnalysisIncident;
 }
 
 export const IncidentCodeSnipViewer: React.FC<IIncidentCodeSnipViewerProps> = ({
-  issueName,
+  issueTitle,
   incident,
 }) => {
   const codeSnipNumberedLines = incident.codeSnip.split("\n");
@@ -63,7 +63,7 @@ export const IncidentCodeSnipViewer: React.FC<IIncidentCodeSnipViewerProps> = ({
             // Red squiggly under the affected line
             monaco.editor.setModelMarkers(model, "my-markers", [
               {
-                message: issueName,
+                message: issueTitle,
                 severity: monaco.MarkerSeverity.Error,
                 startLineNumber: relativeLineNum,
                 startColumn:

--- a/client/src/app/pages/issues/issue-detail-drawer/issue-detail-drawer.tsx
+++ b/client/src/app/pages/issues/issue-detail-drawer/issue-detail-drawer.tsx
@@ -10,6 +10,7 @@ import {
   Tabs,
   TabTitleText,
   Tab,
+  Truncate,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { IssueAffectedFilesTable } from "./issue-affected-files-table";
@@ -60,7 +61,7 @@ export const IssueDetailDrawer: React.FC<IIssueDetailDrawerProps> = ({
               {applicationName}
             </Text>
             <Title headingLevel="h2" size="lg" className={spacing.mtXs}>
-              {issue.name}
+              <Truncate content={issue.description.split("\n")[0]} />
             </Title>
           </TextContent>
           <Tabs


### PR DESCRIPTION
Followup to #1116

When we replaced the issue name property (possibly empty in real data) with the truncated issue description in the table, we failed to replace it everywhere else it is used.

This change uses the first line of the issue/report description where necessary, and truncates it with a tooltip in places with limited available width in case it is a long line.