### PR TITLE
:bug: (Backport release-0.2) - allow svn source repos to be validated (#1346)

### DIFF
--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -1,6 +1,6 @@
+import * as yup from "yup";
 import { AxiosError } from "axios";
 import { FormGroupProps, ToolbarChip } from "@patternfly/react-core";
-import { StringSchema } from "yup";
 
 // Axios error
 
@@ -104,11 +104,15 @@ export const gitUrlRegex =
 export const standardStrictURLRegex =
   /https:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
 
-export const customURLValidation = (schema: StringSchema) => {
-  const containsURL = (string: string) =>
-    gitUrlRegex.test(string) || standardURLRegex.test(string);
+export const svnUrlRegex = /^svn:\/\/[^\s/$.?#].[^\s]*$/;
 
-  return schema.test("gitUrlTest", "Must be a valid URL.", (value) => {
+export const customURLValidation = (schema: yup.StringSchema) => {
+  const containsURL = (string: string) =>
+    gitUrlRegex.test(string) ||
+    standardURLRegex.test(string) ||
+    svnUrlRegex.test(string);
+
+  return schema.test("urlValidation", "Must be a valid URL.", (value) => {
     if (value) {
       return containsURL(value);
     } else {


### PR DESCRIPTION
- Fixes customer case 03608826 "When setting up an a new application to be analysed by the MTA, we select Subversion as the repository type and enter the URL with the SVN protocol. The UI tells us that this is not a valid URL for a Subversion repository. Changing the URL protocol to HTTP makes the error go away but our department wide Subversion server is set to use only SVN protocol and cannot be changed. This leaves us unable to scan an application a Subversion hosted application with a valid SVN URL."

Adds regex to allow SVN repos to be validated when adding as a source repo to applications
