### PR TITLE
:seedling: [backport release-0.4] Test image build when build related files change (#1907)

### DIFF
--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -1,0 +1,105 @@
+name: CI (test image build for a PR with build related changes)
+
+on:
+  pull_request:
+    branches:
+      - "main"
+      - "release-*"
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    outputs:
+      should-test: ${{ steps.check-changes.outputs.should-test }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: What files changed?
+        id: changed
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            Dockerfile
+            package-lock.json
+
+      - name: Check if build related files have been changed in a PR
+        id: check-changes
+        env:
+          IS_PR: ${{ !!github.event.pull_request }}
+          ANY_MODIFIED: ${{ steps.changed.outputs.any_modified }}
+        run: |
+          TEST_IMAGE_BUILD=$(
+            if [[ $IS_PR == true ]] && [[ $ANY_MODIFIED == true ]]; then
+              echo "true"
+            else
+              echo "false"
+            fi
+          )
+
+          echo "is-pr=$IS_PR" >> "$GITHUB_OUTPUT"
+          echo "changed=${ANY_MODIFIED:-false}" >> "$GITHUB_OUTPUT"
+          echo "should-test=$TEST_IMAGE_BUILD" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize findings
+        env:
+          MODIFIED_FILES: ${{ steps.changed.outputs.all_modified_files }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Findings
+          PR triggered? \`${{ steps.check-changes.outputs.is-pr }}\`
+          PR includes a build file related change? \`${{ steps.check-changes.outputs.changed }}\`
+          Should the image build be tested? \`${{ steps.check-changes.outputs.should-test }}\`
+          EOF
+
+          if [[ -n "$MODIFIED_FILES" ]]; then
+            echo "## Build related modified files" >> "$GITHUB_STEP_SUMMARY"
+            for file in ${MODIFIED_FILES}; do
+              echo "  - \`$file\`" >> "$GITHUB_STEP_SUMMARY"
+            done
+          fi
+
+  #
+  # Based on:
+  #   - image-build.yaml
+  #   - konveyor/release-tools/.github/workflows/build-push-images.yaml@main
+  #
+  # Only test the image build, no push to quay is required.
+  #
+  test-image-build:
+    runs-on: ubuntu-latest
+    needs: checks
+    if: ${{ needs.checks.outputs.should-test == 'true' }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        architecture: # keep this list in sync with `image-build.yaml`
+          - amd64
+          - arm64
+
+    concurrency:
+      group: test-image-build-${{ matrix.architecture }}_${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout merge commit for PR${{ github.event.pull_request.number }}
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU to be able to build on ${{ matrix.architecture }}
+        if: ${{ matrix.architecture != 'amd64' }}
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: ${{ matrix.architecture }}
+
+      - name: Test build image on ${{ matrix.architecture }}
+        id: test-build
+        uses: redhat-actions/buildah-build@main
+        with:
+          image: "tackle2-ui"
+          tags: pr${{ github.event.pull_request.number }}-${{ matrix.architecture }}
+          extra-args: "--no-cache --rm --ulimit nofile=4096:4096"
+          archs: ${{ matrix.architecture }}
+          labels: ""
+          containerfiles: "./Dockerfile"
+          context: "."

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -20,9 +20,13 @@ jobs:
       registry: "quay.io/konveyor"
       image_name: "tackle2-ui"
       containerfile: "./Dockerfile"
+
+      # keep the architectures in sync with `ci-image-build.yml`
       architectures: '[ "amd64", "arm64" ]'
+
       # 2023-03-19: currently needed for npm@10
       extra-args: "--ulimit nofile=4096:4096"
+
     secrets:
       registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
       registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}


### PR DESCRIPTION
If the workflow is run from a PR, and the PR includes a change to the `Dockerfile` or `package-lock.json`, then run image builds for all of our target platforms.

The images are built but not pushed to any repository.

We want to be reasonably sure that any major build file changes will not cause the image-build-and-push on PR merge workflow to break. Doing the image build here should reveal most problems much earlier. For example, a npm version update in the build container could break github action `nofiles` or network access capabilities for the npm install.

See #1742, #1746, and #1781 for some other examples of when this check could have caught issues before a PR merge.

Supports: #1883
Backport-of: #1907
