### PR TITLE
:bug: ConfirmDeleteDialog: always clear name input value on action

### DIFF
--- a/client/src/app/components/ConfirmDeleteDialog/ConfirmDeleteDialog.css
+++ b/client/src/app/components/ConfirmDeleteDialog/ConfirmDeleteDialog.css
@@ -1,8 +1,3 @@
 .confirm-deletion {
   margin-top: var(--pf-v5-global--spacer--xl);
 }
-
-.confirm-deletion-input {
-  margin-top: var(--pf-v5-global--spacer--sm);
-  margin-bottom: var(--pf-v5-global--spacer--sm);
-}

--- a/client/src/app/components/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/client/src/app/components/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -46,6 +46,13 @@ const ConfirmDeleteDialog: FC<ConfirmDeleteDialogProps> = ({
     onClose();
   };
 
+  const handleOnConfirmDelete = () => {
+    if (!isDisabled) {
+      setNameToDeleteInput("");
+      onConfirmDelete();
+    }
+  };
+
   const confirmBtn = (
     <Button
       id="confirm-delete-dialog-button"
@@ -53,7 +60,7 @@ const ConfirmDeleteDialog: FC<ConfirmDeleteDialogProps> = ({
       aria-label="confirm"
       variant={ButtonVariant.danger}
       isDisabled={isDisabled}
-      onClick={isDisabled ? undefined : onConfirmDelete}
+      onClick={handleOnConfirmDelete}
     >
       {deleteBtnLabel ?? t("actions.delete")}
     </Button>
@@ -70,6 +77,7 @@ const ConfirmDeleteDialog: FC<ConfirmDeleteDialogProps> = ({
       {cancelBtnLabel ?? t("actions.cancel")}
     </Button>
   );
+
   return (
     <Modal
       id="confirm-delete-dialog"
@@ -91,7 +99,7 @@ const ConfirmDeleteDialog: FC<ConfirmDeleteDialogProps> = ({
         </Trans>
       </Text>
       <TextInput
-        className="confirm-deletion-input"
+        id="confirm-deletion-input"
         value={nameToDeleteInput}
         onChange={(_, value) => setNameToDeleteInput(value)}
       />


### PR DESCRIPTION
`ConfirmDeleteDialog` requires the user to enter the item's name before the delete button is enabled.  The user entered text was being cleared on Cancel and Close, but not on Confirm.  Action handlers now clear the user entered text on ALL actions.

Resolves: #1478
