### PR TITLE
:sparkles: Regroup the dependencies table on name only, version/sha shown in details

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -503,13 +503,10 @@ export interface TrackerProjectIssuetype {
 }
 
 export interface AnalysisDependency {
-  createTime: string;
-  name: string;
   provider: string;
-  version: string;
-  sha: string;
-  applications: number;
+  name: string;
   labels: string[];
+  applications: number;
 }
 
 export interface AnalysisAppDependency {
@@ -519,12 +516,12 @@ export interface AnalysisAppDependency {
   businessService: string;
   dependency: {
     id: number;
+    provider: string;
     name: string;
     version: string;
-    provider: string;
+    sha: string;
     indirect: boolean;
-    //TODO: Glean from labels somehow
-    // management?: string;
+    labels: string[];
   };
 }
 

--- a/client/src/app/pages/dependencies/dependencies.tsx
+++ b/client/src/app/pages/dependencies/dependencies.tsx
@@ -82,6 +82,7 @@ export const Dependencies: React.FC = () => {
     ],
     initialItemsPerPage: 10,
   });
+
   const {
     result: { data: currentPageItems, total: totalItemCount },
     isFetching,
@@ -166,54 +167,49 @@ export const Dependencies: React.FC = () => {
               isNoData={totalItemCount === 0}
               numRenderedColumns={numRenderedColumns}
             >
-              {currentPageItems?.map((dependency, rowIndex) => {
-                return (
-                  <Tbody key={dependency.name + rowIndex}>
-                    <Tr {...getTrProps({ item: dependency })}>
-                      <TableRowContentWithControls
-                        {...tableControls}
-                        item={dependency}
-                        rowIndex={rowIndex}
-                      >
-                        <Td width={25} {...getTdProps({ columnKey: "name" })}>
-                          {dependency.name}
-                        </Td>
-                        <Td
-                          width={10}
-                          {...getTdProps({ columnKey: "foundIn" })}
+              <Tbody>
+                {currentPageItems?.map((dependency, rowIndex) => (
+                  <Tr
+                    key={dependency.name + rowIndex}
+                    {...getTrProps({ item: dependency })}
+                  >
+                    <TableRowContentWithControls
+                      {...tableControls}
+                      item={dependency}
+                      rowIndex={rowIndex}
+                    >
+                      <Td width={25} {...getTdProps({ columnKey: "name" })}>
+                        {dependency.name}
+                      </Td>
+                      <Td width={10} {...getTdProps({ columnKey: "foundIn" })}>
+                        <Button
+                          className={spacing.pl_0}
+                          variant="link"
+                          onClick={(_) => {
+                            if (activeItem && activeItem === dependency) {
+                              clearActiveItem();
+                            } else {
+                              setActiveItem(dependency);
+                            }
+                          }}
                         >
-                          <Button
-                            className={spacing.pl_0}
-                            variant="link"
-                            onClick={(_) => {
-                              if (activeItem && activeItem === dependency) {
-                                clearActiveItem();
-                              } else {
-                                setActiveItem(dependency);
-                              }
-                            }}
-                          >
-                            {`${dependency.applications} application(s)`}
-                          </Button>
-                        </Td>
-                        <Td
-                          width={10}
-                          {...getTdProps({ columnKey: "provider" })}
-                        >
-                          {dependency.provider}
-                        </Td>
-                        <Td width={10} {...getTdProps({ columnKey: "labels" })}>
-                          <LabelGroup>
-                            {dependency?.labels?.map((label, index) => (
-                              <Label key={index}>{label}</Label>
-                            ))}
-                          </LabelGroup>
-                        </Td>
-                      </TableRowContentWithControls>
-                    </Tr>
-                  </Tbody>
-                );
-              })}
+                          {`${dependency.applications} application(s)`}
+                        </Button>
+                      </Td>
+                      <Td width={10} {...getTdProps({ columnKey: "provider" })}>
+                        {dependency.provider}
+                      </Td>
+                      <Td width={10} {...getTdProps({ columnKey: "labels" })}>
+                        <LabelGroup>
+                          {dependency?.labels?.map((label, index) => (
+                            <Label key={index}>{label}</Label>
+                          ))}
+                        </LabelGroup>
+                      </Td>
+                    </TableRowContentWithControls>
+                  </Tr>
+                ))}
+              </Tbody>
             </ConditionalTableBody>
           </Table>
           <SimplePagination

--- a/client/src/app/pages/dependencies/dependencies.tsx
+++ b/client/src/app/pages/dependencies/dependencies.tsx
@@ -79,28 +79,6 @@ export const Dependencies: React.FC = () => {
           }) + "...",
         getServerFilterValue: (value) => (value ? [`*${value[0]}*`] : []),
       },
