### PR TITLE
:seedling: Refactor patternfly, i18n, and dayjs initialization

### DIFF
--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -5,9 +5,6 @@ import { AppRoutes } from "./Routes";
 import { DefaultLayout } from "./layout";
 import { NotificationsProvider } from "./components/NotificationsContext";
 
-import "@patternfly/patternfly/patternfly.css";
-import "@patternfly/patternfly/patternfly-addons.css";
-
 import "./app.css";
 
 const App: React.FC = () => {

--- a/client/src/app/dayjs.ts
+++ b/client/src/app/dayjs.ts
@@ -1,0 +1,10 @@
+import dayjs from "dayjs";
+import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(customParseFormat);
+dayjs.extend(isSameOrBefore);

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,3 +1,6 @@
+import "@patternfly/patternfly/patternfly.css";
+import "@patternfly/patternfly/patternfly-addons.css";
+
 import React from "react";
 import ReactDOM from "react-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -7,16 +10,9 @@ import ENV from "@app/env";
 import App from "@app/App";
 import reportWebVitals from "@app/reportWebVitals";
 import { KeycloakProvider } from "@app/components/KeycloakProvider";
-import dayjs from "dayjs";
-import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
-import customParseFormat from "dayjs/plugin/customParseFormat";
 
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.extend(customParseFormat);
-dayjs.extend(isSameOrBefore);
+import "@app/dayjs";
+import "@app/i18n";
 
 const queryClient = new QueryClient();
 


### PR DESCRIPTION
Refactoring:
  - Explicitly add `i18n` initialization on the root `index.tsx`.

  - Move `dayjs` initialization to its own file `dayjs.ts` referenced from `index.tsx`.  This follows the `i18n` init style.

  - Move PF css includes from `App.tsx` to `index.tsx`
