### PR TITLE
:bug: Update task terminal state check to include "SucceededWithErrors"

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -76,6 +76,7 @@ import {
   useFetchApplications,
 } from "@app/queries/applications";
 import {
+  TaskStates,
   useCancelTaskMutation,
   useFetchTaskDashboard,
 } from "@app/queries/tasks";
@@ -609,12 +610,10 @@ export const ApplicationsTable: React.FC = () => {
       .flatMap((app) => app.tasks.currentAnalyzer)
       .filter(Boolean);
 
-    const terminalStates = ["Succeeded", "Failed", "Canceled", ""];
-
     return (
       currentAnalyzerTasksForSelected.length === 0 ||
       currentAnalyzerTasksForSelected.every(({ state }) =>
-        terminalStates.includes(state ?? "")
+        TaskStates.Terminal.includes(state ?? "")
       )
     );
   };

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -28,6 +28,7 @@ export const TaskStates = {
   Running: ["Running"],
   Success: ["Succeeded", "SucceededWithErrors"],
   SuccessWithErrors: ["SucceededWithErrors"],
+  Terminal: ["Succeeded", "SucceededWithErrors", "Failed", "Canceled"],
 };
 
 export const TasksQueryKey = "tasks";


### PR DESCRIPTION
Resolves: #2017

The check used to only allow starting an analysis if an application's analysis task is still running
(i.e. not in a terminal state) needs to also consider the frontend synthetic state `SucceededWithErrors` as a non-running / terminal state.
