### PR TITLE
:bug: Link java dependencies that don't have a sha

### DIFF
--- a/client/src/app/pages/dependencies/dependency-apps-table.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-table.tsx
@@ -285,11 +285,21 @@ const DependencyVersionColumn = ({
 }: {
   appDependency: AnalysisAppDependency;
 }) => {
-  const isJavaDependency = name && version && sha && provider === "java";
+  let mavenCentralLink;
 
-  const mavenCentralLink = isJavaDependency
-    ? `https://search.maven.org/search?q=1:${extractFirstSha(sha)}`
-    : undefined;
+  if (name && version && provider === "java") {
+    if (sha) {
+      mavenCentralLink = `https://search.maven.org/#search|1:${extractFirstSha(
+        sha
+      )}`;
+    } else {
+      const group = name.substring(0, name.lastIndexOf("."));
+      const artifact = name.substring(name.lastIndexOf(".") + 1);
+      mavenCentralLink = encodeURI(
+        `https://search.maven.org/#search|g:${group} a:${artifact} v:${version}`
+      );
+    }
+  }
 
   return (
     <TextContent>


### PR DESCRIPTION
Resolves: #1982

In some analysis cases, java dependencies may be generated with the full `name` (group id + artifact id) and `version` but lack a `sha` value.  When this occurs, a maven central search string can still be created.

Now, for any java dependency, link to maven central:
  - Use the dependencies `sha`, or
  - Use the `name` and `version`
