### PR TITLE
:bug: Fix issue causing all non-required assessments to show as archived

### DIFF
--- a/client/src/app/pages/assessment/components/assessment-actions/components/assessment-actions-table.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/assessment-actions-table.tsx
@@ -40,6 +40,12 @@ const AssessmentActionsTable: React.FC<AssessmentActionsTableProps> = ({
       nonRequiredQuestionnaireIds.includes(assessment.questionnaire.id) &&
       relevantAssessmentIds.includes(assessment.id)
   );
+  const filteredArchivedQuestionnaires = archivedQuestionnaires.filter(
+    (questionnaire) =>
+      filteredArchivedAssessments.some(
+        (assessment) => assessment.questionnaire.id === questionnaire.id
+      )
+  );
 
   return (
     <>
@@ -56,7 +62,7 @@ const AssessmentActionsTable: React.FC<AssessmentActionsTableProps> = ({
           application={application}
           archetype={archetype}
           isReadonly
-          questionnaires={archivedQuestionnaires}
+          questionnaires={filteredArchivedQuestionnaires}
           assessments={filteredArchivedAssessments}
           isFetching={isFetchingQuestionnaires || isFetchingAssessmentsById}
           tableName="Archived questionnaires"


### PR DESCRIPTION
- Missed this in the first pass. Need to filter the archived questionnaires passed when rendering the archived table.
https://issues.redhat.com/browse/MTA-1722