### PR TITLE
:bug: Fix missing variant for dropdown

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -363,6 +363,7 @@ export const CustomRules: React.FC = () => {
                   toggleId="associated-credentials-select-toggle"
                   toggleAriaLabel="Associated credentials dropdown toggle"
                   aria-label={name}
+                  variant={"typeahead"}
                   value={
                     value
                       ? toOptionLike(value, sourceIdentityOptions)


### PR DESCRIPTION
- Addresses missing default value in the credential dropdown for analysis wizard


Without variant 

![image](https://github.com/konveyor/tackle2-ui/assets/11218376/6428a396-5d93-4f7f-b1a0-8cb1548a6ee1)

With variant
<img width="1254" alt="Screenshot 2023-09-15 at 1 24 26 PM" src="https://github.com/konveyor/tackle2-ui/assets/11218376/a78ced24-3ca8-4305-b65c-5a7757bc7235">
