### PR TITLE
:seedling: Refactor useActiveRowState to allow number or string ids in state for consistency, misc cleanup

### DIFF
--- a/client/src/app/pages/dependencies/dependencies.tsx
+++ b/client/src/app/pages/dependencies/dependencies.tsx
@@ -99,8 +99,6 @@ export const Dependencies: React.FC = () => {
       },
     ],
     initialItemsPerPage: 10,
-    // TODO PF V5 obsolete
-    // hasClickableRows: true,
   });
 
   const {

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -62,8 +62,6 @@ export const AffectedApplications: React.FC = () => {
     initialSort: { columnKey: "name", direction: "asc" },
     filterCategories: useSharedAffectedApplicationFilterCategories(),
     initialItemsPerPage: 10,
-    // TODO PF V5 obsolete
-    // hasClickableRows: true,
   });
 
   const {

--- a/client/src/app/shared/hooks/table-controls/active-row/getActiveRowDerivedState.ts
+++ b/client/src/app/shared/hooks/table-controls/active-row/getActiveRowDerivedState.ts
@@ -15,9 +15,11 @@ export const getActiveRowDerivedState = <TItem>({
   activeRowState: { activeRowId, setActiveRowId },
 }: IActiveRowDerivedStateArgs<TItem>) => ({
   activeRowItem:
-    currentPageItems.find((item) => String(item[idProperty]) === activeRowId) ||
-    null,
-  setActiveRowItem: (item: TItem | null) =>
-    setActiveRowId(item ? String(item[idProperty]) : null),
+    currentPageItems.find((item) => item[idProperty] === activeRowId) || null,
+  setActiveRowItem: (item: TItem | null) => {
+    const itemId =
+      item && item[idProperty] !== undefined ? item[idProperty] : null;
+    setActiveRowId(itemId as string | number | null); // TODO Assertion shouldn't be necessary here but TS isn't fully inferring item[idProperty]?
+  },
   clearActiveRow: () => setActiveRowId(null),
 });

--- a/client/src/app/shared/hooks/table-controls/active-row/useActiveRowState.ts
+++ b/client/src/app/shared/hooks/table-controls/active-row/useActiveRowState.ts
@@ -1,14 +1,17 @@
 import * as React from "react";
 import { useUrlParams } from "../../useUrlParams";
 import { IExtraArgsForURLParamHooks } from "../types";
+import { parseMaybeNumericString } from "@app/utils/utils";
 
 export interface IActiveRowState {
-  activeRowId: string | null;
-  setActiveRowId: (id: string | null) => void;
+  activeRowId: string | number | null;
+  setActiveRowId: (id: string | number | null) => void;
 }
 
 export const useActiveRowState = (): IActiveRowState => {
-  const [activeRowId, setActiveRowId] = React.useState<string | null>(null);
+  const [activeRowId, setActiveRowId] = React.useState<string | number | null>(
+    null
+  );
   return { activeRowId, setActiveRowId };
 };
 
@@ -20,9 +23,11 @@ export const useActiveRowUrlParams = <
   const [activeRowId, setActiveRowId] = useUrlParams({
     keyPrefix: urlParamKeyPrefix,
     keys: ["activeRow"],
-    defaultValue: null as string | null,
-    serialize: (activeRowId) => ({ activeRow: activeRowId || null }),
-    deserialize: ({ activeRow }) => activeRow || null,
+    defaultValue: null as string | number | null,
+    serialize: (activeRowId) => ({
+      activeRow: activeRowId !== null ? String(activeRowId) : null,
+    }),
+    deserialize: ({ activeRow }) => parseMaybeNumericString(activeRow),
   });
   return { activeRowId, setActiveRowId };
 };

--- a/client/src/app/shared/hooks/table-controls/selection/useSelectionState.ts
+++ b/client/src/app/shared/hooks/table-controls/selection/useSelectionState.ts
@@ -1,4 +1,9 @@
-// TODO move useSelectionState as-is into here, rename to useLegacySelectionState
+// TODO move useSelectionState as-is into here, rename to useLegacySelectionState? maybe don't need to?
 // TODO restructure useSelectionState and useSelectionUrlParams like the other concerns in table hooks - rely on idProperty, etc
 // TODO figure out how to make the URL param piece of it optional? give useUrlParams a disabled flag? maybe make that optional for all the concerns? play around with that...
 // TODO make useUrlParams just omit the param from the URL if it is using the default -- does this prevent all the history.replace thrashing on first page mount?
+
+// TODO figure out where it is being used right now with useLocalTableControls and play with it there
+
+// TODO compared with lib-ui useSelectionState, have things driven from selectedItemIds instead of selectedItem objects
+// TODO should we rename ActiveRowState to ActiveItemState? everything is driven from items not rows?

