### PR TITLE
:sparkles: refelect ID -> Id

### DIFF
--- a/client/src/app/pages/applications/components/application-business-service.tsx
+++ b/client/src/app/pages/applications/components/application-business-service.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useFetchBusinessServiceByID } from "@app/queries/businessservices";
+import { useFetchBusinessServiceById } from "@app/queries/businessservices";
 
 export interface ApplicationBusinessServiceProps {
   id: number | string | undefined;
@@ -9,7 +9,7 @@ export interface ApplicationBusinessServiceProps {
 export const ApplicationBusinessService: React.FC<
   ApplicationBusinessServiceProps
 > = ({ id }) => {
-  const { businessService, fetchError } = useFetchBusinessServiceByID(id || "");
+  const { businessService, fetchError } = useFetchBusinessServiceById(id || "");
 
   if (fetchError) {
     return <></>;

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer-analysis.tsx
@@ -18,7 +18,7 @@ import {
 } from "@patternfly/react-icons";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { Identity, MimeType, Task } from "@app/api/models";
-import { getKindIDByRef } from "@app/utils/model-utils";
+import { getKindIdByRef } from "@app/utils/model-utils";
 import { useFetchIdentities } from "@app/queries/identities";
 import {
   ApplicationDetailDrawer,
@@ -53,8 +53,8 @@ export const ApplicationDetailDrawerAnalysis: React.FC<
   let matchingSourceCredsRef: Identity | undefined;
   let matchingMavenCredsRef: Identity | undefined;
   if (application && identities) {
-    matchingSourceCredsRef = getKindIDByRef(identities, application, "source");
-    matchingMavenCredsRef = getKindIDByRef(identities, application, "maven");
+    matchingSourceCredsRef = getKindIdByRef(identities, application, "source");
+    matchingMavenCredsRef = getKindIdByRef(identities, application, "maven");
   }
 
   const notAvailable = <EmptyTextMessage message={t("terms.notAvailable")} />;

--- a/client/src/app/pages/applications/components/application-identity-form/application-identity-form.tsx
+++ b/client/src/app/pages/applications/components/application-identity-form/application-identity-form.tsx
@@ -13,7 +13,7 @@ import WarningTriangleIcon from "@patternfly/react-icons/dist/esm/icons/warning-
 import { Application, Ref } from "@app/api/models";
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { getKindIDByRef, toOptionLike } from "@app/utils/model-utils";
+import { getKindIdByRef, toOptionLike } from "@app/utils/model-utils";
 import {
   APPLICATION_NAME,
   MAVEN_SETTINGS,
@@ -148,12 +148,12 @@ export const ApplicationIdentityForm: React.FC<
   } = useForm<FormValues>({
     defaultValues: {
       [APPLICATION_NAME]: getApplicationNames(applications) || "",
-      [SOURCE_CREDENTIALS]: getKindIDByRef(
+      [SOURCE_CREDENTIALS]: getKindIdByRef(
         identities,
         applications[0],
         "source"
       )?.name,
-      [MAVEN_SETTINGS]: getKindIDByRef(identities, applications[0], "maven")
+      [MAVEN_SETTINGS]: getKindIdByRef(identities, applications[0], "maven")
         ?.name,
     },
     resolver: yupResolver(
@@ -165,10 +165,10 @@ export const ApplicationIdentityForm: React.FC<
   useEffect(() => {
     if (identities && applications) {
       const isExistingSourceCreds = applications.some((app) => {
-        return getKindIDByRef(identities, app, "source");
+        return getKindIdByRef(identities, app, "source");
       });
       const isExistingMavenCreds = applications.some((app) => {
-        return getKindIDByRef(identities, app, "maven");
+        return getKindIdByRef(identities, app, "maven");
       });
       setExistingIdentitiesError(isExistingMavenCreds || isExistingSourceCreds);
     }

--- a/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
+++ b/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
@@ -19,7 +19,7 @@ import { getAxiosErrorMessage } from "@app/utils/utils";
 import { useLegacyPaginationState } from "@app/hooks/useLegacyPaginationState";
 import {
   useFetchImports,
-  useFetchImportSummaryByID,
+  useFetchImportSummaryById,
 } from "@app/queries/imports";
 import {
   FilterCategory,
@@ -63,7 +63,7 @@ export const ManageImportsDetails: React.FC = () => {
     false
   );
 
-  const { importSummary } = useFetchImportSummaryByID(importId);
+  const { importSummary } = useFetchImportSummaryById(importId);
 
   const rows: IRow[] = [];
   imports?.forEach((item) => {

--- a/client/src/app/queries/businessservices.ts
+++ b/client/src/app/queries/businessservices.ts
@@ -27,7 +27,7 @@ export const useFetchBusinessServices = () => {
   };
 };
 
-export const useFetchBusinessServiceByID = (id: number | string) => {
+export const useFetchBusinessServiceById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [BusinessServicesQueryKey, id],
     queryFn: () => getBusinessServiceById(id),

--- a/client/src/app/queries/imports.ts
+++ b/client/src/app/queries/imports.ts
@@ -45,7 +45,7 @@ export const useFetchImportSummaries = () => {
   };
 };
 
-export const useFetchImportSummaryByID = (id: number | string) => {
+export const useFetchImportSummaryById = (id: number | string) => {
   const { data, isLoading, error, refetch } = useQuery(
     [ImportQueryKey, id],
     () => getApplicationImportSummaryById(id),

--- a/client/src/app/utils/model-utils.tsx
+++ b/client/src/app/utils/model-utils.tsx
@@ -181,7 +181,7 @@ export function toISimpleOptionDropdownWithValue<T>(
   };
 }
 
-export const getKindIDByRef = (
+export const getKindIdByRef = (
   identities: Identity[],
   application: Application,
   kind: IdentityKind


### PR DESCRIPTION
<!--
## PR Title Prefix
Appears that konveyor have since settled on "ID->Id". There are still a few places where we need to reflect this decision in the code. E.g. getKindIDByRef, useFetchBusinessServiceByID, etc


Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
close #1307
thank you for reviewing 
-->
Appears that konveyor have since settled on "ID->Id". There are still a few places where we need to reflect this decision in the code. E.g. getKindIDByRef, useFetchBusinessServiceByID, etc

closes #1307 
