### PR TITLE
:bug: ApplicationAnalysisStatus is required for status

### DIFF
--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -46,7 +46,6 @@ import {
   ConditionalTableBody,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { IconedStatus } from "@app/components/IconedStatus";
 import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
 import { SimpleDocumentViewerModal } from "@app/components/SimpleDocumentViewer";
 import { getTaskById } from "@app/api/rest";
@@ -90,6 +89,7 @@ import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
 import { TaskGroupProvider } from "../analysis-wizard/components/TaskGroupContext";
 import { AnalysisWizard } from "../analysis-wizard/analysis-wizard";
+import { ApplicationAnalysisStatus } from "../components/application-analysis-status";
 
 export const ApplicationsTableAnalyze: React.FC = () => {
   const { t } = useTranslation();
@@ -450,6 +450,12 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     tasks.some((task) => task.application?.id === app.id)
   );
 
+  const getTaskState = (application: Application) => {
+    const task = getTask(application);
+    if (task && task.state) return task.state;
+    return "No task";
+  };
+
   return (
     <ConditionalRender
       when={isFetchingApplications && !(applications || applicationsFetchError)}
@@ -659,8 +665,8 @@ export const ApplicationsTableAnalyze: React.FC = () => {
                       modifier="truncate"
                       {...getTdProps({ columnKey: "analysis" })}
                     >
-                      <IconedStatus
-                        preset={application.review ? "Completed" : "NotStarted"}
+                      <ApplicationAnalysisStatus
+                        state={getTaskState(application)}
                       />
                     </Td>
                     <Td

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -450,12 +450,6 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     tasks.some((task) => task.application?.id === app.id)
   );
 
-  const getTaskState = (application: Application) => {
-    const task = getTask(application);
-    if (task && task.state) return task.state;
-    return "No task";
-  };
-
   return (
     <ConditionalRender
       when={isFetchingApplications && !(applications || applicationsFetchError)}

--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -666,7 +666,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
                       {...getTdProps({ columnKey: "analysis" })}
                     >
                       <ApplicationAnalysisStatus
-                        state={getTaskState(application)}
+                        state={getTask(application)?.state || "No task"}
                       />
                     </Td>
                     <Td


### PR DESCRIPTION
https://github.com/konveyor/tackle2-ui/pull/1353 follow-up to fix broken display of analysis status.

`ApplicationAnalysisStatus` must be used to display analysis state.
`IconedStatus` cannot be used here (or at least not yet) because analysis state mapping for tasks is specific.
