### PR TITLE
:seedling: ci-repo: concurrency limits, codecov upload

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -15,6 +15,10 @@ on:
 
   workflow_call:
 
+concurrency:
+  group: ci-repo-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-test-lookup-image:
     runs-on: ubuntu-latest
@@ -61,14 +65,14 @@ jobs:
         run: npm run test -- --coverage --watchAll=false
 
       - name: Upload to codecov (client)
-        if: ${{ github.event.pull_request }}
+        # if: ${{ github.event.pull_request }}
         uses: codecov/codecov-action@v4
         with:
           flags: client
           directory: ./client/coverage
 
       - name: Upload to codecov (server)
-        if: ${{ github.event.pull_request }}
+        # if: ${{ github.event.pull_request }}
         uses: codecov/codecov-action@v4
         with:
           flags: server


### PR DESCRIPTION
  - Setup concurrency on the ci-repo.yml workflow so rapid updates to a PR will have old/pending CI runs just cancel (saving resources)

  - Allow the codecov action to upload on any run. This should allow the codecov reports on PRs be accurate based on the current commit on main (or PR target branch)

Fixes: #1820 
