### PR TITLE
:sparkles: Add mvn:// prefix to application binary value in post request

### DIFF
--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -113,7 +113,12 @@ export const useApplicationFormHook = ({
     application: Application | null,
     fieldName: string
   ) => {
-    const fieldList = application?.binary?.split(":") || [];
+    const binaryString = application?.binary?.startsWith("mvn://")
+      ? application.binary.substring(6)
+      : application?.binary;
+
+    const fieldList = binaryString?.split(":") || [];
+
     switch (fieldName) {
       case "group":
         return fieldList[0] || "";

--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -258,6 +258,13 @@ export const useApplicationFormHook = ({
   });
 
   const onValidSubmit = (formValues: FormValues) => {
+    let binaryValue = formValues.packaging
+      ? `${formValues.group}:${formValues.artifact}:${formValues.version}:${formValues.packaging}`
+      : `${formValues.group}:${formValues.artifact}:${formValues.version}`;
+    if (!binaryValue.startsWith("mvn://")) {
+      binaryValue = `mvn://${binaryValue}`;
+    }
+
     const payload: New<Application> = {
       name: formValues.name.trim(),
       description: formValues.description.trim(),
@@ -282,10 +289,7 @@ export const useApplicationFormHook = ({
             path: formValues.rootPath.trim(),
           }
         : undefined,
-
-      binary: formValues.packaging
-        ? `${formValues.group}:${formValues.artifact}:${formValues.version}:${formValues.packaging}`
-        : `${formValues.group}:${formValues.artifact}:${formValues.version}`,
+      binary: binaryValue,
 
       // Values not editable on the form but still need to be passed through
       identities: application?.identities ?? undefined,


### PR DESCRIPTION
Resolves: https://github.com/konveyor/tackle2-ui/issues/1967

Note: validation is not necessary since the ui already breaks up the input into separate for fields and composes the binary coordinates under the hood. 