### PR TITLE
:seedling: eslint - add react-query checks

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,6 +33,7 @@ module.exports = {
     "@typescript-eslint",
     "react",
     "react-hooks",
+    "@tanstack/query",
   ],
 
   // NOTE: Tweak the rules as needed when bulk fixes get merged
@@ -55,6 +56,9 @@ module.exports = {
 
     // Allow the "cy-data" property for tackle-ui-test (but should really be "data-cy" w/o this rule)
     "react/no-unknown-property": ["error", { ignore: ["cy-data"] }],
+
+    "@tanstack/query/exhaustive-deps": "error",
+    "@tanstack/query/prefer-query-object-syntax": "error",
   },
 
   settings: {

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -3,6 +3,7 @@ export enum MimeType {
   YAML = "yaml",
 }
 
+/** Mark an object as "New" therefore does not have an `id` field. */
 export type New<T extends { id: number }> = Omit<T, "id">;
 
 export interface HubFilter {

--- a/client/src/app/pages/controls/job-functions/components/job-function-form.tsx
+++ b/client/src/app/pages/controls/job-functions/components/job-function-form.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 import { object, string } from "yup";
 
 import {
@@ -70,11 +70,11 @@ export const JobFunctionForm: React.FC<JobFunctionFormProps> = ({
     mode: "all",
   });
 
-  const onCreateJobFunctionSuccess = (response: AxiosResponse<JobFunction>) => {
+  const onCreateJobFunctionSuccess = (data: JobFunction) => {
     pushNotification({
       title: t("toastr.success.createWhat", {
         type: t("terms.jobFunction"),
-        what: response.data.name,
+        what: data.name,
       }),
       variant: "success",
     });
@@ -91,7 +91,7 @@ export const JobFunctionForm: React.FC<JobFunctionFormProps> = ({
     onClose();
   };
 
-  const onCreateJobFunctionError = (error: AxiosError) => {
+  const onCreateJobFunctionError = (_error: AxiosError) => {
     pushNotification({
       title: t("toastr.fail.create", {
         type: t("terms.jobFunction").toLowerCase(),
@@ -105,7 +105,7 @@ export const JobFunctionForm: React.FC<JobFunctionFormProps> = ({
     onCreateJobFunctionError
   );
 
-  const onUpdateJobFunctionError = (error: AxiosError) => {
+  const onUpdateJobFunctionError = (_error: AxiosError) => {
     pushNotification({
       title: t("toastr.fail.save", {
         type: t("terms.jobFunction").toLowerCase(),

--- a/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
@@ -133,19 +133,17 @@ export const AdoptionCandidateGraph: React.FC = () => {
     refetch: refreshChart,
     isFetching,
     error: fetchError,
-  } = useQuery<AssessmentConfidence[]>(
-    ["assessmentconfidence"],
-    async () =>
+  } = useQuery<AssessmentConfidence[]>({
+    queryKey: ["assessmentConfidence"],
+    queryFn: async () =>
       // (
       //   await getAssessmentConfidence(
       //     applications.length > 0 ? applications.map((f) => f.id!) : []
       //   )
       // ).data,
       [],
-    {
-      onError: (error) => console.log("error, ", error),
-    }
-  );
+    onError: (error) => console.log("error, ", error),
+  });
 
   useEffect(() => {
     refreshChart();
@@ -164,6 +162,8 @@ export const AdoptionCandidateGraph: React.FC = () => {
       const appConfidence = confidences.find(
         (elem) => elem.applicationId === current.id
       );
+
+      // TODO: This hook should be pulled outside of the useMemo
       const { review: appReview } = useFetchReviewById(current?.review?.id);
 
       if (appConfidence && appReview) {

--- a/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -14,7 +14,6 @@ import {
 import { RISK_LIST } from "@app/Constants";
 import { Application, Assessment, Ref, Risk } from "@app/api/models";
 
-import { useFetchReviews } from "@app/queries/reviews";
 import { AppTableWithControls } from "@app/components/AppTableWithControls";
 import {
   FilterCategory,
@@ -54,7 +53,6 @@ export const AdoptionCandidateTable: React.FC<IAdoptionCandidateTable> = () => {
   // Table data
   // const { reviews } = useFetchReviews();
   const { assessments } = useFetchAssessments();
-  const { reviews } = useFetchReviews();
 
   const allRows = useMemo(() => {
     return assessments.map((assessment: Assessment) => {

--- a/client/src/app/pages/reports/components/adoption-plan/adoption-plan.tsx
+++ b/client/src/app/pages/reports/components/adoption-plan/adoption-plan.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo } from "react";
+import React, { useContext, useEffect, useMemo } from "react";
 import Measure from "react-measure";
 import { useTranslation } from "react-i18next";
 
@@ -41,18 +41,16 @@ export const AdoptionPlan: React.FC = () => {
     refetch: refreshChart,
     error: fetchError,
     isFetching,
-  } = useQuery<ApplicationAdoptionPlan[]>(
-    ["adoptionplan"],
-    async () =>
+  } = useQuery<ApplicationAdoptionPlan[]>({
+    queryKey: ["adoptionPlan", applications.length],
+    queryFn: async () =>
       (
         await getApplicationAdoptionPlan(
           applications.length > 0 ? applications.map((f) => f.id!) : []
         )
       ).data,
-    {
-      onError: (error) => console.log("error, ", error),
-    }
-  );
+    onError: (error) => console.log("error, ", error),
+  });
 
   useEffect(() => {
     refreshChart();

--- a/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
+++ b/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
@@ -45,19 +45,17 @@ export const IdentifiedRisksTable: React.FC<
     refetch: refreshTable,
     error: fetchError,
     isFetching,
-  } = useQuery<AssessmentQuestionRisk[]>(
-    ["assessmentquestionrisks"],
-    async () =>
+  } = useQuery<AssessmentQuestionRisk[]>({
+    queryKey: ["assessmentQuestionRisks"],
+    queryFn: async () =>
       // (
       //   await getAssessmentIdentifiedRisks(
       //     allApplications.length > 0 ? allApplications.map((f) => f.id!) : []
       //   )
       // ).data,
       [],
-    {
-      onError: (error) => console.log("error, ", error),
-    }
-  );
+    onError: (error) => console.log("error, ", error),
+  });
 
   const tableData: ITableRowData[] = useMemo(() => {
     return (assessmentQuestionRisks || []).map((risk) => ({
@@ -160,8 +158,10 @@ export const IdentifiedRisksTable: React.FC<
     filterCategories
   );
 
-  const { currentPageItems, setPageNumber, paginationProps } =
-    useLegacyPaginationState(filteredItems, 10);
+  const { currentPageItems, paginationProps } = useLegacyPaginationState(
+    filteredItems,
+    10
+  );
 
   const rows: IRow[] = [];
   currentPageItems.forEach((item) => {

--- a/client/src/app/queries/applications.ts
+++ b/client/src/app/queries/applications.ts
@@ -117,8 +117,9 @@ export const useDeleteApplicationMutation = (
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
-  return useMutation(({ id }: { id: number }) => deleteApplication(id), {
-    onSuccess: (res) => {
+  return useMutation({
+    mutationFn: ({ id }: { id: number }) => deleteApplication(id),
+    onSuccess: (_res) => {
       onSuccess(1);
       queryClient.invalidateQueries([ApplicationsQueryKey]);
     },
@@ -131,16 +132,14 @@ export const useBulkDeleteApplicationMutation = (
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
-  return useMutation(
-    ({ ids }: { ids: number[] }) => deleteBulkApplications(ids),
-    {
-      onSuccess: (res, vars) => {
-        onSuccess(vars.ids.length);
-        queryClient.invalidateQueries([ApplicationsQueryKey]);
-      },
-      onError: onError,
-    }
-  );
+  return useMutation({
+    mutationFn: ({ ids }: { ids: number[] }) => deleteBulkApplications(ids),
+    onSuccess: (res, vars) => {
+      onSuccess(vars.ids.length);
+      queryClient.invalidateQueries([ApplicationsQueryKey]);
+    },
+    onError: onError,
+  });
 };
 
 export const downloadStaticReport = async ({
@@ -182,7 +181,7 @@ export const downloadStaticReport = async ({
 };
 
 export const useDownloadStaticReport = () => {
-  return useMutation(downloadStaticReport);
+  return useMutation({ mutationFn: downloadStaticReport });
 };
 
 export const useFetchApplicationDependencies = (
@@ -193,23 +192,21 @@ export const useFetchApplicationDependencies = (
     error: northError,
     isLoading: isLoadingNorth,
     refetch: refetchNorth,
-  } = useQuery<ApplicationDependency[], AxiosError>(
-    [ApplicationDependencyQueryKey, "north"],
-    () => getApplicationDependencies({ to: [`${applicationId}`] }),
-    {
-      enabled: !!applicationId,
-    }
-  );
+  } = useQuery<ApplicationDependency[], AxiosError>({
+    queryKey: [ApplicationDependencyQueryKey, applicationId, "north"],
+    queryFn: () => getApplicationDependencies({ to: [`${applicationId}`] }),
+    enabled: !!applicationId,
+  });
 
   const {
     data: southData,
     error: southError,
     isLoading: isLoadingSouth,
     refetch: refetchSouth,
-  } = useQuery<ApplicationDependency[], AxiosError>(
-    [ApplicationDependencyQueryKey, "south"],
-    () => getApplicationDependencies({ from: [`${applicationId}`] })
-  );
+  } = useQuery<ApplicationDependency[], AxiosError>({
+    queryKey: [ApplicationDependencyQueryKey, applicationId, "south"],
+    queryFn: () => getApplicationDependencies({ from: [`${applicationId}`] }),
+  });
 
   const isFetching = isLoadingNorth || isLoadingSouth;
   const fetchError = northError || southError;
@@ -241,7 +238,8 @@ export const useCreateApplicationDependency = ({
 }: UseCreateApplicationDependencyOptions = {}) => {
   const queryClient = useQueryClient();
 
-  return useMutation(createApplicationDependency, {
+  return useMutation({
+    mutationFn: createApplicationDependency,
     onSuccess: () => {
       queryClient.invalidateQueries([ApplicationDependencyQueryKey]);
       if (onSuccess) {
@@ -259,7 +257,8 @@ export const useCreateApplicationDependency = ({
 export const useDeleteApplicationDependency = () => {
   const queryClient = useQueryClient();
 
-  return useMutation(deleteApplicationDependency, {
+  return useMutation({
+    mutationFn: deleteApplicationDependency,
     onSuccess: () => {
       queryClient.invalidateQueries([ApplicationDependencyQueryKey]);
     },

--- a/client/src/app/queries/assessments.ts
+++ b/client/src/app/queries/assessments.ts
@@ -129,10 +129,10 @@ export const useFetchAssessmentsByItemId = (
   itemId?: number | string
 ) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: [assessmentsByItemIdQueryKey, itemId],
+    queryKey: [assessmentsByItemIdQueryKey, itemId, isArchetype],
     queryFn: () => getAssessmentsByItemId(isArchetype, itemId),
     onError: (error: AxiosError) => console.log("error, ", error),
-    onSuccess: (data) => {},
+    onSuccess: (_data) => {},
     enabled: !!itemId,
   });
 

--- a/client/src/app/queries/dependencies.ts
+++ b/client/src/app/queries/dependencies.ts
@@ -6,7 +6,6 @@ import {
   HubRequestParams,
 } from "@app/api/models";
 import { getAppDependencies, getDependencies } from "@app/api/rest";
-import { serializeRequestParamsForHub } from "@app/hooks/table-controls/getHubRequestParams";
 
 export interface IDependenciesFetchState {
   result: HubPaginatedResult<AnalysisDependency>;
@@ -22,16 +21,13 @@ export interface IAppDependenciesFetchState {
 }
 
 export const DependenciesQueryKey = "dependencies";
-export const AppDependenciesQueryKey = "appdependencies";
+export const AppDependenciesQueryKey = "appDependencies";
 
 export const useFetchDependencies = (
   params: HubRequestParams = {}
 ): IDependenciesFetchState => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [
-      DependenciesQueryKey,
-      serializeRequestParamsForHub(params).toString(),
-    ],
+    queryKey: [DependenciesQueryKey, params],
     queryFn: async () => await getDependencies(params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,
@@ -48,10 +44,7 @@ export const useFetchAppDependencies = (
   params: HubRequestParams = {}
 ): IAppDependenciesFetchState => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [
-      AppDependenciesQueryKey,
-      serializeRequestParamsForHub(params).toString(),
-    ],
+    queryKey: [AppDependenciesQueryKey, params],
     queryFn: async () => await getAppDependencies(params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,

--- a/client/src/app/queries/facts.ts
+++ b/client/src/app/queries/facts.ts
@@ -7,16 +7,14 @@ import { Fact } from "@app/api/models";
 export const FactsQueryKey = "facts";
 
 export const useFetchFacts = (applicationID: number | string | undefined) => {
-  const { data, isLoading, error, refetch } = useQuery(
-    [FactsQueryKey, applicationID],
-    {
-      queryFn: () => getFacts(applicationID),
-      enabled: !!applicationID,
-      onError: (error: AxiosError) => console.log("error, ", error),
-      select: (facts): Fact[] =>
-        Object.keys(facts).map((fact) => ({ name: fact, data: facts[fact] })),
-    }
-  );
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: [FactsQueryKey, applicationID],
+    queryFn: () => getFacts(applicationID),
+    enabled: !!applicationID,
+    onError: (error: AxiosError) => console.log("error, ", error),
+    select: (facts): Fact[] =>
+      Object.keys(facts).map((fact) => ({ name: fact, data: facts[fact] })),
+  });
 
   return {
     facts: data || [],

--- a/client/src/app/queries/identities.ts
+++ b/client/src/app/queries/identities.ts
@@ -16,7 +16,8 @@ export const useUpdateIdentityMutation = (
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
-  const { isLoading, mutate, error } = useMutation(updateIdentity, {
+  const { isLoading, mutate, error } = useMutation({
+    mutationFn: updateIdentity,
     onSuccess: (res) => {
       onSuccess(res);
       queryClient.invalidateQueries([IdentitiesQueryKey]);
@@ -37,7 +38,8 @@ export const useCreateIdentityMutation = (
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
-  const { isLoading, mutate, error } = useMutation(createIdentity, {
+  const { isLoading, mutate, error } = useMutation({
+    mutationFn: createIdentity,
     onSuccess: (res) => {
       onSuccess(res);
       queryClient.invalidateQueries([IdentitiesQueryKey]);
@@ -54,13 +56,11 @@ export const useCreateIdentityMutation = (
 };
 
 export const useFetchIdentities = () => {
-  const { data, isLoading, error, refetch } = useQuery(
-    [IdentitiesQueryKey],
-    async () => (await getIdentities()).data,
-    {
-      onError: (error) => console.log("error, ", error),
-    }
-  );
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: [IdentitiesQueryKey],
+    queryFn: async () => (await getIdentities()).data,
+    onError: (error) => console.log("error, ", error),
+  });
   return {
     identities: data || [],
     isFetching: isLoading,

--- a/client/src/app/queries/imports.ts
+++ b/client/src/app/queries/imports.ts
@@ -15,11 +15,11 @@ export const useFetchImports = (
   importSummaryID: number,
   isValid: boolean | string
 ) => {
-  const { data, isLoading, error, refetch } = useQuery(
-    [ImportsQueryKey, importSummaryID, isValid],
-    () => getApplicationImports(importSummaryID, isValid),
-    { onError: (error) => console.log(error) }
-  );
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: [ImportsQueryKey, importSummaryID, isValid],
+    queryFn: () => getApplicationImports(importSummaryID, isValid),
+    onError: (error) => console.log(error),
+  });
   return {
     imports: data || [],
     isFetching: isLoading,
@@ -29,14 +29,12 @@ export const useFetchImports = (
 };
 
 export const useFetchImportSummaries = () => {
-  const { data, isLoading, error, refetch } = useQuery(
-    [ImportSummariesQueryKey],
-    getApplicationsImportSummary,
-    {
-      refetchInterval: 5000,
-      onError: (error) => console.log(error),
-    }
-  );
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: [ImportSummariesQueryKey],
+    queryFn: getApplicationsImportSummary,
+    refetchInterval: 5000,
+    onError: (error) => console.log(error),
+  });
   return {
     importSummaries: data || [],
     isFetching: isLoading,
@@ -46,11 +44,11 @@ export const useFetchImportSummaries = () => {
 };
 
 export const useFetchImportSummaryByID = (id: number | string) => {
-  const { data, isLoading, error, refetch } = useQuery(
-    [ImportQueryKey, id],
-    () => getApplicationImportSummaryById(id),
-    { onError: (error) => console.log(error) }
-  );
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: [ImportQueryKey, id],
+    queryFn: () => getApplicationImportSummaryById(id),
+    onError: (error) => console.log(error),
+  });
 
   return {
     importSummary: data,
@@ -64,7 +62,8 @@ export const useDeleteImportSummaryMutation = (
   onSuccess: () => void,
   onError: (err: Error | null) => void
 ) => {
-  return useMutation(deleteApplicationImportSummary, {
+  return useMutation({
+    mutationFn: deleteApplicationImportSummary,
     onSuccess: () => {
       onSuccess && onSuccess();
     },

--- a/client/src/app/queries/issues.ts
+++ b/client/src/app/queries/issues.ts
@@ -17,7 +17,6 @@ import {
   getIssueReports,
   getIssue,
 } from "@app/api/rest";
-import { serializeRequestParamsForHub } from "@app/hooks/table-controls";
 
 export const RuleReportsQueryKey = "rulereports";
 export const AppReportsQueryKey = "appreports";
@@ -28,7 +27,7 @@ export const IssueQueryKey = "issue";
 export const IncidentsQueryKey = "incidents";
 
 const injectUiUniqueIds = <
-  T extends BaseAnalysisRuleReport | BaseAnalysisIssueReport
+  T extends BaseAnalysisRuleReport | BaseAnalysisIssueReport,
 >(
   result: HubPaginatedResult<T>
 ): HubPaginatedResult<WithUiId<T>> => {
@@ -48,10 +47,7 @@ export const useFetchRuleReports = (
   params: HubRequestParams = {}
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [
-      RuleReportsQueryKey,
-      serializeRequestParamsForHub(params).toString(),
-    ],
+    queryKey: [RuleReportsQueryKey, params],
     queryFn: () => getRuleReports(params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,
@@ -69,10 +65,7 @@ export const useFetchRuleReports = (
 
 export const useFetchAppReports = (params: HubRequestParams = {}) => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [
-      AppReportsQueryKey,
-      serializeRequestParamsForHub(params).toString(),
-    ],
+    queryKey: [AppReportsQueryKey, params],
     queryFn: () => getAppReports(params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,
@@ -91,11 +84,7 @@ export const useFetchIssueReports = (
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
     enabled: applicationId !== undefined,
-    queryKey: [
-      IssueReportsQueryKey,
-      applicationId,
-      serializeRequestParamsForHub(params).toString(),
-    ],
+    queryKey: [IssueReportsQueryKey, applicationId, params],
     queryFn: () => getIssueReports(applicationId, params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,
@@ -112,7 +101,7 @@ export const useFetchIssueReports = (
 
 export const useFetchIssues = (params: HubRequestParams = {}) => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [IssuesQueryKey, serializeRequestParamsForHub(params).toString()],
+    queryKey: [IssuesQueryKey, params],
     queryFn: () => getIssues(params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,
@@ -146,11 +135,7 @@ export const useFetchFileReports = (
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
     enabled: issueId !== undefined,
-    queryKey: [
-      FileReportsQueryKey,
-      issueId,
-      serializeRequestParamsForHub(params).toString(),
-    ],
+    queryKey: [FileReportsQueryKey, issueId, params],
     queryFn: () => getFileReports(issueId, params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,
@@ -169,11 +154,7 @@ export const useFetchIncidents = (
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
     enabled: issueId !== undefined,
-    queryKey: [
-      IncidentsQueryKey,
-      issueId,
-      serializeRequestParamsForHub(params).toString(),
-    ],
+    queryKey: [IncidentsQueryKey, issueId, params],
     queryFn: () => getIncidents(issueId, params),
     onError: (error) => console.log("error, ", error),
     keepPreviousData: true,

--- a/client/src/app/queries/jobfunctions.ts
+++ b/client/src/app/queries/jobfunctions.ts
@@ -31,15 +31,15 @@ export const useFetchJobFunctions = (): IJobFunctionFetchState => {
 };
 
 export const useCreateJobFunctionMutation = (
-  onSuccess: (res: any) => void,
+  onSuccess: (data: JobFunction) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: createJobFunction,
-    onSuccess: (res) => {
-      onSuccess(res);
+    onSuccess: (data) => {
+      onSuccess(data);
       queryClient.invalidateQueries([JobFunctionsQueryKey]);
     },
     onError,
@@ -62,14 +62,15 @@ export const useUpdateJobFunctionMutation = (
 };
 
 export const useDeleteJobFunctionMutation = (
-  onSuccess: (res: any) => void,
+  onSuccess: (res: JobFunction) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
-  const { isLoading, mutate, error } = useMutation(deleteJobFunction, {
-    onSuccess: (res) => {
-      onSuccess(res);
+  const { isLoading, mutate, error } = useMutation({
+    mutationFn: deleteJobFunction,
+    onSuccess: (data) => {
+      onSuccess(data);
       queryClient.invalidateQueries([JobFunctionsQueryKey]);
     },
     onError: (err: AxiosError) => {

--- a/client/src/app/queries/questionnaires.ts
+++ b/client/src/app/queries/questionnaires.ts
@@ -96,18 +96,16 @@ export const useCreateQuestionnaireMutation = (
   onError?: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
-  const { isLoading, mutate, mutateAsync, error } = useMutation(
-    createQuestionnaire,
-    {
-      onSuccess: (res) => {
-        onSuccess && onSuccess(res);
-        queryClient.invalidateQueries([]);
-      },
-      onError: (err: AxiosError) => {
-        onError && onError(err);
-      },
-    }
-  );
+  const { isLoading, mutate, mutateAsync, error } = useMutation({
+    mutationFn: createQuestionnaire,
+    onSuccess: (res) => {
+      onSuccess && onSuccess(res);
+      queryClient.invalidateQueries([]);
+    },
+    onError: (err: AxiosError) => {
+      onError && onError(err);
+    },
+  });
   return {
     mutate,
     mutateAsync,
@@ -141,5 +139,5 @@ export const downloadQuestionnaire = async (
   }
 };
 export const useDownloadQuestionnaire = () => {
-  return useMutation(downloadQuestionnaire);
+  return useMutation({ mutationFn: downloadQuestionnaire });
 };

--- a/client/src/app/queries/targets.ts
+++ b/client/src/app/queries/targets.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { IReadFile, Target } from "@app/api/models";
+import { HubFile, IReadFile, Target } from "@app/api/models";
 import {
   createFile,
   createTarget,
@@ -12,13 +12,11 @@ import { AxiosError } from "axios";
 export const TargetsQueryKey = "targets";
 
 export const useFetchTargets = () => {
-  const { data, isLoading, error, refetch } = useQuery<Target[]>(
-    [TargetsQueryKey],
-    async () => await getTargets(),
-    {
-      onError: (err) => console.log(err),
-    }
-  );
+  const { data, isLoading, error, refetch } = useQuery<Target[]>({
+    queryKey: [TargetsQueryKey],
+    queryFn: async () => await getTargets(),
+    onError: (err) => console.log(err),
+  });
 
   return {
     targets: data || [],
@@ -33,7 +31,8 @@ export const useUpdateTargetMutation = (
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
-  const { isLoading, mutate, error } = useMutation(updateTarget, {
+  const { isLoading, mutate, error } = useMutation({
+    mutationFn: updateTarget,
     onSuccess: (res) => {
       onSuccess(res);
       queryClient.invalidateQueries([TargetsQueryKey]);
@@ -55,7 +54,8 @@ export const useDeleteTargetMutation = (
 ) => {
   const queryClient = useQueryClient();
 
-  const { isLoading, mutate, error } = useMutation(deleteTarget, {
+  const { isLoading, mutate, error } = useMutation({
+    mutationFn: deleteTarget,
     onSuccess: (res, id) => {
       onSuccess(res, id);
       queryClient.invalidateQueries([TargetsQueryKey]);
@@ -77,7 +77,8 @@ export const useCreateTargetMutation = (
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
-  const { isLoading, mutate, error } = useMutation(createTarget, {
+  const { isLoading, mutate, error } = useMutation({
+    mutationFn: createTarget,
     onSuccess: (res) => {
       onSuccess(res);
       queryClient.invalidateQueries([TargetsQueryKey]);
@@ -94,13 +95,14 @@ export const useCreateTargetMutation = (
 };
 
 export const useCreateFileMutation = (
-  onSuccess?: (res: any, formData: FormData, file: IReadFile) => void,
+  onSuccess?: (data: HubFile, formData: FormData, file: IReadFile) => void,
   onError?: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
-  const { isLoading, mutate, mutateAsync, error } = useMutation(createFile, {
-    onSuccess: (res, { formData, file }) => {
-      onSuccess && onSuccess(res, formData, file);
+  const { isLoading, mutate, mutateAsync, error } = useMutation({
+    mutationFn: createFile,
+    onSuccess: (data, { formData, file }) => {
+      onSuccess && onSuccess(data, formData, file);
       queryClient.invalidateQueries([]);
     },
     onError: (err: AxiosError) => {

--- a/client/src/app/queries/taskgroups.ts
+++ b/client/src/app/queries/taskgroups.ts
@@ -8,17 +8,13 @@ import {
   uploadFileTaskgroup,
 } from "@app/api/rest";
 import { IReadFile, Taskgroup } from "@app/api/models";
-import { AxiosError } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 import { TasksQueryKey } from "./tasks";
 
 export const useCreateTaskgroupMutation = (
-  onSuccess: (res: any) => void,
+  onSuccess: (data: Taskgroup) => void,
   onError: (err: Error | unknown) => void
-) =>
-  useMutation(createTaskgroup, {
-    onSuccess,
-    onError,
-  });
+) => useMutation({ mutationFn: createTaskgroup, onSuccess, onError });
 
 export const useSubmitTaskgroupMutation = (
   onSuccess: (data: Taskgroup) => void,
@@ -26,7 +22,8 @@ export const useSubmitTaskgroupMutation = (
 ) => {
   const queryClient = useQueryClient();
 
-  return useMutation(submitTaskgroup, {
+  return useMutation({
+    mutationFn: submitTaskgroup,
     onSuccess: (data) => {
       onSuccess(data);
       queryClient.invalidateQueries([TasksQueryKey]);
@@ -39,12 +36,13 @@ export const useSubmitTaskgroupMutation = (
 };
 
 export const useRemoveUploadedFileMutation = (
-  successCallback?: (res: any) => void,
+  successCallback?: (data: AxiosResponse<Taskgroup>) => void,
   errorCallback?: (err: AxiosError) => void
 ) => {
-  return useMutation(removeFileTaskgroup, {
-    onSuccess: (res) => {
-      successCallback && successCallback(res);
+  return useMutation({
+    mutationFn: removeFileTaskgroup,
+    onSuccess: (data) => {
+      successCallback && successCallback(data);
     },
     onError: (err: AxiosError) => {
       errorCallback && errorCallback(err);
@@ -52,13 +50,14 @@ export const useRemoveUploadedFileMutation = (
   });
 };
 export const useUploadFileTaskgroupMutation = (
-  successCallback?: (res: any) => void,
+  successCallback?: (data: AxiosResponse<Taskgroup>) => void,
   errorCallback?: (err: AxiosError) => void
 ) => {
-  return useMutation(uploadFileTaskgroup, {
+  return useMutation({
+    mutationFn: uploadFileTaskgroup,
     mutationKey: ["upload"],
-    onSuccess: (res) => {
-      successCallback && successCallback(res);
+    onSuccess: (data) => {
+      successCallback && successCallback(data);
     },
     onError: (err: AxiosError) => {
       errorCallback && errorCallback(err);
@@ -72,7 +71,8 @@ export const useDeleteTaskgroupMutation = (
 ) => {
   const queryClient = useQueryClient();
 
-  return useMutation(deleteTaskgroup, {
+  return useMutation({
+    mutationFn: deleteTaskgroup,
     onSuccess,
     onError: (err) => {
       onError(err);
@@ -83,7 +83,7 @@ export const useDeleteTaskgroupMutation = (
 
 export const useUploadFileMutation = (
   onSuccess: (
-    res: any,
+    data: AxiosResponse<Taskgroup>,
     id: number,
     path: string,
     formData: any,
@@ -91,9 +91,10 @@ export const useUploadFileMutation = (
   ) => void,
   errorCallback: (err: AxiosError) => void
 ) => {
-  return useMutation(uploadFileTaskgroup, {
-    onSuccess: (res, { id, path, formData, file }) => {
-      onSuccess(res, id, path, formData, file);
+  return useMutation({
+    mutationFn: uploadFileTaskgroup,
+    onSuccess: (data, { id, path, formData, file }) => {
+      onSuccess(data, id, path, formData, file);
     },
     onError: (err: AxiosError) => {
       errorCallback && errorCallback(err);

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 
-import { Task } from "@app/api/models";
 import { cancelTask, deleteTask, getTasks } from "@app/api/rest";
 
 interface FetchTasksFilters {
@@ -10,38 +9,36 @@ interface FetchTasksFilters {
 export const TasksQueryKey = "tasks";
 
 export const useFetchTasks = (filters: FetchTasksFilters = {}) => {
-  const { isLoading, error, refetch, data } = useQuery(
-    [TasksQueryKey],
-    getTasks,
-    {
-      refetchInterval: 5000,
-      select: (allTasks) => {
-        const uniqSorted = allTasks
-          .filter((task) =>
-            filters?.addon ? filters.addon === task.addon : true
-          )
-          // sort by application.id (ascending) then createTime (newest to oldest)
-          .sort((a, b) => {
-            if (a.application.id !== b.application.id) {
-              return a.application.id - b.application.id;
-            } else {
-              const aTime = a?.createTime ?? "";
-              const bTime = b?.createTime ?? "";
-              return aTime < bTime ? 1 : aTime > bTime ? -1 : 0;
-            }
-          })
-          // remove old tasks for each application
-          .filter(
-            (task, index, tasks) =>
-              index === 0 ||
-              task.application.id !== tasks[index - 1].application.id
-          );
+  const { isLoading, error, refetch, data } = useQuery({
+    queryKey: [TasksQueryKey],
+    queryFn: getTasks,
+    refetchInterval: 5000,
+    select: (allTasks) => {
+      const uniqSorted = allTasks
+        .filter((task) =>
+          filters?.addon ? filters.addon === task.addon : true
+        )
+        // sort by application.id (ascending) then createTime (newest to oldest)
+        .sort((a, b) => {
+          if (a.application.id !== b.application.id) {
+            return a.application.id - b.application.id;
+          } else {
+            const aTime = a?.createTime ?? "";
+            const bTime = b?.createTime ?? "";
+            return aTime < bTime ? 1 : aTime > bTime ? -1 : 0;
+          }
+        })
+        // remove old tasks for each application
+        .filter(
+          (task, index, tasks) =>
+            index === 0 ||
+            task.application.id !== tasks[index - 1].application.id
+        );
 
-        return uniqSorted;
-      },
-      onError: (err) => console.log(err),
-    }
-  );
+      return uniqSorted;
+    },
+    onError: (err) => console.log(err),
+  });
 
   return {
     tasks: data || [],
@@ -55,7 +52,8 @@ export const useDeleteTaskMutation = (
   onSuccess: () => void,
   onError: (err: Error | null) => void
 ) => {
-  return useMutation(deleteTask, {
+  return useMutation({
+    mutationFn: deleteTask,
     onSuccess: () => {
       onSuccess && onSuccess();
     },
@@ -69,7 +67,8 @@ export const useCancelTaskMutation = (
   onSuccess: () => void,
   onError: (err: Error | null) => void
 ) => {
-  return useMutation(cancelTask, {
+  return useMutation({
+    mutationFn: cancelTask,
     onSuccess: () => {
       onSuccess && onSuccess();
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/plugin-run": "^3.0.1",
         "@rollup/plugin-typescript": "^11.1.2",
+        "@tanstack/eslint-plugin-query": "^4.34.1",
         "@types/jest": "^29.5.4",
         "@types/node": "^18.14.2",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
@@ -2069,6 +2070,19 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "4.34.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-4.34.1.tgz",
+      "integrity": "sha512-RflOwyXamuHhuMX5RL6wtKiVw9Hi5Hhiv9gW2/ICVc4omflB+GflrxwvQ+EWRKrSRv3C0YcR0UzRxuiZ4mLq7Q==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@tanstack/match-sorter-utils": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-run": "^3.0.1",
     "@rollup/plugin-typescript": "^11.1.2",
+    "@tanstack/eslint-plugin-query": "^4.34.1",
     "@types/jest": "^29.5.4",
     "@types/node": "^18.14.2",
     "@typescript-eslint/eslint-plugin": "^6.4.0",


### PR DESCRIPTION
Looking at [1], add eslint rules for react-query.  The rules are currently set to `error` in order to highlight what "best practices" will be enforced with this change.

Fixed the reported errors for the eslint plugins:

  - `"@tanstack/query/prefer-query-object-syntax`: fix the `useQuery()`
    to use the query object syntax throughout the code base.

  - `@tanstack/query/exhaustive-deps`:

    - Fix the `queryKey` params to include all of the variables used
      in the `queryFn`.  This is similar behavior to the `useMemo()`
      lint rule.

    - Where a `params` prop was being transformed to a string in the
      `queryKey`, the transform was removed.  The bare `params` object
      is allowed to be used as part of the queryKey.

  - A number of warnings in the files that were touched were also resolved (some prettier, some no any type, etc).

[1] - https://tanstack.com/query/latest/docs/react/eslint/eslint-plugin-query
