### PR TITLE
:sparkles:Change style buttons edit & delete to tags table

### DIFF
--- a/client/src/app/pages/controls/tags/components/tag-table.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-table.tsx
@@ -1,17 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Table,
-  Thead,
-  Tr,
-  Th,
-  Tbody,
-  Td,
-  ActionsColumn,
-} from "@patternfly/react-table";
+import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
 import { Tag, TagCategory } from "@app/api/models";
 import "./tag-table.css";
 import { universalComparator } from "@app/utils/utils";
+import { ControlTableActionButtons } from "../../ControlTableActionButtons";
 
 export interface TabTableProps {
   tagCategory: TagCategory;
@@ -41,17 +34,9 @@ export const TagTable: React.FC<TabTableProps> = ({
             <Tr key={tag.name}>
               <Td>{tag.name}</Td>
               <Td isActionCell>
-                <ActionsColumn
-                  items={[
-                    {
-                      title: t("actions.edit"),
-                      onClick: () => onEdit(tag),
-                    },
-                    {
-                      title: t("actions.delete"),
-                      onClick: () => onDelete(tag),
-                    },
-                  ]}
+                <ControlTableActionButtons
+                  onEdit={() => onEdit(tag)}
+                  onDelete={() => onDelete(tag)}
                 />
               </Td>
             </Tr>

--- a/client/src/app/pages/controls/tags/tags.tsx
+++ b/client/src/app/pages/controls/tags/tags.tsx
@@ -43,7 +43,6 @@ import { COLOR_NAMES_BY_HEX_VALUE } from "@app/Constants";
 import { TagForm } from "./components/tag-form";
 import { TagCategoryForm } from "./components/tag-category-form";
 import { getTagCategoryFallbackColor } from "@app/components/labels/item-tag-label/item-tag-label";
-import { AppTableActionButtons } from "@app/components/AppTableActionButtons";
 import { Color } from "@app/components/Color";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
@@ -57,6 +56,7 @@ import {
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { RBAC, controlsWriteScopes, RBAC_TYPE } from "@app/rbac";
 import { TagTable } from "./components/tag-table";
+import { ControlTableActionButtons } from "../ControlTableActionButtons";
 
 export const Tags: React.FC = () => {
   const { t } = useTranslation();
@@ -385,9 +385,9 @@ export const Tags: React.FC = () => {
                         >
                           {tagCategory.tags?.length || 0}
                         </Td>
-                        <AppTableActionButtons
+                        <ControlTableActionButtons
                           isDeleteEnabled={!!tagCategory.tags?.length}
-                          tooltipMessage={t(
+                          deleteTooltipMessage={t(
                             "message.cannotDeleteNonEmptyTagCategory"
                           )}
                           onEdit={() => setTagCategoryModalState(tagCategory)}


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
Changing the icons of edit and delete buttons in the tags table #1318 