### PR TITLE
:bug: Update the label for the Tag field on the Application Form

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -305,6 +305,7 @@
     "label": "Label",
     "loading": "Loading",
     "lowRisk": "Low risk",
+    "manualTags": "Manual Tags",
     "maintainers": "Maintainers",
     "mavenConfig": "Maven configuration",
     "mediumRisk": "Medium risk",

--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -107,7 +107,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
 
   const nonManualTags = application?.tags?.filter((t) => t.source !== "") ?? [];
 
-  // TODO: Filter this if we want to exclude non-manual tags from manual tag selection
+  // Allow all tags to be selected manually, even if they are included from another source
   const allowedManualTags = tags;
 
   const getBinaryInitialValue = (
@@ -364,7 +364,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({
             items={allowedManualTags}
             control={control}
             name="tags"
-            label={t("terms.tags")}
+            label={t("terms.manualTags")}
             fieldId="tags"
             noResultsMessage={t("message.noResultsFoundTitle")}
             placeholderText={t("composed.selectMany", {


### PR DESCRIPTION
Resolves: #1410
Follows up: #1408

  - The application form will only show manual tags (i.e. source="")

  - All tags are allowable for selection as a manual tag

  - Change the label on the field from "Tags" to "Manual Tags" to match the "Manual" grouping of tags in the application drawer
