### PR TITLE
:seedling: Update project to use nodejs 20, npm >=10.5.2 (#2062)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
-node_modules
-*/dist/
+**/node_modules
+**/dist
+hack/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,26 @@
 #       a specific version tag. Container build errors have come up locally
 #       and via github action workflow when `:latest` is updated.
 #
-# Image info: https://catalog.redhat.com/software/containers/ubi9/nodejs-18/62e8e7ed22d1d3c2dfe2ca01
+# Image info: https://catalog.redhat.com/software/containers/ubi9/nodejs-20/64770ac7a835530172eee6a9
 # Relevant PRs:
 #   - https://github.com/konveyor/tackle2-ui/pull/1746
 #   - https://github.com/konveyor/tackle2-ui/pull/1781
 
 # Builder image
-FROM registry.access.redhat.com/ubi9/nodejs-18:1-118 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-20:1-54 as builder
 
 USER 1001
 COPY --chown=1001 . .
-RUN npm clean-install --ignore-scripts && npm run build && npm run dist
+
+RUN \
+  npm version && \
+  npm config ls && \
+  npm clean-install --verbose --ignore-scripts --no-audit && \
+  npm run build && \
+  npm run dist
 
 # Runner image
-FROM registry.access.redhat.com/ubi9/nodejs-18-minimal:1-123
+FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:1-57
 
 # Add ps package to allow liveness probe for k8s cluster
 # Add tar package to allow copying files with kubectl scp

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,8 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": ">=18.14.2",
-        "npm": ">=9.5.0"
+        "node": ">=20.12.2",
+        "npm": "^9.5.0 || ^10.5.2"
       }
     },
     "client": {
@@ -3768,9 +3768,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",
@@ -5100,6 +5100,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -15574,9 +15575,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.29.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.29.2.tgz",
-      "integrity": "sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
+      "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "client"
   ],
   "engines": {
-    "node": ">=18.14.2",
-    "npm": ">=9.5.0"
+    "node": ">=20.12.2",
+    "npm": "^9.5.0 || ^10.5.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",


### PR DESCRIPTION
Upgrade the project to use nodejs-20 in the `Dockerfile`, and package.json engine block. More specific entries for `.dockerignore` will help keep the `COPY` step quick (especially for local dev image builds).

Reasoning:
  - nodejs-18 is in LTS until May 2025, but nodejs-20 will be in LTS until May 2026. [^1]

  - node and npm are distributed together, and the `ubi9/nodejs-20` container has a newer version of npm included (10.7.0) than the current `ubi9/nodejs-18` container (10.5.0)

  - Given github issues [^2] and [^3], we can assume that the only versions of npm that will be stable in CI during the `npm install` phase are `npm@9` and `npm@>=10.5.2`. Any npm version <10.5.2 is at severe risk of encountering network errors when installing packages, especially when running in a qemu environment for non-native architecture builds.

  - Being very specific in the `package.json` `engines` block will help keep everyone on working versions of npm.

[^1]: https://nodejs.org/en/about/previous-releases
[^2]: https://github.com/npm/cli/issues/7231
[^3]: https://github.com/npm/cli/issues/7072

Backport-of: #2062