--- a/client/src/app/shared/hooks/table-controls/selection/useSelectionState.ts
+++ b/client/src/app/shared/hooks/table-controls/selection/useSelectionState.ts
@@ -1,0 +1,4 @@
+// TODO move useSelectionState as-is into here, rename to useLegacySelectionState
+// TODO restructure useSelectionState and useSelectionUrlParams like the other concerns in table hooks - rely on idProperty, etc
+// TODO figure out how to make the URL param piece of it optional? give useUrlParams a disabled flag? maybe make that optional for all the concerns? play around with that...
+// TODO make useUrlParams just omit the param from the URL if it is using the default -- does this prevent all the history.replace thrashing on first page mount?

--- a/client/src/app/shared/hooks/table-controls/selection/useSelectionState.ts
+++ b/client/src/app/shared/hooks/table-controls/selection/useSelectionState.ts
@@ -1,9 +1,0 @@
-// TODO move useSelectionState as-is into here, rename to useLegacySelectionState? maybe don't need to?
-// TODO restructure useSelectionState and useSelectionUrlParams like the other concerns in table hooks - rely on idProperty, etc
-// TODO figure out how to make the URL param piece of it optional? give useUrlParams a disabled flag? maybe make that optional for all the concerns? play around with that...
-// TODO make useUrlParams just omit the param from the URL if it is using the default -- does this prevent all the history.replace thrashing on first page mount?
-
-// TODO figure out where it is being used right now with useLocalTableControls and play with it there
-
-// TODO compared with lib-ui useSelectionState, have things driven from selectedItemIds instead of selectedItem objects
-// TODO should we rename ActiveRowState to ActiveItemState? everything is driven from items not rows?

--- a/client/src/app/shared/hooks/table-controls/types.ts
+++ b/client/src/app/shared/hooks/table-controls/types.ts
@@ -48,8 +48,6 @@ export interface ITableControlCommonArgs<
   expandableVariant?: "single" | "compound" | null;
   hasActionsColumn?: boolean;
   variant?: TableProps["variant"];
-  // TODO PF V5 obsolete
-  // hasClickableRows?: boolean;
 }
 
 // URL-param-specific args

--- a/client/src/app/shared/hooks/table-controls/useTableControlProps.ts
+++ b/client/src/app/shared/hooks/table-controls/useTableControlProps.ts
@@ -49,8 +49,6 @@ export const useTableControlProps = <
     isSelectable = false,
     expandableVariant = null,
     hasActionsColumn = false,
-    // TODO PF V5 obsolete
-    // hasClickableRows = false,
     variant,
     idProperty,
   } = args;
@@ -104,8 +102,6 @@ export const useTableControlProps = <
 
   const tableProps: Omit<TableProps, "ref"> = {
     variant,
-    // TODO PF V5 obsolete
-    // hasSelectableRowCaption: hasClickableRows,
   };
 
   const getThProps = ({

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -79,6 +79,14 @@ export const numStr = (num: number | undefined): string => {
   return String(num);
 };
 
+export const parseMaybeNumericString = (
+  numOrStr: string | undefined | null
+): string | number | null => {
+  if (numOrStr === undefined || numOrStr === null) return null;
+  const num = Number(numOrStr);
+  return isNaN(num) ? numOrStr : num;
+};
+
 export const objectKeys = <T extends Object>(obj: T) =>
   Object.keys(obj) as (keyof T)[];
 


### PR DESCRIPTION
I made these small cleanup changes before starting on refactoring useSelectionState to fit the model of the other table-control hooks, but that grew in scope so I broke this part into its own PR and will continue the rest after PTO.

This PR:
* Removes commented-out `hasClickableRows` lines because I confirmed that they are indeed no longer needed with PF v5
* Changes the behavior of `useActiveRowState` and `getActiveRowDerivedState` so that the id of the active row as returned in the `IActiveRowState` object can be a string or a number. This aligns with other state hooks that deal with item ids, which can be strings or numbers in the data model (as permitted by the type of `idProperty` being `KeyWithValueType<string | number>`.
  * Previously, when we added support for numeric ids in https://github.com/konveyor/tackle2-ui/pull/893/files#diff-82ce09cd10287f153f994982c4f69732afc2b20f0a9a9426680bf5358101d146L6 this broke the behavior of `useActiveRowState` which was expecting only string ids to be persisted. We worked around that by casting the id to a string whenever it was passed to the hook's methods in https://github.com/konveyor/tackle2-ui/pull/904/files#diff-82ce09cd10287f153f994982c4f69732afc2b20f0a9a9426680bf5358101d146L20, but that was messy because it meant there were two layers of serialization of these values: once when passed into the helper, and again when serializing for `useUrlParams`.
  * This change paves the way for the upcoming changes to `useSelectionState` which will also allow both numbers and strings for the ids of selected items in state.