### PR TITLE
:bug: Use separate chip groups for tag categories

### DIFF
--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -59,9 +59,7 @@ export interface IMultiselectFilterCategory<
   TFilterCategoryKey extends string,
 > extends IBasicFilterCategory<TItem, TFilterCategoryKey> {
   /** The full set of options to select from for this filter. */
-  selectOptions:
-    | FilterSelectOptionProps[]
-    | Record<string, FilterSelectOptionProps[]>;
+  selectOptions: FilterSelectOptionProps[];
   /** Option search input field placeholder text. */
   placeholderText?: string;
   /** How to connect multiple selected options together. Defaults to "AND". */

--- a/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {
   Badge,
   Button,
+  Label,
   MenuToggle,
   MenuToggleElement,
   Select,
@@ -54,7 +55,7 @@ export const MultiselectFilterControl = <TItem,>({
       .includes(inputValue?.trim().toLowerCase() ?? "")
   );
 
-  const groups = [
+  const [firstGroup, ...otherGroups] = [
     ...new Set([
       ...(category.selectOptions
         ?.map(({ groupLabel }) => groupLabel)
@@ -225,60 +226,72 @@ export const MultiselectFilterControl = <TItem,>({
 
   return (
     <>
-      {groups.reduce(
-        (acc, groupName) => (
+      {[
+        <ToolbarFilter
+          id={`${idPrefix}-${firstGroup}`}
+          chips={chipsFor(firstGroup)}
+          deleteChip={(_, chip) => onFilterClear(chip)}
+          deleteChipGroup={() => onFilterClearAll(firstGroup)}
+          categoryName={firstGroup}
+          key={firstGroup}
+          showToolbarItem={showToolbarItem}
+        >
+          <Select
+            isScrollable={isScrollable}
+            aria-label={category.title}
+            toggle={toggle}
+            selected={filterValue}
+            onOpenChange={(isOpen) => setIsFilterDropdownOpen(isOpen)}
+            onSelect={(_, selection) => onSelect(selection as string)}
+            isOpen={isFilterDropdownOpen}
+          >
+            <SelectList id={withPrefix("select-typeahead-listbox")}>
+              {[
+                ...filteredOptions.map(
+                  ({ groupLabel, label, value, optionProps = {} }, index) => (
+                    <SelectOption
+                      {...optionProps}
+                      {...(!optionProps.isDisabled && { hasCheckbox: true })}
+                      key={value}
+                      id={withPrefix(`option-${index}`)}
+                      value={value}
+                      isFocused={focusedItemIndex === index}
+                      isSelected={filterValue?.includes(value)}
+                    >
+                      {!!groupLabel && <Label>{groupLabel}</Label>}{" "}
+                      {label ?? value}
+                    </SelectOption>
+                  )
+                ),
+                !filteredOptions.length && (
+                  <SelectOption
+                    isDisabled
+                    hasCheckbox={false}
+                    key={NO_RESULTS}
+                    value={NO_RESULTS}
+                    isSelected={false}
+                  >
+                    {`No results found for "${inputValue}"`}
+                  </SelectOption>
+                ),
+              ].filter(Boolean)}
+            </SelectList>
+          </Select>
+        </ToolbarFilter>,
+        ...otherGroups.map((groupName) => (
           <ToolbarFilter
             id={`${idPrefix}-${groupName}`}
             chips={chipsFor(groupName)}
             deleteChip={(_, chip) => onFilterClear(chip)}
             deleteChipGroup={() => onFilterClearAll(groupName)}
             categoryName={groupName}
-            showToolbarItem={showToolbarItem}
+            key={groupName}
+            showToolbarItem={false}
           >
-            {acc}
+            {" "}
           </ToolbarFilter>
-        ),
-        <Select
-          isScrollable={isScrollable}
-          aria-label={category.title}
-          toggle={toggle}
-          selected={filterValue}
-          onOpenChange={(isOpen) => setIsFilterDropdownOpen(isOpen)}
-          onSelect={(_, selection) => onSelect(selection as string)}
-          isOpen={isFilterDropdownOpen}
-        >
-          <SelectList id={withPrefix("select-typeahead-listbox")}>
-            {[
-              ...filteredOptions.map(
-                ({ label, value, optionProps = {} }, index) => (
-                  <SelectOption
-                    {...optionProps}
-                    {...(!optionProps.isDisabled && { hasCheckbox: true })}
-                    key={value}
-                    id={withPrefix(`option-${index}`)}
-                    value={value}
-                    isFocused={focusedItemIndex === index}
-                    isSelected={filterValue?.includes(value)}
-                  >
-                    {label ?? value}
-                  </SelectOption>
-                )
-              ),
-              !filteredOptions.length && (
-                <SelectOption
-                  isDisabled
-                  hasCheckbox={false}
-                  key={NO_RESULTS}
-                  value={NO_RESULTS}
-                  isSelected={false}
-                >
-                  {`No results found for "${inputValue}"`}
-                </SelectOption>
-              ),
-            ].filter(Boolean)}
-          </SelectList>
-        </Select>
-      )}
+        )),
+      ]}
     </>
   );
 };

--- a/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -49,10 +49,12 @@ export const MultiselectFilterControl = <TItem,>({
   const withPrefix = (id: string) => `${idPrefix}-${id}`;
   const defaultGroup = category.title;
 
-  const filteredOptions = category.selectOptions?.filter(({ label, value }) =>
-    String(label ?? value ?? "")
-      .toLowerCase()
-      .includes(inputValue?.trim().toLowerCase() ?? "")
+  const filteredOptions = category.selectOptions?.filter(
+    ({ label, value, groupLabel }) =>
+      [label ?? value, groupLabel]
+        .filter(Boolean)
+        .map((it) => it.toLocaleLowerCase())
+        .some((it) => it.includes(inputValue?.trim().toLowerCase() ?? ""))
   );
 
   const [firstGroup, ...otherGroups] = [
@@ -64,7 +66,7 @@ export const MultiselectFilterControl = <TItem,>({
     ]),
   ];
 
-  const onFilterClearAll = (groupName: string) =>
+  const onFilterClearGroup = (groupName: string) =>
     setFilterValue(
       filterValue
         ?.map((filter): [string, FilterSelectOptionProps | undefined] => [
@@ -226,12 +228,12 @@ export const MultiselectFilterControl = <TItem,>({
 
   return (
     <>
-      {[
+      {
         <ToolbarFilter
           id={`${idPrefix}-${firstGroup}`}
           chips={chipsFor(firstGroup)}
           deleteChip={(_, chip) => onFilterClear(chip)}
-          deleteChipGroup={() => onFilterClearAll(firstGroup)}
+          deleteChipGroup={() => onFilterClearGroup(firstGroup)}
           categoryName={firstGroup}
           key={firstGroup}
           showToolbarItem={showToolbarItem}
@@ -246,52 +248,50 @@ export const MultiselectFilterControl = <TItem,>({
             isOpen={isFilterDropdownOpen}
           >
             <SelectList id={withPrefix("select-typeahead-listbox")}>
-              {[
-                ...filteredOptions.map(
-                  ({ groupLabel, label, value, optionProps = {} }, index) => (
-                    <SelectOption
-                      {...optionProps}
-                      {...(!optionProps.isDisabled && { hasCheckbox: true })}
-                      key={value}
-                      id={withPrefix(`option-${index}`)}
-                      value={value}
-                      isFocused={focusedItemIndex === index}
-                      isSelected={filterValue?.includes(value)}
-                    >
-                      {!!groupLabel && <Label>{groupLabel}</Label>}{" "}
-                      {label ?? value}
-                    </SelectOption>
-                  )
-                ),
-                !filteredOptions.length && (
+              {filteredOptions.map(
+                ({ groupLabel, label, value, optionProps = {} }, index) => (
                   <SelectOption
-                    isDisabled
-                    hasCheckbox={false}
-                    key={NO_RESULTS}
-                    value={NO_RESULTS}
-                    isSelected={false}
+                    {...optionProps}
+                    {...(!optionProps.isDisabled && { hasCheckbox: true })}
+                    key={value}
+                    id={withPrefix(`option-${index}`)}
+                    value={value}
+                    isFocused={focusedItemIndex === index}
+                    isSelected={filterValue?.includes(value)}
                   >
-                    {`No results found for "${inputValue}"`}
+                    {!!groupLabel && <Label>{groupLabel}</Label>}{" "}
+                    {label ?? value}
                   </SelectOption>
-                ),
-              ].filter(Boolean)}
+                )
+              )}
+              {filteredOptions.length === 0 && (
+                <SelectOption
+                  isDisabled
+                  hasCheckbox={false}
+                  key={NO_RESULTS}
+                  value={NO_RESULTS}
+                  isSelected={false}
+                >
+                  {`No results found for "${inputValue}"`}
+                </SelectOption>
+              )}
             </SelectList>
           </Select>
-        </ToolbarFilter>,
-        ...otherGroups.map((groupName) => (
-          <ToolbarFilter
-            id={`${idPrefix}-${groupName}`}
-            chips={chipsFor(groupName)}
-            deleteChip={(_, chip) => onFilterClear(chip)}
-            deleteChipGroup={() => onFilterClearAll(groupName)}
-            categoryName={groupName}
-            key={groupName}
-            showToolbarItem={false}
-          >
-            {" "}
-          </ToolbarFilter>
-        )),
-      ]}
+        </ToolbarFilter>
+      }
+      {otherGroups.map((groupName) => (
+        <ToolbarFilter
+          id={`${idPrefix}-${groupName}`}
+          chips={chipsFor(groupName)}
+          deleteChip={(_, chip) => onFilterClear(chip)}
+          deleteChipGroup={() => onFilterClearGroup(groupName)}
+          categoryName={groupName}
+          key={groupName}
+          showToolbarItem={false}
+        >
+          {" "}
+        </ToolbarFilter>
+      ))}
     </>
   );
 };

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -468,7 +468,7 @@ export const ApplicationsTable: React.FC = () => {
           }) + "...",
         selectOptions: tagItems.map(({ name, tagName, categoryName }) => ({
           value: name,
-          label: name,
+          label: tagName,
           chipLabel: tagName,
           groupLabel: categoryName,
         })),


### PR DESCRIPTION
Use one ToolbarFilter per options group. First filter provides 
the option list. Remaining filters are hidden and used only for
side effects (separate chip groups). The approach follows
similar widgets used by Forklift plugin and OpenShift Console but
uses a flat list of toolbars (nesting trick requires the widget to be
visible all the time).

Related refactorings in MuliselectFilterControl:
1. drop unused feature - using dictionary type for selectedOptions
2. drop state that can be calculated:
   a) active item from focusedItemIndex
   b) selectedOptions from filters
3. centralize id calculations - use prefix based on category title
4. use label styling for tag category part of option

Resolves: #1774 

Reference-Url: https://github.com/kubev2v/forklift-console-plugin/pull/90
Reference-Url: https://github.com/openshift/console/blob/5ba18580676a25e4304df78253aad6a9832d4d56/frontend/public/components/filter-toolbar.tsx#L299