### PR TITLE
:bug: Add taskgroup when uploading binary

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/components/TaskGroupContext.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/TaskGroupContext.tsx
@@ -1,0 +1,34 @@
+import { Taskgroup } from "@app/api/models";
+import React, { createContext, useContext, useState } from "react";
+
+interface TaskGroupContext {
+  updateTaskGroup: (taskGroup: Taskgroup | null) => void;
+  taskGroup: Taskgroup | null;
+}
+
+const TaskGroupContext = createContext<TaskGroupContext>({
+  updateTaskGroup: () => {},
+  taskGroup: null,
+});
+
+export const useTaskGroup = () => useContext(TaskGroupContext);
+
+interface TaskGroupProvider {
+  children: React.ReactNode;
+}
+
+export const TaskGroupProvider: React.FunctionComponent<TaskGroupProvider> = ({
+  children,
+}) => {
+  const [taskGroup, setTaskGroup] = useState<Taskgroup | null>(null);
+
+  const updateTaskGroup = (newTaskGroup: Taskgroup | null) => {
+    setTaskGroup(newTaskGroup);
+  };
+
+  return (
+    <TaskGroupContext.Provider value={{ taskGroup, updateTaskGroup }}>
+      {children}
+    </TaskGroupContext.Provider>
+  );
+};

--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -54,11 +54,11 @@ import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { toOptionLike } from "@app/utils/model-utils";
 import { useFetchIdentities } from "@app/queries/identities";
 import useRuleFiles from "@app/hooks/useRuleFiles";
-interface CustomRulesProps {
-  taskgroupID: number | null;
-}
-export const CustomRules: React.FC<CustomRulesProps> = (props) => {
+import { useTaskGroup } from "./components/TaskGroupContext";
+
+export const CustomRules: React.FC = () => {
   const { t } = useTranslation();
+  const { taskGroup, updateTaskGroup } = useTaskGroup();
 
   const { watch, setValue, control, getValues } =
     useFormContext<AnalysisWizardFormValues>();
@@ -92,7 +92,7 @@ export const CustomRules: React.FC<CustomRulesProps> = (props) => {
     successfullyReadFileCount,
     handleFile,
     removeFiles,
-  } = useRuleFiles(props?.taskgroupID, values.customRulesFiles);
+  } = useRuleFiles(taskGroup?.id, values.customRulesFiles);
 
   const repositoryTypeOptions: OptionWithValue<string>[] = [
     {

--- a/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
@@ -11,15 +11,10 @@ import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
 
 interface ISetMode {
   isSingleApp: boolean;
-  taskgroupID: number | null;
   isModeValid: boolean;
 }
 
-export const SetMode: React.FC<ISetMode> = ({
-  isSingleApp,
-  taskgroupID,
-  isModeValid,
-}) => {
+export const SetMode: React.FC<ISetMode> = ({ isSingleApp, isModeValid }) => {
   const { t } = useTranslation();
 
   const { watch, control, setValue } =
@@ -89,9 +84,7 @@ export const SetMode: React.FC<ISetMode> = ({
           <p>{t("wizard.label.notAllAnalyzableDetails")}</p>
         </Alert>
       )}
-      {mode === "binary-upload" && taskgroupID && (
-        <UploadBinary taskgroupID={taskgroupID} />
-      )}
+      {mode === "binary-upload" && <UploadBinary />}
     </Form>
   );
 };

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -70,6 +70,7 @@ import { AppTableWithControls } from "@app/components/AppTableWithControls";
 import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
 import { KebabDropdown } from "@app/components/KebabDropdown";
 import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+import { TaskGroupProvider } from "../analysis-wizard/components/TaskGroupContext";
 
 const ENTITY_FIELD = "entity";
 
@@ -611,13 +612,15 @@ export const ApplicationsTableAnalyze: React.FC = () => {
           onClose={() => setSaveApplicationsModalState(null)}
         />
       </Modal>{" "}
-      <AnalysisWizard
-        applications={selectedRows}
-        isOpen={isAnalyzeModalOpen}
-        onClose={() => {
-          setAnalyzeModalOpen(false);
-        }}
-      />
+      <TaskGroupProvider>
+        <AnalysisWizard
+          applications={selectedRows}
+          isOpen={isAnalyzeModalOpen}
+          onClose={() => {
+            setAnalyzeModalOpen(false);
+          }}
+        />
+      </TaskGroupProvider>
       <Modal
         isOpen={isApplicationImportModalOpen}
         variant="medium"


### PR DESCRIPTION
- Improve handling of taskgroup state by using contextAPI
- Async create the taskgroup before uploading the custom binary in the single app use case. This is currently broken because we require a task group to exist before navigating to the upload file screen. This regression was caused by the move away from useEffect here https://github.com/konveyor/tackle2-ui/pull/1267
Resolves https://issues.redhat.com/browse/MTA-1175 