### PR TITLE
:bug: [backport release-0.5] Persist filters in URL for applications table (#2033)

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -68,10 +68,7 @@ import { normalizeRisk } from "@app/utils/type-utils";
 import { checkAccess } from "@app/utils/rbac-utils";
 
 // Hooks
-import {
-  deserializeFilterUrlParams,
-  useLocalTableControls,
-} from "@app/hooks/table-controls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 
 // Queries
 import { getArchetypeById, getAssessmentsByItemId } from "@app/api/rest";
@@ -313,11 +310,6 @@ export const ApplicationsTable: React.FC = () => {
   };
 
   // ----- Table controls
-  const urlParams = new URLSearchParams(window.location.search);
-  const filters = urlParams.get("filters");
-
-  const deserializedFilterValues = deserializeFilterUrlParams({ filters });
-
   const tableControls = useLocalTableControls({
     tableName: "applications",
     idProperty: "id",
@@ -338,7 +330,7 @@ export const ApplicationsTable: React.FC = () => {
     isActiveItemEnabled: true,
     persistTo: {
       activeItem: "urlParams",
-      filter: "sessionStorage",
+      filter: "urlParams",
       pagination: "sessionStorage",
       sort: "sessionStorage",
     },
@@ -348,7 +340,6 @@ export const ApplicationsTable: React.FC = () => {
     initialColumns: {
       name: { isIdentity: true },
     },
-    initialFilterValues: deserializedFilterValues,
     getSortValues: (app) => ({
       name: app.name,
       businessService: app.businessService?.name || "",


### PR DESCRIPTION
Backport-of:  (#2033)
Fix regression after: https://github.com/konveyor/tackle2-ui/pull/1980
Resolves: https://issues.redhat.com/browse/MTA-1390

Initial filter values work best if the table is not persisting state between reloads (default strategy, component state). If the table uses session or local storage then any existing filter overwrites the default value. From the end user perspective the functionality works only on the first load with a clean browser (no previous state).

Switching to URL filter persistence provides the same functionality and ensures we have only one source of filters.

Reference-Url:  https://github.com/konveyor/tackle2-ui/pull/1698
