### PR TITLE
:bug: Update the enabled check for the Analysis button

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -626,12 +626,12 @@ export const ApplicationsTable: React.FC = () => {
     const tasksForSelected = tasks.filter((task) =>
       selectedAppIds.includes(task.application.id)
     );
-    const allowedStates = ["Succeeded", "Failed", null, ""];
+    const terminalStates = ["Succeeded", "Failed", "Canceled", ""];
 
     return (
       tasksForSelected.length === 0 ||
       tasksForSelected.every(({ state }) =>
-        allowedStates.includes(state as string)
+        terminalStates.includes(state ?? "")
       )
     );
   };

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -623,8 +623,10 @@ export const ApplicationsTable: React.FC = () => {
     }
 
     const selectedAppIds = selectedRows.map(({ id }) => id);
-    const tasksForSelected = tasks.filter((task) =>
-      selectedAppIds.includes(task.application.id)
+    const tasksForSelected = tasks.filter(
+      (task) =>
+        (task.kind ?? task.addon) === "analyzer" &&
+        selectedAppIds.includes(task.application.id)
     );
     const terminalStates = ["Succeeded", "Failed", "Canceled", ""];
 


### PR DESCRIPTION
On the application table, update the analysis button's enable/disable check such that analysis is only allowed to be started when all of the tasks for the selected applications are in a terminal state (they are not in-flight/queued).

Fixes: #1976
