### PR TITLE
:bug: Upgrade version of follow-redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7627,9 +7627,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "ts-node": "^10.9.1",
     "type-fest": "^3.13.0",
     "typescript": "^5.1.6"
+  },
+  "overrides": {
+    "follow-redirects": "^1.15.6"
   }
 }


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-1952
Resolves: https://issues.redhat.com/browse/MTA-2456

Override `follow-redirects` and upgrade to `follow-redirects@^1.15.6`.
