### PR TITLE
:sparkles: Add Tag Categories to Tag filters

### DIFF
--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -47,7 +47,7 @@ export interface IBasicFilterCategory<
    * For server-side filtering, return the search value for currently selected filter items.
    * Defaults to using the UI state's value if omitted.
    */
-  getServerFilterValue?: (filterValue: FilterValue) => FilterValue;
+  getServerFilterValue?: (filterValue: FilterValue) => string[] | undefined;
 }
 
 export interface IMultiselectFilterCategory<

--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -22,35 +22,51 @@ export enum FilterType {
 
 export type FilterValue = string[] | undefined | null;
 
-export interface OptionPropsWithKey extends SelectOptionProps {
+export interface FilterSelectOptionProps extends SelectOptionProps {
   key: string;
 }
 
 export interface IBasicFilterCategory<
-  TItem, // The actual API objects we're filtering
+  /** The actual API objects we're filtering */
+  TItem,
   TFilterCategoryKey extends string, // Unique identifiers for each filter category (inferred from key properties if possible)
 > {
-  key: TFilterCategoryKey; // For use in the filterValues state object. Must be unique per category.
+  /** For use in the filterValues state object. Must be unique per category. */
+  key: TFilterCategoryKey;
+  /** Title of the filter as displayed in the filter selection dropdown and filter chip groups. */
   title: string;
-  type: FilterType; // If we want to support arbitrary filter types, this could be a React node that consumes context instead of an enum
+  /** Type of filter component to use to select the filter's content. */
+  type: FilterType;
+  /** Optional grouping to display this filter in the filter selection dropdown. */
   filterGroup?: string;
+  /** For client side filtering, return the value of `TItem` the filter will be applied against. */
   getItemValue?: (item: TItem) => string | boolean; // For client-side filtering
-  serverFilterField?: string; // For server-side filtering, defaults to `key` if omitted. Does not need to be unique if the server supports joining repeated filters.
-  getServerFilterValue?: (filterValue: FilterValue) => FilterValue; // For server-side filtering. Defaults to using the UI state's value if omitted.
+  /** For server-side filtering, defaults to `key` if omitted. Does not need to be unique if the server supports joining repeated filters. */
+  serverFilterField?: string;
+  /**
+   * For server-side filtering, return the search value for currently selected filter items.
+   * Defaults to using the UI state's value if omitted.
+   */
+  getServerFilterValue?: (filterValue: FilterValue) => FilterValue;
 }
 
 export interface IMultiselectFilterCategory<
   TItem,
   TFilterCategoryKey extends string,
 > extends IBasicFilterCategory<TItem, TFilterCategoryKey> {
-  selectOptions: OptionPropsWithKey[];
+  /** The full set of options to select from for this filter. */
+  selectOptions:
+    | FilterSelectOptionProps[]
+    | Record<string, FilterSelectOptionProps[]>;
+  /** Option search input field placeholder text. */
   placeholderText?: string;
+  /** How to connect multiple selected options together. Defaults to "AND". */
   logicOperator?: "AND" | "OR";
 }
 
 export interface ISelectFilterCategory<TItem, TFilterCategoryKey extends string>
   extends IBasicFilterCategory<TItem, TFilterCategoryKey> {
-  selectOptions: OptionPropsWithKey[];
+  selectOptions: FilterSelectOptionProps[];
 }
 
 export interface ISearchFilterCategory<TItem, TFilterCategoryKey extends string>

--- a/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ToolbarFilter, Tooltip } from "@patternfly/react-core";
+import { ToolbarChip, ToolbarFilter, Tooltip } from "@patternfly/react-core";
 import {
   Select,
   SelectOption,
@@ -70,8 +70,9 @@ export const MultiselectFilterControl = <TItem,>({
     }
   };
 
-  const onFilterClear = (chip: string) => {
-    const optionKey = getOptionKeyFromChip(chip);
+  const onFilterClear = (chip: string | ToolbarChip) => {
+    const chipKey = typeof chip === "string" ? chip : chip.key;
+    const optionKey = getOptionKeyFromChip(chipKey);
     const newValue = filterValue
       ? filterValue.filter((val) => val !== optionKey)
       : [];
@@ -100,7 +101,7 @@ export const MultiselectFilterControl = <TItem,>({
             <div>{text}</div>
           </Tooltip>
         ),
-      };
+      } as ToolbarChip;
     }
     return chip;
   });
