### PR TITLE
:bug: Add download attribute to csv import template link

### DIFF
--- a/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -349,7 +349,13 @@ export const ManageImports: React.FC = () => {
                       dropdownItems={[
                         <DropdownItem
                           key="download-csv-template"
-                          to="/template_application_import.csv"
+                          component={(props) => (
+                            <a
+                              {...props}
+                              download
+                              href="/template_application_import.csv"
+                            />
+                          )}
                         >
                           {t("actions.downloadCsvTemplate")}
                         </DropdownItem>,


### PR DESCRIPTION
Solves [MTA-1592](https://issues.redhat.com/browse/MTA-1592)

@ibolton336 Could you please review this PR? Thanks!

![image](https://github.com/konveyor/tackle2-ui/assets/117646518/4c58ee01-b456-4c1b-8b93-e1fb3e31a17c)

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
