### PR TITLE
:sparkles: Add lock icon for "system" questionnaires

### DIFF
--- a/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
@@ -25,9 +25,8 @@ import {
 } from "@patternfly/react-core";
 import { AxiosError } from "axios";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { LockIcon } from "@patternfly/react-icons";
-import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
-import EllipsisVIcon from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
+import { LockIcon, EllipsisVIcon, CubesIcon } from "@patternfly/react-icons";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import {
   useDeleteQuestionnaireMutation,
@@ -276,12 +275,7 @@ const AssessmentSettings: React.FC = () => {
                           </Td>
                           <Td width={25} {...getTdProps({ columnKey: "name" })}>
                             {questionnaire.system && (
-                              <LockIcon
-                                style={{
-                                  marginRight:
-                                    "var(--pf-v5-global--spacer--sm)",
-                                }}
-                              />
+                              <LockIcon className={spacing.mrSm} />
                             )}
                             {questionnaire.name}
                           </Td>

--- a/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
@@ -25,6 +25,7 @@ import {
 } from "@patternfly/react-core";
 import { AxiosError } from "axios";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import { LockIcon } from "@patternfly/react-icons";
 import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
 import EllipsisVIcon from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
 
@@ -274,6 +275,14 @@ const AssessmentSettings: React.FC = () => {
                             />
                           </Td>
                           <Td width={25} {...getTdProps({ columnKey: "name" })}>
+                            {questionnaire.system && (
+                              <LockIcon
+                                style={{
+                                  marginRight:
+                                    "var(--pf-v5-global--spacer--sm)",
+                                }}
+                              />
+                            )}
                             {questionnaire.name}
                           </Td>
                           <Td


### PR DESCRIPTION
closes https://github.com/konveyor/tackle2-ui/issues/1292

Adding a lock icon to "system" questionnaire.

Before:
![lock-icon-b4](https://github.com/konveyor/tackle2-ui/assets/67270715/ecb76fd5-ca93-494a-ae93-f65a991120a9)

After:
![lock-icon](https://github.com/konveyor/tackle2-ui/assets/67270715/7756e178-bb36-41ac-86b6-25ef0a42f284)
