### PR TITLE
:seedling: Setup TS to know about `.filter(Boolean)`

### DIFF
--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -597,7 +597,7 @@ const useApplicationFormData = ({
   // Fetch data
   const { tagCategories } = useFetchTagCategories();
   const tags = useMemo(
-    () => tagCategories.flatMap((tc) => tc.tags).filter(Boolean) as Tag[],
+    () => tagCategories.flatMap((tc) => tc.tags).filter(Boolean),
     [tagCategories]
   );
 

--- a/client/src/app/utils/model-utils.tsx
+++ b/client/src/app/utils/model-utils.tsx
@@ -229,7 +229,7 @@ export const toRef = <RefLike extends Ref>(
 export const toRefs = <RefLike extends Ref>(
   source: Iterable<RefLike>
 ): Array<Ref> | undefined =>
-  !source ? undefined : ([...source].map(toRef).filter(Boolean) as Ref[]);
+  !source ? undefined : [...source].map(toRef).filter(Boolean);
 
 /**
  * Take an array of source items that look like a `Ref`, find the first one that matches
@@ -271,11 +271,11 @@ export const matchItemsToRefs = <RefLike extends Ref, V>(
 ): Array<Ref> | undefined =>
   !matchValues
     ? undefined
-    : (matchValues
+    : matchValues
         .map((toMatch) =>
           !toMatch
             ? undefined
             : items.find((item) => matchOperator(itemMatchFn(item), toMatch))
         )
         .map<Ref | undefined>(toRef)
-        .filter(Boolean) as Ref[]);
+        .filter(Boolean);

--- a/client/types/array-filter-Boolean.ts
+++ b/client/types/array-filter-Boolean.ts
@@ -1,0 +1,28 @@
+/**
+ * Fixes https://github.com/microsoft/TypeScript/issues/16655 for `Array.prototype.filter()`
+ * For example, using the fix the type of `bar` is `string[]` in the below snippet as it should be.
+ *
+ *  const foo: (string | null | undefined)[] = [];
+ *  const bar = foo.filter(Boolean);
+ *
+ * For related definitions, see https://github.com/microsoft/TypeScript/blob/master/src/lib/es5.d.ts
+ *
+ * Original licenses apply, see
+ *  - https://github.com/microsoft/TypeScript/blob/master/LICENSE.txt
+ *  - https://stackoverflow.com/help/licensing
+ */
+
+/** See https://stackoverflow.com/a/51390763/1470607  */
+type Falsy = false | 0 | "" | null | undefined;
+
+interface Array<T> {
+  /**
+   * Returns the elements of an array that meet the condition specified in a callback function.
+   * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
+   */
+  filter<S extends T>(
+    predicate: BooleanConstructor,
+    thisArg?: any
+  ): Exclude<S, Falsy>[];
+}


### PR DESCRIPTION
With `array-filter-Boolean.ts`, TS will select a better Array.filter() override so this kind of thing will work automatically without an explicit type casting:

```js
const a: Array<string | undefined | null> = ["A", "B", undefined, null, "C", ""];

const b: string[] = a.filter(Boolean);
// b = ["A", "B", "C"]
```

See https://www.karltarvas.com/typescript-array-filter-boolean.html
See https://stackoverflow.com/a/51390763/1470607
