### PR TITLE
:bug: [backport release-0.2] Always show analysis details in drawer (#1103)

### DIFF
--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
@@ -174,7 +174,9 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                 <Button
                   icon={
                     <span className={spacing.mrXs}>
-                      <ExclamationCircleIcon color="#c9190b"></ExclamationCircleIcon>
+                      <ExclamationCircleIcon
+                        color={COLOR_NAMES_BY_HEX_VALUE.red}
+                      ></ExclamationCircleIcon>
                     </span>
                   }
                   type="button"
@@ -185,22 +187,45 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                 >
                   Analysis details
                 </Button>
-                <SimpleDocumentViewerModal<Task | string>
-                  title={`Analysis details for ${application?.name}`}
-                  fetch={getTaskById}
-                  documentId={taskIdToView}
-                  onClose={() => setTaskIdToView(undefined)}
-                />
               </>
             ) : (
               <span className={spacing.mlSm}>
-                <ExclamationCircleIcon color="#c9190b"></ExclamationCircleIcon>
+                <ExclamationCircleIcon
+                  color={COLOR_NAMES_BY_HEX_VALUE.red}
+                ></ExclamationCircleIcon>
                 Failed
               </span>
             )
           ) : (
-            notAvailable
+            <>
+              {task ? (
+                <Button
+                  icon={
+                    <span className={spacing.mrXs}>
+                      <ExclamationCircleIcon
+                        color={COLOR_NAMES_BY_HEX_VALUE.blue}
+                      ></ExclamationCircleIcon>
+                    </span>
+                  }
+                  type="button"
+                  variant="link"
+                  onClick={() => setTaskIdToView(task?.id)}
+                  className={spacing.ml_0}
+                  style={{ margin: "0", padding: "0" }}
+                >
+                  Analysis details
+                </Button>
+              ) : (
+                notAvailable
+              )}
+            </>
           )}
+          <SimpleDocumentViewerModal<Task | string>
+            title={`Analysis details for ${application?.name}`}
+            fetch={getTaskById}
+            documentId={taskIdToView}
+            onClose={() => setTaskIdToView(undefined)}
+          />
         </TextContent>
       }
       factsTabContent={

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
@@ -28,6 +28,7 @@ import { SimpleDocumentViewerModal } from "@app/shared/components/simple-task-vi
 import { getApplicationAnalysis, getTaskById } from "@app/api/rest";
 import { useSetting } from "@app/queries/settings";
 import { APPLICATIONS } from "@app/api/rest";
+import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
 
 export interface IApplicationDetailDrawerAnalysisProps
   extends Pick<
@@ -107,13 +108,20 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
           {task?.state === "Succeeded" && application ? (
             <>
               <Tooltip content="View Report">
-                <Button variant="link" isInline>
-                  <Link
-                    to={`/hub/applications/${application.id}/bucket${task?.data?.output}`}
-                    target="_blank"
-                  >
-                    Report
-                  </Link>
+                <Button
+                  icon={
+                    <span className={spacing.mrXs}>
+                      <ExclamationCircleIcon
+                        color={COLOR_HEX_VALUES_BY_NAME.blue}
+                      ></ExclamationCircleIcon>
+                    </span>
+                  }
+                  type="button"
+                  variant="link"
+                  isInline
+                  onClick={() => setAppAnalysisToView(application.id)}
+                >
+                  View analysis
                 </Button>
               </Tooltip>
               {(isHTMLDownloadEnabled || isCSVDownloadEnabled) && (
@@ -175,7 +183,7 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                   icon={
                     <span className={spacing.mrXs}>
                       <ExclamationCircleIcon
-                        color={COLOR_NAMES_BY_HEX_VALUE.red}
+                        color={COLOR_HEX_VALUES_BY_NAME.red}
                       ></ExclamationCircleIcon>
                     </span>
                   }
@@ -191,7 +199,7 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
             ) : (
               <span className={spacing.mlSm}>
                 <ExclamationCircleIcon
-                  color={COLOR_NAMES_BY_HEX_VALUE.red}
+                  color={COLOR_HEX_VALUES_BY_NAME.red}
                 ></ExclamationCircleIcon>
                 Failed
               </span>
@@ -203,7 +211,7 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                   icon={
                     <span className={spacing.mrXs}>
                       <ExclamationCircleIcon
-                        color={COLOR_NAMES_BY_HEX_VALUE.blue}
+                        color={COLOR_HEX_VALUES_BY_NAME.blue}
                       ></ExclamationCircleIcon>
                     </span>
                   }
@@ -223,8 +231,11 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
           <SimpleDocumentViewerModal<Task | string>
             title={`Analysis details for ${application?.name}`}
             fetch={getTaskById}
-            documentId={taskIdToView}
-            onClose={() => setTaskIdToView(undefined)}
+            documentId={taskIdToView || appAnalysisToView}
+            onClose={() => {
+              setTaskIdToView(undefined);
+              setAppAnalysisToView(undefined);
+            }}
           />
         </TextContent>
       }

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -99,18 +99,12 @@ export const ApplicationDetailDrawer: React.FC<
             application && <ApplicationTags application={application} />
           )}
         </Tab>
-        {reportsTabContent && (
+        {reportsTabContent && task && (
           <Tab
             eventKey={TabKey.Reports}
             title={<TabTitleText>Reports</TabTitleText>}
           >
-            {task?.state === "Running" ? (
-              <Bullseye className={spacing.mtLg}>
-                <Spinner size="xl">Loading...</Spinner>
-              </Bullseye>
-            ) : (
-              reportsTabContent
-            )}
+            {reportsTabContent}
           </Tab>
         )}
         {factsTabContent && (


### PR DESCRIPTION
cherry-pick: 
0b20ab323687a88a2923873071fcbc95ce8a9a8f 
&& 
0ff95b8b4c014e7fcc8d4699d290928d531c94cf

- It was reported (no bz) that the analysis details should always be accessible from the side drawer. This PR removes the spinner for in-progress analysis status & replaces it with a link to the code viewer modal. Resolves #1013
- Also, this PR hides the facts tab when no facts are present. Resolves
Assists with resolving https://issues.redhat.com/browse/MTA-465 