### PR TITLE
:sparkles: Add Duplicate Archetype action

### DIFF
--- a/client/src/app/pages/archetypes/archetypes-page.tsx
+++ b/client/src/app/pages/archetypes/archetypes-page.tsx
@@ -68,6 +68,9 @@ const Archetypes: React.FC = () => {
     null
   );
 
+  const [archetypeToDuplicate, setArchetypeToDuplicate] =
+    useState<Archetype | null>(null);
+
   const { archetypes, isFetching, error: fetchError } = useFetchArchetypes();
 
   const onError = (error: AxiosError) => {
@@ -283,10 +286,11 @@ const Archetypes: React.FC = () => {
                         <Td isActionCell>
                           <ActionsColumn
                             items={[
-                              // {
-                              //   title: t("actions.duplicate"),
-                              //   onClick: () => alert("TODO"),
-                              // },
+                              {
+                                title: t("actions.duplicate"),
+                                onClick: () =>
+                                  setArchetypeToDuplicate(archetype),
+                              },
                               {
                                 title: t("actions.assess"),
                                 onClick: () =>
@@ -338,6 +342,21 @@ const Archetypes: React.FC = () => {
           key={archetypeToEdit?.id ?? -1}
           archetype={archetypeToEdit}
           onClose={() => setArchetypeToEdit(null)}
+        />
+      </Modal>
+
+      {/* Duplicate modal */}
+      <Modal
+        title={t("dialog.title.newArchetype")}
+        variant="medium"
+        isOpen={!!archetypeToDuplicate}
+        onClose={() => setArchetypeToDuplicate(null)}
+      >
+        <ArchetypeForm
+          key={archetypeToDuplicate?.id ?? -1}
+          archetype={archetypeToDuplicate}
+          isDuplicating
+          onClose={() => setArchetypeToDuplicate(null)}
         />
       </Modal>
 

--- a/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
@@ -51,11 +51,13 @@ export interface ArchetypeFormValues {
 
 export interface ArchetypeFormProps {
   archetype?: Archetype | null;
+  isDuplicating?: boolean;
   onClose: () => void;
 }
 
 export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
   archetype,
+  isDuplicating = false,
   onClose,
 }) => {
   const { t } = useTranslation();
@@ -83,7 +85,11 @@ export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
         "Duplicate name",
         "An archetype with this name already exists. Use a different name.",
         (value) =>
-          duplicateNameCheck(existingArchetypes, archetype || null, value ?? "")
+          duplicateNameCheck(
+            existingArchetypes,
+            (!isDuplicating && archetype) || null,
+            value ?? ""
+          )
       ),
 
     description: yup
@@ -114,6 +120,15 @@ export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
     stakeholderGroups: yup.array().of(yup.string()),
   });
 
+  const getDefaultName = () => {
+    if (!isDuplicating || !archetype) return archetype?.name || "";
+    let name = `${archetype.name} (duplicate)`;
+    for (let i = 2; existingArchetypes.find((a) => a.name === name); i++) {
+      name = `${archetype.name} (duplicate ${i})`;
+    }
+    return name;
+  };
+
   const {
     handleSubmit,
     formState: { isSubmitting, isValidating, isValid, isDirty },
@@ -124,7 +139,7 @@ export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
     formState,
   } = useForm<ArchetypeFormValues>({
     defaultValues: {
-      name: archetype?.name || "",
+      name: getDefaultName(),
       description: archetype?.description || "",
       comments: archetype?.comments || "",
 
@@ -169,7 +184,7 @@ export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
               .filter(Boolean) as StakeholderGroup[]),
     };
 
-    if (archetype) {
+    if (archetype && !isDuplicating) {
       updateArchetype({ id: archetype.id, ...payload });
     } else {
       createArchetype(payload);
@@ -261,7 +276,12 @@ export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
           id="submit"
           aria-label="submit"
           variant={ButtonVariant.primary}
-          isDisabled={!isValid || isSubmitting || isValidating || !isDirty}
+          isDisabled={
+            !isValid ||
+            isSubmitting ||
+            isValidating ||
+            (!isDirty && !isDuplicating)
+          }
         >
           {!archetype ? t("actions.create") : t("actions.save")}
         </Button>

--- a/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
@@ -283,7 +283,9 @@ export const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
             (!isDirty && !isDuplicating)
           }
         >
-          {!archetype ? t("actions.create") : t("actions.save")}
+          {!archetype || isDuplicating
+            ? t("actions.create")
+            : t("actions.save")}
         </Button>
         <Button
           type="button"


### PR DESCRIPTION
Part of #1264, see [checklist here](https://github.com/konveyor/tackle2-ui/issues/1264#issuecomment-1702928566).

The Duplicate action is a cross between create and edit: a "create new archetype" form is opened, but its fields are all prefilled as if we are editing an existing archetype. The prefilled name has an appended " (duplicate)" suffix on it.

Just for fun, in case a user duplicates the same archetype multiple times without touching the default name, we check to see if the new default name is taken and use " (duplicate N)" as the suffix, with N incrementing until we get a name that isn't taken. This is probably unnecessary, but I found it annoying that the "name must be unique" error didn't appear until I touched the field, so this makes sure that case never comes up.

Because ArchetypeForm already had the logic for prefilling the form for editing, all we needed to do was pass in an `archetype` and an `isDuplicating` boolean which slightly changes the behavior:
* When validating that the name is unique, we don't treat the archetype being duplicated as the "current item", so it is not an exception to that validation like it needs to be when editing (if you input the same name of the item you're editing that's valid, but not so for duplicating).
* We have the default name behavior with the suffix as described above.
* Normally the submit button is disabled if the form isn't dirty, but the prefilled form with a generated name is valid for submission, so we allow a non-dirty form to be submitted when `isDuplicating` is true. This way you can rapid-fire duplicating things without touching the form if you so desire (useful for testing the pagination in https://github.com/konveyor/tackle2-ui/pull/1370 😄)
* The submit button says "Create", and on submit we create instead of updating.