### PR TITLE
:bug: UX improvements for app assessment/review discard

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -29,7 +29,9 @@
     "createTags": "Create tags",
     "cancelAnalysis": "Cancel analysis",
     "delete": "Delete",
-    "discardAssessment": "Discard assessment/review",
+    "discardAssessment": "Discard assessment(s)",
+    "discardReview": "Discard review",
+
     "downloadCsvTemplate": "Download CSV template",
     "download": "Download {{what}}",
     "duplicate": "Duplicate",
@@ -360,6 +362,7 @@
     "reports": "Reports",
     "repositoryType": "Repository type",
     "review": "Review",
+    "reviewedArchetype": "Archetype reviewed",
     "reviews": "Reviews",
     "reviewComments": "Review comments",
     "risk": "Risk",

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -17,6 +17,9 @@ import {
   MenuToggle,
   MenuToggleElement,
   Modal,
+  Tooltip,
+  Grid,
+  GridItem,
 } from "@patternfly/react-core";
 import { PencilAltIcon, TagIcon, EllipsisVIcon } from "@patternfly/react-icons";
 import {
@@ -28,6 +31,7 @@ import {
   ActionsColumn,
   Tbody,
 } from "@patternfly/react-table";
+import { QuestionCircleIcon } from "@patternfly/react-icons/dist/esm/icons/question-circle-icon";
 
 // @app components and utilities
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
@@ -184,7 +188,10 @@ export const ApplicationsTable: React.FC = () => {
     Application[]
   >([]);
 
-  const [assessmentOrReviewToDiscard, setAssessmentOrReviewToDiscard] =
+  const [assessmentToDiscard, setAssessmentToDiscard] =
+    React.useState<Application | null>(null);
+
+  const [reviewToDiscard, setReviewToDiscard] =
     React.useState<Application | null>(null);
 
   const {
@@ -257,15 +264,8 @@ export const ApplicationsTable: React.FC = () => {
     onDeleteError
   );
 
-  const discardAssessmentAndReview = async (application: Application) => {
+  const discardAssessment = async (application: Application) => {
     try {
-      if (application.review?.id) {
-        await deleteReview({
-          id: application.review.id,
-          name: application.name,
-        });
-      }
-
       if (application.assessments) {
         await Promise.all(
           application.assessments.map(async (assessment) => {
@@ -277,7 +277,20 @@ export const ApplicationsTable: React.FC = () => {
         );
       }
     } catch (error) {
-      console.error("Error while deleting assessments and/or reviews:", error);
+      console.error("Error while deleting assessments:", error);
+    }
+  };
+
+  const discardReview = async (application: Application) => {
+    try {
+      if (application.review?.id) {
+        await deleteReview({
+          id: application.review.id,
+          name: application.name,
+        });
+      }
+    } catch (error) {
+      console.error("Error while deleting review:", error);
     }
   };
 
@@ -822,13 +835,27 @@ export const ApplicationsTable: React.FC = () => {
                         modifier="truncate"
                         {...getTdProps({ columnKey: "review" })}
                       >
-                        <IconedStatus
-                          preset={
-                            isAppReviewed || hasReviewedArchetype
-                              ? "Completed"
-                              : "NotStarted"
-                          }
-                        />
+                        <Grid>
+                          <GridItem span={10}>
+                            <IconedStatus
+                              preset={
+                                isAppReviewed || hasReviewedArchetype
+                                  ? "Completed"
+                                  : "NotStarted"
+                              }
+                            />
+                          </GridItem>
+                          <GridItem span={2}>
+                            {hasReviewedArchetype ? (
+                              <Tooltip
+                                content={t("terms.reviewedArchetype")}
+                                aria-label="review"
+                              >
+                                <QuestionCircleIcon />
+                              </Tooltip>
+                            ) : null}
+                          </GridItem>
+                        </Grid>
                       </Td>
                       <Td
                         width={10}
@@ -874,14 +901,21 @@ export const ApplicationsTable: React.FC = () => {
                               title: t("actions.review"),
                               onClick: () => reviewSelectedApp(application),
                             },
-                            ...(application?.review
+                            ...(application?.assessments?.length
                               ? [
                                   {
                                     title: t("actions.discardAssessment"),
                                     onClick: () =>
-                                      setAssessmentOrReviewToDiscard(
-                                        application
-                                      ),
+                                      setAssessmentToDiscard(application),
+                                  },
+                                ]
+                              : []),
+                            ...(application?.review
+                              ? [
+                                  {
+                                    title: t("actions.discardReview"),
+                                    onClick: () =>
+                                      setReviewToDiscard(application),
                                   },
                                 ]
                               : []),
@@ -1066,16 +1100,46 @@ export const ApplicationsTable: React.FC = () => {
             what: t("terms.assessment").toLowerCase(),
           })}
           titleIconVariant={"warning"}
-          isOpen={assessmentOrReviewToDiscard !== null}
+          isOpen={assessmentToDiscard !== null}
           message={
             <span>
               <Trans
                 i18nKey="dialog.message.discardAssessment"
                 values={{
-                  applicationName: assessmentOrReviewToDiscard?.name,
+                  applicationName: assessmentToDiscard?.name,
                 }}
               >
-                The assessment for <strong>applicationName</strong> will be
+                The assessment(s) for{" "}
+                <strong>{assessmentToDiscard?.name}</strong> will be discarded.
+                Do you wish to continue?
+              </Trans>
+            </span>
+          }
+          confirmBtnVariant={ButtonVariant.primary}
+          confirmBtnLabel={t("actions.continue")}
+          cancelBtnLabel={t("actions.cancel")}
+          onCancel={() => setAssessmentToDiscard(null)}
+          onClose={() => setAssessmentToDiscard(null)}
+          onConfirm={() => {
+            discardAssessment(assessmentToDiscard!);
+            setAssessmentToDiscard(null);
+          }}
+        />
+        <ConfirmDialog
+          title={t("dialog.title.discard", {
+            what: t("terms.review").toLowerCase(),
+          })}
+          titleIconVariant={"warning"}
+          isOpen={reviewToDiscard !== null}
+          message={
+            <span>
+              <Trans
+                i18nKey="dialog.message.discardReview"
+                values={{
+                  applicationName: reviewToDiscard?.name,
+                }}
+              >
+                The review for <strong>{reviewToDiscard?.name}</strong> will be
                 discarded, as well as the review result. Do you wish to
                 continue?
               </Trans>
@@ -1084,11 +1148,11 @@ export const ApplicationsTable: React.FC = () => {
           confirmBtnVariant={ButtonVariant.primary}
           confirmBtnLabel={t("actions.continue")}
           cancelBtnLabel={t("actions.cancel")}
-          onCancel={() => setAssessmentOrReviewToDiscard(null)}
-          onClose={() => setAssessmentOrReviewToDiscard(null)}
+          onCancel={() => setReviewToDiscard(null)}
+          onClose={() => setReviewToDiscard(null)}
           onConfirm={() => {
-            discardAssessmentAndReview(assessmentOrReviewToDiscard!);
-            setAssessmentOrReviewToDiscard(null);
+            discardReview(reviewToDiscard!);
+            setReviewToDiscard(null);
           }}
         />
         <ConfirmDialog

--- a/client/src/app/queries/applications.ts
+++ b/client/src/app/queries/applications.ts
@@ -21,7 +21,10 @@ import {
   updateApplication,
 } from "@app/api/rest";
 import { reviewsQueryKey } from "./reviews";
-import { assessmentsQueryKey } from "./assessments";
+import {
+  assessmentsByItemIdQueryKey,
+  assessmentsQueryKey,
+} from "./assessments";
 import saveAs from "file-saver";
 
 export const ApplicationDependencyQueryKey = "applicationdependencies";
@@ -43,6 +46,7 @@ export const useFetchApplications = (refetchDisabled: boolean = false) => {
     onSuccess: () => {
       queryClient.invalidateQueries([reviewsQueryKey]);
       queryClient.invalidateQueries([assessmentsQueryKey]);
+      queryClient.invalidateQueries([assessmentsByItemIdQueryKey]);
     },
     onError: (error: AxiosError) => console.log(error),
   });

--- a/client/src/app/queries/archetypes.ts
+++ b/client/src/app/queries/archetypes.ts
@@ -9,16 +9,28 @@ import {
   getArchetypes,
   updateArchetype,
 } from "@app/api/rest";
+import {
+  assessmentsQueryKey,
+  assessmentsByItemIdQueryKey,
+} from "./assessments";
+import { reviewsQueryKey } from "./reviews";
 
 export const ARCHETYPES_QUERY_KEY = "archetypes";
 export const ARCHETYPE_QUERY_KEY = "archetype";
 
 export const useFetchArchetypes = () => {
+  const queryClient = useQueryClient();
   const { isLoading, isSuccess, error, refetch, data } = useQuery({
     initialData: [],
     queryKey: [ARCHETYPES_QUERY_KEY],
     queryFn: getArchetypes,
     refetchInterval: 5000,
+    onSuccess: () => {
+      queryClient.invalidateQueries([reviewsQueryKey]);
+      queryClient.invalidateQueries([assessmentsQueryKey]);
+      queryClient.invalidateQueries([assessmentsByItemIdQueryKey]);
+    },
+
     onError: (error: AxiosError) => console.log(error),
   });
 


### PR DESCRIPTION
- Resolves https://issues.redhat.com/browse/MTA-1611
- Add tooltip to indicate review completed for ARCHETYPE.
- Break up delete for reviews /assessments into two separate options for applications table actions column.
- Invalidate assessments by AppId when fetching apps to fix stale assessment status post-assessmentDelete from the app table. 
- Add discard assessment & discard review options for archetype page.