### PR TITLE
:seedling: Explicitly set NODE_ENV for npm scripts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,9 +9,9 @@
     "extract": "i18next --config i18next-parser.config.js",
     "prebuild": "npm run clean && npm run tsc -- --noEmit",
     "build": "NODE_ENV=production webpack --config ./config/webpack.prod.ts",
-    "build:dev": "webpack --config ./config/webpack.dev.ts",
-    "start:dev": "webpack serve --config ./config/webpack.dev.ts",
-    "test": "jest --rootDir=. --config=./config/jest.config.ts",
+    "build:dev": "NODE_ENV=development webpack --config ./config/webpack.dev.ts",
+    "start:dev": "NODE_ENV=development webpack serve --config ./config/webpack.dev.ts",
+    "test": "NODE_ENV=test jest --rootDir=. --config=./config/jest.config.ts",
     "lint": "eslint .",
     "tsc": "tsc -p ./tsconfig.json"
   },

--- a/common/package.json
+++ b/common/package.json
@@ -19,8 +19,8 @@
     "clean": "rimraf ./dist",
     "lint": "eslint .",
     "prebuild": "npm run clean",
-    "build": "rollup -c",
-    "start:dev": "rollup -c --watch"
+    "build": "NODE_ENV=production rollup -c",
+    "start:dev": "NODE_ENV=development rollup -c --watch"
   },
   "lint-staged": {
     "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}": "eslint --fix",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./dist",
     "lint": "eslint .",
     "build": "NODE_ENV=production rollup -c",
-    "start:dev": "ROLLUP_RUN=true rollup -c -w",
+    "start:dev": "NODE_ENV=development ROLLUP_RUN=true rollup -c -w",
     "start": "npm run build && node --enable-source-maps dist/index.js"
   },
   "lint-staged": {


### PR DESCRIPTION
Being explicit about what the `NODE_ENV` value should be for each npm script where the value could impact the results can help remove any errors in future.  Motivated by working on #1502.
