### PR TITLE
:sparkless: add ActionsColumn to  Migration waves table

### DIFF
--- a/client/src/app/pages/migration-waves/migration-waves.tsx
+++ b/client/src/app/pages/migration-waves/migration-waves.tsx
@@ -20,8 +20,10 @@ import {
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
+  Tooltip,
 } from "@patternfly/react-core";
 import {
+  ActionsColumn,
   ExpandableRowContent,
   Table,
   Tbody,
@@ -62,7 +64,6 @@ import { WaveStatusTable } from "./components/wave-status-table";
 import { WaveForm } from "./components/migration-wave-form";
 import { ManageApplicationsForm } from "./components/manage-applications-form";
 import { deleteMigrationWave } from "@app/api/rest";
-import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
@@ -70,6 +71,7 @@ import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { toRefs } from "@app/utils/model-utils";
 import { useFetchTickets } from "@app/queries/tickets";
 import { isInClosedRange } from "@app/components/FilterToolbar/dateUtils";
+import { PencilAltIcon } from "@patternfly/react-icons";
 
 export const MigrationWaves: React.FC = () => {
   const { t } = useTranslation();
@@ -455,6 +457,15 @@ export const MigrationWaves: React.FC = () => {
                             ? migrationWave.status
                             : "--"}
                         </Td>
+                        <Td isActionCell id="pencil-action">
+                          <Tooltip content={t("actions.edit")}>
+                            <Button
+                              variant="plain"
+                              icon={<PencilAltIcon />}
+                              onClick={() => setWaveModalState(migrationWave)}
+                            />
+                          </Tooltip>
+                        </Td>
                         <Td isActionCell id="row-actions">
                           <Dropdown
                             isOpen={isRowDropdownOpen === migrationWave.id}
@@ -482,74 +493,74 @@ export const MigrationWaves: React.FC = () => {
                             )}
                             shouldFocusToggleOnSelect
                           >
-                            <DropdownItem
-                              key="edit"
-                              component="button"
-                              onClick={() => setWaveModalState(migrationWave)}
-                            >
-                              {t("actions.edit")}
-                            </DropdownItem>
-                            <ConditionalTooltip
-                              key="manage-app"
-                              isTooltipEnabled={applications.length === 0}
-                              content={
-                                "No applications are available for assignment."
-                              }
-                            >
-                              <DropdownItem
-                                key="manage-app"
-                                isAriaDisabled={applications.length === 0}
-                                onClick={() => {
-                                  setWaveToManageModalState(migrationWave);
-                                }}
-                              >
-                                {t("composed.manage", {
-                                  what: t("terms.applications").toLowerCase(),
-                                })}
-                              </DropdownItem>
-                            </ConditionalTooltip>
-                            <ConditionalTooltip
-                              key="export-to-issue-manager"
-                              isTooltipEnabled={
-                                migrationWave.applications?.length < 1 ||
-                                !hasExportableApplications(
-                                  tickets,
-                                  migrationWave?.applications
-                                )
-                              }
-                              content={
-                                "No applications are available for export."
-                              }
-                            >
-                              <DropdownItem
-                                key="export-to-issue-manager"
-                                isAriaDisabled={
-                                  migrationWave.applications?.length < 1 ||
-                                  !hasExportableApplications(
-                                    tickets,
-                                    migrationWave?.applications
-                                  )
-                                }
-                                onClick={() =>
-                                  setApplicationsToExport(
-                                    migrationWave.fullApplications
-                                  )
-                                }
-                              >
-                                {t("terms.exportToIssue")}
-                              </DropdownItem>
-                            </ConditionalTooltip>
-                            <DropdownItem
-                              key="delete"
-                              onClick={() =>
-                                setMigrationWaveToDelete({
-                                  id: migrationWave.id,
-                                  name: migrationWave.name,
-                                })
-                              }
-                            >
-                              {t("actions.delete")}
-                            </DropdownItem>
+                            <ActionsColumn
+                              items={[
+                                // {
+                                //   title: t("actions.edit"),
+                                //   onClick: () => setWaveModalState(migrationWave),
+                                // },
+                                {
+                                  isAriaDisabled:
+                                    migrationWave.applications.length === 0,
+                                  tooltipProps: {
+                                    content:
+                                      migrationWave.applications.length === 0
+                                        ? "No applications are available for assignment."
+                                        : "",
+                                  },
+                                  title: t("composed.manage", {
+                                    what: t("terms.applications").toLowerCase(),
+                                  }),
+                                  onClick: () => {
+                                    if (migrationWave.applications.length > 0) {
+                                      setWaveToManageModalState(migrationWave);
+                                    }
+                                  },
+                                },
+                                {
+                                  isAriaDisabled:
+                                    migrationWave.applications?.length < 1 ||
+                                    !hasExportableApplications(
+                                      tickets,
+                                      migrationWave?.applications
+                                    ),
+                                  tooltipProps: {
+                                    content:
+                                      migrationWave.applications?.length < 1 ||
+                                      !hasExportableApplications(
+                                        tickets,
+                                        migrationWave?.applications
+                                      )
+                                        ? "No applications are available for export."
+                                        : "",
+                                  },
+                                  title: t("terms.exportToIssue"),
+                                  onClick: () => {
+                                    if (
+                                      migrationWave.applications?.length > 0 &&
+                                      hasExportableApplications(
+                                        tickets,
+                                        migrationWave?.applications
+                                      )
+                                    ) {
+                                      setApplicationsToExport(
+                                        migrationWave.fullApplications
+                                      );
+                                    }
+                                  },
+                                },
+                                {
+                                  title: t("actions.delete"),
+                                  onClick: () => {
+                                    setMigrationWaveToDelete({
+                                      id: migrationWave.id,
+                                      name: migrationWave.name,
+                                    });
+                                  },
+                                  isDanger: true,
+                                },
+                              ]}
+                            />
                           </Dropdown>
                         </Td>
                       </TableRowContentWithControls>


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
the same actions that there is currently should stay
but delete should be red & edit should be in another button(not in the list)
implement it by ActionsColumn 


