### PR TITLE
:seedling: Bump lib-ui to 9.0.3 to remove remaining prerelease versions from lockfile

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@hookform/resolvers": "^2.8.0",
     "@hot-loader/react-dom": "^17.0.2",
-    "@migtools/lib-ui": "^9.0.2",
+    "@migtools/lib-ui": "^9.0.3",
     "@patternfly/patternfly": "^5.0.2",
     "@patternfly/react-charts": "^7.1.0",
     "@patternfly/react-code-editor": "^5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@hookform/resolvers": "^2.8.0",
         "@hot-loader/react-dom": "^17.0.2",
-        "@migtools/lib-ui": "^9.0.2",
+        "@migtools/lib-ui": "^9.0.3",
         "@patternfly/patternfly": "^5.0.2",
         "@patternfly/react-charts": "^7.1.0",
         "@patternfly/react-code-editor": "^5.1.0",
@@ -1411,9 +1411,9 @@
       "dev": true
     },
     "node_modules/@migtools/lib-ui": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-9.0.2.tgz",
-      "integrity": "sha512-LHpVSUpfPEEoACv48VqcGjFzu66Kc5h0/JEf6mSD27zxBHd01PtqafrO9CGgN32FMPpKRve0H3cx8fZI16EKIA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@migtools/lib-ui/-/lib-ui-9.0.3.tgz",
+      "integrity": "sha512-ncs1eos8pTIEM1CGyZOXMjlzWoUjBfkyt0lsRJ59gFEUobl0oV+JlKQGD0hwAhr+F8518ZH5zeMBwagC6px5Dg==",
       "dependencies": {
         "@tanstack/react-query": "^4.26.1",
         "fast-deep-equal": "^3.1.3",
@@ -1421,8 +1421,8 @@
         "yup": "^0.32.9"
       },
       "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0-prerelease",
-        "@patternfly/react-tokens": "^5.0.0-prerelease",
+        "@patternfly/react-core": "^5.1.0",
+        "@patternfly/react-tokens": "^5.1.0",
         "axios": "^0.21.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"


### PR DESCRIPTION
#1226 bumped lib-ui to 9.0.2 but that version still uses prerelease PF versions. we need version 9.0.3 which was released with https://github.com/migtools/lib-ui/pull/137