### PR TITLE
:sparkles: Applications: Update Notification and refactors update/create modal

### DIFF
--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -180,11 +180,6 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     close: closeApplicationModal,
   } = useEntityModal<Application>();
 
-  const onApplicationModalSaved = () => {
-    closeApplicationModal();
-    refetch();
-  };
-
   // Delete
 
   const onDeleteApplicationSuccess = (appIDCount: number) => {
@@ -629,8 +624,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
       >
         <ApplicationForm
           application={applicationToUpdate}
-          onSaved={onApplicationModalSaved}
-          onCancel={closeApplicationModal}
+          onClose={closeApplicationModal}
         />
       </Modal>
 

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -180,17 +180,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     close: closeApplicationModal,
   } = useEntityModal<Application>();
 
-  const onApplicationModalSaved = (response: AxiosResponse<Application>) => {
-    if (!applicationToUpdate) {
-      pushNotification({
-        title: t("toastr.success.saveWhat", {
-          what: response.data.name,
-          type: t("terms.application"),
-        }),
-        variant: "success",
-      });
-    }
-
+  const onApplicationModalSaved = () => {
     closeApplicationModal();
     refetch();
   };

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -159,7 +159,6 @@ export const ApplicationsTable: React.FC = () => {
     selectMultiple,
     areAllSelected,
     selectedRows,
-    setPageNumber,
     openDetailDrawer,
     closeDetailDrawer,
     activeAppInDetailDrawer,
@@ -176,11 +175,6 @@ export const ApplicationsTable: React.FC = () => {
     update: openUpdateApplicationModal,
     close: closeApplicationModal,
   } = useEntityModal<Application>();
-
-  const onApplicationModalSaved = () => {
-    closeApplicationModal();
-    fetchApplications();
-  };
 
   const onDeleteApplicationSuccess = (appIDCount: number) => {
     pushNotification({
@@ -799,8 +793,7 @@ export const ApplicationsTable: React.FC = () => {
       >
         <ApplicationForm
           application={applicationToUpdate}
-          onSaved={onApplicationModalSaved}
-          onCancel={closeApplicationModal}
+          onClose={closeApplicationModal}
         />
       </Modal>
       <Modal

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 import { useTranslation, Trans } from "react-i18next";
 
 import {
@@ -177,17 +177,7 @@ export const ApplicationsTable: React.FC = () => {
     close: closeApplicationModal,
   } = useEntityModal<Application>();
 
-  const onApplicationModalSaved = (response: AxiosResponse<Application>) => {
-    if (!applicationToUpdate) {
-      pushNotification({
-        title: t("toastr.success.saveWhat", {
-          what: response.data.name,
-          type: t("terms.application"),
-        }),
-        variant: "success",
-      });
-    }
-
+  const onApplicationModalSaved = () => {
     closeApplicationModal();
     fetchApplications();
   };

--- a/client/src/app/pages/applications/components/application-form/__tests__/application-form.test.tsx
+++ b/client/src/app/pages/applications/components/application-form/__tests__/application-form.test.tsx
@@ -34,9 +34,7 @@ describe("Component: application-form", () => {
 
     mock.onGet(`${BUSINESS_SERVICES}`).reply(200, businessServices);
 
-    render(
-      <ApplicationForm onCancel={mockChangeValue} onSaved={mockChangeValue} />
-    );
+    render(<ApplicationForm onClose={mockChangeValue} />);
     const nameInput = await screen.findByLabelText("Name *");
     fireEvent.change(nameInput, {
       target: { value: "app-name" },

--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -274,25 +274,24 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
     }
   };
 
-  const onCreateUpdateApplicationSuccess = (
-    response: AxiosResponse<Application>
-  ) => {
-    if (application) {
-      pushNotification({
-        title: t("toastr.success.save", {
-          type: t("terms.application"),
-        }),
-        variant: "success",
-      });
-    } else {
-      pushNotification({
-        title: t("toastr.success.createWhat", {
-          type: t("terms.application"),
-          what: response.data.name,
-        }),
-        variant: "success",
-      });
-    }
+  const onCreateApplicationSuccess = (response: AxiosResponse<Application>) => {
+    pushNotification({
+      title: t("toastr.success.createWhat", {
+        type: t("terms.application"),
+        what: response.data.name,
+      }),
+      variant: "success",
+    });
+    onClose();
+  };
+
+  const onUpdateApplicationSuccess = () => {
+    pushNotification({
+      title: t("toastr.success.save", {
+        type: t("terms.application"),
+      }),
+      variant: "success",
+    });
     onClose();
   };
 
@@ -301,12 +300,12 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
   };
 
   const { mutate: createApplication } = useCreateApplicationMutation(
-    onCreateUpdateApplicationSuccess,
+    onCreateApplicationSuccess,
     onCreateUpdateApplicationError
   );
 
   const { mutate: updateApplication } = useUpdateApplicationMutation(
-    onCreateUpdateApplicationSuccess,
+    onUpdateApplicationSuccess,
     onCreateUpdateApplicationError
   );
 

--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -39,6 +39,7 @@ import {
 } from "@app/shared/components/hook-form-pf-fields";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
 import { useFetchStakeholders } from "@app/queries/stakeholders";
+import { NotificationsContext } from "@app/shared/notifications-context";
 
 export interface FormValues {
   name: string;
@@ -61,7 +62,7 @@ export interface FormValues {
 
 export interface ApplicationFormProps {
   application?: Application;
-  onSaved: (response: AxiosResponse<Application>) => void;
+  onSaved: () => void;
   onCancel: () => void;
 }
 
@@ -71,6 +72,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
   onCancel,
 }) => {
   const { t } = useTranslation();
+  const { pushNotification } = React.useContext(NotificationsContext);
 
   const [axiosError, setAxiosError] = useState<AxiosError>();
 
@@ -274,8 +276,26 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
     }
   };
 
-  const onCreateUpdateApplicationSuccess = (response: any) => {
-    onSaved(response);
+  const onCreateUpdateApplicationSuccess = (
+    response: AxiosResponse<Application>
+  ) => {
+    if (application) {
+      pushNotification({
+        title: t("toastr.success.save", {
+          type: t("terms.application"),
+        }),
+        variant: "success",
+      });
+    } else {
+      pushNotification({
+        title: t("toastr.success.createWhat", {
+          type: t("terms.application"),
+          what: response.data.name,
+        }),
+        variant: "success",
+      });
+    }
+    onSaved();
   };
 
   const onCreateUpdateApplicationError = (error: AxiosError) => {

--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -62,14 +62,12 @@ export interface FormValues {
 
 export interface ApplicationFormProps {
   application?: Application;
-  onSaved: () => void;
-  onCancel: () => void;
+  onClose: () => void;
 }
 
 export const ApplicationForm: React.FC<ApplicationFormProps> = ({
   application,
-  onSaved,
-  onCancel,
+  onClose,
 }) => {
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
@@ -295,7 +293,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
         variant: "success",
       });
     }
-    onSaved();
+    onClose();
   };
 
   const onCreateUpdateApplicationError = (error: AxiosError) => {
@@ -702,7 +700,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
           aria-label="cancel"
           variant={ButtonVariant.link}
           isDisabled={isSubmitting || isValidating}
-          onClick={onCancel}
+          onClick={onClose}
         >
           {t("actions.cancel")}
         </Button>

--- a/client/src/app/queries/applications.ts
+++ b/client/src/app/queries/applications.ts
@@ -45,14 +45,14 @@ export const useFetchApplications = () => {
 };
 
 export const useUpdateApplicationMutation = (
-  onSuccess: (res: any) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateApplication,
-    onSuccess: (res) => {
-      onSuccess(res);
+    onSuccess: () => {
+      onSuccess();
       queryClient.invalidateQueries([ApplicationsQueryKey]);
     },
     onError: onError,


### PR DESCRIPTION
While resolving the related notification issues (see associated MTA-1024) this refactors create/update modal.

Includes following changes :

- Push edit/create notifications down to ApplicationForm
- Use onClose to replace onSave and onCancel
- Consolidate New/Edit Modal duplication


Partially address https://issues.redhat.com/browse/MTA-1024