### PR TITLE
:bug: Enhance error message for archetype create/edit tag fields

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -391,7 +391,6 @@
     "repositoryType": "Repository type",
     "review": "Review",
     "reviewedArchetype": "Archetype reviewed",
-
     "reviews": "Reviews",
     "reviewComments": "Review comments",
     "risk": "Risk",
@@ -422,6 +421,7 @@
     "suggestedAdoptionPlan": "Suggested adoption plan",
     "svnConfig": "Subversion configuration",
     "tableView": "Table view",
+    "tag": "Tag",
     "tag(s)": "Tag(s)",
     "tagCount": "Tag count",
     "tagDeleted": "Tag deleted",
@@ -446,7 +446,6 @@
     "user": "User",
     "version": "Version",
     "workPriority": "Work priority",
-    "tag": "Tag",
     "YAMLTemplate": "YAML template"
   },
   "titles": {
@@ -479,6 +478,8 @@
     "max": "This field must be less than {{value}}.",
     "maxLength": "This field must contain fewer than {{length}} characters.",
     "min": "This field must be greater than {{value}}.",
+    "minCount": "At least one {{type}} must be selected.",
+    "minCount_plural": "At least {{count}} {{types}} must be selected.",
     "minLength": "This field must contain at least {{length}} characters.",
     "minOneStakeholderOrGroupRequired": "At least one stakeholder or stakeholder groups is required.",
     "required": "This field is required."

--- a/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
@@ -136,13 +136,25 @@ const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
     criteria: yup
       .array()
       .of(yup.object({ id: yup.number(), name: yup.string() }))
-      .min(1)
+      .min(1, ({ min }) =>
+        t("validation.minCount", {
+          count: min,
+          type: t("terms.tag").toLocaleLowerCase(),
+          types: t("terms.tags").toLocaleLowerCase(),
+        })
+      )
       .required(t("validation.required")),
 
     tags: yup
       .array()
       .of(yup.object({ id: yup.number(), name: yup.string() }))
-      .min(1)
+      .min(1, ({ min }) =>
+        t("validation.minCount", {
+          count: min,
+          type: t("terms.tag").toLocaleLowerCase(),
+          types: t("terms.tags").toLocaleLowerCase(),
+        })
+      )
       .required(t("validation.required")),
 
     stakeholders: yup


### PR DESCRIPTION
Add a custom error message for the min array length check of the criteria tags and archetype tags fields on the create/edit archetype form.  The new error message properly handles a minimum count of 1 or >1.

Resolves: https://issues.redhat.com/browse/MTA-1945

The error message now:
![Screenshot from 2024-01-03 17-42-41](https://github.com/konveyor/tackle2-ui/assets/3985964/4805dc06-836c-4371-991a-9fce97e9fb09)
