### PR TITLE
:bug: Persist filters in URL for applications table

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -63,10 +63,7 @@ import { checkAccess } from "@app/utils/rbac-utils";
 import WarningTriangleIcon from "@patternfly/react-icons/dist/esm/icons/warning-triangle-icon";
 
 // Hooks
-import {
-  deserializeFilterUrlParams,
-  useLocalTableControls,
-} from "@app/hooks/table-controls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 
 // Queries
 import { getArchetypeById, getAssessmentsByItemId } from "@app/api/rest";
@@ -308,11 +305,6 @@ export const ApplicationsTable: React.FC = () => {
   };
 
   // ----- Table controls
-  const urlParams = new URLSearchParams(window.location.search);
-  const filters = urlParams.get("filters");
-
-  const deserializedFilterValues = deserializeFilterUrlParams({ filters });
-
   const tableControls = useLocalTableControls({
     tableName: "applications",
     idProperty: "id",
@@ -333,7 +325,7 @@ export const ApplicationsTable: React.FC = () => {
     isActiveItemEnabled: true,
     persistTo: {
       activeItem: "urlParams",
-      filter: "sessionStorage",
+      filter: "urlParams",
       pagination: "sessionStorage",
       sort: "sessionStorage",
     },
@@ -343,7 +335,6 @@ export const ApplicationsTable: React.FC = () => {
     initialColumns: {
       name: { isIdentity: true },
     },
-    initialFilterValues: deserializedFilterValues,
     getSortValues: (app) => ({
       name: app.name,
       businessService: app.businessService?.name || "",


### PR DESCRIPTION
Fix regression after: https://github.com/konveyor/tackle2-ui/pull/1980
Resolves: https://issues.redhat.com/browse/MTA-1390

Initial filter values work best if the table is not persisting state between reloads (default strategy, component state). If the table uses session or local storage then any existing filter overwrites the default value. From the end user perspective the functionality works only on the first load with a clean browser (no previous state).

Switching to URL filter persistence provides the same functionality and ensures we have only one source of filters.

Reference-Url:  https://github.com/konveyor/tackle2-ui/pull/1698
