### PR TITLE
:bug: Comment out application handler for now

### DIFF
--- a/client/src/mocks/stub-new-work/applications.ts
+++ b/client/src/mocks/stub-new-work/applications.ts
@@ -31,9 +31,9 @@ export const mockApplicationArray: Application[] = [
 ];
 
 export const handlers = [
-  rest.get(AppRest.APPLICATIONS, (req, res, ctx) => {
-    return res(ctx.json(mockApplicationArray));
-  }),
+  // rest.get(AppRest.APPLICATIONS, (req, res, ctx) => {
+  //   return res(ctx.json(mockApplicationArray));
+  // }),
 ];
 
 export default handlers;


### PR DESCRIPTION
- Comment out application fetch stub. This handler is breaking application fetch on main currently. Need to wire up full MSW mocks for applications before uncommenting this. 