### PR TITLE
:seedling: Update codecov settings, make coverage non-blocking

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -18,21 +18,32 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
+
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: Install
         run: npm clean-install
+
       - name: Build
         run: npm run build
+
       - name: Test
         run: npm run test -- --coverage --watchAll=false
-      - name: Code coverage (PR to main or push to main)
-        if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.base_ref == 'refs/heads/main'}}
+
+      - name: Upload to codecov (client)
         uses: codecov/codecov-action@v1
         with:
-          flags: unitests
+          flags: client
+          directory: ./*/coverage
+
+      - name: Upload to codecov (server)
+        uses: codecov/codecov-action@v1
+        with:
+          flags: server
           directory: ./*/coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,19 +1,24 @@
 coverage:
   status:
     project:
-      default:
-        target: 75%
-      unitests:
-        target: 30%
+      default: false
+
+      client:
+        informational: true
+        target: auto
         flags:
-          - unitests
-      e2etests:
-        target: 70%
+          - client
+
+      server:
+        informational: true
+        target: auto
         flags:
-          - e2etests
+          - server
 
 flags:
-  unitests:
-    carryforward: false
-  e2etests:
-    carryforward: false
+  client:
+    paths:
+      - client/
+  server:
+    paths:
+      - server/


### PR DESCRIPTION
Summary of changes:
  - add projects and flags for `client` and `server`, but make the coverage tests non-blocking

  - disable the `default` project and just rely on the flagged projects

  - remove `unitests` and `e2etests` projects and flags since they don't make sense in the current repo

  - github workflow `ci-actions.yml` updated to upload coverage once for each flag

References:
  - Non-blocking: https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks
  - Flags: https://docs.codecov.com/docs/flags
  - `target: auto`: https://docs.codecov.com/docs/commit-status#target