### PR TITLE
:bug: Allow save as draft on first page if answers exist

### DIFF
--- a/client/src/app/pages/assessment/components/custom-wizard-footer/custom-wizard-footer.tsx
+++ b/client/src/app/pages/assessment/components/custom-wizard-footer/custom-wizard-footer.tsx
@@ -93,16 +93,16 @@ export const CustomWizardFooter: React.FC<CustomWizardFooterProps> = ({
           >
             {t("actions.cancel")}
           </Button>
-          {!isFirstStep && (
+          {
             <Button
               variant="link"
               onClick={onSaveAsDraft}
-              isDisabled={isFormInvalid || isFirstStep || isSaveAsDraftDisabled}
+              isDisabled={isFormInvalid || isSaveAsDraftDisabled}
               cy-data="save-as-draft"
             >
               {t("actions.saveAsDraft")}
             </Button>
-          )}
+          }
         </>
       </WizardFooterWrapper>
     </>


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-1676 
- QE raised the point that we should be able to save as draft on the first page of the wizard if the user has navigated back after selecting answers. 