### PR TITLE
:seedling: Increase ulimit nofiles on image-build.yaml

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -21,6 +21,7 @@ jobs:
       image_name: "tackle2-ui"
       containerfile: "./Dockerfile"
       architectures: '[ "amd64", "arm64", "ppc64le", "s390x" ]'
+      extra-args: "--ulimit nofile=4906:4096"
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -21,7 +21,7 @@ jobs:
       image_name: "tackle2-ui"
       containerfile: "./Dockerfile"
       architectures: '[ "amd64", "arm64", "ppc64le", "s390x" ]'
-      extra-args: "--ulimit nofile=4906:4096"
+      extra-args: "--ulimit nofile=4096:4096"
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}


### PR DESCRIPTION
Builds keep failing with EMFILE errors, so follow the advice from a similar issue work around: https://github.com/npm/cli/issues/4783#issuecomment-1908016260

