### PR TITLE
:ghost: Update check for running analysis / cancel analysis 

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -154,9 +154,7 @@ export const ApplicationsTable: React.FC = () => {
 
   const isTaskCancellable = (application: Application) => {
     const task = getTask(application);
-    if (task?.state && task.state.match(/(Created|Running|Ready|Pending)/))
-      return true;
-    return false;
+    return task?.state && !["Succeeded", "Failed"].includes(task.state);
   };
 
   const cancelAnalysis = (row: Application) => {
@@ -610,18 +608,23 @@ export const ApplicationsTable: React.FC = () => {
 
   const dropdownItems = [...importDropdownItems, ...applicationDropdownItems];
 
-  const isAnalyzingAllowed = () => {
-    const candidateTasks = selectedRows.filter(
-      (app) =>
-        !tasks.some(
-          (task) =>
-            task.application?.id === app.id &&
-            task.state?.match(/(Created|Running|Ready|Pending)/)
-        )
-    );
+  const isAnalyzingDisabled = () => {
+    if (tasks.length === 0) {
+      return false;
+    }
 
-    if (candidateTasks.length === selectedRows.length) return true;
-    return false;
+    const allowedStates = ["Succeeded", "Failed", null, ""];
+
+    const candidateTasks = selectedRows.filter((app) => {
+      const hasAllowedState = tasks.some(
+        (task) =>
+          task.application?.id === app.id &&
+          allowedStates.includes(task.state || "")
+      );
+      return !hasAllowedState;
+    });
+
+    return candidateTasks.length > 0;
   };
 
   const hasExistingAnalysis = selectedRows.some((app) =>
@@ -783,7 +786,7 @@ export const ApplicationsTable: React.FC = () => {
                           setAnalyzeModalOpen(true);
                         }}
                         isDisabled={
-                          selectedRows.length < 1 || !isAnalyzingAllowed()
+                          selectedRows.length < 1 || isAnalyzingDisabled()
                         }
                       >
                         {t("actions.analyze")}


### PR DESCRIPTION
This PR narrows down the check for analysis tasks that are cancellable. Also the logic is updated and flipped for "disabling" the creation of a new analysis task. Analysis tasks should be creatable when there are no states for tasks outside of "succeeded" or "failed". This will future proof against any other additional task states that may be added in the future. The "scheduled" state was just added for 0.4 & is the motivation behind this PR ( as requested by @jortel )
