### PR TITLE
:bug: [backport release-0.2] Upgrade version of webpack-dev-middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25856,7 +25856,7 @@
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^5.3.1",
+        "webpack-dev-middleware": "^5.3.4",
         "ws": "^8.4.2"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14479,9 +14479,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",
@@ -25811,9 +25811,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "requires": {
         "colorette": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "rimraf": "^4.4.1"
   },
   "overrides": {
-    "follow-redirects": "^1.15.6"
+    "follow-redirects": "^1.15.6",
+    "webpack-dev-middleware": "^5.3.4"
   }
 }


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-2489
Resolves: https://issues.redhat.com/browse/MTA-2649

Bump to `webpack-dev-middleware@5.3.4` on __release-0.2__ to keep developers safe.
