### PR TITLE
:bug: Business services: Fix create/edit when owner is included

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -41,7 +41,7 @@ export interface BusinessService {
   id: number;
   name: string;
   description?: string;
-  owner?: Stakeholder;
+  owner?: Ref;
 }
 
 export interface Stakeholder {

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -618,27 +618,27 @@ export const updateStakeholderGroup = (
 ): Promise<StakeholderGroup> =>
   axios.put(`${STAKEHOLDER_GROUPS}/${obj.id}`, obj);
 
+// ---------------------------------------
 // Business services
+//
+export const getBusinessServices = () =>
+  axios
+    .get<BusinessService[]>(BUSINESS_SERVICES)
+    .then((response) => response.data);
 
-export const getBusinessServices = (): Promise<BusinessService[]> =>
-  axios.get(BUSINESS_SERVICES).then((response) => response.data);
+export const getBusinessServiceById = (id: number | string) =>
+  axios
+    .get<BusinessService>(`${BUSINESS_SERVICES}/${id}`)
+    .then((response) => response.data);
 
-export const deleteBusinessService = (
-  id: number | string
-): Promise<BusinessService> => axios.delete(`${BUSINESS_SERVICES}/${id}`);
+export const createBusinessService = (obj: New<BusinessService>) =>
+  axios.post<BusinessService>(BUSINESS_SERVICES, obj);
 
-export const createBusinessService = (
-  obj: New<BusinessService>
-): Promise<BusinessService> => axios.post(BUSINESS_SERVICES, obj);
+export const updateBusinessService = (obj: BusinessService) =>
+  axios.put<void>(`${BUSINESS_SERVICES}/${obj.id}`, obj);
 
-export const updateBusinessService = (
-  obj: BusinessService
-): Promise<BusinessService> => axios.put(`${BUSINESS_SERVICES}/${obj.id}`, obj);
-
-export const getBusinessServiceById = (
-  id: number | string
-): Promise<BusinessService> =>
-  axios.get(`${BUSINESS_SERVICES}/${id}`).then((response) => response.data);
+export const deleteBusinessService = (id: number | string) =>
+  axios.delete<void>(`${BUSINESS_SERVICES}/${id}`);
 
 // Job functions
 

--- a/client/src/app/queries/businessservices.ts
+++ b/client/src/app/queries/businessservices.ts
@@ -8,6 +8,7 @@ import {
   getBusinessServices,
   updateBusinessService,
 } from "@app/api/rest";
+import { BusinessService, New } from "@app/api/models";
 
 export const BusinessServicesQueryKey = "businessservices";
 export const BusinessServiceQueryKey = "businessservice";
@@ -40,15 +41,15 @@ export const useFetchBusinessServiceByID = (id: number | string) => {
 };
 
 export const useCreateBusinessServiceMutation = (
-  onSuccess: (res: any) => void,
-  onError: (err: AxiosError) => void
+  onSuccess: (res: BusinessService) => void,
+  onError: (err: AxiosError, payload: New<BusinessService>) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: createBusinessService,
-    onSuccess: (res) => {
-      onSuccess(res);
+    onSuccess: ({ data }, _payload) => {
+      onSuccess(data);
       queryClient.invalidateQueries([BusinessServicesQueryKey]);
     },
     onError,
@@ -56,14 +57,14 @@ export const useCreateBusinessServiceMutation = (
 };
 
 export const useUpdateBusinessServiceMutation = (
-  onSuccess: () => void,
-  onError: (err: AxiosError) => void
+  onSuccess: (payload: BusinessService) => void,
+  onError: (err: AxiosError, payload: BusinessService) => void
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateBusinessService,
-    onSuccess: () => {
-      onSuccess();
+    onSuccess: (_res, payload) => {
+      onSuccess(payload);
       queryClient.invalidateQueries([BusinessServicesQueryKey]);
     },
     onError: onError,
@@ -71,18 +72,19 @@ export const useUpdateBusinessServiceMutation = (
 };
 
 export const useDeleteBusinessServiceMutation = (
-  onSuccess: (res: any) => void,
-  onError: (err: AxiosError) => void
+  onSuccess: (id: number | string) => void,
+  onError: (err: AxiosError, id: number | string) => void
 ) => {
   const queryClient = useQueryClient();
 
-  const { isLoading, mutate, error } = useMutation(deleteBusinessService, {
-    onSuccess: (res) => {
-      onSuccess(res);
+  const { isLoading, mutate, error } = useMutation({
+    mutationFn: deleteBusinessService,
+    onSuccess: (_res, id) => {
+      onSuccess(id);
       queryClient.invalidateQueries([BusinessServicesQueryKey]);
     },
-    onError: (err: AxiosError) => {
-      onError(err);
+    onError: (err: AxiosError, id) => {
+      onError(err, id);
       queryClient.invalidateQueries([BusinessServicesQueryKey]);
     },
   });


### PR DESCRIPTION
The `owner` field on the `BusinessService` payload needs to be a pure `Ref` object or it will be rejected by the REST API call.  Adopt the same set of data transforms used in the application-form to handle getting the correct set of data.

Related changes:
  - Business services related REST API functions updated to have the correct response types

  - Business services queries updated to pass REST API response and input values to `onSuccess()` and `onError()` handlers

  - `BusinessServiceForm` updated to use mutation response data to display the name of the business service in success messages

  - Refactored `business-service-form.tsx` to move all data access/mutation code to hook `useApplicationFormData() to logically divide concerns (data access v. UI handling)

Resolves: https://issues.redhat.com/browse/MTA-1346