### PR TITLE
:sparkles:adding ability to sort&filter by analysis status

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -338,7 +338,7 @@ export const ApplicationsTable: React.FC = () => {
       sort: "sessionStorage",
     },
     isLoading: isFetchingApplications,
-    sortableColumns: ["name", "businessService", "tags", "effort"],
+    sortableColumns: ["name", "businessService", "tags", "effort","analysis"],
     initialSort: { columnKey: "name", direction: "asc" },
     initialColumns: {
       name: { isIdentity: true },
@@ -348,6 +348,7 @@ export const ApplicationsTable: React.FC = () => {
       businessService: app.businessService?.name || "",
       tags: app.tags?.length || 0,
       effort: app.effort || 0,
+      analysis: app.tasks.currentAnalyzer?.state || 0
     }),
     filterCategories: [
       {
@@ -510,18 +511,11 @@ export const ApplicationsTable: React.FC = () => {
           t("actions.filterBy", {
             what: t("terms.analysis").toLowerCase(),
           }) + "...",
-      
-          // taskStateToAnalyze.map(state,icon)=>{
-          //   value:
+        selectOptions: Array.from(taskStateToAnalyze).map(([taskState, displayStatus]) => ({
+          value: taskState, // The task state will be the value
+          label: t(`${displayStatus}`) // The display status translated using t()
+        })),
 
-          // } forEach.toString()}
-          // ApplicationAnalysisStatus.toString() 
-          // Object.entries(Analy)
-          selectOptions: Array.from(taskStateToAnalyze).map(([taskState, displayStatus]) => ({
-            value: taskState, // The task state will be the value
-            label: t(`${displayStatus}`) // The display status translated using t()
-          })),         
-        
         getItemValue: (item) => item?.tasks.currentAnalyzer?.state ||
           "No task"
       },

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -72,7 +72,7 @@ import { useLocalTableControls } from "@app/hooks/table-controls";
 
 // Queries
 import { getArchetypeById, getAssessmentsByItemId } from "@app/api/rest";
-import { Assessment, Ref } from "@app/api/models";
+import { Assessment, Ref, TaskState } from "@app/api/models";
 import {
   useBulkDeleteApplicationMutation,
   useFetchApplications,
@@ -88,7 +88,10 @@ import { useFetchTagsWithTagItems } from "@app/queries/tags";
 
 // Relative components
 import { AnalysisWizard } from "../analysis-wizard/analysis-wizard";
-import { ApplicationAnalysisStatus } from "../components/application-analysis-status";
+import {
+  ApplicationAnalysisStatus,
+  taskStateToAnalyze,
+} from "../components/application-analysis-status";
 import { ApplicationAssessmentStatus } from "../components/application-assessment-status";
 import { ApplicationBusinessService } from "../components/application-business-service";
 import { ApplicationDependenciesForm } from "@app/components/ApplicationDependenciesFormContainer/ApplicationDependenciesForm";
@@ -509,11 +512,17 @@ export const ApplicationsTable: React.FC = () => {
             what: t("terms.analysis").toLowerCase(),
           }) + "...",
         selectOptions: Object.values(applications)
-          .map((a) => ({
-            value: a?.tasks.currentAnalyzer?.state || "No Task",
-            label: a?.tasks.currentAnalyzer?.state || "Not Started",
-          }))
-          .filter((v, i, a) => a.findIndex((v3) => v3.label === v.label) === i)
+          .map((a) => {
+            let value = a?.tasks.currentAnalyzer?.state || "No Task";
+            if (value === "No Task") {
+              value = "No task";
+            }
+            let label = taskStateToAnalyze.get(value as TaskState) || value;
+            console.log(label + "," + value);
+            if (label === "NotStarted") label = "Not started";
+            return { value, label };
+          })
+          .filter((v, i, a) => a.findIndex((v2) => v2.label === v.label) === i)
           .sort((a, b) => a.value.localeCompare(b.value)),
         getItemValue: (item) => item?.tasks.currentAnalyzer?.state || "No Task",
       },

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -513,7 +513,7 @@ export const ApplicationsTable: React.FC = () => {
             value: a?.tasks.currentAnalyzer?.state || "No Task",
             label: a?.tasks.currentAnalyzer?.state || "Not Started",
           }))
