### PR TITLE
:bug: Allow wizard to proceed with an empty custom target

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -222,7 +222,7 @@ export const CustomRules: React.FC = () => {
         </Title>
         <Text> {t("wizard.label.customRules")}</Text>
       </TextContent>
-      {values.formLabels.length === 0 &&
+      {values.selectedTargets.length === 0 &&
         values.customRulesFiles.length === 0 &&
         !values.sourceRepository && (
           <Alert

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -125,10 +125,14 @@ const useCustomRulesStepSchema = (): yup.SchemaOf<CustomRulesStepValues> => {
         then: yup.array().of(customRulesFilesSchema),
         otherwise: (schema) => schema,
       })
-      .when(["formLabels", "rulesKind"], {
-        is: (labels: TargetLabel[], rulesKind: string) =>
-          labels.length === 0 && rulesKind === "manual",
-        then: (schema) => schema.min(1, "At least 1 Rule File is required"), // TODO translation here
+      .when(["formLabels", "rulesKind", "selectedTargets"], {
+        is: (
+          labels: TargetLabel[],
+          rulesKind: string,
+          selectedTargets: number
+        ) =>
+          labels.length === 0 && rulesKind === "manual" && selectedTargets <= 0,
+        then: (schema) => schema.min(1, "At least 1 Rule File is required"),
       }),
     repositoryType: yup.mixed<string>().when("rulesKind", {
       is: "repository",


### PR DESCRIPTION
- Update custom rules step validation to allow custom targets with no labels when using rules from a repo.