-      {
-        key: "version",
-        title: t("terms.version"),
-        type: FilterType.search,
-        filterGroup: "Dependency",
-        placeholderText:
-          t("actions.filterBy", {
-            what: t("terms.label").toLowerCase(),
-          }) + "...",
-        getServerFilterValue: (value) => (value ? [`*${value[0]}*`] : []),
-      },
-      {
-        key: "sha",
-        title: "SHA",
-        type: FilterType.search,
-        filterGroup: "Dependency",
-        placeholderText:
-          t("actions.filterBy", {
-            what: t("terms.name").toLowerCase(),
-          }) + "...",
-        getServerFilterValue: (value) => (value ? [`*${value[0]}*`] : []),
-      },
     ],
     initialItemsPerPage: 10,
   });
@@ -179,8 +157,6 @@ export const Dependencies: React.FC = () => {
                   <Th {...getThProps({ columnKey: "foundIn" })} />
                   <Th {...getThProps({ columnKey: "provider" })} />
                   <Th {...getThProps({ columnKey: "labels" })} />
-                  <Th {...getThProps({ columnKey: "version" })} />
-                  <Th {...getThProps({ columnKey: "sha" })} />
                 </TableHeaderContentWithControls>
               </Tr>
             </Thead>
@@ -228,19 +204,10 @@ export const Dependencies: React.FC = () => {
                         </Td>
                         <Td width={10} {...getTdProps({ columnKey: "labels" })}>
                           <LabelGroup>
-                            {dependency?.labels?.map((label) => {
-                              return <Label>{label}</Label>;
-                            })}
+                            {dependency?.labels?.map((label, index) => (
+                              <Label key={index}>{label}</Label>
+                            ))}
                           </LabelGroup>
-                        </Td>
-                        <Td
-                          width={10}
-                          {...getTdProps({ columnKey: "version" })}
-                        >
-                          {dependency.version}
-                        </Td>
-                        <Td width={10} {...getTdProps({ columnKey: "sha" })}>
-                          {dependency.sha}
                         </Td>
                       </TableRowContentWithControls>
                     </Tr>
@@ -259,7 +226,7 @@ export const Dependencies: React.FC = () => {
       <DependencyAppsDetailDrawer
         dependency={activeItem || null}
         onCloseClick={() => setActiveItem(null)}
-      ></DependencyAppsDetailDrawer>
+      />
     </>
   );
 };

--- a/client/src/app/pages/dependencies/dependency-apps-table.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-table.tsx
@@ -106,8 +106,6 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
       },
       implicitFilters: [
         { field: "dep.name", operator: "=", value: dependency.name },
-        { field: "dep.version", operator: "=", value: dependency.version },
-        { field: "dep.sha", operator: "=", value: dependency.sha },
       ],
     })
   );


### PR DESCRIPTION
Resolves: #1338
Resolves: https://issues.redhat.com/browse/MTA-1585

Depends on hub change https://github.com/konveyor/tackle2-hub/issues/557 / https://github.com/konveyor/tackle2-hub/pull/558.

Summary of changes:
  - The dependency table will show a single row for every named dependency.
  - Multiple versions will be aggregated as a single row.
  - Details about multiple versions will be available in the details drawer.
  - The details view application table will show the application + version, allowing for all versions used to be listed.

Screencap:

https://github.com/konveyor/tackle2-ui/assets/3985964/6d57aa6e-ce8a-4e2f-9a6f-ebedd79e2241


