### PR TITLE
:sparkles: Use hidden filter category for filtering on page load

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -334,6 +334,14 @@ export const ApplicationsTable: React.FC = () => {
     }),
     filterCategories: [
       {
+        categoryKey: "id",
+        title: "ID",
+        type: FilterType.numsearch,
+        matcher: (filter: string, item: Application) =>
+          String(item.id) === filter,
+        hideToolbarItem: true,
+      },
+      {
         categoryKey: "name",
         title: t("terms.name"),
         type: FilterType.multiselect,


### PR DESCRIPTION
Add hidden "id" filter category to application screen to ensure that active item is on page

Example usage: /applications?activeItem=6&filters={"id":["6"]}
