### PR TITLE
:sparkles: Selectors to uniquely identify dropdowns

### DIFF
--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -514,7 +514,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
                 </RBAC>
               </ToolbarItem>
               {dropdownItems.length ? (
-                <ToolbarItem>
+                <ToolbarItem id="toolbar-kebab">
                   <Dropdown
                     isOpen={isToolbarKebabOpen}
                     onSelect={() => setIsToolbarKebabOpen(false)}
@@ -631,7 +631,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
                       <TagIcon />
                       {application.tags ? application.tags.length : 0}
                     </Td>
-                    <Td isActionCell>
+                    <Td isActionCell id="pencil-action">
                       <Button
                         variant="plain"
                         icon={<PencilAltIcon />}
@@ -640,7 +640,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
                         }
                       />
                     </Td>
-                    <Td isActionCell>
+                    <Td isActionCell id="row-actions">
                       <Dropdown
                         isOpen={isRowDropdownOpen === application.id}
                         onSelect={() => setIsRowDropdownOpen(null)}

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -521,7 +521,7 @@ export const ApplicationsTable: React.FC = () => {
                 </RBAC>
               </ToolbarItem>
               {dropdownItems.length ? (
-                <ToolbarItem>
+                <ToolbarItem id="toolbar-kebab">
                   <Dropdown
                     isOpen={isToolbarKebabOpen}
                     onSelect={() => setIsToolbarKebabOpen(false)}
@@ -649,7 +649,7 @@ export const ApplicationsTable: React.FC = () => {
                       <TagIcon />
                       {application.tags ? application.tags.length : 0}
                     </Td>
-                    <Td isActionCell>
+                    <Td isActionCell id="pencil-action">
                       <Button
                         variant="plain"
                         icon={<PencilAltIcon />}
@@ -658,7 +658,7 @@ export const ApplicationsTable: React.FC = () => {
                         }
                       />
                     </Td>
-                    <Td isActionCell>
+                    <Td isActionCell id="row-actions">
                       <ActionsColumn
                         items={[
                           {


### PR DESCRIPTION
@ibragins explained QE needs : 
- A consistent selector across the UI to identify kebab in toolbar, for instance id="toolbar-kebab"
- A consistent selector across the UI to distinct, on a given table row between, between a "pencil" button and the "actions" kebab. There is no need to uniquely identify those selector by row, QE already has selectors for that purpose.

We can see those IDs in action in current PR in applications-table-assessment.tsx.

Meanwhile that cannot be easliy added to the legacy tables (PF4 or PF5 deprecated table) because we don't have access to the wrapper component. Therefore will have to wait for legacy table migration to be finished first.  

This applies to every page having a top kebab (Toolbar) and rows with several actions button/kebab: 
- [x] applications-table-assessment.tsx
- [x] applications-table-analysis.tsx
- [x] migration-waves.tsx

On the MigrationWaves page, the deprecated dropdown has been replaced with PF5 version.

https://github.com/konveyor/tackle2-ui/issues/443