### PR TITLE
:bug: Fix sorting on application inventory tables, misc cleanup in these tables

### DIFF
--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -198,6 +198,12 @@ export const ApplicationsTableAnalyze: React.FC = () => {
     },
     sortableColumns: ["name", "description", "businessService", "tags"],
     initialSort: { columnKey: "name", direction: "asc" },
+    getSortValues: (app) => ({
+      name: app.name,
+      description: app.description || "",
+      businessService: app.businessService?.name || "",
+      tags: app.tags?.length || 0,
+    }),
     filterCategories: [
       {
         key: "name",
@@ -551,7 +557,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
             </ToolbarItem>
           </ToolbarContent>
         </Toolbar>
-        <Table {...tableProps} isExpandable aria-label="App analysis table">
+        <Table {...tableProps} aria-label="App analysis table">
           <Thead>
             <Tr>
               <TableHeaderContentWithControls {...tableControls}>
@@ -560,6 +566,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
                 <Th {...getThProps({ columnKey: "businessService" })} />
                 <Th {...getThProps({ columnKey: "analysis" })} />
                 <Th {...getThProps({ columnKey: "tags" })} />
+                <Th />
               </TableHeaderContentWithControls>
             </Tr>
           </Thead>

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -244,6 +244,12 @@ export const ApplicationsTable: React.FC = () => {
     },
     sortableColumns: ["name", "description", "businessService", "tags"],
     initialSort: { columnKey: "name", direction: "asc" },
+    getSortValues: (app) => ({
+      name: app.name,
+      description: app.description || "",
+      businessService: app.businessService?.name || "",
+      tags: app.tags?.length || 0,
+    }),
     filterCategories: [
       {
         key: "name",
@@ -576,7 +582,7 @@ export const ApplicationsTable: React.FC = () => {
             </ToolbarItem>
           </ToolbarContent>
         </Toolbar>
-        <Table {...tableProps} isExpandable aria-label="App assessments table">
+        <Table {...tableProps} aria-label="App assessments table">
           <Thead>
             <Tr>
               <TableHeaderContentWithControls {...tableControls}>
@@ -586,6 +592,7 @@ export const ApplicationsTable: React.FC = () => {
                 <Th {...getThProps({ columnKey: "assessment" })} />
                 <Th {...getThProps({ columnKey: "review" })} />
                 <Th {...getThProps({ columnKey: "tags" })} />
+                <Th />
               </TableHeaderContentWithControls>
             </Tr>
           </Thead>


### PR DESCRIPTION
* The `getSortValues` property was missing from these two tables which turned sorting into a noop.
* The `isExpandable` prop was present on the analysis table even though it is no longer expandable.
* There was a missing empty `<Th />` in each of these tables to correspond to the edit-pencil column. (perhaps `hasActionsColumn` is a bad idea since it makes us incorrectly assume the column counts will always be aligned for us?)