### PR TITLE
:bug: Archetype detail drawer, tab renamed "Review"

### DIFF
--- a/client/src/app/pages/archetypes/components/archetype-detail-drawer.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-detail-drawer.tsx
@@ -212,7 +212,7 @@ const ArchetypeDetailDrawer: React.FC<IArchetypeDetailDrawerProps> = ({
           </Tab>
           <Tab
             eventKey={TabKey.Reviews}
-            title={<TabTitleText>{t("terms.reviews")}</TabTitleText>}
+            title={<TabTitleText>{t("terms.review")}</TabTitleText>}
           >
             <ReviewFields archetype={archetype} />
           </Tab>


### PR DESCRIPTION
After some discussions in the Jira ticket, the archetype detail drawer tab should be named "Review" since an archetype will only have a single review.  The application detail drawer tab will remain "Reviews" since applications can inherit multiple reviews from multiple archetype matches.

Follow up to: #1626
Resolves: https://issues.redhat.com/browse/MTA-1888