### PR TITLE
:sparkles: Add custom matchers to client side filters

### DIFF
--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -52,6 +52,8 @@ export interface IBasicFilterCategory<
    * Defaults to using the UI state's value if omitted.
    */
   getServerFilterValue?: (filterValue: FilterValue) => string[] | undefined;
+  /** For client side filtering, provide custom algorithm for testing if the value of `TItem` matches the filter value. */
+  matcher?: (filter: string, item: TItem) => boolean;
 }
 
 export interface IMultiselectFilterCategory<


### PR DESCRIPTION
Before this PR, all values were matched in the same way:
1. value needs to be string or have string representation via
   getItemValue
2. positive match is returned if (lowercased) value contains
   (lowercased) filter value.

After this PR, a custom algorithm can be provided using "matcher"
property. Direct motivation is DateRange filter which stores filter
values as ISO 8601 time intervals i.e. "2024-04-01/2024-05-01".
Positive match (value is in the range) requires parsing to date objects.

Reference-Url: https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
Reference-Url: https://github.com/konveyor/tackle2-ui/pull/1913