### PR TITLE
:bug: Fix session expiry when refresh tokens are disabled

### DIFF
--- a/client/src/app/components/KeycloakProvider.tsx
+++ b/client/src/app/components/KeycloakProvider.tsx
@@ -1,12 +1,8 @@
-import { initInterceptors } from "@app/axios-config";
-import { isAuthRequired } from "@app/Constants";
-import i18n from "@app/i18n";
-import keycloak from "@app/keycloak";
-import { deleteCookie, getCookie, setCookie } from "@app/queries/cookies";
-import { AppPlaceholder } from "./AppPlaceholder";
-import { Flex, FlexItem, Spinner } from "@patternfly/react-core";
-import { ReactKeycloakProvider } from "@react-keycloak/web";
 import React, { Suspense } from "react";
+import { ReactKeycloakProvider } from "@react-keycloak/web";
+import keycloak from "@app/keycloak";
+import { AppPlaceholder } from "./AppPlaceholder";
+import { initInterceptors } from "@app/axios-config";
 
 interface IKeycloakProviderProps {
   children: React.ReactNode;
@@ -15,81 +11,17 @@ interface IKeycloakProviderProps {
 export const KeycloakProvider: React.FC<IKeycloakProviderProps> = ({
   children,
 }) => {
-  const checkAuthCookie = () => {
-    if (!getCookie("keycloak_cookie") && keycloak?.token) {
-      setCookie("keycloak_cookie", keycloak.token, 365);
-    }
-  };
-  if (isAuthRequired) {
-    return (
-      <>
-        <ReactKeycloakProvider
-          authClient={keycloak}
-          initOptions={{ onLoad: "login-required" }}
-          LoadingComponent={
-            <Flex
-              spaceItems={{ default: "spaceItemsSm" }}
-              alignItems={{ default: "alignItemsCenter" }}
-              flexWrap={{ default: "nowrap" }}
-              style={{
-                width: "100%",
-                height: "100%",
-              }}
-            >
-              <FlexItem
-                style={{
-                  margin: "auto auto",
-                  textAlign: "center",
-                }}
-              >
-                <Spinner>Loading...</Spinner>
-              </FlexItem>
-            </Flex>
-          }
-          isLoadingCheck={(keycloak) => {
-            if (keycloak.authenticated) {
-              initInterceptors(
-                () =>
-                  new Promise<string>((resolve, reject) => {
-                    if (keycloak.token) {
-                      if (keycloak.refreshToken) {
-                        keycloak
-                          .updateToken(60)
-                          .then(() => {
-                            deleteCookie("keycloak_cookie");
-                            checkAuthCookie();
-                            return resolve(keycloak.token!);
-                          })
-                          .catch((err) => {
-                            console.log("err", err);
-                            return reject("Failed to refresh token");
-                          });
-                      } else return resolve(keycloak.token!);
-                    } else {
-                      keycloak.login();
-                      reject("Not logged in");
-                    }
-                  })
-              );
+  React.useEffect(() => {
+    initInterceptors();
+  }, []);
 
-              const kcLocale = (keycloak.tokenParsed as any)["locale"];
-              if (kcLocale) {
-                i18n.changeLanguage(kcLocale);
-              }
-            }
-
-            return !keycloak.authenticated;
-          }}
-        >
-          {children}
-        </ReactKeycloakProvider>
-      </>
-    );
-  } else {
-    return (
-      <>
-        <Suspense fallback={<AppPlaceholder />}>{children}</Suspense>
-      </>
-    );
-  }
+  return (
+    <ReactKeycloakProvider
+      authClient={keycloak}
+      initOptions={{ onLoad: "login-required" }}
+      LoadingComponent={<AppPlaceholder />}
+    >
+      <Suspense fallback={<AppPlaceholder />}>{children}</Suspense>
+    </ReactKeycloakProvider>
+  );
 };

--- a/client/src/app/layout/HeaderApp/SSOMenu.tsx
+++ b/client/src/app/layout/HeaderApp/SSOMenu.tsx
@@ -45,7 +45,8 @@ export const SSOMenu: React.FC = () => {
                 id="sso-actions-toggle"
                 onClick={() => onDropdownToggle(!isDropdownOpen)}
               >
-                {(keycloak?.idTokenParsed as any)["preferred_username"]}
+                {(keycloak?.idTokenParsed as any)?.["preferred_username"] ??
+                  "DefaultUsername"}
               </MenuToggle>
             )}
           >
@@ -63,8 +64,6 @@ export const SSOMenu: React.FC = () => {
                   id="logout"
                   key="sso_logout"
                   onClick={() => {
-                    // Clears selected persona from storage without updating it in React state so we don't re-render the persona selector while logging out.
-                    // We have to clear it before logout because the redirect can happen before the logout promise resolves.
                     window.localStorage.removeItem(
                       LocalStorageKey.selectedPersona
                     );


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-1255

- Since we no longer have to support windup reports in a new tab, this code can be cleaned up to use keycloaks internal session management