### PR TITLE
:seedling: Drop ppc and s390x image build architectures

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -20,7 +20,7 @@ jobs:
       registry: "quay.io/konveyor"
       image_name: "tackle2-ui"
       containerfile: "./Dockerfile"
-      architectures: '[ "amd64", "arm64", "ppc64le", "s390x" ]'
+      architectures: '[ "amd64", "arm64" ]'
       # 2023-03-19: currently needed for npm@10
       extra-args: "--ulimit nofile=4096:4096"
     secrets:


### PR DESCRIPTION
Drop the ppc and s390x image build architectures.  They are not needed.

Similar to https://github.com/konveyor/tackle2-addon-analyzer/pull/91
