### PR TITLE
:bug: Exclude non-required questionnaires in assessed calculation

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -735,6 +735,7 @@ export interface Assessment
   confidence?: number;
   stakeholders?: Ref[];
   stakeholderGroups?: Ref[];
+  required?: boolean;
 }
 export interface CategorizedTag {
   category: TagCategory;
@@ -793,4 +794,8 @@ export interface AssessmentWithSectionOrder extends Assessment {
 export interface AssessmentWithArchetypeApplications
   extends AssessmentWithSectionOrder {
   archetypeApplications: Ref[];
+}
+export interface AssessmentsWithArchetype {
+  archetype: Archetype;
+  assessments: Assessment[];
 }

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -57,6 +57,7 @@ import { LabelsFromItems } from "@app/components/labels/labels-from-items/labels
 import { RiskLabel } from "@app/components/RiskLabel";
 import { ApplicationDetailFields } from "./application-detail-fields";
 import { useFetchArchetypes } from "@app/queries/archetypes";
+import { AssessedArchetypes } from "./components/assessed-archetypes";
 
 export interface IApplicationDetailDrawerProps
   extends Pick<IPageDrawerContentProps, "onCloseClick"> {
@@ -100,14 +101,6 @@ export const ApplicationDetailDrawer: React.FC<
   const notAvailable = <EmptyTextMessage message={t("terms.notAvailable")} />;
 
   const enableDownloadSetting = useSetting("download.html.enabled");
-
-  const assessedArchetypes =
-    application?.archetypes
-      ?.map((archetypeRef) =>
-        archetypes.find((archetype) => archetype.id === archetypeRef.id)
-      )
-      .filter((fullArchetype) => fullArchetype?.assessed)
-      .filter(Boolean) || [];
 
   const reviewedArchetypes =
     application?.archetypes
@@ -211,18 +204,9 @@ export const ApplicationDetailDrawer: React.FC<
                     {t("terms.archetypesAssessed")}
                   </DescriptionListTerm>
                   <DescriptionListDescription>
-                    <LabelGroup>
-                      {assessedArchetypes?.length ? (
-                        assessedArchetypes.map((assessedArchetype) => (
-                          <ArchetypeItem
-                            key={assessedArchetype?.id}
-                            archetype={assessedArchetype}
-                          />
-                        ))
-                      ) : (
-                        <EmptyTextMessage message={t("terms.none")} />
-                      )}
-                    </LabelGroup>
+                    <AssessedArchetypes
+                      archetypeRefs={application?.archetypes}
+                    />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
 

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -204,9 +204,7 @@ export const ApplicationDetailDrawer: React.FC<
                     {t("terms.archetypesAssessed")}
                   </DescriptionListTerm>
                   <DescriptionListDescription>
-                    <AssessedArchetypes
-                      archetypeRefs={application?.archetypes}
-                    />
+                    <AssessedArchetypes application={application} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
 

--- a/client/src/app/pages/applications/components/application-detail-drawer/components/assessed-archetypes.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/components/assessed-archetypes.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Ref } from "@app/api/models";
+import { Application } from "@app/api/models";
 import { Label, LabelGroup, Spinner } from "@patternfly/react-core";
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { useTranslation } from "react-i18next";
@@ -7,17 +7,17 @@ import { useFetchArchetypes } from "@app/queries/archetypes";
 import { useFetchAllAssessmentsWithArchetypes } from "@app/queries/assessments";
 
 interface IAssessedArchetypesProps {
-  archetypeRefs: Ref[] | undefined;
+  application: Application | null;
 }
 
 export const AssessedArchetypes: React.FC<IAssessedArchetypesProps> = ({
-  archetypeRefs,
+  application,
 }) => {
   const { t } = useTranslation();
-  const { archetypes, isFetching: isFetchingArchetypes } = useFetchArchetypes();
-  const applicationArchetypes = archetypes.filter(
-    (archetype) => archetypeRefs?.some((ref) => ref.id === archetype.id)
-  );
+  const {
+    archetypes: applicationArchetypes,
+    isFetching: isFetchingArchetypes,
+  } = useFetchArchetypes(application);
 
   const {
     assessmentsWithArchetypes,

--- a/client/src/app/pages/applications/components/application-detail-drawer/components/assessed-archetypes.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/components/assessed-archetypes.tsx
@@ -22,8 +22,9 @@ export const AssessedArchetypes: React.FC<IAssessedArchetypesProps> = ({
   const {
     assessmentsWithArchetypes,
     isLoading: isFetchingAllAssessmentsWithArchetypesLoading,
-  } = useFetchAllAssessmentsWithArchetypes(applicationArchetypes || []);
-  const filteredArchetypes = assessmentsWithArchetypes
+  } = useFetchAllAssessmentsWithArchetypes(applicationArchetypes);
+
+  const assessedArchetypesWithARequiredAssessment = assessmentsWithArchetypes
     ?.filter((assessmentsWithArchetype) => {
       return (
         assessmentsWithArchetype.archetype.assessed &&
@@ -39,8 +40,8 @@ export const AssessedArchetypes: React.FC<IAssessedArchetypesProps> = ({
   }
   return (
     <LabelGroup>
-      {filteredArchetypes?.length ? (
-        filteredArchetypes?.map((archetype) => (
+      {assessedArchetypesWithARequiredAssessment?.length ? (
+        assessedArchetypesWithARequiredAssessment?.map((archetype) => (
           <Label key={archetype?.id}>{archetype?.name}</Label>
         ))
       ) : (

--- a/client/src/app/pages/applications/components/application-detail-drawer/components/assessed-archetypes.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/components/assessed-archetypes.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Ref } from "@app/api/models";
+import { Label, LabelGroup, Spinner } from "@patternfly/react-core";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+import { useTranslation } from "react-i18next";
+import { useFetchArchetypes } from "@app/queries/archetypes";
+import { useFetchAllAssessmentsWithArchetypes } from "@app/queries/assessments";
+
+interface IAssessedArchetypesProps {
+  archetypeRefs: Ref[] | undefined;
+}
+
+export const AssessedArchetypes: React.FC<IAssessedArchetypesProps> = ({
+  archetypeRefs,
+}) => {
+  const { t } = useTranslation();
+  const { archetypes, isFetching: isFetchingArchetypes } = useFetchArchetypes();
+  const applicationArchetypes = archetypes.filter(
+    (archetype) => archetypeRefs?.some((ref) => ref.id === archetype.id)
+  );
+
+  const {
+    assessmentsWithArchetypes,
+    isLoading: isFetchingAllAssessmentsWithArchetypesLoading,
+  } = useFetchAllAssessmentsWithArchetypes(applicationArchetypes || []);
+  const filteredArchetypes = assessmentsWithArchetypes
+    ?.filter((assessmentsWithArchetype) => {
+      return (
+        assessmentsWithArchetype.archetype.assessed &&
+        assessmentsWithArchetype.assessments.some(
+          (assessment) => assessment?.required === true
+        )
+      );
+    })
+    .map((assessmentsWithArchetype) => assessmentsWithArchetype.archetype);
+
+  if (isFetchingArchetypes || isFetchingAllAssessmentsWithArchetypesLoading) {
+    return <Spinner size="md" />;
+  }
+  return (
+    <LabelGroup>
+      {filteredArchetypes?.length ? (
+        filteredArchetypes?.map((archetype) => (
+          <Label key={archetype?.id}>{archetype?.name}</Label>
+        ))
+      ) : (
+        <EmptyTextMessage message={t("terms.none")} />
+      )}
+    </LabelGroup>
+  );
+};

--- a/client/src/app/queries/assessments.ts
+++ b/client/src/app/queries/assessments.ts
@@ -17,9 +17,11 @@ import {
 } from "@app/api/rest";
 import { AxiosError } from "axios";
 import {
+  Archetype,
   Assessment,
   AssessmentWithArchetypeApplications,
   AssessmentWithSectionOrder,
+  AssessmentsWithArchetype,
   InitialAssessment,
 } from "@app/api/models";
 import { QuestionnairesQueryKey } from "./questionnaires";
@@ -260,5 +262,35 @@ export const useFetchAssessmentsWithArchetypeApplications = () => {
   return {
     assessmentsWithArchetypeApplications,
     isLoading: assessmentsLoading || isArchetypesLoading,
+  };
+};
+
+export const useFetchAllAssessmentsWithArchetypes = (
+  archetypes: Archetype[]
+) => {
+  const assessmentQueries = useQueries({
+    queries: archetypes.map((archetype) => ({
+      queryKey: ["assessmentsForArchetype", archetype.id],
+      queryFn: () => getAssessmentsByItemId(true, archetype.id), // Replace with actual API call
+    })),
+  });
+
+  const assessmentsWithArchetypes: AssessmentsWithArchetype[] =
+    assessmentQueries
+      .map((query, index) => {
+        if (query.isSuccess) {
+          return {
+            archetype: archetypes[index],
+            assessments: query.data,
+          };
+        }
+        return null;
+      })
+      .filter(Boolean);
+
+  return {
+    assessmentsWithArchetypes,
+    isLoading: assessmentQueries.some((query) => query.isLoading),
+    isError: assessmentQueries.some((query) => query.isError),
   };
 };

--- a/client/src/app/queries/assessments.ts
+++ b/client/src/app/queries/assessments.ts
@@ -216,7 +216,7 @@ const removeSectionOrderFromQuestions = (
     ...assessmentWithOrder,
     sections: assessmentWithOrder.sections.map((section) => ({
       ...section,
-      questions: section.questions.map(({ sectionOrder, ...rest }) => rest), // Destructure out sectionOrder
+      questions: section.questions.map(({ sectionOrder, ...rest }) => rest),
     })),
   };
 };
@@ -266,12 +266,12 @@ export const useFetchAssessmentsWithArchetypeApplications = () => {
 };
 
 export const useFetchAllAssessmentsWithArchetypes = (
-  archetypes: Archetype[]
+  archetypes: Archetype[] = []
 ) => {
   const assessmentQueries = useQueries({
     queries: archetypes.map((archetype) => ({
       queryKey: ["assessmentsForArchetype", archetype.id],
-      queryFn: () => getAssessmentsByItemId(true, archetype.id), // Replace with actual API call
+      queryFn: () => getAssessmentsByItemId(true, archetype.id),
     })),
   });
 


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-1967

Addresses an issue where the assessed boolean for archetypes is set to true when all questionnaires are marked as not-required. Uses the new assessment.required boolean surfaced in https://github.com/konveyor/tackle2-hub/commit/25522337608b2dbab5df85ce4a5b5a9fc78a2289 to filter out these false positives. 