### PR TITLE
:bug: Rename Rules tags to rules labels for better clarity

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -514,7 +514,7 @@
       "packages": "Packages",
       "review": "Review",
       "rules": "Rules",
-      "rulesTags": "rules tags",
+      "rulesTags": "rules labels",
       "scope": "Scope",
       "setTargets": "Set targets",
       "source": "Source",


### PR DESCRIPTION
This is to address an issue where a user expected the technology tags on the output report to be filtered, when the filtering is based on the labels on the rule itself. This PR just makes sure the UI and analyzer use the same terminology

tried to keep the change minimal, can change the internal variables/div names as well if we want.

wasn't sure if :bug: or :ghost: was more appropriate