### PR TITLE
:seedling: Require node/npm versions as used in ubi9/nodejs-18

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "client",
     "server"
   ],
+  "engines": {
+    "node": ">=18.14.2",
+    "npm": ">=9.5.0"
+  },
   "devDependencies": {
     "concurrently": "^8.0.1",
     "copyfiles": "^2.4.1",


### PR DESCRIPTION
Versions pulled from `registry.access.redhat.com/ubi9/nodejs-18:1-59.1690899127`
  - node: 18.14.2
  - npm: 9.5.0

If the node or npm versions don't match the versions in `package.json`, any `npm install` will flag a warning.

The `.npmrc` file setting `engine-strict=true` forces the install version mismatch warnings to become errors.


