### PR TITLE
:bug: fix styling for ssoMenu

### DIFF
--- a/client/src/app/layout/HeaderApp/SSOMenu.tsx
+++ b/client/src/app/layout/HeaderApp/SSOMenu.tsx
@@ -69,9 +69,15 @@ export const SSOMenu: React.FC = () => {
                       LocalStorageKey.selectedPersona
                     );
                     {
-                      keycloak.logout().finally(() => {
-                        history.push("/");
-                      });
+                      keycloak
+                        .logout()
+                        .then((res) => {
+                          history.push("/");
+                        })
+                        .catch((err) => {
+                          console.error("Logout failed:", err);
+                          history.push("/");
+                        });
                     }
                   }}
                 >

--- a/client/src/app/layout/HeaderApp/SSOMenu.tsx
+++ b/client/src/app/layout/HeaderApp/SSOMenu.tsx
@@ -36,11 +36,11 @@ export const SSOMenu: React.FC = () => {
           }} /** this user dropdown is hidden on mobile sizes */
         >
           <Dropdown
-            isPlain
             onSelect={onDropdownSelect}
             isOpen={isDropdownOpen}
             toggle={(toggleRef) => (
               <MenuToggle
+                isFullHeight
                 ref={toggleRef}
                 id="sso-actions-toggle"
                 onClick={() => onDropdownToggle(!isDropdownOpen)}
@@ -69,14 +69,9 @@ export const SSOMenu: React.FC = () => {
                       LocalStorageKey.selectedPersona
                     );
                     {
-                      keycloak
-                        .logout()
-                        .then((res) => {
-                          history.push("/");
-                        })
-                        .catch((err) => {
-                          history.push("/");
-                        });
+                      keycloak.logout().finally(() => {
+                        history.push("/");
+                      });
                     }
                   }}
                 >


### PR DESCRIPTION
addresses https://issues.redhat.com/browse/MTA-1247

was:
![image](https://github.com/konveyor/tackle2-ui/assets/5322142/bdd27aea-451c-48ee-b5c2-307d7f68be2d)


now:
![image](https://github.com/konveyor/tackle2-ui/assets/5322142/28da1332-b9c3-4110-bd9d-89a6f834716f)
