### PR TITLE
:sparkles: Update stakeholder groups table to use ActionsColumn

### DIFF
--- a/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
@@ -39,7 +39,6 @@ import {
 } from "@app/queries/stakeholdergroups";
 import { NotificationsContext } from "@app/components/NotificationsContext";
 import { StakeholderGroupForm } from "./components/stakeholder-group-form";
-import { AppTableActionButtons } from "@app/components/AppTableActionButtons";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
@@ -52,6 +51,7 @@ import {
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import CubesIcon from "@patternfly/react-icons/dist/js/icons/cubes-icon";
+import { ControlTableActionButtons } from "../ControlTableActionButtons";
 
 export const StakeholderGroups: React.FC = () => {
   const { t } = useTranslation();
@@ -284,7 +284,7 @@ export const StakeholderGroups: React.FC = () => {
                           >
                             {stakeholderGroup.stakeholders?.length}
                           </Td>
-                          <AppTableActionButtons
+                          <ControlTableActionButtons
                             onEdit={() =>
                               setCreateUpdateModalState(stakeholderGroup)
                             }


### PR DESCRIPTION
Addition ActionsColumn to  Stakeholder groups table
Relates to https://github.com/konveyor/tackle2-ui/issues/1318
UI tests PR: 1222