### PR TITLE
:bug: Fix inconsistent styles between app inventory tables, fix wrong drawer component being used on analysis table, remove stray character

### DIFF
--- a/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
+++ b/client/src/app/pages/applications/applications-table-analyze/applications-table-analyze.tsx
@@ -74,7 +74,7 @@ import { useFetchTagCategories } from "@app/queries/tags";
 
 // Relative components
 import { ApplicationBusinessService } from "../components/application-business-service";
-import { ApplicationDetailDrawerAssessment } from "../components/application-detail-drawer";
+import { ApplicationDetailDrawerAnalysis } from "../components/application-detail-drawer";
 import { ApplicationForm } from "../components/application-form";
 import { ApplicationIdentityForm } from "../components/application-identity-form/application-identity-form";
 import { ImportApplicationsForm } from "../components/import-applications-form";
@@ -550,7 +550,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
 
             <ToolbarItem {...paginationToolbarItemProps}>
               <SimplePagination
-                idPrefix="s-table"
+                idPrefix="app-analysis-table"
                 isTop
                 paginationProps={paginationProps}
               />
@@ -585,7 +585,7 @@ export const ApplicationsTableAnalyze: React.FC = () => {
             }
             numRenderedColumns={numRenderedColumns}
           >
-            <Tbody style={{ cursor: "pointer" }}>
+            <Tbody>
               {currentPageItems.map((application, rowIndex) => (
                 <Tr
                   key={application.id}
@@ -748,12 +748,13 @@ export const ApplicationsTableAnalyze: React.FC = () => {
           </ConditionalTableBody>
         </Table>
         <SimplePagination
-          idPrefix="app-assessments-table"
+          idPrefix="app-analysis-table"
           isTop={false}
           paginationProps={paginationProps}
         />
-        <ApplicationDetailDrawerAssessment
+        <ApplicationDetailDrawerAnalysis
           application={activeRowItem}
+          applications={applications}
           onCloseClick={clearActiveRow}
           task={activeRowItem ? getTask(activeRowItem) : null}
         />

--- a/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
+++ b/client/src/app/pages/applications/applications-table-assessment/applications-table-assessment.tsx
@@ -26,6 +26,7 @@ import {
   Th,
   Td,
   ActionsColumn,
+  Tbody,
 } from "@patternfly/react-table";
 
 // @app components and utilities
@@ -575,7 +576,7 @@ export const ApplicationsTable: React.FC = () => {
 
             <ToolbarItem {...paginationToolbarItemProps}>
               <SimplePagination
-                idPrefix="s-table"
+                idPrefix="app-assessments-table"
                 isTop
                 paginationProps={paginationProps}
               />
@@ -611,115 +612,120 @@ export const ApplicationsTable: React.FC = () => {
             }
             numRenderedColumns={numRenderedColumns}
           >
-            {currentPageItems?.map((application, rowIndex) => {
-              return (
-                <Tr
-                  style={{ cursor: "pointer" }}
-                  key={application.name}
-                  {...getClickableTrProps({ item: application })}
-                >
-                  <TableRowContentWithControls
-                    {...tableControls}
-                    item={application}
-                    rowIndex={rowIndex}
+            <Tbody>
+              {currentPageItems?.map((application, rowIndex) => {
+                return (
+                  <Tr
+                    key={application.name}
+                    {...getClickableTrProps({ item: application })}
                   >
-                    <Td
-                      width={20}
-                      {...getTdProps({ columnKey: "name" })}
-                      modifier="truncate"
+                    <TableRowContentWithControls
+                      {...tableControls}
+                      item={application}
+                      rowIndex={rowIndex}
                     >
-                      {application.name}
-                    </Td>
-                    <Td
-                      width={25}
-                      {...getTdProps({ columnKey: "description" })}
-                      modifier="truncate"
-                    >
-                      {application.description}
-                    </Td>
-                    <Td
-                      width={10}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "businessService" })}
-                    >
-                      {application.businessService && (
-                        <ApplicationBusinessService
-                          id={application.businessService.id}
+                      <Td
+                        width={20}
+                        {...getTdProps({ columnKey: "name" })}
+                        modifier="truncate"
+                      >
+                        {application.name}
+                      </Td>
+                      <Td
+                        width={25}
+                        {...getTdProps({ columnKey: "description" })}
+                        modifier="truncate"
+                      >
+                        {application.description}
+                      </Td>
+                      <Td
+                        width={10}
+                        modifier="truncate"
+                        {...getTdProps({ columnKey: "businessService" })}
+                      >
+                        {application.businessService && (
+                          <ApplicationBusinessService
+                            id={application.businessService.id}
+                          />
+                        )}
+                      </Td>
+                      <Td
+                        width={10}
+                        modifier="truncate"
+                        {...getTdProps({ columnKey: "assessment" })}
+                      >
+                        <ApplicationAssessmentStatus
+                          assessments={application.assessments}
                         />
-                      )}
-                    </Td>
-                    <Td
-                      width={10}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "assessment" })}
-                    >
-                      <ApplicationAssessmentStatus
-                        assessments={application.assessments}
-                      />
-                    </Td>
-                    <Td
-                      width={10}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "review" })}
-                    >
-                      <IconedStatus
-                        preset={application.review ? "Completed" : "NotStarted"}
-                      />
-                    </Td>
-                    <Td
-                      width={10}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "tags" })}
-                    >
-                      <TagIcon />
-                      {application.tags ? application.tags.length : 0}
-                    </Td>
-                    <Td isActionCell id="pencil-action">
-                      <Button
-                        variant="plain"
-                        icon={<PencilAltIcon />}
-                        onClick={() =>
-                          setSaveApplicationModalState(application)
-                        }
-                      />
-                    </Td>
-                    <Td isActionCell id="row-actions">
-                      <ActionsColumn
-                        items={[
-                          {
-                            title: t("actions.assess"),
-                            onClick: () => assessSelectedApp(application),
-                          },
-                          {
-                            title: t("actions.review"),
-                            onClick: () => reviewSelectedApp(application),
-                          },
-                          ...(application?.review
-                            ? [
-                                {
-                                  title: t("actions.discardAssessment"),
-                                  onClick: () =>
-                                    setAssessmentOrReviewToDiscard(application),
-                                },
-                              ]
-                            : []),
-                          {
-                            title: t("actions.delete"),
-                            onClick: () =>
-                              setApplicationsToDelete([application]),
-                          },
-                          {
-                            title: t("actions.manageDependencies"),
-                            onClick: () =>
-                              setApplicationDependenciesToManage(application),
-                          },
-                        ]}
-                      />
-                    </Td>
-                  </TableRowContentWithControls>
-                </Tr>
-              );
-            })}
+                      </Td>
+                      <Td
+                        width={10}
+                        modifier="truncate"
+                        {...getTdProps({ columnKey: "review" })}
+                      >
+                        <IconedStatus
+                          preset={
+                            application.review ? "Completed" : "NotStarted"
+                          }
+                        />
+                      </Td>
+                      <Td
+                        width={10}
+                        modifier="truncate"
+                        {...getTdProps({ columnKey: "tags" })}
+                      >
+                        <TagIcon />
+                        {application.tags ? application.tags.length : 0}
+                      </Td>
+                      <Td isActionCell id="pencil-action">
+                        <Button
+                          variant="plain"
+                          icon={<PencilAltIcon />}
+                          onClick={() =>
+                            setSaveApplicationModalState(application)
+                          }
+                        />
+                      </Td>
+                      <Td isActionCell id="row-actions">
+                        <ActionsColumn
+                          items={[
+                            {
+                              title: t("actions.assess"),
+                              onClick: () => assessSelectedApp(application),
+                            },
+                            {
+                              title: t("actions.review"),
+                              onClick: () => reviewSelectedApp(application),
+                            },
+                            ...(application?.review
+                              ? [
+                                  {
+                                    title: t("actions.discardAssessment"),
+                                    onClick: () =>
+                                      setAssessmentOrReviewToDiscard(
+                                        application
+                                      ),
+                                  },
+                                ]
+                              : []),
+                            {
+                              title: t("actions.delete"),
+                              onClick: () =>
+                                setApplicationsToDelete([application]),
+                            },
+                            {
+                              title: t("actions.manageDependencies"),
+                              onClick: () =>
+                                setApplicationDependenciesToManage(application),
+                            },
+                          ]}
+                        />
+                      </Td>
+                    </TableRowContentWithControls>
+                  </Tr>
+                );
+              })}
+            </Tbody>
           </ConditionalTableBody>
         </Table>
         <SimplePagination

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-risk.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-risk.tsx
@@ -30,7 +30,7 @@ export const ApplicationRisk: React.FC<IApplicationRiskProps> = ({
   if (!assessments || assessments.length === 0) {
     return (
       <>
-        <RiskLabel risk={"unknown"} />;
+        <RiskLabel risk={"unknown"} />
         {isFetchingAssessmentsById && <Spinner />}
       </>
     );


### PR DESCRIPTION
* Fixes the difference in cell spacing between the two tabs of the application inventory page - one was using a `<Tbody>` and one was not.
* Removes `style={{ cursor: "pointer" }}` inline styles from these tables as they seem to have no effect with the `getClickableTrProps` being used
* Restores the use of the `ApplicationDetailDrawerAnalysis` component on the analysis table instead of the `ApplicationDetailDrawerAssessment`
* Removes a `;` character that snuck into the drawer