### PR TITLE
:bug: URL-encode ruleset and rule in affected apps page URL so it doesn't break when ruleset contains a slash (/) character

### DIFF
--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -45,7 +45,9 @@ interface IAffectedApplicationsRouteParams {
 export const AffectedApplications: React.FC = () => {
   const { t } = useTranslation();
 
-  const { ruleset, rule } = useParams<IAffectedApplicationsRouteParams>();
+  const routeParams = useParams<IAffectedApplicationsRouteParams>();
+  const ruleset = decodeURIComponent(routeParams.ruleset);
+  const rule = decodeURIComponent(routeParams.rule);
   const issueTitle =
     new URLSearchParams(useLocation().search).get("issueTitle") ||
     "Active rule";

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -109,8 +109,8 @@ export const getAffectedAppsUrl = ({
     if (fromFilterValues[key]) toFilterValues[key] = fromFilterValues[key];
   });
   const baseUrl = Paths.issuesAllAffectedApplications
-    .replace("/:ruleset/", `/${ruleReport.ruleset}/`)
-    .replace("/:rule/", `/${ruleReport.rule}/`);
+    .replace("/:ruleset/", `/${encodeURIComponent(ruleReport.ruleset)}/`)
+    .replace("/:rule/", `/${encodeURIComponent(ruleReport.rule)}/`);
   const prefix = (key: string) =>
     `${TableURLParamKeyPrefix.issuesAffectedApps}:${key}`;
   return `${baseUrl}?${trimAndStringifyUrlParams({


### PR DESCRIPTION
Fixes an issue @ibolton336 identified where navigating to the affected apps page from the issues page causes a broken URL if the issue's ruleset contains a `/`.