### PR TITLE
:bug: Remove redundant targets from defaults list and sort targets

### DIFF
--- a/client/src/app/data/targets.ts
+++ b/client/src/app/data/targets.ts
@@ -1,53 +1,16 @@
-import { APP_BRAND, BrandType } from "@app/Constants";
 import { TargetLabel } from "@app/api/models";
 
-const openTargets: TargetLabel[] = [
-  {
-    name: "konveyor.io/target=camel",
-    label: "konveyor.io/target=camel",
-  },
-  {
-    name: "cloud-readiness",
-    label: "konveyor.io/target=cloud-readiness",
-  },
-  {
-    name: "drools",
-    label: "konveyor.io/target=drools",
-  },
-  { name: "eap", label: "konveyor.io/target=eap" },
-  { name: "eap6", label: "konveyor.io/target=eap6" },
-  { name: "eap7", label: "konveyor.io/target=eap7" },
-  { name: "eap8", label: "konveyor.io/target=eap8" },
-  { name: "eapxp", label: "konveyor.io/target=eapxp" },
-  { name: "fsw", label: "konveyor.io/target=fsw" },
-  {
-    name: "fuse",
-    label: "konveyor.io/target=fuse",
-  },
-  { name: "hibernate", label: "konveyor.io/target=hibernate" },
-  { name: "hibernate-search", label: "konveyor.io/target=hibernate-search" },
-  { name: "jakarta-ee", label: "konveyor.io/target=jakarta-ee" },
-  { name: "java-ee", label: "konveyor.io/target=java-ee" },
-  { name: "jbpm", label: "konveyor.io/target=jbpm" },
-  { name: "linux", label: "konveyor.io/target=linux" },
-  { name: "openjdk", label: "konveyor.io/target=openjdk" },
-  { name: "openjdk11", label: "konveyor.io/target=openjdk11" },
-  { name: "openjdk17", label: "konveyor.io/target=openjdk17" },
-  { name: "openliberty", label: "konveyor.io/target=openliberty" },
-  { name: "quarkus", label: "konveyor.io/target=quarkus" },
-  { name: "resteasy", label: "konveyor.io/target=resteasy" },
-  { name: "rhr", label: "konveyor.io/target=rhr" },
-  { name: "azure-appservice", label: "konveyor.io/target=azure-appservice" },
+export const defaultTargets: TargetLabel[] = [
+  { name: "Drools", label: "konveyor.io/target=drools" },
+  { name: "EAP", label: "konveyor.io/target=eap" },
+  { name: "EAP 6", label: "konveyor.io/target=eap6" },
+  { name: "EAP XP", label: "konveyor.io/target=eapxp" },
+  { name: "FSW", label: "konveyor.io/target=fsw" },
+  { name: "Fuse", label: "konveyor.io/target=fuse" },
+  { name: "Hibernate", label: "konveyor.io/target=hibernate" },
+  { name: "Hibernate Search", label: "konveyor.io/target=hibernate-search" },
+  { name: "Java EE", label: "konveyor.io/target=java-ee" },
+  { name: "jBPM", label: "konveyor.io/target=jbpm" },
+  { name: "OpenJDK", label: "konveyor.io/target=openjdk" },
+  { name: "RESTEasy", label: "konveyor.io/target=resteasy" },
 ];
-
-const proprietaryTargets = [
-  {
-    name: "konveyor.io/target=azure-aks",
-    label: "konveyor.io/target=azure-aks",
-  },
-];
-
-export const defaultTargets =
-  APP_BRAND === BrandType.Konveyor
-    ? [...openTargets, ...proprietaryTargets]
-    : [...openTargets];

--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -25,12 +25,11 @@ import { getParsedLabel } from "@app/utils/rules-utils";
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { useFetchTargets } from "@app/queries/targets";
 import defaultSources from "./sources";
-import { Target } from "@app/api/models";
 
 export const SetOptions: React.FC = () => {
   const { t } = useTranslation();
 
-  const { watch, control, setValue, getValues } =
+  const { watch, control, setValue } =
     useFormContext<AnalysisWizardFormValues>();
 
   const { formLabels, diva, excludedRulesTags, autoTaggingEnabled } = watch();
@@ -61,8 +60,13 @@ export const SetOptions: React.FC = () => {
   });
 
   const defaultTargetsAndTargetsLabels = [
-    ...new Set(defaultTargets.concat(allTargetLabelsFromTargets)),
-  ];
+    ...defaultTargets,
+    ...allTargetLabelsFromTargets,
+  ].sort((t1, t2) => {
+    if (t1.label > t2.label) return 1;
+    if (t1.label < t2.label) return -1;
+    return 0;
+  });
 
   const defaultSourcesAndSourcesLabels = [
     ...new Set(defaultSources.concat(allSourceLabelsFromTargets)),
@@ -110,7 +114,7 @@ export const SetOptions: React.FC = () => {
               onSelect={(_, selection) => {
                 const selectionWithLabelSelector = `konveyor.io/target=${selection}`;
                 const matchingLabel =
-                  defaultTargetsAndTargetsLabels?.find(
+                  defaultTargetsAndTargetsLabels.find(
                     (label) => label.label === selectionWithLabelSelector
                   ) || "";
 


### PR DESCRIPTION
- Remove from "default targets" the targets already stored in the hub.
- Sort all targets by `label` so they appear alphabetically in the select option (especially important because the whole is a concatenation of the default and hub targets, which is why this wasn't obvious when looking at the list from dropdown).
- Use proper `name` for defaults targets. It makes them more consistent with struct of hub stored targets. Although those names (for the default targets only) seems to not be used anywhere in the UI. And easier if down the track we merge both (defaults and hub targets) in the back-end. 

Resolves https://issues.redhat.com/browse/MTA-1258