### PR TITLE
:bug: application can only have one review

### DIFF
--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -425,7 +425,7 @@ export const ApplicationDetailDrawer: React.FC<
           </Tab>
           <Tab
             eventKey={TabKey.Reviews}
-            title={<TabTitleText>{t("terms.reviews")}</TabTitleText>}
+            title={<TabTitleText>{t("terms.review")}</TabTitleText>}
           >
             <ReviewFields application={application} />
           </Tab>

--- a/client/src/app/pages/applications/components/application-detail-drawer/review-fields.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/review-fields.tsx
@@ -4,11 +4,8 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   DescriptionListDescription,
-  Title,
-  TextContent,
 } from "@patternfly/react-core";
 import { Application, Archetype, Review } from "@app/api/models";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { useFetchReviewById, useFetchReviews } from "@app/queries/reviews";
 import { useFetchArchetypes } from "@app/queries/archetypes";
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
@@ -75,11 +72,6 @@ export const ReviewFields: React.FC<{
 
   return (
     <>
-      <TextContent className={spacing.mtLg}>
-        <Title headingLevel="h3" size="md">
-          {t("terms.review")}
-        </Title>
-      </TextContent>
       <DescriptionListGroup>
         <DescriptionListTerm>{t("terms.proposedAction")}</DescriptionListTerm>
         <DescriptionListDescription cy-data="proposed-action">


### PR DESCRIPTION
https://issues.redhat.com/browse/MTA-1888

It appears that an application can only have a single review. So this changes the Tab title from `Reviews` -> `Review` and drops the redundant header inside.