### PR TITLE
:bug: Rename stakeholder and stakeholder group table's entity name column

### DIFF
--- a/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
@@ -102,7 +102,7 @@ export const StakeholderGroups: React.FC = () => {
     idProperty: "name",
     items: stakeholderGroups,
     columnNames: {
-      displayName: "Display name",
+      name: "Name",
       description: "Description",
       count: "Member count",
     },
@@ -153,13 +153,13 @@ export const StakeholderGroups: React.FC = () => {
         },
       },
     ],
-    sortableColumns: ["displayName", "description", "count"],
+    sortableColumns: ["name", "description", "count"],
     getSortValues: (item) => ({
-      displayName: item?.name || "",
+      name: item?.name || "",
       description: item?.description || "",
       count: numStr(item?.stakeholders?.length),
     }),
-    initialSort: { columnKey: "displayName", direction: "asc" },
+    initialSort: { columnKey: "name", direction: "asc" },
     isLoading: isFetching,
   });
 
@@ -225,7 +225,7 @@ export const StakeholderGroups: React.FC = () => {
             <Thead>
               <Tr>
                 <TableHeaderContentWithControls {...tableControls}>
-                  <Th {...getThProps({ columnKey: "displayName" })} />
+                  <Th {...getThProps({ columnKey: "name" })} />
                   <Th {...getThProps({ columnKey: "description" })} />
                   <Th {...getThProps({ columnKey: "count" })} />
                 </TableHeaderContentWithControls>
@@ -264,10 +264,7 @@ export const StakeholderGroups: React.FC = () => {
                         item={stakeholderGroup}
                         rowIndex={rowIndex}
                       >
-                        <Td
-                          width={25}
-                          {...getTdProps({ columnKey: "displayName" })}
-                        >
+                        <Td width={25} {...getTdProps({ columnKey: "name" })}>
                           {stakeholderGroup.name}
                         </Td>
                         <Td

--- a/client/src/app/pages/controls/stakeholders/stakeholders.tsx
+++ b/client/src/app/pages/controls/stakeholders/stakeholders.tsx
@@ -95,11 +95,11 @@ export const Stakeholders: React.FC = () => {
   };
 
   const tableControls = useLocalTableControls({
-    idProperty: "name",
+    idProperty: "email",
     items: stakeholders,
     columnNames: {
-      name: "Email",
-      displayName: "Display name",
+      email: "Email",
+      name: "Name",
       jobFunction: "Job function",
       groupCount: "Group count",
     },
@@ -162,10 +162,10 @@ export const Stakeholders: React.FC = () => {
         },
       },
     ],
-    sortableColumns: ["name", "displayName", "jobFunction"],
+    sortableColumns: ["email", "name", "jobFunction"],
     getSortValues: (item) => ({
-      name: item?.email || "",
-      displayName: item?.name || "",
+      email: item?.email || "",
+      name: item?.name || "",
       jobFunction: item.jobFunction?.name || "",
     }),
     initialSort: { columnKey: "name", direction: "asc" },
@@ -233,8 +233,8 @@ export const Stakeholders: React.FC = () => {
             <Thead>
               <Tr>
                 <TableHeaderContentWithControls {...tableControls}>
+                  <Th {...getThProps({ columnKey: "email" })} />
                   <Th {...getThProps({ columnKey: "name" })} />
-                  <Th {...getThProps({ columnKey: "displayName" })} />
                   <Th {...getThProps({ columnKey: "jobFunction" })} />
                   <Th {...getThProps({ columnKey: "groupCount" })} />
                 </TableHeaderContentWithControls>
@@ -273,13 +273,10 @@ export const Stakeholders: React.FC = () => {
                         item={stakeholder}
                         rowIndex={rowIndex}
                       >
-                        <Td width={25} {...getTdProps({ columnKey: "name" })}>
+                        <Td width={25} {...getTdProps({ columnKey: "email" })}>
                           {stakeholder.email}
                         </Td>
-                        <Td
-                          width={10}
-                          {...getTdProps({ columnKey: "displayName" })}
-                        >
+                        <Td width={10} {...getTdProps({ columnKey: "name" })}>
                           {stakeholder.name}
                         </Td>
                         <Td


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-1694

On the Stakeholder and Stakeholder Group tables, the column "Display Name" was renamed to "Name" to match the add/edit form.  Any other columns and filters that needed to be adjusted to accommodate this change were adjusted.
