### PR TITLE
:bug: Remove pb0 class from application section header

### DIFF
--- a/client/src/app/pages/applications/applications.tsx
+++ b/client/src/app/pages/applications/applications.tsx
@@ -7,7 +7,6 @@ import {
   Title,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 const ApplicationsTable = lazy(() => import("./applications-table"));
 
@@ -16,7 +15,7 @@ export const Applications: React.FC = () => {
 
   return (
     <>
-      <PageSection variant={PageSectionVariants.light} className={spacing.pb_0}>
+      <PageSection variant={PageSectionVariants.light}>
         <Level>
           <LevelItem>
             <Title headingLevel="h1">


### PR DESCRIPTION
Solves [MTA-1644](https://issues.redhat.com/browse/MTA-1644)

![image](https://github.com/konveyor/tackle2-ui/assets/117646518/2add7ffa-3cdc-4c04-b1c5-86025ed59ab6)

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
