### PR TITLE
:bug: Address targets falling out of sync after label selection changes

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -19,6 +19,7 @@ import { useFetchTargets } from "@app/queries/targets";
 import { Application, TagCategory, Target } from "@app/api/models";
 import { useFetchTagCategories } from "@app/queries/tags";
 import { SimpleSelectCheckbox } from "@app/components/SimpleSelectCheckbox";
+import { getUpdatedFormLabels, updateSelectedTargets } from "./utils";
 interface SetTargetsProps {
   applications: Application[];
 }
@@ -101,61 +102,23 @@ export const SetTargets: React.FC<SetTargetsProps> = ({ applications }) => {
     selectedLabelName: string,
     target: Target
   ) => {
-    const updatedSelectedTargets = getUpdatedSelectedTargets(
-      isSelecting,
-      target
+    const updatedSelectedTargets = updateSelectedTargets(
+      target.id,
+      selectedTargets
     );
 
     const updatedFormLabels = getUpdatedFormLabels(
       isSelecting,
       selectedLabelName,
-      target
+      target,
+      formLabels
     );
 
     setValue("formLabels", updatedFormLabels);
     setValue("selectedTargets", updatedSelectedTargets);
   };
 
-  const getUpdatedSelectedTargets = (isSelecting: boolean, target: Target) => {
-    const { selectedTargets } = values;
-    if (isSelecting) {
-      return [...selectedTargets, target.id];
-    }
-    return selectedTargets.filter((id) => id !== target.id);
-  };
-
-  const getUpdatedFormLabels = (
-    isSelecting: boolean,
-    selectedLabelName: string,
-    target: Target
-  ) => {
-    const { formLabels } = values;
-    if (target.custom) {
-      const customTargetLabelNames = target.labels?.map((label) => label.name);
-      const otherSelectedLabels = formLabels?.filter(
-        (formLabel) => !customTargetLabelNames?.includes(formLabel.name)
-      );
-      return isSelecting && target.labels
-        ? [...otherSelectedLabels, ...target.labels]
-        : otherSelectedLabels;
-    } else {
-      const otherSelectedLabels = formLabels?.filter(
-        (formLabel) => formLabel.name !== selectedLabelName
-      );
-      if (isSelecting) {
-        const matchingLabel = target.labels?.find(
-          (label) => label.name === selectedLabelName
-        );
-        return matchingLabel
-          ? [...otherSelectedLabels, matchingLabel]
-          : otherSelectedLabels;
-      }
-      return otherSelectedLabels;
-    }
-  };
-
   const allProviders = targets.flatMap((target) => target.provider);
-
   const languageOptions = Array.from(new Set(allProviders));
 
   return (


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-3180

- Currently, the set-options screen allows edit of target labels which can be set manually on the Advanced options step or by way of selecting a target card on the target card step. This PR brings the form labels and selectedTarget form values in sync by updating the selected targets to reflect any form label changes in the set options page. This fixes the mta-3180 scenario by causing validation to reflect the now accurate state of the selectedTargets form value. 

https://github.com/user-attachments/assets/d580f857-8236-4e30-bf28-ebd3a4c73792

