### PR TITLE
:bug: Restore missing params object when fetching issuereports

### DIFF
--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -515,7 +515,8 @@ export const getIssueReports = (
     ANALYSIS_REPORT_APP_ISSUES.replace(
       "/:applicationId/",
       `/${String(applicationId)}/`
-    )
+    ),
+    params
   );
 
 export const getIssues = (params: HubRequestParams = {}) =>


### PR DESCRIPTION
Fixes a bug @ibolton336 found where filters weren't working on the Single Application tab of the Issues page.

Looks like this param was removed in #1077 