### PR TITLE
:sparkles: Add search toolbar and "all questions" tab to questionnaire view page, clean up layout

### DIFF
--- a/client/src/app/hooks/table-controls/types.ts
+++ b/client/src/app/hooks/table-controls/types.ts
@@ -65,6 +65,7 @@ export interface IExtraArgsForURLParamHooks<
 export interface ITableControlDataDependentArgs<TItem> {
   isLoading?: boolean;
   idProperty: KeyWithValueType<TItem, string | number>;
+  forceNumRenderedColumns?: number;
 }
 
 // Derived state option args
@@ -112,6 +113,5 @@ export interface IUseTableControlPropsArgs<
     IExpansionDerivedStateArgs<TItem, TColumnKey>,
     IActiveRowDerivedStateArgs<TItem> {
   currentPageItems: TItem[];
-  forceNumRenderedColumns?: number;
   selectionState: ReturnType<typeof useSelectionState<TItem>>; // TODO make this optional? fold it in?
 }

--- a/client/src/app/pages/assessment-management/questionnaire/components/questionnaire-section-tab-title.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/components/questionnaire-section-tab-title.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { TabTitleText, Badge } from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { CustomYamlAssessmentQuestion } from "@app/api/models";
+
+const QuestionnaireSectionTabTitle: React.FC<{
+  isSearching: boolean;
+  sectionName: string;
+  unfilteredQuestions: CustomYamlAssessmentQuestion[];
+  filteredQuestions: CustomYamlAssessmentQuestion[];
+}> = ({ isSearching, sectionName, unfilteredQuestions, filteredQuestions }) => (
+  <TabTitleText aria-label="vertical" role="region">
+    {sectionName}
+    <br />
+    <small>
+      {unfilteredQuestions.length} questions
+      {isSearching ? (
+        <Badge
+          screenReaderText="Questions matching search"
+          className={spacing.mlSm}
+          isRead={filteredQuestions.length === 0}
+        >
+          {`${filteredQuestions.length} match${
+            filteredQuestions.length === 1 ? "" : "es"
+          }`}
+        </Badge>
+      ) : null}
+    </small>
+  </TabTitleText>
+);
+
+export default QuestionnaireSectionTabTitle;

