### PR TITLE
:ghost: Refactor tags table to remove deprecated legacy table dep

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -177,6 +177,7 @@
     "blockedDeleteTarget": "Cannot delete {{what}} because it is associated with a target.",
     "defaultBlockedDelete": "Cannot delete {{what}} because it is associated with another object.",
     "cannotDeleteApplicationsAssignedToMigrationWave": "Cannot delete applications that are assigned to a migration wave.",
+    "cannotDeleteNonEmptyTagCategory": "Cannot delete a tag category that contains tags.",
     "continueConfirmation": "Yes, continue",
     "copyAssessmentAndReviewBody": "Some of the selected target applications have an in-progress or complete assessment/review. By continuing, the existing assessment(s)/review(s) will be replaced by the copied assessment/review. Do you wish to continue?",
     "copyAssessmentAndReviewQuestion": "Copy assessment and review?",
@@ -218,7 +219,9 @@
     "toTagApplication": "Either no tags exist yet or you may not have permission to view any. If you have permission, try creating a new custom tag.",
     "unsavedChanges": "Are you sure you want to close the assessment? Any unsaved changes will be lost.",
     "noAnswers": "Are you sure you want to close the assessment? There are no answers to save.",
-    "unlinkTicket": "Unlink from Jira"
+    "unlinkTicket": "Unlink from Jira",
+    "noTagsAvailable": "No tags available",
+    "noAssociatedTags": "This tag category has no associated tags."
   },
   "proposedActions": {
     "refactor": "Refactor",

--- a/client/src/app/components/labels/item-tag-label/item-tag-label.tsx
+++ b/client/src/app/components/labels/item-tag-label/item-tag-label.tsx
@@ -3,7 +3,7 @@ import { Tag, TagCategory } from "@app/api/models";
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
 import { LabelCustomColor } from "@app/components/LabelCustomColor";
 
-export const getTagCategoryFallbackColor = (category?: TagCategory) => {
+export const getTagCategoryFallbackColor = (category?: TagCategory | null) => {
   if (!category?.id) return COLOR_HEX_VALUES_BY_NAME.gray;
   const colorValues = Object.values(COLOR_HEX_VALUES_BY_NAME);
   return colorValues[category?.id % colorValues.length];

--- a/client/src/app/pages/controls/tags/components/tag-table.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-table.tsx
@@ -8,20 +8,9 @@ import {
   Tbody,
   Td,
   ActionsColumn,
-  IAction,
-  cellWidth,
-  ICell,
-  IRow,
-  IRowData,
 } from "@patternfly/react-table";
 import { Tag, TagCategory } from "@app/api/models";
 import "./tag-table.css";
-
-const ENTITY_FIELD = "entity";
-
-const getRow = (rowData: IRowData): Tag => {
-  return rowData[ENTITY_FIELD];
-};
 
 export interface TabTableProps {
   tagCategory: TagCategory;
@@ -30,79 +19,42 @@ export interface TabTableProps {
 }
 
 export const TagTable: React.FC<TabTableProps> = ({
-  tagCategory: tagCategory,
+  tagCategory,
   onEdit,
   onDelete,
 }) => {
   const { t } = useTranslation();
-
-  const columns: ICell[] = [
-    {
-      title: t("terms.tagName"),
-      transforms: [cellWidth(100)],
-      cellFormatters: [],
-      props: {
-        className: "columnPadding",
-      },
-    },
-  ];
-
-  const rows: IRow[] = [];
-  (tagCategory.tags || [])
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .forEach((item) => {
-      rows.push({
-        [ENTITY_FIELD]: item,
-        noPadding: true,
-        cells: [
-          {
-            title: item.name,
-          },
-        ],
-      });
-    });
-
-  const editRow = (row: Tag) => {
-    onEdit(row);
-  };
-
-  const deleteRow = (row: Tag) => {
-    onDelete(row);
-  };
-
-  const defaultActions = (tag: IRowData): IAction[] => [
-    {
-      title: t("actions.edit"),
-      onClick: () => editRow(getRow(tag)),
-    },
-    {
-      title: t("actions.delete"),
-      onClick: () => deleteRow(getRow(tag)),
-    },
-  ];
 
   return (
     <Table borders={false} aria-label="Tag table" variant="compact" isNested>
       <Thead noWrap>
         <Tr>
           <Th>{t("terms.tagName")}</Th>
-          <Td></Td>
+          <Td />
         </Tr>
       </Thead>
       <Tbody>
-        {rows.map((row: IRow) => {
-          const rowActions = defaultActions(row);
-          return (
-            <Tr>
-              {row.cells?.map((cell: any) => (
-                <Td>{cell.title}</Td>
-              ))}
+        {(tagCategory.tags || [])
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((tag) => (
+            <Tr key={tag.name}>
+              <Td>{tag.name}</Td>
               <Td isActionCell>
-                {rowActions && <ActionsColumn items={rowActions} />}
+                <ActionsColumn
+                  items={[
+                    {
+                      title: t("actions.edit"),
+                      onClick: () => onEdit(tag),
+                    },
+                    {
+                      title: t("actions.delete"),
+                      onClick: () => onDelete(tag),
+                    },
+                  ]}
+                />
               </Td>
             </Tr>
-          );
-        })}
+          ))}
       </Tbody>
     </Table>
   );

--- a/client/src/app/pages/controls/tags/tags.tsx
+++ b/client/src/app/pages/controls/tags/tags.tsx
@@ -1,36 +1,38 @@
 import React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
-import { useSelectionState } from "@migtools/lib-ui";
 import {
   Button,
   ButtonVariant,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
   Modal,
   ModalVariant,
+  Title,
+  Toolbar,
+  ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
 import {
-  expandable,
-  ICell,
-  IExtraData,
-  IRow,
-  IRowData,
-  sortable,
+  ExpandableRowContent,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
 } from "@patternfly/react-table";
+import { CubesIcon } from "@patternfly/react-icons";
 
-import { dedupeFunction, getAxiosErrorMessage } from "@app/utils/utils";
-import { Tag, TagCategory } from "@app/api/models";
-import { TagTable } from "./components/tag-table";
-import { useLegacyPaginationState } from "@app/hooks/useLegacyPaginationState";
 import {
-  FilterCategory,
-  FilterToolbar,
-  FilterType,
-} from "@app/components/FilterToolbar";
-import { useLegacyFilterState } from "@app/hooks/useLegacyFilterState";
-import { useLegacySortState } from "@app/hooks/useLegacySortState";
-import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
+  dedupeFunction,
+  getAxiosErrorMessage,
+  localeNumericCompare,
+} from "@app/utils/utils";
+import { Tag, TagCategory } from "@app/api/models";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import {
   useDeleteTagMutation,
   useDeleteTagCategoryMutation,
@@ -45,15 +47,17 @@ import { AppTableActionButtons } from "@app/components/AppTableActionButtons";
 import { Color } from "@app/components/Color";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { AppTableWithControls } from "@app/components/AppTableWithControls";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
-
-const ENTITY_FIELD = "entity";
-
-const getRow = (rowData: IRowData): TagCategory => {
-  return rowData[ENTITY_FIELD];
-};
+import { SimplePagination } from "@app/components/SimplePagination";
+import {
+  TableHeaderContentWithControls,
+  ConditionalTableBody,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+import { RBAC, controlsWriteScopes, RBAC_TYPE } from "@app/rbac";
+import { TagTable } from "./components/tag-table";
+import i18n from "@app/i18n";
 
 export const Tags: React.FC = () => {
   const { t } = useTranslation();
@@ -69,10 +73,6 @@ export const Tags: React.FC = () => {
   const isTagCategoryModalOpen = tagCategoryModalState !== null;
   const tagCategoryToUpdate =
     tagCategoryModalState !== "create" ? tagCategoryModalState : null;
-
-  // const [isNewTagCategoryModalOpen, setIsNewTagCategoryModalOpen] =
-  //   useState(false);
-  // const [rowToUpdate, setRowToUpdate] = useState<TagCategory>();
 
   const [tagModalState, setTagModalState] = React.useState<
     "create" | Tag | null
@@ -157,210 +157,110 @@ export const Tags: React.FC = () => {
     refetch,
   } = useFetchTagCategories();
 
-  const {
-    isItemSelected: isItemExpanded,
-    toggleItemSelected: toggleItemExpanded,
-  } = useSelectionState<TagCategory>({
-    items: tagCategories || [],
-    isEqual: (a, b) => a.id === b.id,
-  });
+  const deleteTagFromTable = (tag: Tag) => {
+    setTagToDelete(tag);
+  };
 
-  const filterCategories: FilterCategory<
-    TagCategory,
-    "tags" | "rank" | "color"
-  >[] = [
-    {
-      key: "tags",
-      title: t("terms.name"),
-      type: FilterType.multiselect,
-      placeholderText:
-        t("actions.filterBy", {
+  const tableControls = useLocalTableControls({
+    idProperty: "name",
+    items: tagCategories,
+    columnNames: {
+      name: t("terms.name"),
+      rank: t("terms.rank"),
+      color: t("terms.color"),
+      tagCount: t("terms.tagCount"),
+    },
+    isFilterEnabled: true,
+    isSortEnabled: true,
+    isPaginationEnabled: true,
+    hasActionsColumn: true,
+    isExpansionEnabled: true,
+    expandableVariant: "single",
+    filterCategories: [
+      {
+        key: "tags",
+        title: t("terms.name"),
+        type: FilterType.multiselect,
+        placeholderText: t("actions.filterBy", {
           what: t("terms.name").toLowerCase(),
-        }) + "...",
-      getItemValue: (item) => {
-        const tagCategoryNames = item.name?.toString() || "";
-        const tagNames = item?.tags
-          ?.map((tag) => tag.name)
-          .concat(tagCategoryNames)
-          .join("");
-
-        return tagNames || "";
+        }),
+        getItemValue: (item) => {
+          const tagCategoryNames = item.name?.toString() || "";
+          const tagNames = item?.tags
+            ?.map((tag) => tag.name)
+            .concat(tagCategoryNames)
+            .join("");
+          return tagNames || "";
+        },
+        selectOptions: dedupeFunction(
+          tagCategories
+            ?.flatMap((tagCategory) => tagCategory?.tags ?? [])
+            .filter((tag) => tag && tag.name)
+            .map((tag) => ({ key: tag.name, value: tag.name }))
+            .concat(
+              tagCategories?.map((tagCategory) => ({
+                key: tagCategory?.name,
+                value: tagCategory?.name,
+              })) ?? []
+            )
+            .sort((a, b) =>
+              localeNumericCompare(a.value, b.value, i18n.language)
+            )
+        ),
       },
-      selectOptions: dedupeFunction(
-        tagCategories
-          ?.map((tagCategory) => tagCategory?.tags)
-          .flat()
-          .filter((tag) => tag && tag.name)
-          .map((tag) => ({ key: tag?.name, value: tag?.name }))
-          .concat(
-            tagCategories?.map((tagCategory) => ({
-              key: tagCategory?.name,
-              value: tagCategory?.name,
-            }))
-          )
-          .sort((a, b) => {
-            if (a.value && b.value) {
-              return a?.value.localeCompare(b?.value);
-            } else {
-              return 0;
-            }
-          })
-      ),
-    },
-    {
-      key: "rank",
-      title: t("terms.rank"),
-      type: FilterType.search,
-      placeholderText:
-        t("actions.filterBy", {
-          what: t("terms.rank").toLowerCase(),
-        }) + "...",
-      getItemValue: (item) => {
-        return item.rank?.toString() || "";
+      {
+        key: "rank",
+        title: t("terms.rank"),
+        type: FilterType.search,
+        placeholderText:
+          t("actions.filterBy", {
+            what: t("terms.rank").toLowerCase(),
+          }) + "...",
+        getItemValue: (item) => {
+          return item.rank?.toString() || "";
+        },
       },
-    },
-    {
-      key: "color",
-      title: t("terms.color"),
-      type: FilterType.search,
-      placeholderText:
-        t("actions.filterBy", {
-          what: t("terms.color").toLowerCase(),
-        }) + "...",
-      getItemValue: (item) => {
-        const hex = item?.colour || "";
-        const colorLabel = COLOR_NAMES_BY_HEX_VALUE[hex.toLowerCase()];
-        return colorLabel || hex;
+      {
+        key: "color",
+        title: t("terms.color"),
+        type: FilterType.search,
+        placeholderText:
+          t("actions.filterBy", {
+            what: t("terms.color").toLowerCase(),
+          }) + "...",
+        getItemValue: (item) => {
+          const hex = item?.colour || "";
+          const colorLabel = COLOR_NAMES_BY_HEX_VALUE[hex.toLowerCase()];
+          return colorLabel || hex;
+        },
       },
-    },
-  ];
-  const { filterValues, setFilterValues, filteredItems } = useLegacyFilterState(
-    tagCategories || [],
-    filterCategories
-  );
-
-  const getSortValues = (item: TagCategory) => [
-    "",
-    item?.name || "",
-    typeof item?.rank === "number" ? item.rank : Number.MAX_VALUE,
-
-    "",
-    item?.tags?.length || 0,
-    "", // Action column
-  ];
-
-  const { sortBy, onSort, sortedItems } = useLegacySortState(
-    filteredItems,
-    getSortValues
-  );
-
-  const { currentPageItems, setPageNumber, paginationProps } =
-    useLegacyPaginationState(sortedItems, 10);
-
-  const deleteTagFromTable = (row: Tag) => {
-    setTagToDelete(row);
-  };
-
-  const columns: ICell[] = [
-    {
-      title: t("terms.tagCategory"),
-      transforms: [sortable],
-      cellFormatters: [expandable],
-    },
-    { title: t("terms.rank"), transforms: [sortable] },
-    {
-      title: t("terms.color"),
-      transforms: [],
-    },
-    {
-      title: t("terms.tagCount"),
-      transforms: [sortable],
-    },
-    {
-      title: "",
-      props: {
-        className: "pf-v5-u-text-align-right",
-      },
-    },
-  ];
-
-  const rows: IRow[] = [];
-  currentPageItems.forEach((item) => {
-    const isExpanded = isItemExpanded(item) && !!item?.tags?.length;
-    const categoryColor = item.colour || getTagCategoryFallbackColor(item);
-    rows.push({
-      [ENTITY_FIELD]: item,
-      isOpen: (item.tags || []).length > 0 ? isExpanded : undefined,
-      cells: [
-        {
-          title: item.name,
-        },
-        {
-          title: item.rank,
-        },
-        {
-          title: <Color hex={categoryColor} />,
-        },
-        {
-          title: item.tags ? item.tags.length : 0,
-        },
-        {
-          title: (
-            <AppTableActionButtons
-              isDeleteEnabled={!!item.tags?.length}
-              tooltipMessage="Cannot delete non empty tag category"
-              onEdit={() => setTagCategoryModalState(item)}
-              onDelete={() => deleteRow(item)}
-            />
-          ),
-        },
-      ],
-    });
-
-    if (isExpanded) {
-      rows.push({
-        parent: rows.length - 1,
-        fullWidth: true,
-        noPadding: true,
-        cells: [
-          {
-            title: (
-              <div>
-                <TagTable
-                  tagCategory={item}
-                  onEdit={setTagModalState}
-                  onDelete={deleteTagFromTable}
-                />
-              </div>
-            ),
-          },
-        ],
-      });
-    }
+    ],
+    initialItemsPerPage: 10,
+    sortableColumns: ["name", "rank", "tagCount"],
+    initialSort: { columnKey: "name", direction: "asc" },
+    getSortValues: (item) => ({
+      name: item?.name || "",
+      rank: typeof item?.rank === "number" ? item.rank : Number.MAX_VALUE,
+      tagCount: item?.tags?.length || 0,
+    }),
+    isLoading: isFetching,
   });
 
-  // Rows
-
-  const collapseRow = (
-    event: React.MouseEvent,
-    rowIndex: number,
-    isOpen: boolean,
-    rowData: IRowData,
-    extraData: IExtraData
-  ) => {
-    const row = getRow(rowData);
-    toggleItemExpanded(row);
-  };
-
-  const deleteRow = (row: TagCategory) => {
-    setTagCategoryToDelete(row);
-  };
-
-  // Advanced filters
-
-  const handleOnClearAllFilters = () => {
-    setFilterValues({});
-  };
+  const {
+    currentPageItems,
+    numRenderedColumns,
+    propHelpers: {
+      toolbarProps,
+      filterToolbarProps,
+      paginationToolbarItemProps,
+      paginationProps,
+      tableProps,
+      getThProps,
+      getTrProps,
+      getTdProps,
+    },
+    expansionDerivedState: { isCellExpanded },
+  } = tableControls;
 
   return (
     <>
@@ -368,70 +268,165 @@ export const Tags: React.FC = () => {
         when={isFetching && !(tagCategories || fetchError)}
         then={<AppPlaceholder />}
       >
-        <AppTableWithControls
-          paginationProps={paginationProps}
-          paginationIdPrefix="tags"
-          count={tagCategories ? tagCategories.length : 0}
-          sortBy={sortBy}
-          onSort={onSort}
-          onCollapse={collapseRow}
-          cells={columns}
-          rows={rows}
-          isLoading={isFetching}
-          loadingVariant="skeleton"
-          fetchError={fetchError}
-          toolbarClearAllFilters={handleOnClearAllFilters}
-          toolbarToggle={
-            <FilterToolbar
-              filterCategories={filterCategories}
-              filterValues={filterValues}
-              setFilterValues={setFilterValues}
-            />
-          }
-          toolbarActions={
-            <ToolbarGroup variant="button-group">
-              <RBAC
-                allowedPermissions={controlsWriteScopes}
-                rbacType={RBAC_TYPE.Scope}
-              >
-                <ToolbarItem>
-                  <Button
-                    type="button"
-                    id="create-tag"
-                    aria-label="Create tag"
-                    variant={ButtonVariant.primary}
-                    onClick={() => setTagModalState("create")}
+        <div
+          style={{
+            backgroundColor: "var(--pf-v5-global--BackgroundColor--100)",
+          }}
+        >
+          <Toolbar {...toolbarProps}>
+            <ToolbarContent>
+              <FilterToolbar {...filterToolbarProps} />
+              <ToolbarGroup variant="button-group">
+                <RBAC
+                  allowedPermissions={controlsWriteScopes}
+                  rbacType={RBAC_TYPE.Scope}
+                >
+                  <ToolbarItem>
+                    <Button
+                      type="button"
+                      id="create-tag"
+                      aria-label="Create tag"
+                      variant={ButtonVariant.primary}
+                      onClick={() => setTagModalState("create")}
+                    >
+                      {t("actions.createTag")}
+                    </Button>
+                  </ToolbarItem>
+                  <ToolbarItem>
+                    <Button
+                      type="button"
+                      id="create-tag-category"
+                      aria-label="Create tag category"
+                      variant={ButtonVariant.secondary}
+                      onClick={() => setTagCategoryModalState("create")}
+                    >
+                      {t("actions.createTagCategory")}
+                    </Button>
+                  </ToolbarItem>
+                </RBAC>
+              </ToolbarGroup>
+              <ToolbarItem {...paginationToolbarItemProps}>
+                <SimplePagination
+                  idPrefix="tag-category-table"
+                  isTop
+                  paginationProps={paginationProps}
+                />
+              </ToolbarItem>
+            </ToolbarContent>
+          </Toolbar>
+          <Table {...tableProps} aria-label="Tag category table">
+            <Thead>
+              <Tr>
+                <TableHeaderContentWithControls {...tableControls}>
+                  <Th {...getThProps({ columnKey: "name" })} />
+                  <Th {...getThProps({ columnKey: "rank" })} />
+                  <Th {...getThProps({ columnKey: "color" })} />
+                  <Th {...getThProps({ columnKey: "tagCount" })} />
+                </TableHeaderContentWithControls>
+              </Tr>
+            </Thead>
+            <ConditionalTableBody
+              isLoading={isFetching}
+              isError={!!fetchError}
+              isNoData={currentPageItems.length === 0}
+              noDataEmptyState={
+                <EmptyState variant="sm">
+                  <EmptyStateIcon icon={CubesIcon} />
+                  <Title headingLevel="h2" size="lg">
+                    {t("composed.noDataStateTitle", {
+                      what: t("terms.tags").toLowerCase(),
+                    })}
+                  </Title>
+                  <EmptyStateBody>
+                    {t("composed.noDataStateBody", {
+                      how: t("terms.create"),
+                      what: t("terms.tags").toLowerCase(),
+                    })}
+                  </EmptyStateBody>
+                </EmptyState>
+              }
+              numRenderedColumns={numRenderedColumns}
+            >
+              {currentPageItems?.map((tagCategory, rowIndex) => {
+                const hasTags = tagCategory.tags && tagCategory.tags.length > 0;
+                const categoryColor =
+                  tagCategory.colour ||
+                  getTagCategoryFallbackColor(tagCategory);
+
+                return (
+                  <Tbody
+                    key={tagCategory.id}
+                    isExpanded={isCellExpanded(tagCategory)}
                   >
-                    {t("actions.createTag")}
-                  </Button>
-                </ToolbarItem>
-                <ToolbarItem>
-                  <Button
-                    type="button"
-                    id="create-tag-category"
-                    aria-label="Create tag category"
-                    variant={ButtonVariant.secondary}
-                    onClick={() => setTagCategoryModalState("create")}
-                  >
-                    {t("actions.createTagCategory")}
-                  </Button>
-                </ToolbarItem>
-              </RBAC>
-            </ToolbarGroup>
-          }
-          noDataState={
-            <NoDataEmptyState
-              // t('terms.tagCategories')
-              title={t("composed.noDataStateTitle", {
-                what: t("terms.tagCategories").toLowerCase(),
+                    <Tr {...getTrProps({ item: tagCategory })}>
+                      <TableRowContentWithControls
+                        {...tableControls}
+                        item={tagCategory}
+                        rowIndex={rowIndex}
+                      >
+                        <Td width={25} {...getTdProps({ columnKey: "name" })}>
+                          {tagCategory.name}
+                        </Td>
+                        <Td width={10} {...getTdProps({ columnKey: "rank" })}>
+                          {tagCategory.rank}
+                        </Td>
+                        <Td width={10} {...getTdProps({ columnKey: "color" })}>
+                          <Color hex={categoryColor} />
+                        </Td>
+                        <Td
+                          width={10}
+                          {...getTdProps({ columnKey: "tagCount" })}
+                        >
+                          {tagCategory.tags?.length || 0}
+                        </Td>
+                        <Td width={20}>
+                          <AppTableActionButtons
+                            isDeleteEnabled={!!tagCategory.tags?.length}
+                            tooltipMessage={t(
+                              "message.cannotDeleteNonEmptyTagCategory"
+                            )}
+                            onEdit={() => setTagCategoryModalState(tagCategory)}
+                            onDelete={() => setTagCategoryToDelete(tagCategory)}
+                          />
+                        </Td>
+                      </TableRowContentWithControls>
+                    </Tr>
+                    {isCellExpanded(tagCategory) && (
+                      <Tr>
+                        <Td colSpan={numRenderedColumns}>
+                          <ExpandableRowContent>
+                            {hasTags ? (
+                              <TagTable
+                                tagCategory={tagCategory}
+                                onEdit={setTagModalState}
+                                onDelete={deleteTagFromTable}
+                              />
+                            ) : (
+                              <EmptyState variant="sm">
+                                <EmptyStateIcon icon={CubesIcon} />
+                                <Title headingLevel="h4" size="lg">
+                                  {t("message.noTagsAvailable")}
+                                </Title>
+                                <EmptyStateBody>
+                                  {t("message.noAssociatedTags")}
+                                </EmptyStateBody>
+                              </EmptyState>
+                            )}
+                          </ExpandableRowContent>
+                        </Td>
+                      </Tr>
+                    )}
+                  </Tbody>
+                );
               })}
-              // t('terms.stakeholderGroup')
-              description={t("composed.noDataStateBody", {
-                what: t("terms.tagCategory").toLowerCase(),
-              })}
-            />
-          }
-        />
+            </ConditionalTableBody>
+          </Table>
+          <SimplePagination
+            idPrefix="tag-category-table"
+            isTop={false}
+            paginationProps={paginationProps}
+          />
+        </div>
       </ConditionalRender>
 
       <Modal


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTA-2224

---------

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
