### PR TITLE
:sparkles: [backport release-0.2] MigrationWave form: Properly notify user of duplicate wave (#1173)

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -141,6 +141,7 @@
     "couldNotFetchBody": "Resource doesn't exists or you don't have access to it",
     "couldNotFetchTitle": "Not available",
     "duplicateTag": "A tag with this name already exists. Use a different name.",
+    "duplicateWave": "The migration wave could not be created due to a conflict with an existing wave. Make sure the name and start/end dates are unique and try again.",
     "importErrorCheckDocumentation": "For status Error imports, check the documentation to ensure your file is structured correctly.",
     "insecureTracker": "Insecure mode deactivates certificate verification. Use insecure mode for instances that have self-signed certificates.",
     "jiraInstanceNotConnected": "Jira instance {{name}} is not connected.",

--- a/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
+++ b/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
@@ -96,12 +96,18 @@ export const WaveForm: React.FC<WaveFormProps> = ({
   };
 
   const onCreateMigrationWaveError = (error: AxiosError) => {
-    pushNotification({
-      title: t("toastr.fail.create", {
-        type: t("terms.migrationWave").toLowerCase(),
-      }),
-      variant: "danger",
-    });
+    if (error.response?.status === 409)
+      pushNotification({
+        title: t("message.duplicateWave"),
+        variant: "danger",
+      });
+    else
+      pushNotification({
+        title: t("toastr.fail.create", {
+          type: t("terms.migrationWave").toLowerCase(),
+        }),
+        variant: "danger",
+      });
   };
 
   const { mutate: createMigrationWave } = useCreateMigrationWaveMutation(
@@ -119,12 +125,18 @@ export const WaveForm: React.FC<WaveFormProps> = ({
   };
 
   const onUpdateMigrationWaveError = (error: AxiosError) => {
-    pushNotification({
-      title: t("toastr.fail.save", {
-        type: t("terms.migrationWave").toLowerCase(),
-      }),
-      variant: "danger",
-    });
+    if (error.response?.status === 409)
+      pushNotification({
+        title: t("message.duplicateWave"),
+        variant: "danger",
+      });
+    else
+      pushNotification({
+        title: t("toastr.fail.save", {
+          type: t("terms.migrationWave").toLowerCase(),
+        }),
+        variant: "danger",
+      });
   };
 
   const { mutate: updateMigrationWave } = useUpdateMigrationWaveMutation(


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-923

(cherry picked from commit 5c1839cf6c5899b8f94c51c5db6ed3af507db95f)
