### PR TITLE
:bug: Remove extra link from empty task drawer

### DIFF
--- a/client/src/app/components/task-manager/TaskManagerDrawer.tsx
+++ b/client/src/app/components/task-manager/TaskManagerDrawer.tsx
@@ -6,9 +6,7 @@ import {
   DropdownItem,
   DropdownList,
   EmptyState,
-  EmptyStateActions,
   EmptyStateBody,
-  EmptyStateFooter,
   EmptyStateHeader,
   EmptyStateIcon,
   EmptyStateVariant,
@@ -101,11 +99,6 @@ export const TaskManagerDrawer: React.FC<TaskManagerDrawerProps> = forwardRef(
                 running. Completed and cancelled tasks may be viewed on the full
                 task list.
               </EmptyStateBody>
-              <EmptyStateFooter>
-                <EmptyStateActions>
-                  <Link to="/tasks">View All Tasks</Link>
-                </EmptyStateActions>
-              </EmptyStateFooter>
             </EmptyState>
           ) : (
             <NotificationDrawerList>


### PR DESCRIPTION
On the task drawer's empty state, remove the "View all tasks" link from the empty state. The link is already available in the task drawer header.

Resolves: https://issues.redhat.com/browse/MTA-3220
