### PR TITLE
:bug: Import questionnaire form - fix success toast message

### DIFF
--- a/client/src/app/pages/assessment-management/import-questionnaire-form/import-questionnaire-form.tsx
+++ b/client/src/app/pages/assessment-management/import-questionnaire-form/import-questionnaire-form.tsx
@@ -56,12 +56,13 @@ export const ImportQuestionnaireForm: React.FC<
     trigger,
   } = methods;
 
-  const onHandleSuccessfullQuestionnaireCreation = (
-    response: Questionnaire
-  ) => {
+  const onHandleSuccessfulQuestionnaireCreation = (response: Questionnaire) => {
     onSaved(response);
     pushNotification({
-      title: t("toastr.success.questionnaireCreated"),
+      title: t("toastr.success.createWhat", {
+        type: t("terms.questionnaire"),
+        what: response.name,
+      }),
       variant: "success",
     });
     onSaved();
@@ -75,7 +76,7 @@ export const ImportQuestionnaireForm: React.FC<
   };
 
   const { mutate: createQuestionnaire } = useCreateQuestionnaireMutation(
-    onHandleSuccessfullQuestionnaireCreation,
+    onHandleSuccessfulQuestionnaireCreation,
     onHandleFailedQuestionnaireCreation
   );
 


### PR DESCRIPTION
The message displayed on successful import of a questionnaire did not exist in the translation file.  The message key now uses an existing message to say:

  "Questionnaire _Name Used_ was successfully created."

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
