### PR TITLE
:bug: Restore report button for analysis

### DIFF
--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
@@ -108,20 +108,13 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
           {task?.state === "Succeeded" && application ? (
             <>
               <Tooltip content="View Report">
-                <Button
-                  icon={
-                    <span className={spacing.mrXs}>
-                      <ExclamationCircleIcon
-                        color={COLOR_HEX_VALUES_BY_NAME.blue}
-                      ></ExclamationCircleIcon>
-                    </span>
-                  }
-                  type="button"
-                  variant="link"
-                  isInline
-                  onClick={() => setAppAnalysisToView(application.id)}
-                >
-                  View analysis
+                <Button variant="link" isInline>
+                  <Link
+                    to={`/hub/applications/${application.id}/bucket${task?.data?.output}`}
+                    target="_blank"
+                  >
+                    Report
+                  </Link>
                 </Button>
               </Tooltip>
               {(isHTMLDownloadEnabled || isCSVDownloadEnabled) && (


### PR DESCRIPTION
- For release-0.2, we still want to be able to view the windup report in the browser. This fixes that regression