### PR TITLE
:seedling: Image build, use variables for repo push

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -17,8 +17,8 @@ jobs:
   image-build:
     uses: konveyor/release-tools/.github/workflows/build-push-images.yaml@main
     with:
-      registry: "quay.io/konveyor"
-      image_name: "tackle2-ui"
+      registry: ${{ vars.IMAGE_BUILD_REGISTRY || 'quay.io/konveyor' }}
+      image_name: ${{ vars.IMAGE_BUILD_IMAGE_NAME || 'tackle2-ui' }}
       containerfile: "./Dockerfile"
 
       # keep the architectures in sync with `ci-image-build.yml`


### PR DESCRIPTION
To help out people building images in a fork, use github action variables to be able to configure the target registry and image names.

Now on a fork, the destination of an image build can be set by using action variables[^1]:
  - IMAGE_BUILD_REGISTRY (default: "quay.io/konveyor")
  - IMAGE_BUILD_IMAGE_NAME (default: "tackle2-ui")

and action secrets[^2]:
  - QUAY_PUBLISH_ROBOT
  - QUAY_PUBLISH_TOKEN

[^1]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository
[^2]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secret