### PR TITLE
:bug: Split the reports landscape unknown/unassessed chart

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -485,7 +485,6 @@
     "ticket": "Ticket",
     "trivialButMigratable": "Trivial but migratable",
     "type": "Type",
-    "unassessedOrUnknown": "Unassessed or unknown",
     "unassessed": "Unassessed",
     "unassigned": "Not yet assigned",
     "unknown": "Unknown",

--- a/client/src/app/pages/reports/components/application-landscape/application-landscape.tsx
+++ b/client/src/app/pages/reports/components/application-landscape/application-landscape.tsx
@@ -190,16 +190,29 @@ export const ApplicationLandscape: React.FC<IApplicationLandscapeProps> = ({
           <FlexItem>
             <Donut
               isAssessment={false}
-              id="landscape-donut-unassessed"
-              value={landscapeData.unassessed + landscapeData.unknown}
+              id="landscape-donut-unknown"
+              value={landscapeData.unknown}
               total={landscapeData.applicationsCount}
               color={RISK_LIST.unknown.hexColor}
               riskLabel={
-                <Link to={getRisksUrl(["unknown"])}>
-                  {`${t("terms.unassessed")}/${t("terms.unknown")}`}
+                <Link to={getRisksUrl(["unknown"])}>{t("terms.unknown")}</Link>
+              }
+              riskTitle={t("terms.unknown")}
+            />
+          </FlexItem>
+          <FlexItem>
+            <Donut
+              isAssessment={false}
+              id="landscape-donut-unassessed"
+              value={landscapeData.unassessed}
+              total={landscapeData.applicationsCount}
+              color={RISK_LIST.unassessed.hexColor}
+              riskLabel={
+                <Link to={getRisksUrl(["unassessed"])}>
+                  {t("terms.unassessed")}
                 </Link>
               }
-              riskTitle={t("terms.unassessedOrUnknown")}
+              riskTitle={t("terms.unassessed")}
             />
           </FlexItem>
         </Flex>


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-2678

On the reports page, split the combine Unknown / Unassessed landscape chart into separate charts.

Unknown and unassessed are two different risk states.
