### PR TITLE
:bug: Fix pagination effects - for client tables, use `filteredItems` instead of `items` length for `totalItemCount`

### DIFF
--- a/client/src/app/hooks/table-controls/getLocalTableControlDerivedState.ts
+++ b/client/src/app/hooks/table-controls/getLocalTableControlDerivedState.ts
@@ -48,7 +48,7 @@ export const getLocalTableControlDerivedState = <
     items: sortedItems,
   });
   return {
-    totalItemCount: items.length,
+    totalItemCount: filteredItems.length,
     currentPageItems: isPaginationEnabled ? currentPageItems : sortedItems,
   };
 };

--- a/client/src/app/hooks/table-controls/types.ts
+++ b/client/src/app/hooks/table-controls/types.ts
@@ -231,7 +231,7 @@ export type ITableControlDerivedState<TItem> = {
    */
   currentPageItems: TItem[];
   /**
-   * The total number of items in the entire un-filtered, un-paginated table (the size of the entire API collection being tabulated).
+   * The total number of items after filtering but before pagination.
    */
   totalItemCount: number;
 };


### PR DESCRIPTION
Made the same fix in the new react-table-batteries code as well. Note to self: Perhaps we should rename the `totalItemCount` to `filteredItemCount` in the new version, since it really should be the count of all items just before pagination (after filtering), not the total number of items in the unfiltered collection.

For client-side tables, the `totalItemCount` is derived internally inside `getLocalTableControlDerivedState`, and it was incorrectly using `items.length`. Changing that to `filteredItems.length` makes the logic in `usePaginationEffects` behave as intended, which means if the user ends up on an invalid pagination page (e.g. they are on page 2 and they apply a filter that has results on one page), it will kick them back to the last valid page.

cc @ibolton336 

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
