### PR TITLE
:bug: Swap reports download tooltip messages

### DIFF
--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
@@ -135,7 +135,7 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                   <DescriptionListTerm>Download</DescriptionListTerm>
                   <DescriptionListDescription>
                     <Tooltip
-                      content="Click to download Analysis report YAML file"
+                      content="Click to download Analysis report TAR file"
                       position="top"
                     >
                       <DownloadButton
@@ -147,7 +147,7 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                     </Tooltip>
                     {" | "}
                     <Tooltip
-                      content="Click to download Analysis report TAR file"
+                      content="Click to download Analysis report YAML file"
                       position="top"
                     >
                       <DownloadButton


### PR DESCRIPTION
Resolves [MTA-1264](https://issues.redhat.com/browse/MTA-1264)
<!--


## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
