### PR TITLE
:seedling: [backport release-0.3] Add and allow test image builds for more changes (#1926)

### DIFF
--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           files: |
             Dockerfile
+            **/package.json
             package-lock.json
 
       - name: Check if build related files have been changed in a PR

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "engines": {
     "node": ">=18.14.2",
-    "npm": "^9.5.0"
+    "npm": ">=9.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",


### PR DESCRIPTION
Changes:
  - If any of the `package.json` files change, test the image builds. We want to make sure that changes to the `engine` or `script` blocks receive a full image build testing.

  - Update the npm version check to `>=9.5.0`. This will allow the test image build CI to check new builder images that also have npm major version updates.

Backport-of: #1926
