### PR TITLE
:bug: Fix label on Archetype detail drawer, Reviews tab

### DIFF
--- a/client/src/app/pages/archetypes/components/archetype-detail-drawer.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-detail-drawer.tsx
@@ -212,7 +212,7 @@ const ArchetypeDetailDrawer: React.FC<IArchetypeDetailDrawerProps> = ({
           </Tab>
           <Tab
             eventKey={TabKey.Reviews}
-            title={<TabTitleText>{t("terms.review")}</TabTitleText>}
+            title={<TabTitleText>{t("terms.reviews")}</TabTitleText>}
           >
             <ReviewFields archetype={archetype} />
           </Tab>


### PR DESCRIPTION
Use "Reviews" instead of "Review" on the Archetype details drawer Reviews tab.  This keeps the terms used on the tab labels all consistent.

Resolves: https://issues.redhat.com/browse/MTA-1888
