### PR TITLE
Revert :bug: Add tooltip for migration wave delete option in app tab…

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -176,7 +176,6 @@
     "blockedDeleteApplication": "Cannot delete {{what}} because it is associated with an application.",
     "blockedDeleteTarget": "Cannot delete {{what}} because it is associated with a target.",
     "defaultBlockedDelete": "Cannot delete {{what}} because it is associated with another object.",
-    "cannotDeleteApplicationsAssignedToMigrationWave": "Cannot delete applications that are assigned to a migration wave.",
     "continueConfirmation": "Yes, continue",
     "copyAssessmentAndReviewBody": "Some of the selected target applications have an in-progress or complete assessment/review. By continuing, the existing assessment(s)/review(s) will be replaced by the copied assessment/review. Do you wish to continue?",
     "copyAssessmentAndReviewQuestion": "Copy assessment and review?",

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -573,12 +573,15 @@ export const ApplicationsTable: React.FC = () => {
         </DropdownItem>,
       ]
     : [];
+
   const applicationDropdownItems = applicationWriteAccess
     ? [
         <ConditionalTooltip
           key="delete-app-tooltip"
           isTooltipEnabled={areAppsInWaves}
-          content={t("message.cannotDeleteApplicationsAssignedToMigrationWave")}
+          content={
+            "Cannot delete application(s) assigned to migration wave(s)."
+          }
         >
           <DropdownItem
             key="applications-bulk-delete"
@@ -979,20 +982,11 @@ export const ApplicationsTable: React.FC = () => {
                             ...(applicationWriteAccess
                               ? [
                                   {
-                                    isAriaDisabled:
-                                      application.migrationWave !== null,
-                                    tooltipProps: {
-                                      content:
-                                        application.migrationWave !== null
-                                          ? t(
-                                              "message.cannotDeleteApplicationsAssignedToMigrationWave"
-                                            )
-                                          : "",
-                                    },
-
                                     title: t("actions.delete"),
                                     onClick: () =>
                                       setApplicationsToDelete([application]),
+                                    isDisabled:
+                                      application.migrationWave !== null,
                                   },
                                 ]
                               : []),


### PR DESCRIPTION
…le (#1705)"

This reverts commit 6040a5d8c6f85b2cf99e284304fe52e358fc6597.

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
