### PR TITLE
:seedling: Action PR Checks / Verify PR contents does not require checkout

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,10 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify PR contents
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Check Title
-      id: verifier
-      uses: konveyor/release-tools/cmd/verify-pr@main
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check Title
+        id: verifier
+        uses: konveyor/release-tools/cmd/verify-pr@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `konveyor/release-tools/cmd/verify-pr` action does not require a source checkout to run.  Just skip the step.