### PR TITLE
:sparkles: Add handling for tasks "Succeeded with errors" in task and application tables

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -261,7 +261,17 @@
     "tasks": "Task Manager"
   },
   "taskState": {
-    "NoTask": "No Task"
+    "Canceled": "Canceled",
+    "Created": "Created",
+    "Failed": "Failed",
+    "NoTask": "No Task",
+    "Pending": "Pending",
+    "Postponed": "Postponed",
+    "QuotaBlocked": "Quota Blocked",
+    "Ready": "Ready",
+    "Running": "Running",
+    "Succeeded": "Succeeded",
+    "SucceededWithErrors": "Succeeded with Errors"
   },
   "terms": {
     "accepted": "Accepted",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -325,6 +325,7 @@
     "comments": "Comments",
     "commentsFromApplication": "Application comments",
     "completed": "Completed",
+    "completedWithErrors": "Completed with Errors",
     "confidence": "Confidence",
     "connected": "Connected",
     "contributors": "Contributors",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -260,6 +260,9 @@
     "dependencies": "Dependencies",
     "tasks": "Task Manager"
   },
+  "taskState": {
+    "NoTask": "No Task"
+  },
   "terms": {
     "accepted": "Accepted",
     "acceptedAppsAndDeps": "Accepted applications and dependencies",

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -335,6 +335,24 @@ export interface Task {
   attached?: TaskAttachment[];
 }
 
+/** A smaller version of `Task` fetched from the report/dashboard endpoint. */
+export interface TaskDashboard {
+  id: number;
+  createUser: string;
+  updateUser: string;
+  createTime: string; // ISO-8601
+  name: string;
+  kind?: string;
+  addon?: string;
+  state: TaskState;
+  application: Ref;
+  started?: string; // ISO-8601
+  terminated?: string; // ISO-8601
+
+  /** Count of errors recorded on the task - even Succeeded tasks may have errors. */
+  errors?: number;
+}
+
 export interface TaskPolicy {
   isolated?: boolean;
   preemptEnabled?: boolean;

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -304,7 +304,8 @@ export type TaskState =
   | "QuotaBlocked"
   | "Ready"
   | "Pending"
-  | "Postponed";
+  | "Postponed"
+  | "SucceededWithErrors"; // synthetic state for ease-of-use in UI;
 
 export interface Task {
   id: number;

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -42,6 +42,7 @@ import {
   Task,
   Taskgroup,
   TaskQueue,
+  TaskDashboard,
   Ticket,
   Tracker,
   TrackerProject,
@@ -357,8 +358,10 @@ export function getTaskByIdAndFormat(
     });
 }
 
-export const getTasks = () =>
-  axios.get<Task[]>(TASKS).then((response) => response.data);
+export const getTasksDashboard = () =>
+  axios
+    .get<TaskDashboard[]>(`${TASKS}/report/dashboard`)
+    .then((response) => response.data);
 
 export const getServerTasks = (params: HubRequestParams = {}) =>
   getHubPaginatedResult<Task>(TASKS, params);

--- a/client/src/app/components/Icons/IconedStatus.tsx
+++ b/client/src/app/components/Icons/IconedStatus.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import { Icon } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
-import TimesCircleIcon from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
-import InProgressIcon from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
-import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
-import UnknownIcon from "@patternfly/react-icons/dist/esm/icons/unknown-icon";
-import TopologyIcon from "@patternfly/react-icons/dist/esm/icons/topology-icon";
 import { IconWithLabel } from "./IconWithLabel";
 import { ReactElement } from "react-markdown/lib/react-markdown";
+
+import {
+  CheckCircleIcon,
+  TimesCircleIcon,
+  InProgressIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  UnknownIcon,
+  TopologyIcon,
+} from "@patternfly/react-icons";
 
 export type IconedStatusPreset =
   | "InheritedReviews"
@@ -17,6 +21,7 @@ export type IconedStatusPreset =
   | "InheritedAssessments"
   | "Canceled"
   | "Completed"
+  | "CompletedWithErrors"
   | "Error"
   | "Failed"
   | "InProgress"
@@ -103,6 +108,11 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
       icon: <CheckCircleIcon />,
       status: "success",
       label: t("terms.completed"),
+    },
+    CompletedWithErrors: {
+      icon: <ExclamationTriangleIcon />,
+      status: "warning",
+      label: t("terms.completedWithErrors"),
     },
     Error: {
       icon: <ExclamationCircleIcon />,

--- a/client/src/app/components/Icons/TaskStateIcon.tsx
+++ b/client/src/app/components/Icons/TaskStateIcon.tsx
@@ -6,6 +6,7 @@ import {
   TimesCircleIcon,
   InProgressIcon,
   ExclamationCircleIcon,
+  ExclamationTriangleIcon,
   UnknownIcon,
   PendingIcon,
   TaskIcon,
@@ -27,6 +28,12 @@ export const TaskStateIcon: FC<{ state?: TaskState }> = ({ state }) => {
       return (
         <Icon status="success">
           <CheckCircleIcon />
+        </Icon>
+      );
+    case "SucceededWithErrors":
+      return (
+        <Icon status="warning">
+          <ExclamationTriangleIcon />
         </Icon>
       );
     case "Failed":

--- a/client/src/app/components/tests/__snapshots__/StatusIcon.test.tsx.snap
+++ b/client/src/app/components/tests/__snapshots__/StatusIcon.test.tsx.snap
@@ -17,7 +17,19 @@ exports[`StatusIcon Renders without crashing 1`] = `
             <span
               class="pf-v5-c-icon__content"
             >
-              <test-file-stub />
+              <svg
+                aria-hidden="true"
+                class="pf-v5-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                />
+              </svg>
             </span>
           </span>
         </div>
@@ -42,7 +54,19 @@ exports[`StatusIcon Renders without crashing 1`] = `
           <span
             class="pf-v5-c-icon__content"
           >
-            <test-file-stub />
+            <svg
+              aria-hidden="true"
+              class="pf-v5-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+              />
+            </svg>
           </span>
         </span>
       </div>

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -75,14 +75,13 @@ import {
   useBulkDeleteApplicationMutation,
   useFetchApplications,
 } from "@app/queries/applications";
-import { useCancelTaskMutation, useFetchTasks } from "@app/queries/tasks";
 import {
-  useDeleteAssessmentMutation,
-  useFetchAssessments,
-} from "@app/queries/assessments";
+  useCancelTaskMutation,
+  useFetchTaskDashboard,
+} from "@app/queries/tasks";
+import { useDeleteAssessmentMutation } from "@app/queries/assessments";
 import { useDeleteReviewMutation } from "@app/queries/reviews";
 import { useFetchTagsWithTagItems } from "@app/queries/tags";
-import { useFetchArchetypes } from "@app/queries/archetypes";
 
 // Relative components
 import { AnalysisWizard } from "../analysis-wizard/analysis-wizard";
@@ -182,7 +181,7 @@ export const ApplicationsTable: React.FC = () => {
   // ----- Table data fetches and mutations
   const { tagItems } = useFetchTagsWithTagItems();
 
-  const { tasks, hasActiveTasks } = useFetchTasks(isAnalyzeModalOpen);
+  const { tasks, hasActiveTasks } = useFetchTaskDashboard(isAnalyzeModalOpen);
 
   const completedCancelTask = () => {
     pushNotification({
@@ -230,11 +229,6 @@ export const ApplicationsTable: React.FC = () => {
     referencedArchetypeRefs,
     referencedBusinessServiceRefs,
   } = useDecoratedApplications(baseApplications, tasks);
-
-  const { assessments, isFetching: isFetchingAssessments } =
-    useFetchAssessments();
-
-  const { archetypes, isFetching: isFetchingArchetypes } = useFetchArchetypes();
 
   const onDeleteApplicationSuccess = (appIDCount: number) => {
     pushNotification({
@@ -913,11 +907,7 @@ export const ApplicationsTable: React.FC = () => {
                       >
                         <ApplicationAssessmentStatus
                           application={application}
-                          isLoading={
-                            isFetchingApplications ||
-                            isFetchingArchetypes ||
-                            isFetchingAssessments
-                          }
+                          isLoading={isFetchingApplications}
                           key={`${application?.id}-assessment-status`}
                         />
                       </Td>
@@ -1067,12 +1057,9 @@ export const ApplicationsTable: React.FC = () => {
 
         <ApplicationDetailDrawer
           application={activeItem}
-          applications={applications}
-          assessments={assessments}
-          archetypes={archetypes}
           onCloseClick={clearActiveItem}
           onEditClick={() => setSaveApplicationModalState(activeItem)}
-          task={activeItem ? activeItem.tasks.currentAnalyzer : null}
+          task={activeItem?.tasks?.currentAnalyzer ?? null}
         />
 
         <TaskGroupProvider>

--- a/client/src/app/pages/applications/applications-table/components/column-application-name.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-application-name.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import dayjs from "dayjs";
 
 import { Icon, Popover, PopoverProps, Tooltip } from "@patternfly/react-core";
 import {
@@ -10,17 +11,16 @@ import {
   ExclamationTriangleIcon,
   PendingIcon,
 } from "@patternfly/react-icons";
+import { Table, Tbody, Td, Thead, Tr } from "@patternfly/react-table";
 
 import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
+import { Paths } from "@app/Paths";
+import { formatPath, universalComparator } from "@app/utils/utils";
+import { TaskDashboard } from "@app/api/models";
 import {
   ApplicationTasksStatus,
   DecoratedApplication,
 } from "../useDecoratedApplications";
-import { Paths } from "@app/Paths";
-import { formatPath, universalComparator } from "@app/utils/utils";
-import dayjs from "dayjs";
-import { Table, Tbody, Td, Thead, Tr } from "@patternfly/react-table";
-import { Task } from "@app/api/models";
 
 interface StatusData {
   popoverVariant: PopoverProps["alertSeverityVariant"];
@@ -96,7 +96,7 @@ const linkToTasks = (applicationName: string) => {
   return `${formatPath(Paths.tasks, {})}?${search}`;
 };
 
-const linkToDetails = (task: Task) => {
+const linkToDetails = (task: TaskDashboard) => {
   return formatPath(Paths.taskDetails, {
     taskId: task.id,
   });

--- a/client/src/app/pages/applications/applications-table/components/column-application-name.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-application-name.tsx
@@ -7,6 +7,7 @@ import {
   TimesCircleIcon,
   InProgressIcon,
   ExclamationCircleIcon,
+  ExclamationTriangleIcon,
   PendingIcon,
 } from "@patternfly/react-icons";
 
@@ -76,6 +77,15 @@ const statusMap: Record<ApplicationTasksStatus, StatusData> = {
     icon: () => (
       <Icon status="success">
         <CheckCircleIcon />
+      </Icon>
+    ),
+  },
+  SuccessWithErrors: {
+    popoverVariant: "warning",
+    headerText: "All tasks succeeded, but some errors occurred",
+    icon: () => (
+      <Icon status="warning">
+        <ExclamationTriangleIcon />
       </Icon>
     ),
   },

--- a/client/src/app/pages/applications/applications-table/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/applications-table/useDecoratedApplications.ts
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
-import { Application, Identity, Task } from "@app/api/models";
+import { Application, Identity, TaskDashboard } from "@app/api/models";
 import { group, listify, mapEntries, unique } from "radash";
 import { TaskStates } from "@app/queries/tasks";
 import { universalComparator } from "@app/utils/utils";
 import { useFetchIdentities } from "@app/queries/identities";
 
 export interface TasksGroupedByKind {
-  [key: string]: Task[];
+  [key: string]: TaskDashboard[];
 }
 
 /**
@@ -37,7 +37,7 @@ export interface DecoratedApplication extends Application {
     latestHasSuccessWithErrors: boolean;
 
     /** The most recently created `kind === "analyzer"` task for the application */
-    currentAnalyzer: Task | undefined;
+    currentAnalyzer: TaskDashboard | undefined;
   };
   tasksStatus: ApplicationTasksStatus;
 
@@ -50,10 +50,10 @@ export interface DecoratedApplication extends Application {
 /**
  * Take an array of `Tasks`, group by application id and then by task kind.
  */
-const groupTasks = (tasks: Task[]) => {
+const groupTasks = (tasks: TaskDashboard[]) => {
   const byApplicationId = group(tasks, (task) => task.application.id) as Record<
     number,
-    Task[]
+    TaskDashboard[]
   >;
 
   const groupedByIdByKind = mapEntries(byApplicationId, (id, tasks) => [
@@ -96,7 +96,7 @@ const chooseApplicationTaskStatus = ({
  */
 const decorateApplications = (
   applications: Application[],
-  tasks: Task[],
+  tasks: TaskDashboard[],
   identities: Identity[]
 ) => {
   const { tasksById, tasksByIdByKind } = groupTasks(tasks);
@@ -152,7 +152,7 @@ const decorateApplications = (
 
 export const useDecoratedApplications = (
   applications: Application[],
-  tasks: Task[]
+  tasks: TaskDashboard[]
 ) => {
   const { identities } = useFetchIdentities();
 

--- a/client/src/app/pages/applications/applications-table/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/applications-table/useDecoratedApplications.ts
@@ -19,7 +19,8 @@ export type ApplicationTasksStatus =
   | "Queued"
   | "Failed"
   | "Canceled"
-  | "Success";
+  | "Success"
+  | "SuccessWithErrors";
 
 export interface DecoratedApplication extends Application {
   /** reference to the Application being decorated */
@@ -33,6 +34,7 @@ export interface DecoratedApplication extends Application {
     latestHasQueued: boolean;
     latestHasRunning: boolean;
     latestHasSuccess: boolean;
+    latestHasSuccessWithErrors: boolean;
 
     /** The most recently created `kind === "analyzer"` task for the application */
     currentAnalyzer: Task | undefined;
@@ -83,6 +85,8 @@ const chooseApplicationTaskStatus = ({
     ? "Failed"
     : tasks.latestHasCanceled
     ? "Canceled"
+    : tasks.latestHasSuccessWithErrors
+    ? "SuccessWithErrors"
     : "Success";
 };
 
@@ -124,6 +128,9 @@ const decorateApplications = (
         ),
         latestHasSuccess: latest.some((task) =>
           TaskStates.Success.includes(task.state ?? "")
+        ),
+        latestHasSuccessWithErrors: latest.some((task) =>
+          TaskStates.SuccessWithErrors.includes(task.state ?? "")
         ),
 
         currentAnalyzer: tasksByKind["analyzer"]?.[0],

--- a/client/src/app/pages/applications/components/application-analysis-status.tsx
+++ b/client/src/app/pages/applications/components/application-analysis-status.tsx
@@ -1,25 +1,18 @@
 import React from "react";
 
 import { TaskState } from "@app/api/models";
-import { IconedStatus } from "@app/components/Icons";
+import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";
 
 export interface ApplicationAnalysisStatusProps {
   state: TaskState;
 }
 
-export type AnalysisState =
-  | "Canceled"
-  | "Scheduled"
-  | "Completed"
-  | "Failed"
-  | "InProgress"
-  | "NotStarted";
-
-const taskStateToAnalyze: Map<TaskState, AnalysisState> = new Map([
+const taskStateToAnalyze: Map<TaskState, IconedStatusPreset> = new Map([
   ["not supported", "Canceled"],
   ["Canceled", "Canceled"],
   ["Created", "Scheduled"],
   ["Succeeded", "Completed"],
+  ["SucceededWithErrors", "CompletedWithErrors"],
   ["Failed", "Failed"],
   ["Running", "InProgress"],
   ["No task", "NotStarted"],
@@ -28,16 +21,16 @@ const taskStateToAnalyze: Map<TaskState, AnalysisState> = new Map([
   ["Ready", "Scheduled"],
 ]);
 
+const getTaskStatus = (state: TaskState): IconedStatusPreset => {
+  if (taskStateToAnalyze.has(state)) {
+    const value = taskStateToAnalyze.get(state);
+    if (value) return value;
+  }
+  return "NotStarted";
+};
+
 export const ApplicationAnalysisStatus: React.FC<
   ApplicationAnalysisStatusProps
 > = ({ state }) => {
-  const getTaskStatus = (state: TaskState): AnalysisState => {
-    if (taskStateToAnalyze.has(state)) {
-      const value = taskStateToAnalyze.get(state);
-      if (value) return value;
-    }
-    return "NotStarted";
-  };
-
   return <IconedStatus preset={getTaskStatus(state)} />;
 };

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -29,13 +29,11 @@ import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 
 import {
-  Application,
   Identity,
-  Task,
   MimeType,
   Ref,
   Archetype,
-  AssessmentWithSectionOrder,
+  TaskDashboard,
 } from "@app/api/models";
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
 import { useFetchFacts } from "@app/queries/facts";
@@ -63,14 +61,14 @@ import { ApplicationDetailFields } from "./application-detail-fields";
 import { ApplicationFacts } from "./application-facts";
 import { formatPath } from "@app/utils/utils";
 import { Paths } from "@app/Paths";
+import { useFetchArchetypes } from "@app/queries/archetypes";
+import { useFetchAssessments } from "@app/queries/assessments";
+import { DecoratedApplication } from "../../applications-table/useDecoratedApplications";
 
 export interface IApplicationDetailDrawerProps
   extends Pick<IPageDrawerContentProps, "onCloseClick"> {
-  application: Application | null;
-  task: Task | undefined | null;
-  applications?: Application[];
-  assessments?: AssessmentWithSectionOrder[];
-  archetypes?: Archetype[];
+  application: DecoratedApplication | null;
+  task: TaskDashboard | null;
   onEditClick: () => void;
 }
 
@@ -84,53 +82,11 @@ enum TabKey {
 
 export const ApplicationDetailDrawer: React.FC<
   IApplicationDetailDrawerProps
-> = ({
-  onCloseClick,
-  application,
-  assessments,
-  archetypes,
-  task,
-  onEditClick,
-}) => {
+> = ({ application, task, onCloseClick, onEditClick }) => {
   const { t } = useTranslation();
   const [activeTabKey, setActiveTabKey] = React.useState<TabKey>(
     TabKey.Details
   );
-
-  const isTaskRunning = task?.state === "Running";
-
-  const { identities } = useFetchIdentities();
-  const { facts, isFetching } = useFetchFacts(application?.id);
-
-  let matchingSourceCredsRef: Identity | undefined;
-  let matchingMavenCredsRef: Identity | undefined;
-  if (application && identities) {
-    matchingSourceCredsRef = getKindIdByRef(identities, application, "source");
-    matchingMavenCredsRef = getKindIdByRef(identities, application, "maven");
-  }
-
-  const notAvailable = <EmptyTextMessage message={t("terms.notAvailable")} />;
-
-  const enableDownloadSetting = useSetting("download.html.enabled");
-  const history = useHistory();
-  const navigateToAnalysisDetails = () =>
-    application?.id &&
-    task?.id &&
-    history.push(
-      formatPath(Paths.applicationsAnalysisDetails, {
-        applicationId: application?.id,
-        taskId: task?.id,
-      })
-    );
-
-  const reviewedArchetypes =
-    application?.archetypes
-      ?.map(
-        (archetypeRef) =>
-          archetypes?.find((archetype) => archetype.id === archetypeRef.id)
-      )
-      .filter((fullArchetype) => fullArchetype?.review)
-      .filter(Boolean) || [];
 
   return (
     <PageDrawerContent
@@ -150,284 +106,299 @@ export const ApplicationDetailDrawer: React.FC<
       }
     >
       <div>
+        {/* this div is required so the tabs are visible */}
         <Tabs
           activeKey={activeTabKey}
           onSelect={(_event, tabKey) => setActiveTabKey(tabKey as TabKey)}
           className={spacing.mtLg}
         >
-          <Tab
-            eventKey={TabKey.Details}
-            title={<TabTitleText>{t("terms.details")}</TabTitleText>}
-          >
-            <TextContent className={`${spacing.mtMd} ${spacing.mbMd}`}>
-              <Text component="small">{application?.description}</Text>
-              <List isPlain>
-                {application ? (
-                  <>
-                    <ListItem>
-                      <Link
-                        to={getIssuesSingleAppSelectedLocation(application.id)}
-                      >
-                        Issues
-                      </Link>
-                    </ListItem>
-                    <ListItem>
-                      <Link
-                        to={getDependenciesUrlFilteredByAppName(
-                          application?.name
-                        )}
-                      >
-                        Dependencies
-                      </Link>
-                    </ListItem>
-                  </>
-                ) : null}
-              </List>
-              <Title headingLevel="h3" size="md">
-                {t("terms.effort")}
-              </Title>
-              <Text component="small">
-                <Text component="small">
-                  {application?.effort !== 0 &&
-                  application?.effort !== undefined
-                    ? application?.effort
-                    : t("terms.unassigned")}
-                </Text>
-              </Text>
-            </TextContent>
-            <>
-              <Title headingLevel="h3" size="md">
-                {t("terms.archetypes")}
-              </Title>
-              <DescriptionList
-                isHorizontal
-                isCompact
-                columnModifier={{ default: "1Col" }}
-                horizontalTermWidthModifier={{
-                  default: "15ch",
-                }}
-              >
-                <DescriptionListGroup>
-                  <DescriptionListTerm>
-                    {t("terms.associatedArchetypes")}
-                  </DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {application?.archetypes?.length ? (
-                      <>
-                        <DescriptionListDescription>
-                          {application.archetypes.length ?? 0 > 0 ? (
-                            <ArchetypeLabels
-                              archetypeRefs={application.archetypes as Ref[]}
-                            />
-                          ) : (
-                            <EmptyTextMessage message={t("terms.none")} />
-                          )}
-                        </DescriptionListDescription>
-                      </>
-                    ) : (
-                      <EmptyTextMessage message={t("terms.none")} />
-                    )}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
+          {!application ? null : (
+            <Tab
+              eventKey={TabKey.Details}
+              title={<TabTitleText>{t("terms.details")}</TabTitleText>}
+            >
+              <TabDetailsContent
+                application={application}
+                onCloseClick={onCloseClick}
+                onEditClick={onEditClick}
+              />
+            </Tab>
+          )}
 
-                <DescriptionListGroup>
-                  <DescriptionListTerm>
-                    {t("terms.archetypesAssessed")}
-                  </DescriptionListTerm>
-                  {assessments && assessments.length ? (
-                    <DescriptionListDescription>
-                      <AssessedArchetypes
-                        application={application}
-                        assessments={assessments}
-                      />
-                    </DescriptionListDescription>
+          {!application ? null : (
+            <Tab
+              eventKey={TabKey.Tags}
+              title={<TabTitleText>Tags</TabTitleText>}
+            >
+              <TabTagsContent application={application} task={task} />
+            </Tab>
+          )}
+
+          {!application ? null : (
+            <Tab
+              eventKey={TabKey.Reports}
+              title={<TabTitleText>{t("terms.reports")}</TabTitleText>}
+            >
+              <TabReportsContent application={application} task={task} />
+            </Tab>
+          )}
+
+          {!application ? null : (
+            <Tab
+              eventKey={TabKey.Reviews}
+              title={<TabTitleText>{t("terms.review")}</TabTitleText>}
+            >
+              <ReviewFields application={application} />
+            </Tab>
+          )}
+        </Tabs>
+      </div>
+    </PageDrawerContent>
+  );
+};
+const ArchetypeLabels: React.FC<{ archetypeRefs?: Ref[] }> = ({
+  archetypeRefs,
+}) => <LabelsFromItems items={archetypeRefs} />;
+
+const ArchetypeItem: React.FC<{ archetype: Archetype }> = ({ archetype }) => {
+  return <Label color="grey">{archetype.name}</Label>;
+};
+
+const TabDetailsContent: React.FC<{
+  application: DecoratedApplication;
+  onCloseClick: () => void;
+  onEditClick: () => void;
+}> = ({ application, onCloseClick, onEditClick }) => {
+  const { t } = useTranslation();
+
+  const { assessments } = useFetchAssessments();
+
+  const { archetypesById } = useFetchArchetypes();
+  const reviewedArchetypes = !application?.archetypes
+    ? []
+    : application.archetypes
+        .map((archetypeRef) => archetypesById[archetypeRef.id])
+        .filter((fullArchetype) => fullArchetype?.review)
+        .filter(Boolean);
+
+  return (
+    <>
+      <TextContent className={`${spacing.mtMd} ${spacing.mbMd}`}>
+        <Text component="small">{application?.description}</Text>
+
+        <List isPlain>
+          {application ? (
+            <>
+              <ListItem>
+                <Link to={getIssuesSingleAppSelectedLocation(application.id)}>
+                  Issues
+                </Link>
+              </ListItem>
+              <ListItem>
+                <Link
+                  to={getDependenciesUrlFilteredByAppName(application?.name)}
+                >
+                  Dependencies
+                </Link>
+              </ListItem>
+            </>
+          ) : null}
+        </List>
+
+        <Title headingLevel="h3" size="md">
+          {t("terms.effort")}
+        </Title>
+        <Text component="small">
+          <Text component="small">
+            {application?.effort !== 0 && application?.effort !== undefined
+              ? application?.effort
+              : t("terms.unassigned")}
+          </Text>
+        </Text>
+      </TextContent>
+
+      <Title headingLevel="h3" size="md">
+        {t("terms.archetypes")}
+      </Title>
+      <DescriptionList
+        isHorizontal
+        isCompact
+        columnModifier={{ default: "1Col" }}
+        horizontalTermWidthModifier={{
+          default: "15ch",
+        }}
+      >
+        <DescriptionListGroup>
+          <DescriptionListTerm>
+            {t("terms.associatedArchetypes")}
+          </DescriptionListTerm>
+          <DescriptionListDescription>
+            {application?.archetypes?.length ? (
+              <>
+                <DescriptionListDescription>
+                  {application.archetypes.length ?? 0 > 0 ? (
+                    <ArchetypeLabels
+                      archetypeRefs={application.archetypes as Ref[]}
+                    />
                   ) : (
                     <EmptyTextMessage message={t("terms.none")} />
                   )}
-                </DescriptionListGroup>
+                </DescriptionListDescription>
+              </>
+            ) : (
+              <EmptyTextMessage message={t("terms.none")} />
+            )}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
 
-                <DescriptionListGroup>
-                  <DescriptionListTerm>
-                    {t("terms.archetypesReviewed")}
-                  </DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <LabelGroup>
-                      {reviewedArchetypes?.length ? (
-                        reviewedArchetypes.map((reviewedArchetype) => (
-                          <ArchetypeItem
-                            key={reviewedArchetype?.id}
-                            archetype={reviewedArchetype}
-                          />
-                        ))
-                      ) : (
-                        <EmptyTextMessage message={t("terms.none")} />
-                      )}
-                    </LabelGroup>
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              </DescriptionList>
-              <TextContent className={spacing.mtLg}>
-                <Title headingLevel="h3" size="md">
-                  {t("terms.riskFromApplication")}
-                </Title>
-                <Text component="small" cy-data="comments">
-                  <RiskLabel risk={application?.risk || "unknown"} />
-                </Text>
-              </TextContent>
-              <ApplicationDetailFields
+        <DescriptionListGroup>
+          <DescriptionListTerm>
+            {t("terms.archetypesAssessed")}
+          </DescriptionListTerm>
+          {(assessments?.length ?? 0) > 0 ? (
+            <DescriptionListDescription>
+              <AssessedArchetypes
                 application={application}
-                onEditClick={onEditClick}
-                onCloseClick={onCloseClick}
+                assessments={assessments}
               />
-            </>
-          </Tab>
+            </DescriptionListDescription>
+          ) : (
+            <EmptyTextMessage message={t("terms.none")} />
+          )}
+        </DescriptionListGroup>
 
-          <Tab eventKey={TabKey.Tags} title={<TabTitleText>Tags</TabTitleText>}>
-            {application && isTaskRunning ? (
-              <Bullseye className={spacing.mtLg}>
-                <TextContent>
-                  <Text component={TextVariants.h3}>
-                    {t("message.taskInProgressForTags")}
-                    <Spinner
-                      isInline
-                      aria-label="spinner when a new analysis is running"
-                    />
-                  </Text>
-                </TextContent>
-              </Bullseye>
-            ) : null}
-
-            {application ? <ApplicationTags application={application} /> : null}
-          </Tab>
-
-          <Tab
-            eventKey={TabKey.Reports}
-            title={<TabTitleText>{t("terms.reports")}</TabTitleText>}
-          >
-            <TextContent className={spacing.mtMd}>
-              <Title headingLevel="h3" size="md">
-                Credentials
-              </Title>
-              {matchingSourceCredsRef && matchingMavenCredsRef ? (
-                <Text component="small">
-                  <CheckCircleIcon color="green" />
-                  <span className={spacing.mlSm}>Source and Maven</span>
-                </Text>
-              ) : matchingMavenCredsRef ? (
-                <Text component="small">
-                  <CheckCircleIcon color="green" />
-                  <span className={spacing.mlSm}>Maven</span>
-                </Text>
-              ) : matchingSourceCredsRef ? (
-                <Text component="small">
-                  <CheckCircleIcon color="green" />
-                  <span className={spacing.mlSm}>Source</span>
-                </Text>
+        <DescriptionListGroup>
+          <DescriptionListTerm>
+            {t("terms.archetypesReviewed")}
+          </DescriptionListTerm>
+          <DescriptionListDescription>
+            <LabelGroup>
+              {reviewedArchetypes?.length ? (
+                reviewedArchetypes.map((reviewedArchetype) => (
+                  <ArchetypeItem
+                    key={reviewedArchetype?.id}
+                    archetype={reviewedArchetype}
+                  />
+                ))
               ) : (
-                notAvailable
+                <EmptyTextMessage message={t("terms.none")} />
               )}
-              <Title headingLevel="h3" size="md">
-                Analysis
-              </Title>
-              {task?.state === "Succeeded" && application ? (
-                <>
-                  <DescriptionList
-                    isHorizontal
-                    columnModifier={{ default: "2Col" }}
-                  >
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>Details</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        <Tooltip content="View the analysis task details">
-                          <Button
-                            icon={
-                              <span className={spacing.mrXs}>
-                                <ExclamationCircleIcon
-                                  color={COLOR_HEX_VALUES_BY_NAME.blue}
-                                ></ExclamationCircleIcon>
-                              </span>
-                            }
-                            type="button"
-                            variant="link"
-                            onClick={navigateToAnalysisDetails}
-                            className={spacing.ml_0}
-                            style={{ margin: "0", padding: "0" }}
-                          >
-                            View analysis details
-                          </Button>
-                        </Tooltip>
-                      </DescriptionListDescription>
-                      <DescriptionListTerm>Download</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        <Tooltip
-                          content={
-                            enableDownloadSetting.data
-                              ? "Click to download TAR file with HTML static analysis report"
-                              : "Download TAR file with HTML static analysis report is disabled by administrator"
-                          }
-                          position="top"
-                        >
-                          <DownloadButton
-                            application={application}
-                            mimeType={MimeType.TAR}
-                            isDownloadEnabled={enableDownloadSetting.data}
-                          >
-                            HTML
-                          </DownloadButton>
-                        </Tooltip>
-                        {" | "}
-                        <Tooltip
-                          content={
-                            enableDownloadSetting.data
-                              ? "Click to download YAML file with static analysis report"
-                              : "Download YAML file with static analysis report is disabled by administrator"
-                          }
-                          position="top"
-                        >
-                          <DownloadButton
-                            application={application}
-                            mimeType={MimeType.YAML}
-                            isDownloadEnabled={enableDownloadSetting.data}
-                          >
-                            YAML
-                          </DownloadButton>
-                        </Tooltip>
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                  </DescriptionList>
-                  <Divider className={spacing.mtMd}></Divider>
-                </>
-              ) : task?.state === "Failed" ? (
-                task ? (
-                  <>
-                    <Button
-                      icon={
-                        <span className={spacing.mrXs}>
-                          <ExclamationCircleIcon
-                            color={COLOR_HEX_VALUES_BY_NAME.red}
-                          ></ExclamationCircleIcon>
-                        </span>
-                      }
-                      type="button"
-                      variant="link"
-                      onClick={navigateToAnalysisDetails}
-                      className={spacing.ml_0}
-                      style={{ margin: "0", padding: "0" }}
-                    >
-                      Analysis details
-                    </Button>
-                  </>
-                ) : (
-                  <span className={spacing.mlSm}>
-                    <ExclamationCircleIcon
-                      color={COLOR_HEX_VALUES_BY_NAME.red}
-                    ></ExclamationCircleIcon>
-                    Failed
-                  </span>
-                )
-              ) : (
-                <>
-                  {task ? (
+            </LabelGroup>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+
+      <TextContent className={spacing.mtLg}>
+        <Title headingLevel="h3" size="md">
+          {t("terms.riskFromApplication")}
+        </Title>
+        <Text component="small" cy-data="comments">
+          <RiskLabel risk={application?.risk || "unknown"} />
+        </Text>
+      </TextContent>
+
+      <ApplicationDetailFields
+        application={application}
+        onEditClick={onEditClick}
+        onCloseClick={onCloseClick}
+      />
+    </>
+  );
+};
+
+const TabTagsContent: React.FC<{
+  application: DecoratedApplication;
+  task: TaskDashboard | null;
+}> = ({ application, task }) => {
+  const { t } = useTranslation();
+  const isTaskRunning = task?.state === "Running";
+
+  return (
+    <>
+      {isTaskRunning ? (
+        <Bullseye className={spacing.mtLg}>
+          <TextContent>
+            <Text component={TextVariants.h3}>
+              {t("message.taskInProgressForTags")}
+              <Spinner
+                isInline
+                aria-label="spinner when a new analysis is running"
+              />
+            </Text>
+          </TextContent>
+        </Bullseye>
+      ) : null}
+
+      <ApplicationTags application={application} />
+    </>
+  );
+};
+
+const TabReportsContent: React.FC<{
+  application: DecoratedApplication;
+  task: TaskDashboard | null;
+}> = ({ application, task }) => {
+  const { t } = useTranslation();
+  const { facts, isFetching } = useFetchFacts(application?.id);
+
+  const { identities } = useFetchIdentities();
+  let matchingSourceCredsRef: Identity | undefined;
+  let matchingMavenCredsRef: Identity | undefined;
+  if (application && identities) {
+    matchingSourceCredsRef = getKindIdByRef(identities, application, "source");
+    matchingMavenCredsRef = getKindIdByRef(identities, application, "maven");
+  }
+
+  const notAvailable = <EmptyTextMessage message={t("terms.notAvailable")} />;
+
+  const enableDownloadSetting = useSetting("download.html.enabled");
+
+  const history = useHistory();
+  const navigateToAnalysisDetails = () =>
+    application?.id &&
+    task?.id &&
+    history.push(
+      formatPath(Paths.applicationsAnalysisDetails, {
+        applicationId: application?.id,
+        taskId: task?.id,
+      })
+    );
+
+  return (
+    <>
+      <TextContent className={spacing.mtMd}>
+        <Title headingLevel="h3" size="md">
+          Credentials
+        </Title>
+        {matchingSourceCredsRef && matchingMavenCredsRef ? (
+          <Text component="small">
+            <CheckCircleIcon color="green" />
+            <span className={spacing.mlSm}>Source and Maven</span>
+          </Text>
+        ) : matchingMavenCredsRef ? (
+          <Text component="small">
+            <CheckCircleIcon color="green" />
+            <span className={spacing.mlSm}>Maven</span>
+          </Text>
+        ) : matchingSourceCredsRef ? (
+          <Text component="small">
+            <CheckCircleIcon color="green" />
+            <span className={spacing.mlSm}>Source</span>
+          </Text>
+        ) : (
+          notAvailable
+        )}
+
+        <Title headingLevel="h3" size="md">
+          Analysis
+        </Title>
+        {task?.state === "Succeeded" && application ? (
+          <>
+            <DescriptionList isHorizontal columnModifier={{ default: "2Col" }}>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Details</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Tooltip content="View the analysis task details">
                     <Button
                       icon={
                         <span className={spacing.mrXs}>
@@ -442,33 +413,105 @@ export const ApplicationDetailDrawer: React.FC<
                       className={spacing.ml_0}
                       style={{ margin: "0", padding: "0" }}
                     >
-                      Analysis details
+                      View analysis details
                     </Button>
-                  ) : (
-                    notAvailable
-                  )}
-                </>
-              )}
-            </TextContent>
-            {!isFetching && !!facts.length && (
-              <ApplicationFacts facts={facts} />
-            )}
-          </Tab>
-          <Tab
-            eventKey={TabKey.Reviews}
-            title={<TabTitleText>{t("terms.review")}</TabTitleText>}
-          >
-            <ReviewFields application={application} />
-          </Tab>
-        </Tabs>
-      </div>
-    </PageDrawerContent>
-  );
-};
-const ArchetypeLabels: React.FC<{ archetypeRefs?: Ref[] }> = ({
-  archetypeRefs,
-}) => <LabelsFromItems items={archetypeRefs} />;
+                  </Tooltip>
+                </DescriptionListDescription>
 
-const ArchetypeItem: React.FC<{ archetype: Archetype }> = ({ archetype }) => {
-  return <Label color="grey">{archetype.name}</Label>;
+                <DescriptionListTerm>Download</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Tooltip
+                    content={
+                      enableDownloadSetting.data
+                        ? "Click to download TAR file with HTML static analysis report"
+                        : "Download TAR file with HTML static analysis report is disabled by administrator"
+                    }
+                    position="top"
+                  >
+                    <DownloadButton
+                      application={application}
+                      mimeType={MimeType.TAR}
+                      isDownloadEnabled={enableDownloadSetting.data}
+                    >
+                      HTML
+                    </DownloadButton>
+                  </Tooltip>
+                  {" | "}
+                  <Tooltip
+                    content={
+                      enableDownloadSetting.data
+                        ? "Click to download YAML file with static analysis report"
+                        : "Download YAML file with static analysis report is disabled by administrator"
+                    }
+                    position="top"
+                  >
+                    <DownloadButton
+                      application={application}
+                      mimeType={MimeType.YAML}
+                      isDownloadEnabled={enableDownloadSetting.data}
+                    >
+                      YAML
+                    </DownloadButton>
+                  </Tooltip>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+            <Divider className={spacing.mtMd}></Divider>
+          </>
+        ) : task?.state === "Failed" ? (
+          task ? (
+            <>
+              <Button
+                icon={
+                  <span className={spacing.mrXs}>
+                    <ExclamationCircleIcon
+                      color={COLOR_HEX_VALUES_BY_NAME.red}
+                    ></ExclamationCircleIcon>
+                  </span>
+                }
+                type="button"
+                variant="link"
+                onClick={navigateToAnalysisDetails}
+                className={spacing.ml_0}
+                style={{ margin: "0", padding: "0" }}
+              >
+                Analysis details
+              </Button>
+            </>
+          ) : (
+            <span className={spacing.mlSm}>
+              <ExclamationCircleIcon
+                color={COLOR_HEX_VALUES_BY_NAME.red}
+              ></ExclamationCircleIcon>
+              Failed
+            </span>
+          )
+        ) : (
+          <>
+            {task ? (
+              <Button
+                icon={
+                  <span className={spacing.mrXs}>
+                    <ExclamationCircleIcon
+                      color={COLOR_HEX_VALUES_BY_NAME.blue}
+                    ></ExclamationCircleIcon>
+                  </span>
+                }
+                type="button"
+                variant="link"
+                onClick={navigateToAnalysisDetails}
+                className={spacing.ml_0}
+                style={{ margin: "0", padding: "0" }}
+              >
+                Analysis details
+              </Button>
+            ) : (
+              notAvailable
+            )}
+          </>
+        )}
+      </TextContent>
+      {!isFetching && !!facts.length && <ApplicationFacts facts={facts} />}
+    </>
+  );
 };

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -64,6 +64,7 @@ import { Paths } from "@app/Paths";
 import { useFetchArchetypes } from "@app/queries/archetypes";
 import { useFetchAssessments } from "@app/queries/assessments";
 import { DecoratedApplication } from "../../applications-table/useDecoratedApplications";
+import { TaskStates } from "@app/queries/tasks";
 
 export interface IApplicationDetailDrawerProps
   extends Pick<IPageDrawerContentProps, "onCloseClick"> {
@@ -364,6 +365,10 @@ const TabReportsContent: React.FC<{
       })
     );
 
+  const taskState = application.tasks.currentAnalyzer?.state ?? "";
+  const taskSucceeded = TaskStates.Success.includes(taskState);
+  const taskFailed = TaskStates.Failed.includes(taskState);
+
   return (
     <>
       <TextContent className={spacing.mtMd}>
@@ -392,7 +397,7 @@ const TabReportsContent: React.FC<{
         <Title headingLevel="h3" size="md">
           Analysis
         </Title>
-        {task?.state === "Succeeded" && application ? (
+        {taskSucceeded ? (
           <>
             <DescriptionList isHorizontal columnModifier={{ default: "2Col" }}>
               <DescriptionListGroup>
@@ -458,7 +463,7 @@ const TabReportsContent: React.FC<{
             </DescriptionList>
             <Divider className={spacing.mtMd}></Divider>
           </>
-        ) : task?.state === "Failed" ? (
+        ) : taskFailed ? (
           task ? (
             <>
               <Button
@@ -511,6 +516,7 @@ const TabReportsContent: React.FC<{
           </>
         )}
       </TextContent>
+
       {!isFetching && !!facts.length && <ApplicationFacts facts={facts} />}
     </>
   );

--- a/client/src/app/pages/tasks/tasks-page.tsx
+++ b/client/src/app/pages/tasks/tasks-page.tsx
@@ -42,13 +42,28 @@ import { TablePersistenceKeyPrefix } from "@app/Constants";
 
 import { useSelectionState } from "@migtools/lib-ui";
 import { useServerTasks } from "@app/queries/tasks";
-import { Task } from "@app/api/models";
+import { Task, TaskState } from "@app/api/models";
 import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
 import { ManageColumnsToolbar } from "../applications/applications-table/components/manage-columns-toolbar";
 import dayjs from "dayjs";
 import { formatPath } from "@app/utils/utils";
 import { Paths } from "@app/Paths";
 import { TaskActionColumn } from "./TaskActionColumn";
+
+const taskStateToLabel: Record<TaskState, string> = {
+  "No task": "taskState.NoTask",
+  "not supported": "",
+  Canceled: "Canceled",
+  Created: "Created",
+  Succeeded: "Succeeded",
+  Failed: "Failed",
+  Running: "Running",
+  QuotaBlocked: "Quota Blocked",
+  Ready: "Ready",
+  Pending: "Pending",
+  Postponed: "Postponed",
+  SucceededWithErrors: "Succeeded with Errors",
+};
 
 export const TasksPage: React.FC = () => {
   const { t } = useTranslation();
@@ -235,7 +250,7 @@ export const TasksPage: React.FC = () => {
               taskId: id,
             })}
           >
-            {state ?? "No task"}
+            {t(taskStateToLabel[state ?? "No task"])}
           </Link>
         }
       />

--- a/client/src/app/pages/tasks/tasks-page.tsx
+++ b/client/src/app/pages/tasks/tasks-page.tsx
@@ -53,16 +53,16 @@ import { TaskActionColumn } from "./TaskActionColumn";
 const taskStateToLabel: Record<TaskState, string> = {
   "No task": "taskState.NoTask",
   "not supported": "",
-  Canceled: "Canceled",
-  Created: "Created",
-  Succeeded: "Succeeded",
-  Failed: "Failed",
-  Running: "Running",
-  QuotaBlocked: "Quota Blocked",
-  Ready: "Ready",
-  Pending: "Pending",
-  Postponed: "Postponed",
-  SucceededWithErrors: "Succeeded with Errors",
+  Canceled: "taskState.Canceled",
+  Created: "taskState.Created",
+  Succeeded: "taskState.Succeeded",
+  Failed: "taskState.Failed",
+  Running: "taskState.Running",
+  QuotaBlocked: "taskState.QuotaBlocked",
+  Ready: "taskState.Ready",
+  Pending: "taskState.Pending",
+  Postponed: "taskState.Postponed",
+  SucceededWithErrors: "taskState.SucceededWithErrors",
 };
 
 export const TasksPage: React.FC = () => {

--- a/client/src/app/queries/archetypes.ts
+++ b/client/src/app/queries/archetypes.ts
@@ -10,7 +10,7 @@ import {
   updateArchetype,
 } from "@app/api/rest";
 import { assessmentsByItemIdQueryKey } from "./assessments";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 export const ARCHETYPES_QUERY_KEY = "archetypes";
 export const ARCHETYPE_QUERY_KEY = "archetype";
@@ -42,8 +42,13 @@ export const useFetchArchetypes = (forApplication?: Application | null) => {
     onError: (error: AxiosError) => console.log(error),
   });
 
+  const archetypesById = useMemo(() => {
+    return Object.fromEntries(filteredArchetypes.map((a) => [a.id, a]));
+  }, [filteredArchetypes]);
+
   return {
     archetypes: filteredArchetypes,
+    archetypesById,
     isFetching: isLoading,
     isSuccess,
     error,

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -25,27 +25,36 @@ export const TaskStates = {
   Failed: ["Failed"],
   Queued: ["Ready", "Postponed", "Pending", "Running"], // "Created", "QuotaBlocked" ??
   Running: ["Running"],
-  Success: ["Succeeded"],
+  Success: ["Succeeded", "SucceededWithErrors"],
 };
 
 export const TasksQueryKey = "tasks";
-export const TasksQueueKey = "TasksQueue";
+export const TasksPagedQueryKey = "tasksPaged";
+export const TasksQueueKey = "tasksQueue";
 export const TaskByIDQueryKey = "taskByID";
 export const TaskAttachmentByIDQueryKey = "taskAttachmentByID";
+
+/**
+ * Rebuild the __state__ of a Task to include the UI synthetic "SucceededWithErrors"
+ */
+const calculateSyntheticState = (task: Task): Task => {
+  if (task.state === "Succeeded" && (task.errors?.length ?? 0) > 0) {
+    task.state = "SucceededWithErrors";
+  }
+
+  return task;
+};
 
 export const useFetchTasks = (refetchDisabled: boolean = false) => {
   const { isLoading, error, refetch, data } = useQuery({
     queryKey: [TasksQueryKey],
     queryFn: getTasks,
-    refetchInterval: !refetchDisabled ? 5000 : false,
-    select: (allTasks) => {
-      // sort by createTime (newest to oldest)
-      allTasks.sort(
-        (a, b) => -1 * universalComparator(a.createTime, b.createTime)
-      );
-      return allTasks;
-    },
+    select: (tasks) =>
+      tasks
+        .map(calculateSyntheticState)
+        .sort((a, b) => -1 * universalComparator(a.createTime, b.createTime)),
     onError: (err) => console.log(err),
+    refetchInterval: !refetchDisabled ? 5000 : false,
   });
 
   const hasActiveTasks =
@@ -61,13 +70,19 @@ export const useFetchTasks = (refetchDisabled: boolean = false) => {
 };
 
 export const useServerTasks = (
-  params: HubRequestParams = {},
+  params: HubRequestParams,
   refetchInterval?: number
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [TasksQueryKey, params],
+    queryKey: [TasksPagedQueryKey, params],
     queryFn: async () => await getServerTasks(params),
-    onError: (error) => console.log("error, ", error),
+    select: (data) => {
+      if (data?.data?.length > 0) {
+        data.data = data.data.map(calculateSyntheticState);
+      }
+      return data;
+    },
+    onError: (error: Error) => console.log("error, ", error),
     keepPreviousData: true,
     refetchInterval: refetchInterval ?? false,
   });
@@ -184,6 +199,8 @@ export const useFetchTaskByID = (taskId?: number) => {
   const { isLoading, error, data, refetch } = useQuery({
     queryKey: [TaskByIDQueryKey, taskId],
     queryFn: () => (taskId ? getTaskById(taskId) : null),
+    select: (task: Task | null) =>
+      task === null ? null : calculateSyntheticState(task),
     enabled: !!taskId,
   });
 

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -29,7 +29,6 @@ export const TaskStates = {
 };
 
 export const TasksQueryKey = "tasks";
-export const TasksPagedQueryKey = "tasksPaged";
 export const TasksQueueKey = "tasksQueue";
 export const TaskByIDQueryKey = "taskByID";
 export const TaskAttachmentByIDQueryKey = "taskAttachmentByID";
@@ -74,7 +73,7 @@ export const useServerTasks = (
   refetchInterval?: number
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [TasksPagedQueryKey, params],
+    queryKey: [TasksQueryKey, params],
     queryFn: async () => await getServerTasks(params),
     select: (data) => {
       if (data?.data?.length > 0) {
@@ -200,7 +199,7 @@ export const useFetchTaskByID = (taskId?: number) => {
     queryKey: [TaskByIDQueryKey, taskId],
     queryFn: () => (taskId ? getTaskById(taskId) : null),
     select: (task: Task | null) =>
-      task === null ? null : calculateSyntheticState(task),
+      !task ? null : calculateSyntheticState(task),
     enabled: !!taskId,
   });
 

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -26,6 +26,7 @@ export const TaskStates = {
   Queued: ["Ready", "Postponed", "Pending", "Running"], // "Created", "QuotaBlocked" ??
   Running: ["Running"],
   Success: ["Succeeded", "SucceededWithErrors"],
+  SuccessWithErrors: ["SucceededWithErrors"],
 };
 
 export const TasksQueryKey = "tasks";


### PR DESCRIPTION
### Summary
Resolves: #1997

When a task is succeeded but has attached errors, render task state, application tasks state and application analysis state with a warning.

### Details of Changes
With this change, hub is not adding a new terminal state, but having a new terminal state is an easy way to handle things.  The task queries will now evaluate the `state` and `errors` props to determine if "Succeeded" should be "SucceededWithErrors".  This synthetic task status makes updating all of the UI component much simpler.

To function properly, HUB [Issue 725](https://github.com/konveyor/tackle2-hub/issues/725)  / [PR 720](https://github.com/konveyor/tackle2-hub/pull/720) are required.

Changes have also been made to utilize the `/tasks/reports/dashboard` endpoint to get a much smaller view of tasks when dealing with them in aggregate.

The application details drawer was refactored to push data fetching closer to actual use, and to break up a very large component into a container component with a component dedicated to each tab.

### Screenshots
Application inventory page:
![screenshot-localhost_9000-2024 07 15-18_33_20](https://github.com/user-attachments/assets/b7015ebf-4305-4d6d-a670-5e4fe532981d)

Application tasks popover:
![image](https://github.com/user-attachments/assets/14d4d19e-eaca-4505-88be-d5016da1e70b)

Task Manager page:
![screenshot-localhost_9000-2024 07 15-18_35_15](https://github.com/user-attachments/assets/2547a46a-1fa6-456f-836c-4e59cc0fd074)