-          .filter((v, i, a) => a.findIndex((v2) => v2.label === v.label) === i)
+          .filter((v, i, a) => a.findIndex((v3) => v3.label === v.label) === i)
           .sort((a, b) => a.value.localeCompare(b.value)),
         getItemValue: (item) => item?.tasks.currentAnalyzer?.state || "No Task",
       },

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -85,10 +85,11 @@ import {
 import { useDeleteAssessmentMutation } from "@app/queries/assessments";
 import { useDeleteReviewMutation } from "@app/queries/reviews";
 import { useFetchTagsWithTagItems } from "@app/queries/tags";
+import { TaskState } from "@app/api/models";
 
 // Relative components
 import { AnalysisWizard } from "../analysis-wizard/analysis-wizard";
-import { ApplicationAnalysisStatus } from "../components/application-analysis-status";
+import { ApplicationAnalysisStatus, taskStateToAnalyze } from "../components/application-analysis-status";
 import { ApplicationAssessmentStatus } from "../components/application-assessment-status";
 import { ApplicationBusinessService } from "../components/application-business-service";
 import { ApplicationDependenciesForm } from "@app/components/ApplicationDependenciesFormContainer/ApplicationDependenciesForm";
@@ -109,6 +110,8 @@ import {
   DecoratedApplication,
   useDecoratedApplications,
 } from "./useDecoratedApplications";
+import { Item } from "@app/pages/migration-targets/components/dnd/item";
+import AnalysisDetails from "../analysis-details";
 
 export const ApplicationsTable: React.FC = () => {
   const { t } = useTranslation();
@@ -367,7 +370,7 @@ export const ApplicationsTable: React.FC = () => {
         title: t("terms.archetypes"),
         type: FilterType.multiselect,
         placeholderText:
-          t("actions.filterBy", {
+          t("action s.filterBy", {
             what: t("terms.archetypes").toLowerCase(),
           }) + "...",
         selectOptions: referencedArchetypeRefs.map(({ name }) => ({
@@ -499,6 +502,29 @@ export const ApplicationsTable: React.FC = () => {
         ],
         getItemValue: (item) => normalizeRisk(item.risk) ?? "",
       },
+      {
+        categoryKey: "analysis",
+        title: t("terms.analysis"),
+        type: FilterType.multiselect,
+        placeholderText:
+          t("actions.filterBy", {
+            what: t("terms.analysis").toLowerCase(),
+          }) + "...",
+      
+          // taskStateToAnalyze.map(state,icon)=>{
+          //   value:
+
+          // } forEach.toString()}
+          // ApplicationAnalysisStatus.toString() 
+          // Object.entries(Analy)
+          selectOptions: Array.from(taskStateToAnalyze).map(([taskState, displayStatus]) => ({
+            value: taskState, // The task state will be the value
+            label: t(`${displayStatus}`) // The display status translated using t()
+          })),         
+        
+        getItemValue: (item) => item?.tasks.currentAnalyzer?.state ||
+          "No task"
+      },
     ],
     initialItemsPerPage: 10,
     hasActionsColumn: true,
@@ -547,48 +573,48 @@ export const ApplicationsTable: React.FC = () => {
 
   const importDropdownItems = importWriteAccess
     ? [
-        <DropdownItem
-          key="import-applications"
-          component="button"
-          onClick={() => setIsApplicationImportModalOpen(true)}
-        >
-          {t("actions.import")}
-        </DropdownItem>,
-        <DropdownItem
-          key="manage-import-applications"
-          onClick={() => {
-            history.push(Paths.applicationsImports);
-          }}
-        >
-          {t("actions.manageImports")}
-        </DropdownItem>,
-      ]
+      <DropdownItem
+        key="import-applications"
+        component="button"
+        onClick={() => setIsApplicationImportModalOpen(true)}
+      >
+        {t("actions.import")}
+      </DropdownItem>,
+      <DropdownItem
+        key="manage-import-applications"
+        onClick={() => {
+          history.push(Paths.applicationsImports);
+        }}
+      >
+        {t("actions.manageImports")}
+      </DropdownItem>,
+    ]
     : [];
   const applicationDropdownItems = applicationWriteAccess
     ? [
-        <DropdownItem
-          key="applications-bulk-delete"
-          isDisabled={selectedRows.length < 1}
-          onClick={() => {
-            setApplicationsToDelete(selectedRows);
-          }}
-        >
-          {t("actions.delete")}
-        </DropdownItem>,
-        ...(credentialsReadAccess
-          ? [
-              <DropdownItem
-                key="manage-applications-credentials"
-                isDisabled={selectedRows.length < 1}
-                onClick={() => {
-                  setSaveApplicationsCredentialsModalState(selectedRows);
-                }}
-              >
-                {t("actions.manageCredentials")}
-              </DropdownItem>,
-            ]
-          : []),
-      ]
+      <DropdownItem
+        key="applications-bulk-delete"
+        isDisabled={selectedRows.length < 1}
+        onClick={() => {
+          setApplicationsToDelete(selectedRows);
+        }}
+      >
+        {t("actions.delete")}
+      </DropdownItem>,
+      ...(credentialsReadAccess
+        ? [
+          <DropdownItem
+            key="manage-applications-credentials"
+            isDisabled={selectedRows.length < 1}
+            onClick={() => {
+              setSaveApplicationsCredentialsModalState(selectedRows);
+            }}
+          >
+            {t("actions.manageCredentials")}
+          </DropdownItem>,
+        ]
+        : []),
+    ]
     : [];
 
   const dropdownItems = [...importDropdownItems, ...applicationDropdownItems];
@@ -977,58 +1003,58 @@ export const ApplicationsTable: React.FC = () => {
                             onClick: () => assessSelectedApp(application),
                           },
                           assessmentWriteAccess &&
-                            (application.assessments?.length ?? 0) > 0 && {
-                              title: t("actions.discardAssessment"),
-                              onClick: () =>
-                                setAssessmentToDiscard(application),
-                            },
+                          (application.assessments?.length ?? 0) > 0 && {
+                            title: t("actions.discardAssessment"),
+                            onClick: () =>
+                              setAssessmentToDiscard(application),
+                          },
                           reviewsWriteAccess && {
                             title: t("actions.review"),
                             onClick: () => reviewSelectedApp(application),
                           },
                           reviewsWriteAccess &&
-                            application?.review && {
-                              title: t("actions.discardReview"),
-                              onClick: () => setReviewToDiscard(application),
-                            },
+                          application?.review && {
+                            title: t("actions.discardReview"),
+                            onClick: () => setReviewToDiscard(application),
+                          },
                           dependenciesWriteAccess && {
                             title: t("actions.manageDependencies"),
                             onClick: () =>
                               setApplicationDependenciesToManage(application),
                           },
                           credentialsReadAccess &&
-                            applicationWriteAccess && {
-                              title: t("actions.manageCredentials"),
-                              onClick: () =>
-                                setSaveApplicationsCredentialsModalState([
-                                  application,
-                                ]),
-                            },
+                          applicationWriteAccess && {
+                            title: t("actions.manageCredentials"),
+                            onClick: () =>
+                              setSaveApplicationsCredentialsModalState([
+                                application,
+                              ]),
+                          },
                           analysesReadAccess &&
-                            !!application.tasks.currentAnalyzer && {
-                              title: t("actions.analysisDetails"),
-                              onClick: () => {
-                                const taskId =
-                                  application.tasks.currentAnalyzer?.id;
-                                if (taskId && application.id) {
-                                  history.push(
-                                    formatPath(
-                                      Paths.applicationsAnalysisDetails,
-                                      {
-                                        applicationId: application.id,
-                                        taskId,
-                                      }
-                                    )
-                                  );
-                                }
-                              },
+                          !!application.tasks.currentAnalyzer && {
+                            title: t("actions.analysisDetails"),
+                            onClick: () => {
+                              const taskId =
+                                application.tasks.currentAnalyzer?.id;
+                              if (taskId && application.id) {
+                                history.push(
+                                  formatPath(
+                                    Paths.applicationsAnalysisDetails,
+                                    {
+                                      applicationId: application.id,
+                                      taskId,
+                                    }
+                                  )
+                                );
+                              }
                             },
+                          },
                           tasksReadAccess &&
-                            tasksWriteAccess &&
-                            isTaskCancellable(application) && {
-                              title: t("actions.cancelAnalysis"),
-                              onClick: () => cancelAnalysis(application),
-                            },
+                          tasksWriteAccess &&
+                          isTaskCancellable(application) && {
+                            title: t("actions.cancelAnalysis"),
+                            onClick: () => cancelAnalysis(application),
+                          },
                           applicationWriteAccess && { isSeparator: true },
                           applicationWriteAccess && {
                             title: t("actions.delete"),
@@ -1131,11 +1157,10 @@ export const ApplicationsTable: React.FC = () => {
           )}
           titleIconVariant={"warning"}
           isOpen={applicationsToDelete.length > 0}
-          message={`${
-            applicationsToDelete.length > 1
-              ? t("dialog.message.applicationsBulkDelete")
-              : ""
-          } ${t("dialog.message.delete")}`}
+          message={`${applicationsToDelete.length > 1
+            ? t("dialog.message.applicationsBulkDelete")
+            : ""
+            } ${t("dialog.message.delete")}`}
           aria-label="Applications bulk delete"
           confirmBtnVariant={ButtonVariant.danger}
           confirmBtnLabel={t("actions.delete")}

--- a/client/src/app/pages/applications/components/application-analysis-status.tsx
+++ b/client/src/app/pages/applications/components/application-analysis-status.tsx
@@ -7,7 +7,7 @@ export interface ApplicationAnalysisStatusProps {
   state: TaskState;
 }
 
-const taskStateToAnalyze: Map<TaskState, IconedStatusPreset> = new Map([
+export const taskStateToAnalyze: Map<TaskState, IconedStatusPreset> = new Map([
   ["not supported", "Canceled"],
   ["Canceled", "Canceled"],
   ["Created", "Scheduled"],


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
adding the ability to sort and filter by analysis status in the application inventory table.
before the change:
![image](https://github.com/user-attachments/assets/36661a72-1f00-45fd-91b4-65e13b4f3508)
after the change:
![image](https://github.com/user-attachments/assets/b8180159-b5a9-4c14-9b82-5e7f691a5113)



