### PR TITLE
:ghost: Refactor archetype table app column text

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -156,7 +156,8 @@
     "small": "Small"
   },
   "message": {
-    "archetypeApplicationCount": "{{count}} applications",
+    "archetypeApplicationCount": "{{count}} application",
+    "archetypeApplicationCount_plural": "{{count}} applications",
     "archetypeNoApplications": "No applications currently match the criteria tags.",
     "appNotAssesedTitle": "Assessment has not been completed",
     "appNotAssessedBody": "In order to review an application it must be assessed first. Assess the application and try again.",


### PR DESCRIPTION
On the archetype table, applications column, update the translation key used to be plural aware via i18next:
  - When `count == 1`, use key `archetypeApplicationCount`
  - When `count != 1`, use key `archetypeApplicationCount_plural`

Net result is "1 application" and "3 applications" will be rendered. The "(s)" suffix is no longer required.

Note: The app is currently using `i18next` v19.  In current versions, and therefore current docs, the count suffixes are different.
