### PR TITLE
:bug: [backport release-0.2] Fix wave display to show current users timezone (#1195)

### DIFF
--- a/client/src/app/pages/migration-waves/migration-waves.tsx
+++ b/client/src/app/pages/migration-waves/migration-waves.tsx
@@ -21,6 +21,7 @@ import {
 import { useTranslation } from "react-i18next";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
 
 import {
@@ -73,10 +74,13 @@ import { deleteMigrationWave } from "@app/api/rest";
 import { ConditionalTooltip } from "@app/shared/components/ConditionalTooltip";
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export const MigrationWaves: React.FC = () => {
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
+
+  const currentTimezone = dayjs.tz.guess();
 
   const { migrationWaves, isFetching, fetchError } = useFetchMigrationWaves();
   const { trackers: trackers } = useFetchTrackers();
@@ -220,6 +224,7 @@ export const MigrationWaves: React.FC = () => {
     },
     expansionDerivedState: { isCellExpanded },
   } = tableControls;
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -361,16 +366,16 @@ export const MigrationWaves: React.FC = () => {
                             width={10}
                             {...getTdProps({ columnKey: "startDate" })}
                           >
-                            {dayjs
-                              .utc(migrationWave.startDate)
+                            {dayjs(migrationWave.startDate)
+                              .tz(currentTimezone)
                               .format("MM/DD/YYYY")}
                           </Td>
                           <Td
                             width={10}
                             {...getTdProps({ columnKey: "endDate" })}
                           >
-                            {dayjs
-                              .utc(migrationWave.endDate)
+                            {dayjs(migrationWave.endDate)
+                              .tz(currentTimezone)
                               .format("MM/DD/YYYY")}
                           </Td>
                           <Td


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-748 

I was finally able to reproduce this by spoofing my TZ within chrome dev tools. Using the dayjs timezone plugin, we can guess the users timezone and display the utc date accordingly within the waves table.
