### PR TITLE
:bug: On Issues>Affected Application table, update column data-label to match displayed text

### DIFF
--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -64,7 +64,7 @@ export const AffectedApplications: React.FC = () => {
       name: "Name",
       description: "Description",
       businessService: "Business service",
-      effort: "Total Effort",
+      effort: "Effort",
       incidents: "Incidents",
     },
     isFilterEnabled: true,


### PR DESCRIPTION
Resolves: #1936 
UI Tests PR: 1124
Addresses mismatch between data column and displayed text for "Effort" Column in affected applications table

PR konveyor/tackle2-ui#1846 intended to revert back to using effort favoring tooltips to differentiate what is being displayed in fields labeled effort.  The Issues>Affected Application table effort column heading text was updated, but the data-label used was still "Total Effort".