@@ -152,7 +153,7 @@ export const MultiselectFilterControl = <TItem,>({
     <ToolbarFilter
       id={`filter-control-${category.key}`}
       chips={chips}
-      deleteChip={(_, chip) => onFilterClear(chip as string)}
+      deleteChip={(_, chip) => onFilterClear(chip)}
       categoryName={category.title}
       showToolbarItem={showToolbarItem}
     >

--- a/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ToolbarFilter } from "@patternfly/react-core";
+import { ToolbarFilter, Tooltip } from "@patternfly/react-core";
 import {
   Select,
   SelectOption,
@@ -16,6 +16,8 @@ import {
 import { css } from "@patternfly/react-styles";
 
 import "./select-overrides.css";
+
+const CHIP_BREAK_DELINEATOR = " / ";
 
 export interface IMultiselectFilterControlProps<TItem>
   extends IFilterControlProps<TItem, string> {
@@ -79,11 +81,29 @@ export const MultiselectFilterControl = <TItem,>({
   // Select expects "selections" to be an array of the "value" props from the relevant optionProps
   const selections = filterValue?.map(getOptionValueFromOptionKey) ?? [];
 
-  // TODO: Chips could be a `ToolbarChip` instead of a `string` and embed a tooltip.
-  // TODO: However, the selections value would need to be more specific to be able to
-  // TODO: map a group name to a specific select option (assuming that an item with the
-  // TODO: same name can exist in multiple groups)
-  const chips = selections.map((s) => s?.toString() ?? "");
+  /*
+   * Note: Chips can be a `ToolbarChip` or a plain `string`.  Use a hack to split a
+   *       selected option in 2 parts.  Assuming the option is in the format "Group / Item"
+   *       break the text and show a chip with the Item and the Group as a tooltip.
+   */
+  const chips = selections.map((s, index) => {
+    const chip: string = s?.toString() ?? "";
+    const idx = chip.indexOf(CHIP_BREAK_DELINEATOR);
+
+    if (idx > 0) {
+      const tooltip = chip.substring(0, idx);
+      const text = chip.substring(idx + CHIP_BREAK_DELINEATOR.length);
+      return {
+        key: chip,
+        node: (
+          <Tooltip id={`tooltip-chip-${index}`} content={<div>{tooltip}</div>}>
+            <div>{text}</div>
+          </Tooltip>
+        ),
+      };
+    }
+    return chip;
+  });
 
   const renderSelectOptions = (
     filter: (option: FilterSelectOptionProps, groupName?: string) => boolean

--- a/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
@@ -6,14 +6,17 @@ import {
   SelectOptionObject,
 } from "@patternfly/react-core/deprecated";
 import { IFilterControlProps } from "./FilterControl";
-import { ISelectFilterCategory, OptionPropsWithKey } from "./FilterToolbar";
+import {
+  ISelectFilterCategory,
+  FilterSelectOptionProps,
+} from "./FilterToolbar";
 import { css } from "@patternfly/react-styles";
 
 import "./select-overrides.css";
 
 export interface ISelectFilterControlProps<
   TItem,
-  TFilterCategoryKey extends string
+  TFilterCategoryKey extends string,
 > extends IFilterControlProps<TItem, TFilterCategoryKey> {
   category: ISelectFilterCategory<TItem, TFilterCategoryKey>;
   isScrollable?: boolean;
@@ -72,7 +75,7 @@ export const SelectFilterControl = <TItem, TFilterCategoryKey extends string>({
 
   const chips = selections ? selections.map(getChipFromOptionValue) : [];
 
-  const renderSelectOptions = (options: OptionPropsWithKey[]) =>
+  const renderSelectOptions = (options: FilterSelectOptionProps[]) =>
     options.map((optionProps) => (
       <SelectOption {...optionProps} key={optionProps.key} />
     ));

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -78,7 +78,7 @@ import { useCancelTaskMutation, useFetchTasks } from "@app/queries/tasks";
 import { useDeleteAssessmentMutation } from "@app/queries/assessments";
 import { useDeleteReviewMutation } from "@app/queries/reviews";
 import { useFetchIdentities } from "@app/queries/identities";
-import { useFetchTagCategories } from "@app/queries/tags";
+import { useFetchTagsWithTagItems } from "@app/queries/tags";
 
 // Relative components
 import { ApplicationAssessmentStatus } from "../components/application-assessment-status";
@@ -169,7 +169,7 @@ export const ApplicationsTable: React.FC = () => {
   );
   /*** Analysis */
 
-  const { tagCategories: tagCategories } = useFetchTagCategories();
+  const { tagItems } = useFetchTagsWithTagItems();
 
   const [applicationDependenciesToManage, setApplicationDependenciesToManage] =
     React.useState<Application | null>(null);
@@ -429,18 +429,21 @@ export const ApplicationsTable: React.FC = () => {
           t("actions.filterBy", {
             what: t("terms.tagName").toLowerCase(),
           }) + "...",
-        selectOptions: Object.fromEntries(
-          tagCategories
-            .map(({ name, tags }) =>
-              !tags
-                ? undefined
-                : [name, tags.map(({ name }) => ({ key: name, value: name }))]
-            )
-            .filter(Boolean)
-        ),
+        selectOptions: tagItems.map(({ name }) => ({ key: name, value: name })),
+        /**
+         * Create a single string from an Application's Tags that can be used to
+         * match against the `selectOptions`'s values (here on the client side)
+         */
         getItemValue: (item) => {
-          const tagNames = item?.tags?.map((tag) => tag.name).join("");
-          return tagNames || "";
+          const appTagItems = item?.tags
+            ?.map(({ id }) => tagItems.find((item) => id === item.id))
+            .filter(Boolean);
+
+          const matchString = !appTagItems
+            ? ""
+            : appTagItems.map(({ name }) => name).join("^");
+
+          return matchString;
         },
       },
     ],

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -429,17 +429,19 @@ export const ApplicationsTable: React.FC = () => {
           t("actions.filterBy", {
             what: t("terms.tagName").toLowerCase(),
           }) + "...",
+        selectOptions: Object.fromEntries(
+          tagCategories
+            .map(({ name, tags }) =>
+              !tags
+                ? undefined
+                : [name, tags.map(({ name }) => ({ key: name, value: name }))]
+            )
+            .filter(Boolean)
+        ),
         getItemValue: (item) => {
           const tagNames = item?.tags?.map((tag) => tag.name).join("");
           return tagNames || "";
         },
-        selectOptions: dedupeFunction(
-          tagCategories
-            ?.map((tagCategory) => tagCategory?.tags)
-            .flat()
-            .filter((tag) => tag && tag.name)
-            .map((tag) => ({ key: tag?.name, value: tag?.name }))
-        ),
       },
     ],
     initialItemsPerPage: 10,
@@ -641,7 +643,7 @@ export const ApplicationsTable: React.FC = () => {
         <Toolbar {...toolbarProps}>
           <ToolbarContent>
             <ToolbarBulkSelector {...toolbarBulkSelectorProps} />
-            <FilterToolbar {...filterToolbarProps} />
+            <FilterToolbar<Application, string> {...filterToolbarProps} />
             <ToolbarGroup variant="button-group">
               <ToolbarItem>
                 <RBAC

--- a/client/src/app/pages/dependencies/dependency-apps-table.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-table.tsx
@@ -31,7 +31,7 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
 }) => {
   const { t } = useTranslation();
   const { businessServices } = useFetchBusinessServices();
-  const { tagCategories, tags } = useFetchTagsWithTagItems();
+  const { tagItems } = useFetchTagsWithTagItems();
 
   const tableControlState = useTableControlState({
     persistTo: "urlParams",
@@ -78,25 +78,16 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
           t("actions.filterBy", {
             what: t("terms.tagName").toLowerCase(),
           }) + "...",
-        selectOptions: Object.fromEntries(
-          tagCategories
-            .map(({ name, tags }) =>
-              !tags
-                ? undefined
-                : [name, tags.map(({ name }) => ({ key: name, value: name }))]
-            )
+        selectOptions: tagItems.map(({ name }) => ({ key: name, value: name })),
+        /**
+         * Convert the selected `selectOptions` to an array of tag ids the server side
+         * filtering will understand.
+         */
+        getServerFilterValue: (selectedOptions) =>
+          selectedOptions
+            ?.map((option) => tagItems.find((item) => option === item.name))
             .filter(Boolean)
-        ),
-        // NOTE: The same tag name can appear in multiple tag categories.
-        //       To replicate the behavior of the app inventory page, selecting a tag name
-        //       will perform an OR filter matching all tags with that name across tag categories.
-        //       In the future we may instead want to present the tag select options to the user in category sections.
-        getServerFilterValue: (tagNames) =>
-          tagNames?.flatMap((tagName) =>
-            tags
-              .filter((tag) => tag.name === tagName)
-              .map((tag) => String(tag.id))
-          ),
+            .map(({ id }) => String(id)) ?? [],
       },
     ],
     initialItemsPerPage: 10,

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -37,7 +37,7 @@ export const useSharedAffectedApplicationFilterCategories = <
 >(): FilterCategory<TItem, string>[] => {
   const { t } = useTranslation();
   const { businessServices } = useFetchBusinessServices();
-  const { tagCategories, tags } = useFetchTagsWithTagItems();
+  const { tagCategories, tags, tagItems } = useFetchTagsWithTagItems();
 
   return [
     {
@@ -73,25 +73,16 @@ export const useSharedAffectedApplicationFilterCategories = <
         t("actions.filterBy", {
           what: t("terms.tagName").toLowerCase(),
         }) + "...",
-      selectOptions: Object.fromEntries(
-        tagCategories
-          .map(({ name, tags }) =>
-            !tags
-              ? undefined
-              : [name, tags.map(({ name }) => ({ key: name, value: name }))]
-          )
+      selectOptions: tagItems.map(({ name }) => ({ key: name, value: name })),
+      /**
+       * Convert the selected `selectOptions` to an array of tag ids the server side
+       * filtering will understand.
+       */
+      getServerFilterValue: (selectedOptions) =>
+        selectedOptions
+          ?.map((option) => tagItems.find((item) => option === item.name))
           .filter(Boolean)
-      ),
-      // NOTE: The same tag name can appear in multiple tag categories.
-      //       To replicate the behavior of the app inventory page, selecting a tag name
-      //       will perform an OR filter matching all tags with that name across tag categories.
-      //       In the future we may instead want to present the tag select options to the user in category sections.
-      getServerFilterValue: (tagNames) =>
-        tagNames?.flatMap((tagName) =>
-          tags
-            .filter((tag) => tag.name === tagName)
-            .map((tag) => String(tag.id))
-        ),
+          .map(({ id }) => String(id)) ?? [],
     },
   ];
 };

--- a/client/src/app/queries/tags.ts
+++ b/client/src/app/queries/tags.ts
@@ -52,6 +52,8 @@ export const useFetchTagCategories = () => {
 export interface TagItemType {
   id: number;
   name: string;
+  categoryName: string;
+  tagName: string;
   tooltip?: string;
 }
 
@@ -81,6 +83,8 @@ export const useFetchTagsWithTagItems = () => {
     return tags
       .map<TagItemType>((tag) => ({
         id: tag.id,
+        categoryName: tag.category?.name ?? "",
+        tagName: tag.name,
         name: `${tag.category?.name} / ${tag.name}`,
         tooltip: tag.category?.name,
       }))

--- a/client/src/app/queries/tags.ts
+++ b/client/src/app/queries/tags.ts
@@ -88,6 +88,7 @@ export const useFetchTagsWithTagItems = () => {
   }, [tags]);
 
   return {
+    tagCategories,
     tags,
     tagItems,
     isFetching,


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-1534

## Summary
On the following tables, the Tag filter has been enhanced to show the Tag with Tag Category:
  - Applications
  - Issues / All Issues
  - Dependencies
  - Dependency Details Drawer / Application Table

Tables that use Tag filters now use a set of options in the format "Tag Category Name / Tag Name".  The filter render component `MultiselectFilterControl` has been updated to have special handling of selected values where the selection chips display the Tag Name and the Tag Category Name is displayed as a tooltip.

Existing item filtering and filter values are still operating as a `string` or `string[]`, but use a string that can uniquely identify each tag.  The net effect means that if a tag of the same name exists in more than one category, they are unique.  Selecting one of those Tags will only select the tag in that specific category.

Additional change details:
  - Type `OptionPropsWithKey` renamed `FilterSelectOptionProps` for more consistent type/component naming
  - Added some jsdoc to `FilterToolbar`

## Screenshots
**Tag chips displayed for selected tags**:
![image](https://github.com/konveyor/tackle2-ui/assets/3985964/3386a3d6-5b9c-4026-a9cb-a5458dfe2a25)


**Tag filter select**:
![image](https://github.com/konveyor/tackle2-ui/assets/3985964/295dde98-c826-4e2e-be1b-2c9b08d0ff33)



