### PR TITLE
:bug: Missing manage columns title translation

### DIFF
--- a/client/src/app/pages/applications/applications-table/components/manage-columns-toolbar.tsx
+++ b/client/src/app/pages/applications/applications-table/components/manage-columns-toolbar.tsx
@@ -45,7 +45,7 @@ export const ManageColumnsToolbar = <TColumnKey extends string>({
           columns={columns}
           saveLabel={t("actions.save")}
           cancelLabel={t("actions.cancel")}
-          title={t("title.manageColumns")}
+          title={t("dialog.title.manageColumns")}
         />
       )}
     </>


### PR DESCRIPTION
Missing full path to translation text in manage columns modal. 