### PR TITLE
:seedling: Have dependabot track `Dockerfile` referenced images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     allow:
       - dependency-name: "@patternfly/*"
         dependency-type: "direct"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: ":seedling: "


### PR DESCRIPTION
Configure dependabot to create PRs when the images we use in the `Dockerfile` have a newer version.  This allows us to reference specific container images and be automatically notified of newer versions.

Supports: #1883

CI added in #1907 will run against the PRs dependabot will open for `Dockerfile` changes.  This will allow us to have confidence that the update will be successful.
