### PR TITLE
:seedling: Revert ":seedling: Bump ubi9/nodejs-18 from 1-88 to 1-112.1720017853"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #   - https://github.com/konveyor/tackle2-ui/pull/1781
 
 # Builder image
-FROM registry.access.redhat.com/ubi9/nodejs-18:1-112.1720017853 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-18:1-88 as builder
 
 USER 1001
 COPY --chown=1001 . .


### PR DESCRIPTION
Reverts konveyor/tackle2-ui#2000

Seeing arm64 build errors consistently today.  For example:
https://github.com/konveyor/tackle2-ui/actions/runs/9947082580/job/27480216025#step:8:85

If the CI test build works, merging this revert is probably a good stop-gap measure to make sure image builds continue to work as expected.