### PR TITLE
:sparkles: Archetype form for Create and Edit

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -128,6 +128,7 @@
       "newTag": "New Tag",
       "newTagCategory": "New tag category",
       "update": "Update {{what}}",
+      "updateArchetype": "Update archetype",
       "updateApplication": "Update application",
       "updateBusinessService": "Update business service",
       "updateJobFunction": "Update job function",

--- a/client/src/app/components/Autocomplete.tsx
+++ b/client/src/app/components/Autocomplete.tsx
@@ -15,6 +15,7 @@ import {
 
 export interface IAutocompleteProps {
   onChange: (selections: string[]) => void;
+  id?: string;
   allowUserOptions?: boolean;
   options?: string[];
   placeholderText?: string;
@@ -27,6 +28,7 @@ export interface IAutocompleteProps {
 }
 
 export const Autocomplete: React.FC<IAutocompleteProps> = ({
+  id = "",
   onChange,
   options = [],
   allowUserOptions = false,
@@ -258,6 +260,7 @@ export const Autocomplete: React.FC<IAutocompleteProps> = ({
   const inputGroup = (
     <div ref={searchInputRef}>
       <SearchInput
+        id={id}
         value={inputValue}
         hint={hint}
         onChange={handleInputChange}
@@ -285,7 +288,7 @@ export const Autocomplete: React.FC<IAutocompleteProps> = ({
 
   return (
     <Flex direction={{ default: "column" }}>
-      <FlexItem>
+      <FlexItem key="input">
         <Popper
           trigger={inputGroup}
           triggerRef={searchInputRef}
@@ -296,7 +299,7 @@ export const Autocomplete: React.FC<IAutocompleteProps> = ({
           onDocumentClick={handleClick}
         />
       </FlexItem>
-      <FlexItem>
+      <FlexItem key="chips">
         <Flex spaceItems={{ default: "spaceItemsXs" }}>
           {Array.from(currentChips).map((currentChip) => (
             <FlexItem key={currentChip}>

--- a/client/src/app/pages/archetypes/archetypes-page.tsx
+++ b/client/src/app/pages/archetypes/archetypes-page.tsx
@@ -63,7 +63,9 @@ const Archetypes: React.FC = () => {
   const [openCreateArchetype, setOpenCreateArchetype] =
     useState<boolean>(false);
 
-  const [archetypeToEdit, setArchetypeToEdit] = useState<Archetype>();
+  const [archetypeToEdit, setArchetypeToEdit] = useState<Archetype | null>(
+    null
+  );
 
   const { archetypes, isFetching, error: fetchError } = useFetchArchetypes();
 
@@ -292,12 +294,12 @@ const Archetypes: React.FC = () => {
         title={t("dialog.title.updateArchetype")}
         variant="medium"
         isOpen={!!archetypeToEdit}
-        onClose={() => setArchetypeToEdit(undefined)}
+        onClose={() => setArchetypeToEdit(null)}
       >
         <ArchetypeForm
           key={archetypeToEdit?.id ?? -1}
           toEdit={archetypeToEdit}
-          onClose={() => setArchetypeToEdit(undefined)}
+          onClose={() => setArchetypeToEdit(null)}
         />
       </Modal>
 

--- a/client/src/app/pages/archetypes/archetypes-page.tsx
+++ b/client/src/app/pages/archetypes/archetypes-page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {
@@ -9,6 +9,7 @@ import {
   EmptyStateFooter,
   EmptyStateHeader,
   EmptyStateIcon,
+  Modal,
   PageSection,
   PageSectionVariants,
   Text,
@@ -57,6 +58,13 @@ const Archetypes: React.FC = () => {
   const { t } = useTranslation();
   const history = useHistory();
   const { pushNotification } = React.useContext(NotificationsContext);
+
+  const [openCreateArchetype, setOpenCreateArchetype] =
+    useState<boolean>(false);
+
+  const [archetypeToEdit, setArchetypeToEdit] = useState<Archetype | null>(
+    null
+  );
 
   const { archetypes, isFetching, error: fetchError } = useFetchArchetypes();
 
@@ -271,6 +279,24 @@ const Archetypes: React.FC = () => {
       </PageSection>
 
       {/* TODO: Add create/edit modal */}
+      <Modal
+        title={t("dialog.title.newArchetype")}
+        variant="medium"
+        isOpen={openCreateArchetype}
+        onClose={() => setOpenCreateArchetype(false)}
+      >
+        <ArchetypeForm />
+      </Modal>
+      <Modal
+        title={t("dialog.title.updateArchetype")}
+        variant="medium"
+        isOpen={!!archetypeToEdit}
+        onClose={() => setArchetypeToEdit(null)}
+        key={archetypeToEdit?.id ?? -1}
+      >
+        <ArchetypeForm />
+      </Modal>
+
       {/* TODO: Add duplicate confirm modal */}
       <ConfirmDialog
         title={t("dialog.title.deleteWithName", {

--- a/client/src/app/pages/archetypes/archetypes-page.tsx
+++ b/client/src/app/pages/archetypes/archetypes-page.tsx
@@ -47,6 +47,7 @@ import {
 
 import ArchetypeApplicationsColumn from "./components/archetype-applications-column";
 import ArchetypeDescriptionColumn from "./components/archetype-description-column";
+import ArchetypeForm from "./components/archetype-form";
 import ArchetypeMaintainersColumn from "./components/archetype-maintainers-column";
 import ArchetypeTagsColumn from "./components/archetype-tags-column";
 import { Archetype } from "@app/api/models";
@@ -62,9 +63,7 @@ const Archetypes: React.FC = () => {
   const [openCreateArchetype, setOpenCreateArchetype] =
     useState<boolean>(false);
 
-  const [archetypeToEdit, setArchetypeToEdit] = useState<Archetype | null>(
-    null
-  );
+  const [archetypeToEdit, setArchetypeToEdit] = useState<Archetype>();
 
   const { archetypes, isFetching, error: fetchError } = useFetchArchetypes();
 
@@ -151,7 +150,7 @@ const Archetypes: React.FC = () => {
       id="create-new-archetype"
       aria-label="Create new archetype"
       variant={ButtonVariant.primary}
-      onClick={() => {}} // TODO: Add create archetype modal
+      onClick={() => setOpenCreateArchetype(true)}
     >
       {t("dialog.title.newArchetype")}
     </Button>
@@ -255,7 +254,7 @@ const Archetypes: React.FC = () => {
                               },
                               {
                                 title: t("actions.edit"),
-                                onClick: () => alert("TODO"),
+                                onClick: () => setArchetypeToEdit(archetype),
                               },
                               { isSeparator: true },
                               {
@@ -278,26 +277,33 @@ const Archetypes: React.FC = () => {
         </ConditionalRender>
       </PageSection>
 
-      {/* TODO: Add create/edit modal */}
+      {/* Create modal */}
       <Modal
         title={t("dialog.title.newArchetype")}
         variant="medium"
         isOpen={openCreateArchetype}
         onClose={() => setOpenCreateArchetype(false)}
       >
-        <ArchetypeForm />
+        <ArchetypeForm onClose={() => setOpenCreateArchetype(false)} />
       </Modal>
+
+      {/* Edit modal */}
       <Modal
         title={t("dialog.title.updateArchetype")}
         variant="medium"
         isOpen={!!archetypeToEdit}
-        onClose={() => setArchetypeToEdit(null)}
-        key={archetypeToEdit?.id ?? -1}
+        onClose={() => setArchetypeToEdit(undefined)}
       >
-        <ArchetypeForm />
+        <ArchetypeForm
+          key={archetypeToEdit?.id ?? -1}
+          toEdit={archetypeToEdit}
+          onClose={() => setArchetypeToEdit(undefined)}
+        />
       </Modal>
 
       {/* TODO: Add duplicate confirm modal */}
+
+      {/* Delete confirm modal */}
       <ConfirmDialog
         title={t("dialog.title.deleteWithName", {
           what: t("terms.archetype").toLowerCase(),

--- a/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { AxiosError } from "axios";
-import { Control, useForm, Path } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
@@ -14,11 +14,9 @@ import {
 
 import type { Archetype, Tag } from "@app/api/models";
 import {
-  HookFormPFGroupController,
   HookFormPFTextArea,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
-import { Autocomplete } from "@app/components/Autocomplete";
 import { NotificationsContext } from "@app/components/NotificationsContext";
 import {
   useFetchArchetypes,
@@ -29,7 +27,9 @@ import {
 import { duplicateNameCheck, getAxiosErrorMessage } from "@app/utils/utils";
 import { useFetchTagCategories } from "@app/queries/tags";
 
-interface ArchetypeFormValues {
+import TagsSelect from "../tags-select";
+
+export interface ArchetypeFormValues {
   name: string;
   description?: string;
   comments?: string;
@@ -232,54 +232,6 @@ export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
 };
 
 export default ArchetypeForm;
-
-// TODO: Currently only supports working with tag names (which only work if tags names are globally unique)
-// TODO: Does not support select menu grouping by tag category
-// TODO: Does not support select menu selection checkboxes
-// TODO: Does not support rendering tag labels with tag category color
-// TODO: Does not support rendering tag labels in tag category groups
-const TagsSelect: React.FC<{
-  tags: Tag[];
-  control: Control<ArchetypeFormValues>;
-  name: Path<ArchetypeFormValues>;
-  label: string;
-  fieldId: string;
-  noResultsMessage: string;
-  placeholderText: string;
-  searchInputAriaLabel: string;
-  isRequired: boolean;
-}> = ({
-  tags,
-  control,
-  name,
-  label,
-  fieldId,
-  noResultsMessage,
-  placeholderText,
-  searchInputAriaLabel,
-  isRequired = false,
-}) => {
-  return (
-    <HookFormPFGroupController
-      isRequired={isRequired}
-      control={control}
-      name={name}
-      label={label}
-      fieldId={fieldId}
-      renderInput={({ field: { value, onChange } }) => (
-        <Autocomplete
-          id={fieldId}
-          noResultsMessage={noResultsMessage}
-          placeholderText={placeholderText}
-          searchInputAriaLabel={searchInputAriaLabel}
-          options={tags.map((tag) => tag.name).sort()}
-          selections={Array.isArray(value) ? value : [value]}
-          onChange={onChange}
-        />
-      )}
-    />
-  );
-};
 
 const useArchetypeFormData = ({
   id,

--- a/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
@@ -40,19 +40,19 @@ interface ArchetypeFormValues {
 }
 
 export interface ArchetypeFormProps {
-  toEdit?: Archetype;
+  toEdit: Archetype | null;
   onClose: () => void;
 }
 
 export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
-  toEdit = undefined,
+  toEdit = null,
   onClose,
 }) => {
-  const isCreate = toEdit === undefined;
+  const isCreate = toEdit === null;
   const { t } = useTranslation();
 
   const {
-    archetype,
+    archetype, // TODO: Use this or just rely on `toEdit`?
     existingArchetypes,
     tags,
     createArchetype,

--- a/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
@@ -1,0 +1,242 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { AxiosError } from "axios";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+
+import {
+  ActionGroup,
+  Button,
+  ButtonVariant,
+  Form,
+} from "@patternfly/react-core";
+
+import type { Archetype, TagRef } from "@app/api/models";
+import {
+  HookFormPFTextArea,
+  HookFormPFTextInput,
+} from "@app/components/HookFormPFFields";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import {
+  useFetchArchetypes,
+  useFetchArchetypeById,
+  useCreateArchetypeMutation,
+  useUpdateArchetypeMutation,
+} from "@app/queries/archetypes";
+import { duplicateNameCheck, getAxiosErrorMessage } from "@app/utils/utils";
+
+interface ArchetypeFormValues {
+  name: string;
+  description?: string;
+  comments?: string;
+  criteriaTags: TagRef[];
+  tags: TagRef[];
+  stakeholders?: object[];
+  stakeholderGroups?: object[];
+}
+
+export interface ArchetypeFormProps {
+  toEdit?: Archetype;
+  onClose: () => void;
+}
+
+export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
+  toEdit = undefined,
+  onClose,
+}) => {
+  const isCreate = toEdit === undefined;
+  const { t } = useTranslation();
+
+  const { archetype, existingArchetypes, createArchetype, updateArchetype } =
+    useArchetypeFormData({
+      id: toEdit?.id,
+      onActionSuccess: onClose,
+    });
+
+  const validationSchema = yup.object().shape({
+    // for text input fields
+    name: yup
+      .string()
+      .trim()
+      .required(t("validation.required"))
+      .min(3, t("validation.minLength", { length: 3 }))
+      .max(120, t("validation.maxLength", { length: 120 }))
+      .test(
+        "Duplicate name",
+        "An archetype with this name already exists. Use a different name.",
+        (value) =>
+          duplicateNameCheck(existingArchetypes, toEdit || null, value ?? "")
+      ),
+
+    description: yup
+      .string()
+      .trim()
+      .max(250, t("validation.maxLength", { length: 250 })),
+
+    comments: yup
+      .string()
+      .trim()
+      .max(250, t("validation.maxLength", { length: 250 })),
+
+    // for complex data fields
+    // TODO: add criteriaTags (at least 1 required)
+    // TODO: add tags (at least 1 required)
+    // TODO: add stakeholders (optional)
+    // TODO: add stakeholderGroups (optional)
+  });
+
+  const {
+    handleSubmit,
+    formState: { isSubmitting, isValidating, isValid, isDirty },
+    control,
+  } = useForm<ArchetypeFormValues>({
+    defaultValues: {
+      name: toEdit?.name || "",
+      description: toEdit?.description || "",
+      comments: toEdit?.comments || "",
+
+      // TODO: add for criteriaTags, tags, stakeholders, stakeholderGroups
+    },
+    resolver: yupResolver(validationSchema),
+    mode: "all",
+  });
+
+  const onValidSubmit = (formValues: ArchetypeFormValues) => {
+    const payload: Archetype = {
+      id: toEdit?.id || -1, // TODO: verify the -1 will be thrown out on create
+      name: formValues.name.trim(),
+      description: formValues.description?.trim() ?? "",
+      comments: formValues.comments?.trim() ?? "",
+
+      criteriaTags: [], // TODO: add criteriaTags
+      archetypeTags: [], // TODO: add tags
+      stakeholders: undefined, // TODO: add stakeholders
+      stakeholderGroups: undefined, // TODO: add stakeholderGroups
+    };
+
+    if (isCreate) {
+      createArchetype(payload);
+    } else {
+      updateArchetype(payload);
+    }
+  };
+
+  return (
+    <Form onSubmit={handleSubmit(onValidSubmit)} id="archetype-form">
+      <HookFormPFTextInput
+        control={control}
+        name="name"
+        label="Name"
+        fieldId="name"
+        isRequired
+      />
+
+      <HookFormPFTextInput
+        control={control}
+        name="description"
+        label="Description"
+        fieldId="description"
+      />
+
+      {/* TODO: add criteriaTags */}
+      {/* TODO: add tags */}
+      {/* TODO: add stakeholders */}
+      {/* TODO: add stakeholderGroups */}
+
+      <HookFormPFTextArea
+        control={control}
+        name="comments"
+        label={t("terms.comments")}
+        fieldId="comments"
+        resizeOrientation="vertical"
+      />
+
+      <ActionGroup>
+        <Button
+          type="submit"
+          id="submit"
+          aria-label="submit"
+          variant={ButtonVariant.primary}
+          isDisabled={!isValid || isSubmitting || isValidating || !isDirty}
+        >
+          {isCreate ? t("actions.create") : t("actions.save")}
+        </Button>
+        <Button
+          type="button"
+          id="cancel"
+          aria-label="cancel"
+          variant={ButtonVariant.link}
+          isDisabled={isSubmitting || isValidating}
+          onClick={onClose}
+        >
+          {t("actions.cancel")}
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};
+
+export default ArchetypeForm;
+
+const useArchetypeFormData = ({
+  id,
+  onActionSuccess = () => {},
+  onActionFail = () => {},
+}: {
+  id?: number;
+  onActionSuccess?: () => void;
+  onActionFail?: () => void;
+}) => {
+  const { t } = useTranslation();
+  const { pushNotification } = React.useContext(NotificationsContext);
+
+  const { archetypes: existingArchetypes } = useFetchArchetypes();
+  const { archetype } = useFetchArchetypeById(id);
+
+  const onCreateSuccess = (archetype: Archetype) => {
+    pushNotification({
+      title: t("toastr.success.createWhat", {
+        type: t("terms.archetype"),
+        what: archetype.name,
+      }),
+      variant: "success",
+    });
+    onActionSuccess();
+  };
+
+  const onUpdateSuccess = (_id: number) => {
+    pushNotification({
+      title: t("toastr.success.save", {
+        type: t("terms.archetype"),
+      }),
+      variant: "success",
+    });
+    onActionSuccess();
+  };
+
+  const onCreateUpdateError = (error: AxiosError) => {
+    pushNotification({
+      title: getAxiosErrorMessage(error),
+      variant: "danger",
+    });
+    onActionFail();
+  };
+
+  const { mutate: createArchetype } = useCreateArchetypeMutation(
+    onCreateSuccess,
+    onCreateUpdateError
+  );
+
+  const { mutate: updateArchetype } = useUpdateArchetypeMutation(
+    onUpdateSuccess,
+    onCreateUpdateError
+  );
+
+  return {
+    archetype,
+    existingArchetypes,
+    createArchetype,
+    updateArchetype,
+  };
+};

--- a/client/src/app/pages/archetypes/components/archetype-form/index.ts
+++ b/client/src/app/pages/archetypes/components/archetype-form/index.ts
@@ -1,1 +1,2 @@
+export * from "./archetype-form";
 export { ArchetypeForm as default } from "./archetype-form";

--- a/client/src/app/pages/archetypes/components/archetype-form/index.ts
+++ b/client/src/app/pages/archetypes/components/archetype-form/index.ts
@@ -1,0 +1,1 @@
+export { ArchetypeForm as default } from "./archetype-form";

--- a/client/src/app/pages/archetypes/components/items-select.tsx
+++ b/client/src/app/pages/archetypes/components/items-select.tsx
@@ -1,17 +1,16 @@
 import React from "react";
 import { Control, Path } from "react-hook-form";
-import type { Tag } from "@app/api/models";
 import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
 import { Autocomplete } from "@app/components/Autocomplete";
 import type { ArchetypeFormValues } from "./archetype-form";
 
-// TODO: Currently only supports working with tag names (which only work if tags names are globally unique)
-// TODO: Does not support select menu grouping by tag category
+// TODO: Currently only supports working with tag names (which only work if item names are globally unique)
+// TODO: Does not support select menu grouping by category
 // TODO: Does not support select menu selection checkboxes
-// TODO: Does not support rendering tag labels with tag category color
-// TODO: Does not support rendering tag labels in tag category groups
-const TagsSelect = ({
-  tags,
+// TODO: Does not support rendering item labels with item category color
+// TODO: Does not support rendering item labels in item category groups
+const ItemsSelect = <ItemType extends { name: string }>({
+  items = [],
   control,
   name,
   label,
@@ -21,7 +20,7 @@ const TagsSelect = ({
   searchInputAriaLabel,
   isRequired = false,
 }: {
-  tags: Tag[];
+  items: ItemType[];
   control: Control<ArchetypeFormValues>;
   name: Path<ArchetypeFormValues>;
   label: string;
@@ -29,8 +28,13 @@ const TagsSelect = ({
   noResultsMessage: string;
   placeholderText: string;
   searchInputAriaLabel: string;
-  isRequired: boolean;
+  isRequired?: boolean;
 }) => {
+  const itemsToName = () => items.map((item) => item.name).sort();
+
+  const normalizeSelections = (values: string | string[] | undefined) =>
+    (Array.isArray(values) ? values : [values]).filter(Boolean) as string[];
+
   return (
     <HookFormPFGroupController
       isRequired={isRequired}
@@ -44,8 +48,8 @@ const TagsSelect = ({
           noResultsMessage={noResultsMessage}
           placeholderText={placeholderText}
           searchInputAriaLabel={searchInputAriaLabel}
-          options={tags.map((tag) => tag.name).sort()}
-          selections={Array.isArray(value) ? value : [value]}
+          options={itemsToName()}
+          selections={normalizeSelections(value)}
           onChange={onChange}
         />
       )}
@@ -53,4 +57,4 @@ const TagsSelect = ({
   );
 };
 
-export default TagsSelect;
+export default ItemsSelect;

--- a/client/src/app/pages/archetypes/components/tags-select.tsx
+++ b/client/src/app/pages/archetypes/components/tags-select.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Control, Path } from "react-hook-form";
+import type { Tag } from "@app/api/models";
+import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
+import { Autocomplete } from "@app/components/Autocomplete";
+import type { ArchetypeFormValues } from "./archetype-form";
+
+// TODO: Currently only supports working with tag names (which only work if tags names are globally unique)
+// TODO: Does not support select menu grouping by tag category
+// TODO: Does not support select menu selection checkboxes
+// TODO: Does not support rendering tag labels with tag category color
+// TODO: Does not support rendering tag labels in tag category groups
+const TagsSelect = ({
+  tags,
+  control,
+  name,
+  label,
+  fieldId,
+  noResultsMessage,
+  placeholderText,
+  searchInputAriaLabel,
+  isRequired = false,
+}: {
+  tags: Tag[];
+  control: Control<ArchetypeFormValues>;
+  name: Path<ArchetypeFormValues>;
+  label: string;
+  fieldId: string;
+  noResultsMessage: string;
+  placeholderText: string;
+  searchInputAriaLabel: string;
+  isRequired: boolean;
+}) => {
+  return (
+    <HookFormPFGroupController
+      isRequired={isRequired}
+      control={control}
+      name={name}
+      label={label}
+      fieldId={fieldId}
+      renderInput={({ field: { value, onChange } }) => (
+        <Autocomplete
+          id={fieldId}
+          noResultsMessage={noResultsMessage}
+          placeholderText={placeholderText}
+          searchInputAriaLabel={searchInputAriaLabel}
+          options={tags.map((tag) => tag.name).sort()}
+          selections={Array.isArray(value) ? value : [value]}
+          onChange={onChange}
+        />
+      )}
+    />
+  );
+};
+
+export default TagsSelect;

--- a/client/src/app/queries/archetypes.ts
+++ b/client/src/app/queries/archetypes.ts
@@ -30,11 +30,13 @@ export const useFetchArchetypes = () => {
   };
 };
 
-export const useFetchArchetypeById = (id: number) => {
+export const useFetchArchetypeById = (id?: number) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [ARCHETYPE_QUERY_KEY, id],
-    queryFn: () => getArchetypeById(id),
+    queryFn: () =>
+      id === undefined ? Promise.resolve(undefined) : getArchetypeById(id),
     onError: (error: AxiosError) => console.log("error, ", error),
+    enabled: id !== undefined,
   });
 
   return {

--- a/client/src/mocks/stub-new-work/index.ts
+++ b/client/src/mocks/stub-new-work/index.ts
@@ -1,13 +1,10 @@
 import { type RestHandler } from "msw";
 
-import questionnaires from "./questionnaires";
-import assessments from "./assessments";
-import applications from "./applications";
 import archetypes from "./archetypes";
 
 export default [
   // ...questionnaires,
   // ...assessments,
   // ...applications,
-  // ...archetypes,
+  ...archetypes,
 ] as RestHandler[];


### PR DESCRIPTION
Add the Archetype form along with Create and Edit actions from the archetype table.

MSW stubs for the hub archetype api are enabled by default for now.

Resolves #1265

## Screenshots
Create new (empty):
![Screenshot from 2023-09-11 19-48-12](https://github.com/konveyor/tackle2-ui/assets/3985964/01ea2f22-827f-4446-b8f8-6b6a07da5358)

Tag selection field open with typeahead active:
![Screenshot from 2023-09-11 19-49-19](https://github.com/konveyor/tackle2-ui/assets/3985964/e65ce42c-0138-433f-9140-443ad9555ca1)

Create fully filled in:
![Screenshot from 2023-09-11 19-49-35](https://github.com/konveyor/tackle2-ui/assets/3985964/630cb76e-6e04-4402-9d19-87c18f675c89)

Create in error with an archetype name that already exists:
![Screenshot from 2023-09-11 19-49-51](https://github.com/konveyor/tackle2-ui/assets/3985964/f983af19-d0d2-4e6f-a83a-a0a121789b65)

Edit existing:
![Screenshot from 2023-09-11 19-52-39](https://github.com/konveyor/tackle2-ui/assets/3985964/541b9126-70d8-4e77-9453-ef8cd20fa27f)

