### PR TITLE
:seedling: Refactor FilterSelectOptionProps

### DIFF
--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -22,8 +22,12 @@ export enum FilterType {
 
 export type FilterValue = string[] | undefined | null;
 
-export interface FilterSelectOptionProps extends SelectOptionProps {
-  key: string;
+export interface FilterSelectOptionProps {
+  optionProps?: SelectOptionProps;
+  value: string;
+  label?: string;
+  chipLabel?: string;
+  groupLabel?: string;
 }
 
 export interface IBasicFilterCategory<

--- a/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
@@ -33,20 +33,26 @@ export const SelectFilterControl = <TItem, TFilterCategoryKey extends string>({
 >): JSX.Element | null => {
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = React.useState(false);
 
-  const getOptionKeyFromOptionValue = (optionValue: string) =>
-    category.selectOptions.find(({ value }) => value === optionValue)?.key;
+  const getOptionFromOptionValue = (optionValue: string) =>
+    category.selectOptions.find(({ value }) => value === optionValue);
 
-  const getOptionValueFromOptionKey = (optionKey: string) =>
-    category.selectOptions.find(({ key }) => key === optionKey)?.value;
-
-  const chips = filterValue?.map((key) => {
-    const displayValue = getOptionValueFromOptionKey(key);
-    return displayValue ? displayValue : key;
-  });
+  const chips = filterValue
+    ?.map((value) => {
+      const option = getOptionFromOptionValue(value);
+      if (!option) {
+        return null;
+      }
+      const { chipLabel, label } = option;
+      return {
+        key: value,
+        node: chipLabel ?? label ?? value,
+      };
+    })
+    .filter(Boolean);
 
   const onFilterSelect = (value: string) => {
-    const optionKey = getOptionKeyFromOptionValue(value);
-    setFilterValue(optionKey ? [optionKey] : null);
+    const option = getOptionFromOptionValue(value);
+    setFilterValue(option ? [value] : null);
     setIsFilterDropdownOpen(false);
   };
 
@@ -59,7 +65,7 @@ export const SelectFilterControl = <TItem, TFilterCategoryKey extends string>({
     let displayText = "Any";
     if (filterValue && filterValue.length > 0) {
       const selectedKey = filterValue[0];
-      const selectedDisplayValue = getOptionValueFromOptionKey(selectedKey);
+      const selectedDisplayValue = getOptionFromOptionValue(selectedKey)?.label;
       displayText = selectedDisplayValue ? selectedDisplayValue : selectedKey;
     }
 
@@ -103,15 +109,16 @@ export const SelectFilterControl = <TItem, TFilterCategoryKey extends string>({
         shouldFocusToggleOnSelect
       >
         <SelectList>
-          {category.selectOptions.map((o, index) => {
-            const isSelected = filterValue?.includes(o.key);
+          {category.selectOptions.map(({ label, value, optionProps }) => {
+            const isSelected = filterValue?.includes(value);
             return (
               <SelectOption
-                {...o}
-                key={`${index}-${o.value}`}
+                {...optionProps}
+                key={value}
+                value={value}
                 isSelected={isSelected}
               >
-                {o.value}
+                {label ?? value}
               </SelectOption>
             );
           })}

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -395,9 +395,9 @@ export const ApplicationsTable: React.FC = () => {
           }) + "...",
         type: FilterType.multiselect,
         selectOptions: [
-          { key: "source", value: "Source" },
-          { key: "maven", value: "Maven" },
-          { key: "proxy", value: "Proxy" },
+          { value: "source", label: "Source" },
+          { value: "maven", label: "Maven" },
+          { value: "proxy", label: "Proxy" },
         ],
         getItemValue: (item) => {
           const searchStringArr: string[] = [];
@@ -420,8 +420,8 @@ export const ApplicationsTable: React.FC = () => {
           }) + "...",
         type: FilterType.select,
         selectOptions: [
-          { key: "git", value: "Git" },
-          { key: "subversion", value: "Subversion" },
+          { value: "git", label: "Git" },
+          { value: "subversion", label: "Subversion" },
         ],
         getItemValue: (item) => item?.repository?.kind || "",
       },
@@ -434,8 +434,8 @@ export const ApplicationsTable: React.FC = () => {
           }) + "...",
         type: FilterType.select,
         selectOptions: [
-          { key: "binary", value: t("terms.artifactAssociated") },
-          { key: "none", value: t("terms.artifactNotAssociated") },
+          { value: "binary", label: t("terms.artifactAssociated") },
+          { value: "none", label: t("terms.artifactNotAssociated") },
         ],
         getItemValue: (item) => {
           const hasBinary =
@@ -454,7 +454,12 @@ export const ApplicationsTable: React.FC = () => {
           t("actions.filterBy", {
             what: t("terms.tagName").toLowerCase(),
           }) + "...",
-        selectOptions: tagItems.map(({ name }) => ({ key: name, value: name })),
+        selectOptions: tagItems.map(({ name, tagName, categoryName }) => ({
+          value: name,
+          label: name,
+          chipLabel: tagName,
+          groupLabel: categoryName,
+        })),
         /**
          * Create a single string from an Application's Tags that can be used to
          * match against the `selectOptions`'s values (here on the client side)
@@ -480,10 +485,10 @@ export const ApplicationsTable: React.FC = () => {
             what: t("terms.risk").toLowerCase(),
           }) + "...",
         selectOptions: [
-          { key: "green", value: "Low" },
-          { key: "yellow", value: "Medium" },
-          { key: "red", value: "High" },
-          { key: "unknown", value: "Unknown" },
+          { value: "green", label: "Low" },
+          { value: "yellow", label: "Medium" },
+          { value: "red", label: "High" },
+          { value: "unknown", label: "Unknown" },
         ],
         getItemValue: (item) => item.risk || "",
       },

--- a/client/src/app/pages/dependencies/dependency-apps-table.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-table.tsx
@@ -97,7 +97,12 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
           t("actions.filterBy", {
             what: t("terms.tagName").toLowerCase(),
           }) + "...",
-        selectOptions: tagItems.map(({ name }) => ({ key: name, value: name })),
+        selectOptions: tagItems.map(({ name, tagName, categoryName }) => ({
+          value: name,
+          label: name,
+          chipLabel: tagName,
+          groupLabel: categoryName,
+        })),
         /**
          * Convert the selected `selectOptions` to an array of tag ids the server side
          * filtering will understand.

--- a/client/src/app/pages/identities/identities.tsx
+++ b/client/src/app/pages/identities/identities.tsx
@@ -126,7 +126,10 @@ export const Identities: React.FC = () => {
       title: "Type",
       type: FilterType.select,
       placeholderText: "Filter by type...",
-      selectOptions: typeOptions,
+      selectOptions: typeOptions.map(({ key, value }) => ({
+        value: key,
+        label: value,
+      })),
       getItemValue: (item) => {
         return item.kind || "";
       },

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -122,7 +122,12 @@ export const useSharedAffectedApplicationFilterCategories = <
         t("actions.filterBy", {
           what: t("terms.tagName").toLowerCase(),
         }) + "...",
-      selectOptions: tagItems.map(({ name }) => ({ key: name, value: name })),
+      selectOptions: tagItems.map(({ name, tagName, categoryName }) => ({
+        value: name,
+        label: name,
+        chipLabel: tagName,
+        groupLabel: categoryName,
+      })),
       /**
        * Convert the selected `selectOptions` to an array of tag ids the server side
        * filtering will understand.

--- a/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
+++ b/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
@@ -247,10 +247,10 @@ export const IdentifiedRisksTable: React.FC<IIdentifiedRisksTableProps> = ({
           return riskValue.toString();
         },
         selectOptions: [
-          { key: "3", value: "High" },
-          { key: "2", value: "Medium" },
-          { key: "1", value: "Low" },
-          { key: "0", value: "Unknown" },
+          { value: "3", label: "High" },
+          { value: "2", label: "Medium" },
+          { value: "1", label: "Low" },
+          { value: "0", label: "Unknown" },
         ],
       },
     ],

--- a/client/src/app/pages/review/components/application-assessment-summary-table/application-assessment-summary-table.tsx
+++ b/client/src/app/pages/review/components/application-assessment-summary-table/application-assessment-summary-table.tsx
@@ -90,7 +90,10 @@ export const ApplicationAssessmentSummaryTable: React.FC<
       getItemValue: (item) => {
         return item.riskValue || "";
       },
-      selectOptions: typeOptions,
+      selectOptions: typeOptions.map(({ key, value }) => ({
+        value: key,
+        label: value,
+      })),
     },
   ];
 


### PR DESCRIPTION
Key points:
1. do not extend PF SelectOptionProps interface - this allows to add
   custom props to the interface and provides better control what prop
   are forwarded to SelectOption
2. remove key prop as it's a special prop used internally by React
3. use value prop according to PF documentation - effectively replace
   previously used key prop
4. add label prop - to be used as human friendly representation of the
   value
5. add groupLabel prop
6. add chipLabel prop - for cases where it differs from the label prop
   (main use case are tag items)
