### PR TITLE
:sparkles: Add download modal for analysis details reports

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -192,6 +192,7 @@
     "duplicateTag": "A tag with this name already exists. Use a different name.",
     "duplicateWave": "The migration wave could not be created due to a conflict with an existing wave. Make sure the name and start/end dates are unique and try again.",
     "importErrorCheckDocumentation": "For status Error imports, check the documentation to ensure your file is structured correctly.",
+    "unsupportedFileType": "Unsupported file type. Only Excel, ODS, and CSV files are allowed.",
     "insecureTracker": "Insecure mode deactivates certificate verification. Use insecure mode for instances that have self-signed certificates.",
     "inheritedReviewTooltip": "This application is inheriting a review from an archetype.",
     "inheritedReviewTooltip_plural": "This application is inheriting reviews from {{count}} archetypes.",

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -358,6 +358,24 @@ export function getTaskByIdAndFormat(
     });
 }
 
+export function getTasksByIds(
+  ids: number[],
+  format: "json" | "yaml"
+): Promise<Task[]> {
+  const isYaml = format === "yaml";
+  const headers = isYaml ? { ...yamlHeaders } : { ...jsonHeaders };
+  const responseType = isYaml ? "text" : "json";
+
+  return axios
+    .post<Task[]>(`${TASKS}/multiple`, ids, {
+      headers: headers,
+      responseType: responseType,
+    })
+    .then((response) => {
+      return response.data;
+    });
+}
+
 export const getTasksDashboard = () =>
   axios
     .get<TaskDashboard[]>(`${TASKS}/report/dashboard`)

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -215,6 +215,20 @@ export const ApplicationsTable: React.FC = () => {
         selectedFormat === "yaml"
           ? yaml.dump(tasks, { indent: 2 })
           : JSON.stringify(tasks, null, 2);
+
+      const blob = new Blob([data], {
+        type:
+          selectedFormat === "json" ? "application/json" : "application/x-yaml",
+      });
+      const url = URL.createObjectURL(blob);
+      const downloadLink = document.createElement("a"); // שינוי שם למשתנה
+      downloadLink.href = url;
+      downloadLink.download = `logs - ${ids}.${selectedFormat}`;
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+      URL.revokeObjectURL(url);
+
       setIsDownloadModalOpen(false);
     } catch (error) {
       console.error("Error fetching tasks:", error);

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -16,8 +16,10 @@ import {
   DropdownItem,
   Modal,
   Tooltip,
+  FormGroup,
 } from "@patternfly/react-core";
 import {
+  CodeIcon,
   PencilAltIcon,
   TagIcon,
   WarningTriangleIcon,
@@ -1357,6 +1359,35 @@ export const ApplicationsTable: React.FC = () => {
           }}
         />
       </div>
+      <Modal
+        isOpen={isDownloadModalOpen}
+        variant="small"
+        title={t("actions.download", { what: "analysis details reports" })}
+        onClose={() => setIsDownloadModalOpen(false)} // סגור את המודל
+      >
+        <FormGroup label="Select Format" fieldId="format-select">
+          <div>
+            <Button
+              variant={selectedFormat === "json" ? "primary" : "secondary"}
+              onClick={() => setSelectedFormat("json")}
+            >
+              {<CodeIcon />}
+              JSON
+            </Button>
+            <Button
+              variant={selectedFormat === "yaml" ? "primary" : "secondary"}
+              onClick={() => setSelectedFormat("yaml")}
+            >
+              {<CodeIcon />}
+              YAML
+            </Button>
+          </div>
+          <p>Selected Format: {selectedFormat}</p>
+        </FormGroup>
+        <Button variant="primary" onClick={handleDownload}>
+          {t("actions.download")}
+        </Button>
+      </Modal>
     </ConditionalRender>
   );
 };

--- a/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
+++ b/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
@@ -112,7 +112,7 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
           <FormHelperText>
             <HelperText>
               <HelperTextItem variant="error">
-                You should select a CSV/EXEL/ODS file.
+                {t("message.unsupportedFileType")}
               </HelperTextItem>
             </HelperText>
           </FormHelperText>

--- a/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
+++ b/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
@@ -95,8 +95,13 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
             }
           }}
           dropzoneProps={{
-            accept: { "text/csv": [".csv"] },
-            onDropRejected: handleFileRejected,
+            accept: {
+              "text/csv": [".csv"],
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+                [".xlsx"],
+              "application/vnd.ms-excel": [".xls"],
+              "application/vnd.oasis.opendocument.spreadsheet": [".ods"],
+            },
           }}
           onClearClick={() => {
             setFile(undefined);
@@ -106,7 +111,7 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
           <FormHelperText>
             <HelperText>
               <HelperTextItem variant="error">
-                You should select a CSV file.
+                {t("errors.invalidFileFormat")}
               </HelperTextItem>
             </HelperText>
           </FormHelperText>

--- a/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
+++ b/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
@@ -102,6 +102,7 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
               "application/vnd.ms-excel": [".xls"],
               "application/vnd.oasis.opendocument.spreadsheet": [".ods"],
             },
+            onDropRejected: handleFileRejected,
           }}
           onClearClick={() => {
             setFile(undefined);
@@ -111,7 +112,7 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
           <FormHelperText>
             <HelperText>
               <HelperTextItem variant="error">
-                {t("errors.invalidFileFormat")}
+                You should select a CSV/EXEL/ODS file.
               </HelperTextItem>
             </HelperText>
           </FormHelperText>


### PR DESCRIPTION
Implement download modal for analysis details reports. 
Added buttons to select between JSON and YAML formats, 
and displayed the selected format. 