### PR TITLE
:bug: Fix `getIconByRisk` in `answer-table.tsx`

### DIFF
--- a/client/src/app/pages/assessment-management/questionnaire/components/answer-table.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/components/answer-table.tsx
@@ -44,7 +44,7 @@ const AnswerTable: React.FC<IAnswerTableProps> = ({ answers }) => {
       case "green":
         return <IconedStatus preset="Ok" />;
       case "red":
-        <IconedStatus icon={<TimesCircleIcon />} status="danger" />;
+        return <IconedStatus icon={<TimesCircleIcon />} status="danger" />;
       case "yellow":
         return <IconedStatus icon={<WarningTriangleIcon />} status="warning" />;
       default:


### PR DESCRIPTION
While working on upgrading eslint (PR #1291), a switch/case `no-fallthrough` error was found in the `getIconByRisk` function in the `AnswerTable` component. This error would cause a risk of "red" to actually render as a risk of "yellow".  Fixing it separately from the eslint upgrade seems like a good thing.

