### PR TITLE
:bug: Fix application edit data source

### DIFF
--- a/client/src/app/pages/applications/applications-table/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/applications-table/useDecoratedApplications.ts
@@ -39,7 +39,10 @@ export interface DecoratedApplication extends Application {
   };
   tasksStatus: ApplicationTasksStatus;
 
-  identities?: Identity[];
+  /** Contain directly referenced versions of `Ref[]` Application props */
+  direct: {
+    identities?: Identity[];
+  };
 }
 
 /**
@@ -126,9 +129,11 @@ const decorateApplications = (
         currentAnalyzer: tasksByKind["analyzer"]?.[0],
       },
 
-      identities: app.identities
-        ?.map((identity) => identities.find(({ id }) => id === identity.id))
-        ?.filter(Boolean),
+      direct: {
+        identities: app.identities
+          ?.map((identity) => identities.find(({ id }) => id === identity.id))
+          ?.filter(Boolean),
+      },
     };
 
     da.tasksStatus = chooseApplicationTaskStatus(da);


### PR DESCRIPTION
Resolves: #2007
Resolves: https://issues.redhat.com/browse/MTA-3232

Summary of changes:
  - The application edit form needs to use the base `Application` data and not the `DecoratedApplication` as its basis for generating an update request.  Extra information added by the decoration will be unknown to the hub endpoint and will cause issues.

  - All references to `Application` in the application table code have been updated to `DecoratedApplication`

  - Any adjustments needed when a `DecoratedApplication` is passed to a child component as an `Application` have been made

  - The dereferencing part of decoration has been moved to a `direct` container.  This will allow the reuse of the `Application` property name without replacing it.
