### PR TITLE
:bug: Add useEffect for action state sync

### DIFF
--- a/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
@@ -102,7 +102,7 @@ const DynamicAssessmentActionsRow: FunctionComponent<
     onDeleteError
   );
 
-  const determineAction = () => {
+  const determineAction = React.useCallback(() => {
     if (!assessment) {
       return AssessmentAction.Take;
     } else if (assessment.status === "started") {
@@ -110,7 +110,13 @@ const DynamicAssessmentActionsRow: FunctionComponent<
     } else {
       return AssessmentAction.Retake;
     }
-  };
+  }, [assessment]);
+
+  const [action, setAction] = React.useState(determineAction());
+
+  React.useEffect(() => {
+    setAction(determineAction());
+  }, [determineAction, assessment]);
 
   const determineButtonClassName = () => {
     const action = determineAction();
@@ -213,7 +219,7 @@ const DynamicAssessmentActionsRow: FunctionComponent<
                 onHandleAssessmentAction();
               }}
             >
-              {determineAction()}
+              {action}
             </Button>
           ) : (
             <Spinner role="status" size="md">

--- a/client/src/app/queries/assessments.ts
+++ b/client/src/app/queries/assessments.ts
@@ -182,7 +182,6 @@ export const useFetchAssessmentsByItemId = (
   };
   const assessmentsWithOrder: AssessmentWithSectionOrder[] =
     data?.map(addSectionOrderToQuestions) || [];
-
   return {
     assessments: assessmentsWithOrder,
     isFetching: isLoading,


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-1826

- Uses a useEffect hook to synchronize the state of the action based on the assessment object. This way, whenever assessment changes, we can ensure that the action is recalculated.
