### PR TITLE
:ghost: Disable codecov annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -30,3 +30,8 @@ flags:
 
 ignore:
   - "**/mockServiceWorker.js"
+
+# turn off github annotations, too many annotations are not useful
+# see: https://docs.codecov.com/docs/github-checks
+github_checks:
+  annotations: false


### PR DESCRIPTION
Resolves: #1909

Disable codecov's github annotations feature since it generates an annoying amount of annotations with our current level of testing coverage.
