### PR TITLE
:bug: Only load keycloak when `AUTH_REQUIRED` is "true"

### DIFF
--- a/client/src/app/components/KeycloakProvider.tsx
+++ b/client/src/app/components/KeycloakProvider.tsx
@@ -3,12 +3,23 @@ import { ReactKeycloakProvider } from "@react-keycloak/web";
 import keycloak from "@app/keycloak";
 import { AppPlaceholder } from "./AppPlaceholder";
 import { initInterceptors } from "@app/axios-config";
+import ENV from "@app/env";
 
 interface IKeycloakProviderProps {
   children: React.ReactNode;
 }
 
 export const KeycloakProvider: React.FC<IKeycloakProviderProps> = ({
+  children,
+}) => {
+  return ENV.AUTH_REQUIRED !== "true" ? (
+    <>{children}</>
+  ) : (
+    <AuthEnabledKeycloakProvider>{children}</AuthEnabledKeycloakProvider>
+  );
+};
+
+const AuthEnabledKeycloakProvider: React.FC<IKeycloakProviderProps> = ({
   children,
 }) => {
   React.useEffect(() => {


### PR DESCRIPTION
Only add the actual `AuthEnabledKeycloakProvider` keycloak handler if the `AUTH_REQUIRED` environment variable is set `"true"`.