--- a/client/src/app/pages/assessment-management/questionnaire/components/questions-table.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/components/questions-table.tsx
@@ -79,7 +79,9 @@ const QuestionsTable: React.FC<{
           <NoDataEmptyState
             title={
               isSearching
-                ? "No questions in this section match your search"
+                ? isAllQuestionsTab
+                  ? "No questions match your search"
+                  : "No questions in this section match your search"
                 : "This section is empty"
             }
           />

--- a/client/src/app/pages/assessment-management/questionnaire/components/questions-table.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/components/questions-table.tsx
@@ -15,7 +15,7 @@ import {
 } from "@app/components/TableControls";
 import { useTranslation } from "react-i18next";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { CustomYamlAssessmentQuestion } from "@app/api/models";
+import { CustomYamlAssessmentQuestion, YamlAssessment } from "@app/api/models";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { Label } from "@patternfly/react-core";
 import AnswerTable from "./answer-table";
@@ -25,16 +25,24 @@ const QuestionsTable: React.FC<{
   fetchError?: Error;
   questions?: CustomYamlAssessmentQuestion[];
   isSearching?: boolean;
-}> = ({ fetchError, questions, isSearching = false }) => {
+  assessmentData?: YamlAssessment | null;
+  isAllQuestionsTab?: boolean;
+}> = ({
+  fetchError,
+  questions,
+  isSearching = false,
+  assessmentData,
+  isAllQuestionsTab = false,
+}) => {
   const tableControls = useLocalTableControls({
     idProperty: "formulation",
     items: questions || [],
     columnNames: {
       formulation: "Name",
+      section: "Section",
     },
-    hasActionsColumn: true,
-    isSelectable: false,
     expandableVariant: "single",
+    forceNumRenderedColumns: isAllQuestionsTab ? 3 : 2, // columns+1 for expand control
   });
 
   const {
@@ -57,6 +65,9 @@ const QuestionsTable: React.FC<{
         <Tr>
           <TableHeaderContentWithControls {...tableControls}>
             <Th {...getThProps({ columnKey: "formulation" })} />
+            {isAllQuestionsTab ? (
+              <Th {...getThProps({ columnKey: "section" })} />
+            ) : null}
           </TableHeaderContentWithControls>
         </Tr>
       </Thead>
@@ -75,39 +86,53 @@ const QuestionsTable: React.FC<{
         }
       >
         <Tbody>
-          {currentPageItems?.map((question, rowIndex) => (
-            <>
-              <Tr key={question.formulation}>
-                <TableRowContentWithControls
-                  {...tableControls}
-                  item={question}
-                  rowIndex={rowIndex}
-                >
-                  <Td width={100} {...getTdProps({ columnKey: "formulation" })}>
-                    {(!!question?.include_if_tags_present?.length ||
-                      !!question?.skip_if_tags_present?.length) && (
-                      <Label className={spacing.mrSm}>Conditional</Label>
-                    )}
-                    {question.formulation}
-                  </Td>
-                </TableRowContentWithControls>
-              </Tr>
-              {isCellExpanded(question) ? (
-                <Tr isExpanded>
-                  <Td />
-                  <Td
-                    {...getExpandedContentTdProps({ item: question })}
-                    className={spacing.pyLg}
+          {currentPageItems?.map((question, rowIndex) => {
+            const sectionName =
+              assessmentData?.sections.find((section) =>
+                section.questions.includes(question)
+              )?.name || "";
+            return (
+              <>
+                <Tr key={question.formulation}>
+                  <TableRowContentWithControls
+                    {...tableControls}
+                    item={question}
+                    rowIndex={rowIndex}
                   >
-                    <ExpandableRowContent>
-                      {question.explanation}
-                      <AnswerTable answers={question.answers} />
-                    </ExpandableRowContent>
-                  </Td>
+                    <Td
+                      width={isAllQuestionsTab ? 60 : 100}
+                      {...getTdProps({ columnKey: "formulation" })}
+                    >
+                      {(!!question?.include_if_tags_present?.length ||
+                        !!question?.skip_if_tags_present?.length) && (
+                        <Label className={spacing.mrSm}>Conditional</Label>
+                      )}
+                      {question.formulation}
+                    </Td>
+                    {isAllQuestionsTab ? (
+                      <Td width={40} {...getTdProps({ columnKey: "section" })}>
+                        {sectionName}
+                      </Td>
+                    ) : null}
+                  </TableRowContentWithControls>
                 </Tr>
-              ) : null}
-            </>
-          ))}
+                {isCellExpanded(question) ? (
+                  <Tr isExpanded>
+                    <Td />
+                    <Td
+                      {...getExpandedContentTdProps({ item: question })}
+                      className={spacing.pyLg}
+                    >
+                      <ExpandableRowContent>
+                        {question.explanation}
+                        <AnswerTable answers={question.answers} />
+                      </ExpandableRowContent>
+                    </Td>
+                  </Tr>
+                ) : null}
+              </>
+            );
+          })}
         </Tbody>
       </ConditionalTableBody>
     </Table>

--- a/client/src/app/pages/assessment-management/questionnaire/components/questions-table.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/components/questions-table.tsx
@@ -9,6 +9,7 @@ import {
   ExpandableRowContent,
 } from "@patternfly/react-table";
 import {
+  ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
@@ -18,11 +19,13 @@ import { CustomYamlAssessmentQuestion } from "@app/api/models";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { Label } from "@patternfly/react-core";
 import AnswerTable from "./answer-table";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 
 const QuestionsTable: React.FC<{
-  fetchError: boolean;
+  fetchError?: Error;
   questions?: CustomYamlAssessmentQuestion[];
-}> = ({ fetchError = false, questions }) => {
+  isSearching?: boolean;
+}> = ({ fetchError, questions, isSearching = false }) => {
   const tableControls = useLocalTableControls({
     idProperty: "formulation",
     items: questions || [],
@@ -57,41 +60,56 @@ const QuestionsTable: React.FC<{
           </TableHeaderContentWithControls>
         </Tr>
       </Thead>
-      <Tbody>
-        {currentPageItems?.map((question, rowIndex) => (
-          <>
-            <Tr key={question.formulation}>
-              <TableRowContentWithControls
-                {...tableControls}
-                item={question}
-                rowIndex={rowIndex}
-              >
-                <Td width={100} {...getTdProps({ columnKey: "formulation" })}>
-                  {(!!question?.include_if_tags_present?.length ||
-                    !!question?.skip_if_tags_present?.length) && (
-                    <Label className={spacing.mrSm}>Conditional</Label>
-                  )}
-                  {question.formulation}
-                </Td>
-              </TableRowContentWithControls>
-            </Tr>
-            {isCellExpanded(question) ? (
-              <Tr isExpanded>
-                <Td />
-                <Td
-                  {...getExpandedContentTdProps({ item: question })}
-                  className={spacing.pyLg}
+      <ConditionalTableBody
+        numRenderedColumns={numRenderedColumns}
+        isError={!!fetchError}
+        isNoData={questions?.length === 0}
+        noDataEmptyState={
+          <NoDataEmptyState
+            title={
+              isSearching
+                ? "No questions in this section match your search"
+                : "This section is empty"
+            }
+          />
+        }
+      >
+        <Tbody>
+          {currentPageItems?.map((question, rowIndex) => (
+            <>
+              <Tr key={question.formulation}>
+                <TableRowContentWithControls
+                  {...tableControls}
+                  item={question}
+                  rowIndex={rowIndex}
                 >
-                  <ExpandableRowContent>
-                    {question.explanation}
-                    <AnswerTable answers={question.answers} />
-                  </ExpandableRowContent>
-                </Td>
+                  <Td width={100} {...getTdProps({ columnKey: "formulation" })}>
+                    {(!!question?.include_if_tags_present?.length ||
+                      !!question?.skip_if_tags_present?.length) && (
+                      <Label className={spacing.mrSm}>Conditional</Label>
+                    )}
+                    {question.formulation}
+                  </Td>
+                </TableRowContentWithControls>
               </Tr>
-            ) : null}
-          </>
-        ))}
-      </Tbody>
+              {isCellExpanded(question) ? (
+                <Tr isExpanded>
+                  <Td />
+                  <Td
+                    {...getExpandedContentTdProps({ item: question })}
+                    className={spacing.pyLg}
+                  >
+                    <ExpandableRowContent>
+                      {question.explanation}
+                      <AnswerTable answers={question.answers} />
+                    </ExpandableRowContent>
+                  </Td>
+                </Tr>
+              ) : null}
+            </>
+          ))}
+        </Tbody>
+      </ConditionalTableBody>
     </Table>
   );
 };

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.css
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.css
@@ -1,6 +1,6 @@
-.tabs-vertical-container {
-  width: 20em;
+.tabs-vertical-container .pf-v5-c-tabs {
+  width: 20%;
 }
-.tab-content-container {
-  width: 80em;
+.tabs-vertical-container .pf-v5-c-tab-content {
+  width: 80%;
 }

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.css
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.css
@@ -1,6 +1,11 @@
+.tabs-vertical-container {
+  display: flex;
+}
+
 .tabs-vertical-container .pf-v5-c-tabs {
   width: 20%;
 }
+
 .tabs-vertical-container .pf-v5-c-tab-content {
   width: 80%;
 }

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -152,6 +152,8 @@ const Questionnaire: React.FC = () => {
                       fetchError={fetchError}
                       questions={allMatchingQuestions}
                       isSearching={!!searchValue}
+                      assessmentData={assessmentData}
+                      isAllQuestionsTab
                     />
                   </Tab>,
                   ...(assessmentData?.sections.map((section, index) => {
@@ -173,6 +175,7 @@ const Questionnaire: React.FC = () => {
                           fetchError={fetchError}
                           questions={filteredQuestions}
                           isSearching={!!searchValue}
+                          assessmentData={assessmentData}
                         />
                       </Tab>
                     );

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -32,7 +32,6 @@ const Questionnaire: React.FC = () => {
   const [activeSectionIndex, setActiveSectionIndex] = React.useState<
     "all" | number
   >("all");
-  console.log({ activeSectionIndex });
 
   const handleTabClick = (
     _event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -98,14 +98,14 @@ const Questionnaire: React.FC = () => {
               backgroundColor: "var(--pf-v5-global--BackgroundColor--100)",
               display: "flex",
             }}
+            className="tabs-vertical-container"
           >
             <Tabs
               activeKey={activeTabKey}
               onSelect={handleTabClick}
               isVertical
-              aria-label="Tabs in the vertical example"
+              aria-label="Tabs for questionnaire sections"
               role="region"
-              className="tabs-vertical-container"
             >
               {assessmentData?.sections.map((section, index) => {
                 return (
@@ -117,16 +117,10 @@ const Questionnaire: React.FC = () => {
                       </TabTitleText>
                     }
                   >
-                    <TabContent
-                      id={section.name}
-                      className="tab-content-container"
-                      style={{ flex: 1 }}
-                    >
-                      <QuestionsTable
-                        fetchError={fetchError}
-                        questions={activeSection?.questions}
-                      />
-                    </TabContent>
+                    <QuestionsTable
+                      fetchError={fetchError}
+                      questions={activeSection?.questions}
+                    />
                   </Tab>
                 );
               })}

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -7,15 +7,16 @@ import {
   PageSectionVariants,
   Breadcrumb,
   BreadcrumbItem,
+  Button,
   Tab,
   TabTitleText,
   Tabs,
-  TabContent,
   Toolbar,
   ToolbarItem,
   SearchInput,
   ToolbarContent,
 } from "@patternfly/react-core";
+import AngleLeftIcon from "@patternfly/react-icons/dist/esm/icons/angle-left-icon";
 import { YamlAssessment } from "@app/api/models";
 import { Link } from "react-router-dom";
 import { Paths } from "@app/Paths";
@@ -80,51 +81,56 @@ const Questionnaire: React.FC = () => {
           when={fetchError}
           then={<AppPlaceholder />}
         >
-          <Toolbar>
-            <ToolbarContent>
-              <ToolbarItem widths={{ default: "300px" }}>
-                <SearchInput
-                  placeholder="Search questions"
-                  value={searchValue}
-                  onChange={(_event, value) => setSearchValue(value)}
-                  onClear={() => setSearchValue("")}
-                  resultsCount={2}
-                />
-              </ToolbarItem>
-            </ToolbarContent>
-          </Toolbar>
           <div
             style={{
               backgroundColor: "var(--pf-v5-global--BackgroundColor--100)",
-              display: "flex",
             }}
-            className="tabs-vertical-container"
           >
-            <Tabs
-              activeKey={activeTabKey}
-              onSelect={handleTabClick}
-              isVertical
-              aria-label="Tabs for questionnaire sections"
-              role="region"
-            >
-              {assessmentData?.sections.map((section, index) => {
-                return (
-                  <Tab
-                    eventKey={index}
-                    title={
-                      <TabTitleText aria-label="vertical" role="region">
-                        {section.name}
-                      </TabTitleText>
-                    }
-                  >
-                    <QuestionsTable
-                      fetchError={fetchError}
-                      questions={activeSection?.questions}
-                    />
-                  </Tab>
-                );
-              })}
-            </Tabs>
+            <Toolbar>
+              <ToolbarContent>
+                <ToolbarItem widths={{ default: "300px" }}>
+                  <SearchInput
+                    placeholder="Search questions"
+                    value={searchValue}
+                    onChange={(_event, value) => setSearchValue(value)}
+                    onClear={() => setSearchValue("")}
+                    resultsCount={2}
+                  />
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
+            <Link to={Paths.assessment}>
+              <Button variant="link" icon={<AngleLeftIcon />}>
+                Back to questionnaires
+              </Button>
+            </Link>
+            <div className="tabs-vertical-container">
+              <Tabs
+                activeKey={activeTabKey}
+                onSelect={handleTabClick}
+                isVertical
+                aria-label="Tabs for questionnaire sections"
+                role="region"
+              >
+                {assessmentData?.sections.map((section, index) => {
+                  return (
+                    <Tab
+                      eventKey={index}
+                      title={
+                        <TabTitleText aria-label="vertical" role="region">
+                          {section.name}
+                        </TabTitleText>
+                      }
+                    >
+                      <QuestionsTable
+                        fetchError={fetchError}
+                        questions={activeSection?.questions}
+                      />
+                    </Tab>
+                  );
+                })}
+              </Tabs>
+            </div>
           </div>
         </ConditionalRender>
       </PageSection>

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -11,6 +11,10 @@ import {
   TabTitleText,
   Tabs,
   TabContent,
+  Toolbar,
+  ToolbarItem,
+  SearchInput,
+  ToolbarContent,
 } from "@patternfly/react-core";
 import { YamlAssessment } from "@app/api/models";
 import { Link } from "react-router-dom";
@@ -52,6 +56,8 @@ const Questionnaire: React.FC = () => {
   }, []);
   // ------------------------!!
 
+  const [searchValue, setSearchValue] = React.useState("");
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -74,6 +80,19 @@ const Questionnaire: React.FC = () => {
           when={fetchError}
           then={<AppPlaceholder />}
         >
+          <Toolbar>
+            <ToolbarContent>
+              <ToolbarItem widths={{ default: "300px" }}>
+                <SearchInput
+                  placeholder="Search questions"
+                  value={searchValue}
+                  onChange={(_event, value) => setSearchValue(value)}
+                  onClear={() => setSearchValue("")}
+                  resultsCount={2}
+                />
+              </ToolbarItem>
+            </ToolbarContent>
+          </Toolbar>
           <div
             style={{
               backgroundColor: "var(--pf-v5-global--BackgroundColor--100)",
@@ -86,7 +105,6 @@ const Questionnaire: React.FC = () => {
               isVertical
               aria-label="Tabs in the vertical example"
               role="region"
-              width="50px"
               className="tabs-vertical-container"
             >
               {assessmentData?.sections.map((section, index) => {


### PR DESCRIPTION
Resolves #1293. We determined we don't need the filter dropdown (at least for now), just the search bar.
* Cleans up some layout issues on the page.
* Adds an "All questions" tab above the section tabs. When viewing this tab, the questions table has a "Section" column so you can still tell the sections apart when they are viewed together.
* Adds the total number of questions under each tab title. When the search bar is used, a badge appears next to this to show how many questions match the search.
* Adds an empty state to the table if there are no questions matching your search.

<img width="1500" alt="Screenshot 2023-08-25 at 2 24 18 PM" src="https://github.com/konveyor/tackle2-ui/assets/811963/c655ba4e-4a18-493a-87ad-ff1e3c926da3">

![U4kHZuOvzh](https://github.com/konveyor/tackle2-ui/assets/811963/3698dc9e-5841-44e4-9fee-40752b4def86)

<img width="1501" alt="Screenshot 2023-08-25 at 2 31 19 PM" src="https://github.com/konveyor/tackle2-ui/assets/811963/27e547c8-76dc-4398-9a2f-84cd9da64e8c">
