### PR TITLE
:bug: Application drawer > reports: show analysis details for successful task

### DIFF
--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
@@ -47,7 +47,6 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
 
   const { identities } = useFetchIdentities();
   const { facts, isFetching } = useFetchFacts(application?.id);
-  const [appAnalysisToView, setAppAnalysisToView] = React.useState<number>();
   const [taskIdToView, setTaskIdToView] = React.useState<number>();
 
   let matchingSourceCredsRef: Identity | undefined;
@@ -124,7 +123,7 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
                         }
                         type="button"
                         variant="link"
-                        onClick={() => setAppAnalysisToView(application.id)}
+                        onClick={() => setTaskIdToView(task.id)}
                         className={spacing.ml_0}
                         style={{ margin: "0", padding: "0" }}
                       >
@@ -213,10 +212,9 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
           <SimpleDocumentViewerModal<Task | string>
             title={`Analysis details for ${application?.name}`}
             fetch={getTaskById}
-            documentId={taskIdToView || appAnalysisToView}
+            documentId={taskIdToView}
             onClose={() => {
               setTaskIdToView(undefined);
-              setAppAnalysisToView(undefined);
             }}
           />
         </TextContent>


### PR DESCRIPTION
Clicking the 'View analysis details' link in the application analysis detail drawer, reports tab should show the most current application's task details.  If no task is available for an application, "Not available" is shown.

The link for a successful task was broken.  It has been updated to use the task id instead of the application id.
