### PR TITLE
:bug: Prefer `Task` field `kind` over `addon`

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -312,16 +312,16 @@ export interface Task {
   updateUser?: string;
   createTime?: string;
 
-  name: string;
-  kind: string;
-  addon: string;
-  extensions: string[];
+  name?: string;
+  kind?: string;
+  addon?: string;
+  extensions?: string[];
   state?: TaskState;
   locator?: string;
   priority?: number;
-  policy: TaskPolicy;
-  ttl: TTL;
-  data: TaskData;
+  policy?: TaskPolicy;
+  ttl?: TTL;
+  data?: TaskData;
   application: Ref;
   bucket?: Ref;
   pod?: string;
@@ -407,9 +407,10 @@ export interface TaskgroupTask {
 }
 
 export interface Taskgroup {
-  id?: number;
+  id: number;
   name: string;
-  addon: string;
+  kind?: string;
+  addon?: string;
   data: TaskData;
   tasks: TaskgroupTask[];
 }

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -376,7 +376,7 @@ export const getTaskQueue = (addon?: string): Promise<TaskQueue> =>
 export const updateTask = (task: Partial<Task> & { id: number }) =>
   axios.patch<Task>(`${TASKS}/${task.id}`, task);
 
-export const createTaskgroup = (obj: Taskgroup) =>
+export const createTaskgroup = (obj: New<Taskgroup>) =>
   axios.post<Taskgroup>(TASKGROUPS, obj).then((response) => response.data);
 
 export const submitTaskgroup = (obj: Taskgroup) =>

--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 
 import {
   Application,
+  New,
   TaskData,
   Taskgroup,
   TaskgroupTask,
@@ -70,9 +71,9 @@ const defaultTaskData: TaskData = {
   },
 };
 
-export const defaultTaskgroup: Taskgroup = {
+export const defaultTaskgroup: New<Taskgroup> = {
   name: `taskgroup.analyzer`,
-  addon: "analyzer",
+  kind: "analyzer",
   data: {
     ...defaultTaskData,
   },

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -148,7 +148,7 @@ export const ApplicationsTable: React.FC = () => {
     tasks.find((task: Task) => task.application?.id === application.id);
 
   const { tasks, hasActiveTasks } = useFetchTasks(
-    { addon: "analyzer" },
+    { kind: "analyzer", addon: "analyzer" },
     isAnalyzeModalOpen
   );
 

--- a/client/src/app/pages/tasks/tasks-page.tsx
+++ b/client/src/app/pages/tasks/tasks-page.tsx
@@ -164,8 +164,7 @@ export const TasksPage: React.FC = () => {
 
   const tableControls = useTableControlProps({
     ...tableControlState,
-    // task.id is defined as optional
-    idProperty: "name",
+    idProperty: "id",
     currentPageItems,
     totalItemCount,
     isLoading: isFetching,

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -21,6 +21,7 @@ import {
 
 interface FetchTasksFilters {
   addon?: string;
+  kind?: string;
 }
 
 export const TasksQueryKey = "tasks";
@@ -39,7 +40,16 @@ export const useFetchTasks = (
     select: (allTasks) => {
       const uniqSorted = allTasks
         .filter((task) =>
-          filters?.addon ? filters.addon === task.addon : true
+          // If there are any tasks with the addon field, we will still need to consider those older
+          // tasks that do not have the kind field. This is because the kind field was added later and is
+          // preferred over the addon field.
+
+          // The task manager will determine and assign the addon field when the addon is specified and addon isnt
+          // which will result in both being set.
+
+          filters?.kind || filters?.addon
+            ? filters.kind === task.kind || filters.addon === task.addon
+            : true
         )
         // sort by application.id (ascending) then createTime (newest to oldest)
         .sort((a, b) =>


### PR DESCRIPTION
Resolves: #1970

  - When creating a new `Taskgroup`, specify `kind` instead of `addon`

  - Process Tasks where `kind` may be missing and `addon` is given instead (i.e. tasks created before this change)

  - Make `Task.id` and `Taskgroup.id` required, `New<>` as needed
