### PR TITLE
:bug: Ensure a tag category rank of 0 is  the lowest value when sorting

### DIFF
--- a/client/src/app/pages/controls/tags/tags.tsx
+++ b/client/src/app/pages/controls/tags/tags.tsx
@@ -242,7 +242,8 @@ export const Tags: React.FC = () => {
   const getSortValues = (item: TagCategory) => [
     "",
     item?.name || "",
-    item?.rank || "",
+    typeof item?.rank === "number" ? item.rank : Number.MAX_VALUE,
+
     "",
     item?.tags?.length || 0,
     "", // Action column


### PR DESCRIPTION
https://issues.redhat.com/browse/MTA-1787