### PR TITLE
:ghost: Add setting for disabling download

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -262,6 +262,7 @@
     "customTarget": "Custom migration target",
     "customTargets": "Custom migration targets",
     "customTargetsDetails": "Create and manage custom migration targets. You can also drag and drop the cards to rearrange them. Note that any changes to the layout here will be reflected in the Analysis wizard",
+    "reportDownloadSetting": "Allow reports to be downloaded after running an analysis.",
     "date": "Date",
     "decision": "Decision",
     "dependencies": "Dependencies",

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -273,7 +273,7 @@ export type SettingTypes = {
   "git.insecure.enabled": boolean;
   "mvn.dependencies.update.forced": boolean;
   "mvn.insecure.enabled": boolean;
-  "review.assessment.required": boolean;
+  "download.html.enabled": boolean;
   "svn.insecure.enabled": boolean;
   "ui.target.order": number[];
 };

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
@@ -31,6 +31,7 @@ import { SimpleDocumentViewerModal } from "@app/components/SimpleDocumentViewer"
 import { getTaskById } from "@app/api/rest";
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
 import DownloadButton from "./components/download-button";
+import { useSetting } from "@app/queries/settings";
 
 export interface IApplicationDetailDrawerAnalysisProps
   extends Pick<
@@ -61,6 +62,7 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
   const updatedApplication = applications?.find(
     (app) => app.id === application?.id
   );
+  const enableDownloadSetting = useSetting("download.html.enabled");
 
   return (
     <ApplicationDetailDrawer
@@ -134,23 +136,37 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                   <DescriptionListTerm>Download</DescriptionListTerm>
                   <DescriptionListDescription>
                     <Tooltip
-                      content="Click to download Analysis report TAR file"
+                      content={
+                        enableDownloadSetting.data
+                          ? "Click to download TAR file with HTML static analysis report"
+                          : "Download TAR file with HTML static analysis report is disabled by administrator"
+                      }
                       position="top"
                     >
                       <DownloadButton
                         application={application}
                         mimeType={MimeType.TAR}
-                      />
+                        isDownloadEnabled={enableDownloadSetting.data}
+                      >
+                        HTML
+                      </DownloadButton>
                     </Tooltip>
                     {" | "}
                     <Tooltip
-                      content="Click to download Analysis report YAML file"
+                      content={
+                        enableDownloadSetting.data
+                          ? "Click to download YAML file with static analysis report"
+                          : "Download YAML file with static analysis report is disabled by administrator"
+                      }
                       position="top"
                     >
                       <DownloadButton
                         application={application}
                         mimeType={MimeType.YAML}
-                      />
+                        isDownloadEnabled={enableDownloadSetting.data}
+                      >
+                        YAML
+                      </DownloadButton>
                     </Tooltip>
                   </DescriptionListDescription>
                 </DescriptionListGroup>

--- a/client/src/app/pages/applications/components/application-detail-drawer/components/download-button.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/components/download-button.tsx
@@ -1,21 +1,23 @@
 import React from "react";
-import { Alert, Button } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { Spinner } from "@patternfly/react-core";
 import { useDownloadStaticReport } from "@app/queries/applications";
 import { Application } from "@app/api/models";
+import { Spinner, Alert } from "@patternfly/react-core";
 
-export enum MimeType {
-  TAR = "tar",
-  YAML = "yaml",
-}
+import { MimeType } from "@app/api/models";
+
 interface IDownloadButtonProps {
   application: Application;
   mimeType: MimeType;
+  isDownloadEnabled?: boolean;
+  children: React.ReactNode;
 }
 export const DownloadButton: React.FC<IDownloadButtonProps> = ({
   application,
   mimeType,
+  children,
+  isDownloadEnabled,
 }) => {
   const {
     mutate: downloadFile,
@@ -41,12 +43,14 @@ export const DownloadButton: React.FC<IDownloadButtonProps> = ({
       ) : (
         <>
           <Button
+            key={mimeType}
             onClick={handleDownload}
             id={`download-${mimeType}-button`}
             variant="link"
             className={spacing.pXs}
+            isAriaDisabled={!isDownloadEnabled}
           >
-            {mimeType === MimeType.YAML ? "YAML" : "Report"}
+            {children}
           </Button>
         </>
       )}

--- a/client/src/app/pages/general/general.tsx
+++ b/client/src/app/pages/general/general.tsx
@@ -1,36 +1,29 @@
-import * as React from "react";
+import React from "react";
 import {
   Alert,
   Card,
   CardBody,
-  EmptyState,
-  EmptyStateIcon,
   Form,
   PageSection,
   PageSectionVariants,
-  Spinner,
   Switch,
   Text,
   TextContent,
-  Title,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-
-import "./general.css";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { useSetting, useSettingMutation } from "@app/queries/settings";
 
 export const General: React.FC = () => {
   const { t } = useTranslation();
 
-  const reviewAssessmentSetting = useSetting("review.assessment.required");
-  const reviewAssessmentSettingMutation = useSettingMutation(
-    "review.assessment.required"
+  const enableDownloadSetting = useSetting("download.html.enabled");
+  const enableDownloadSettingMutation = useSettingMutation(
+    "download.html.enabled"
   );
 
-  const onChangeReviewAssessmentSetting = () => {
-    if (reviewAssessmentSetting.isSuccess)
-      reviewAssessmentSettingMutation.mutate(!reviewAssessmentSetting.data);
+  const onChangeEnableDownloadSetting = () => {
+    enableDownloadSettingMutation.mutate(!enableDownloadSetting.data);
   };
 
   return (
@@ -43,25 +36,24 @@ export const General: React.FC = () => {
       <PageSection>
         <Card>
           <CardBody>
-            {reviewAssessmentSetting.isError && (
+            {enableDownloadSetting.isError && (
               <Alert
                 variant="danger"
                 isInline
-                title={reviewAssessmentSetting.error}
+                title={enableDownloadSetting.error}
               />
             )}
             <Form className={spacing.mMd}>
               <Switch
-                id="reviewAssessment"
-                className="repo"
-                label={t("terms.settingsAllowApps")}
-                aria-label="Allow applications review without assessment"
+                id="enable-download-report"
+                label={t("terms.reportDownloadSetting")}
+                aria-label="Allow reports to be downloaded"
                 isChecked={
-                  reviewAssessmentSetting.isSuccess
-                    ? reviewAssessmentSetting.data
+                  enableDownloadSetting.isSuccess
+                    ? enableDownloadSetting.data
                     : false
                 }
-                onChange={onChangeReviewAssessmentSetting}
+                onChange={onChangeEnableDownloadSetting}
               />
             </Form>
           </CardBody>


### PR DESCRIPTION
- Remove old setting for assess/review. This setting was determined to be no longer useful once it was identified as a workaround for pathfinder limitations. This bug should be closed as a result.  https://issues.redhat.com/browse/MTA-1295 
- Add new setting for disabling download - Ramon requested that this setting should be added back in. Initial enhancement https://github.com/konveyor/enhancements/issues/91 
- Change TAR -> HTML for download button. Also suggested by Jeff & Ramon.
