### PR TITLE
:bug: Drop UTC offset for local time used in tasks table

### DIFF
--- a/client/src/app/pages/tasks/tasks-page.tsx
+++ b/client/src/app/pages/tasks/tasks-page.tsx
@@ -242,8 +242,10 @@ export const TasksPage: React.FC = () => {
     preemption: String(!!policy?.preemptEnabled),
     createUser,
     pod,
-    started: started ? dayjs(started).format() : "",
-    terminated: terminated ? dayjs(terminated).format() : "",
+    started: started ? dayjs(started).format("YYYY-MM-DD HH:mm:ss") : "",
+    terminated: terminated
+      ? dayjs(terminated).format("YYYY-MM-DD HH:mm:ss")
+      : "",
   });
 
   return (


### PR DESCRIPTION
The API provides date/time in UTC. For user convenience we display it in the browser time zone. Before this PR, UTC offset for the local time zone was included.

The format used is a subset of ISO 8601 which allows for predictable sorting in the table.
Format string: "YYYY-MM-DD HH:mm:ss".
Example date: "2024-07-03 13:21:44".

Part-of: #1969 