### PR TITLE
:sparkles:  Validation error messages

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -538,7 +538,21 @@
     "minCount_plural": "At least {{count}} {{types}} must be selected.",
     "minLength": "This field must contain at least {{length}} characters.",
     "minOneStakeholderOrGroupRequired": "At least one stakeholder or stakeholder groups is required.",
-    "required": "This field is required."
+    "required": "This field is required.",
+    "unsupportedMode": "Selected mode not supported for selected applications",
+    "requiredFile": "A file is required",
+    "minOneRequired": "At least one {{type}} is required",
+    "requiredRepositoryURL": "Repository URL is required",
+    "duplicateName": "{type} with this name already exists. Use a different name.",
+    "enterRepositoryUrl": "Enter repository url.",
+    "duplicateEmail": "A stakeholder with this email address already exists. Use a different email address.",
+    "invalidDateFormat": "Date must be formatted as MM/DD/YYYY",
+    "nameInvalid": "Name is invalid. The name must be between 3 and 120 characters.",
+    "startDateAfterToday": "Start date can be no sooner than today.",
+    "endDateAfterStartDate": "End date must be after start date",
+    "validEmail": "Username must be a valid email",
+    "requiredField": "{{field}} is a required field",
+    "minOneRequiredRuleFile": "At least 1 valid custom rule file must be uploaded."
   },
   "wizard": {
     "alert": {

--- a/client/src/app/pages/applications/components/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/components/application-form/application-form.tsx
@@ -142,7 +142,7 @@ export const useApplicationFormHook = ({
         .max(120, t("validation.maxLength", { length: 120 }))
         .test(
           "Duplicate name",
-          "An application with this name already exists. Use a different name.",
+          t("duplicateName", { type: "An application" }),
           (value) =>
             duplicateNameCheck(
               existingApplications,
@@ -176,46 +176,50 @@ export const useApplicationFormHook = ({
         .when("branch", {
           is: (branch: string) => branch?.length > 0,
           then: (schema) =>
-            customURLValidation(schema).required("Enter repository url."),
+            customURLValidation(schema).required(
+              t("validation.requiredRepositoryURL")
+            ),
           otherwise: (schema) => customURLValidation(schema),
         })
         .when("rootPath", {
           is: (rootPath: string) => rootPath?.length > 0,
           then: (schema) =>
-            customURLValidation(schema).required("Enter repository url."),
+            customURLValidation(schema).required(
+              t("validation.requiredRepositoryURL")
+            ),
           otherwise: (schema) => customURLValidation(schema),
         }),
       group: string()
         .when("artifact", {
           is: (artifact: string) => artifact?.length > 0,
-          then: (schema) => schema.required("This field is required."),
+          then: (schema) => schema.required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         })
         .when("version", {
           is: (version: string) => version?.length > 0,
-          then: (schema) => schema.required("This field is required."),
+          then: (schema) => schema.required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         }),
       artifact: string()
         .when("group", {
           is: (group: string) => group?.length > 0,
-          then: (schema) => schema.required("This field is required."),
+          then: (schema) => schema.required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         })
         .when("version", {
           is: (version: string) => version?.length > 0,
-          then: (schema) => schema.required("This field is required."),
+          then: (schema) => schema.required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         }),
       version: string()
         .when("group", {
           is: (group: string) => group?.length > 0,
-          then: (schema) => schema.required("This field is required."),
+          then: (schema) => schema.required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         })
         .when("artifact", {
           is: (artifact: string) => artifact?.length > 0,
-          then: (schema) => schema.required("This field is required."),
+          then: (schema) => schema.required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         }),
     },

--- a/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form/archetype-form.tsx
@@ -117,7 +117,7 @@ const ArchetypeForm: React.FC<ArchetypeFormProps> = ({
       .max(120, t("validation.maxLength", { length: 120 }))
       .test(
         "Duplicate name",
-        "An archetype with this name already exists. Use a different name.",
+        t("duplicateName", { type: "An archetype" }),
         (value) =>
           duplicateNameCheck(
             existingArchetypes,

--- a/client/src/app/pages/controls/business-services/components/business-service-form.tsx
+++ b/client/src/app/pages/controls/business-services/components/business-service-form.tsx
@@ -71,7 +71,7 @@ export const BusinessServiceForm: React.FC<BusinessServiceFormProps> = ({
       .max(120, t("validation.maxLength", { length: 120 }))
       .test(
         "Duplicate name",
-        "A business service with this name already exists. Use a different name.",
+        t("duplicateName", { type: "A business service" }),
         (value) => {
           return duplicateNameCheck(
             businessServices || [],

--- a/client/src/app/pages/controls/job-functions/components/job-function-form.tsx
+++ b/client/src/app/pages/controls/job-functions/components/job-function-form.tsx
@@ -47,7 +47,7 @@ export const JobFunctionForm: React.FC<JobFunctionFormProps> = ({
       .max(120, t("validation.maxLength", { length: 120 }))
       .test(
         "Duplicate name",
-        "A job function with this name already exists. Use a different name.",
+        t("duplicateName", { type: "A job function " }),
         (value) => {
           return duplicateNameCheck(
             jobFunctions || [],

--- a/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
@@ -76,7 +76,7 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
       .max(120, t("validation.maxLength", { length: 120 }))
       .test(
         "Duplicate name",
-        "An stakeholder group with this name already exists. Use a different name.",
+        t("duplicateName", { type: "An stakeholder group" }),
         (value) => {
           return duplicateNameCheck(
             stakeholderGroups || [],

--- a/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
+++ b/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
@@ -72,16 +72,13 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
       .min(3, t("validation.minLength", { length: 3 }))
       .max(120, t("validation.maxLength", { length: 120 }))
       .email(t("validation.email"))
-      .test(
-        "Duplicate email",
-        "A stakeholder with this email address already exists. Use a different email address.",
-        (value) =>
-          duplicateFieldCheck(
-            "email",
-            stakeholders,
-            stakeholder || null,
-            value || ""
-          )
+      .test("Duplicate email", t("duplicateEmail"), (value) =>
+        duplicateFieldCheck(
+          "email",
+          stakeholders,
+          stakeholder || null,
+          value || ""
+        )
       ),
     name: string()
       .trim()
@@ -90,7 +87,7 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
       .max(120, t("validation.maxLength", { length: 120 }))
       .test(
         "Duplicate name",
-        "A stakeholder with this name already exists. Use a different name.",
+        t("duplicateName", { type: "An stakeholder group" }),
         (value) =>
           duplicateNameCheck(stakeholders, stakeholder || null, value || "")
       ),

--- a/client/src/app/pages/controls/tags/components/tag-category-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-category-form.tsx
@@ -63,7 +63,7 @@ export const TagCategoryForm: React.FC<TagCategoryFormProps> = ({
       .max(40, t("validation.maxLength", { length: 40 }))
       .test(
         "Duplicate name",
-        "A tag type with this name already exists. Use a different name.",
+        t("duplicateName", { type: "A tag type" }),
         (value) => {
           return duplicateNameCheck(
             tagCategories || [],

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -152,7 +152,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
       .max(120, t("validation.maxLength", { length: 120 }))
       .test(
         "Duplicate name",
-        "An identity with this name already exists. Use a different name.",
+        t("duplicateName", { type: "An identity" }),
         (value) => duplicateNameCheck(trackers, tracker || null, value || "")
       )
       .required(t("validation.required")),

--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -191,7 +191,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
         .max(120, t("validation.maxLength", { length: 120 }))
         .test(
           "Duplicate name",
-          "An identity with this name already exists. Use a different name.",
+          t("duplicateName", { type: "An identity" }),
           (value) =>
             duplicateNameCheck(identities, identity || null, value || "")
         ),
@@ -288,7 +288,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           is: (value: string) => value === "proxy" || value === "jira",
           then: yup
             .string()
-            .required("This value is required")
+            .required(t("validation.required"))
             .min(3, t("validation.minLength", { length: 3 }))
             .max(120, t("validation.maxLength", { length: 120 })),
           otherwise: (schema) => schema.trim(),
@@ -297,7 +297,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           is: (value: string) => value === "proxy",
           then: yup
             .string()
-            .required("This value is required")
+            .required(t("validation.required"))
             .min(3, t("validation.minLength", { length: 3 }))
             .max(120, t("validation.maxLength", { length: 120 })),
           otherwise: (schema) => schema.trim(),
@@ -306,10 +306,10 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           is: (value: string) => value === "jira",
           then: yup
             .string()
-            .email("Username must be a valid email")
+            .email(t("validation.validEmail"))
             .min(3, t("validation.minLength", { length: 3 }))
             .max(120, t("validation.maxLength", { length: 120 }))
-            .required("This value is required"),
+            .required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         })
         .when(["kind", "userCredentials"], {
@@ -317,7 +317,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
             kind === "source" && userCredentials === "userpass",
           then: (schema) =>
             schema
-              .required("This field is required.")
+              .required(t("validation.required"))
               .min(3, t("validation.minLength", { length: 3 }))
               .max(120, t("validation.maxLength", { length: 120 })),
         }),
@@ -328,7 +328,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           is: (value: string) => value === "proxy",
           then: yup
             .string()
-            .required("This value is required")
+            .required(t("validation.required"))
             .min(3, t("validation.minLength", { length: 3 }))
             .max(220, t("validation.maxLength", { length: 220 })),
           otherwise: (schema) => schema.trim(),
@@ -337,7 +337,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           is: (value: string) => value === "basic-auth",
           then: yup
             .string()
-            .required("This value is required")
+            .required(t("validation.required"))
             .min(3, t("validation.minLength", { length: 3 }))
             .max(281, t("validation.maxLength", { length: 281 })),
           otherwise: (schema) => schema.trim(),
@@ -347,7 +347,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
             kind === "source" && userCredentials === "userpass",
           then: (schema) =>
             schema
-              .required("This field is required.")
+              .required(t("validation.required"))
               .min(3, t("validation.minLength", { length: 3 }))
               .max(120, t("validation.maxLength", { length: 120 })),
         }),
@@ -357,12 +357,12 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
         .when(["kind", "userCredentials"], {
           is: (kind: string, userCredentials: string) =>
             kind === "source" && userCredentials === "source",
-          then: (schema) => schema.required("This field is required."),
+          then: (schema) => schema.required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         })
         .when("kind", {
           is: (kind: string) => kind === "bearer",
-          then: (schema) => schema.required("This field is required."),
+          then: (schema) => schema.required(t("validation.required")),
           otherwise: (schema) => schema.trim(),
         }),
       keyFilename: yup.string().defined(),

--- a/client/src/app/pages/migration-targets/components/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/components/custom-target-form.tsx
@@ -122,7 +122,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
         .max(120, t("validation.maxLength", { length: 120 }))
         .test(
           "Duplicate name",
-          "A custom target with this name already exists. Use a different name.",
+          t("duplicateName", { type: "A custom target" }),
           (value) => duplicateNameCheck(targets, target || null, value || "")
         ),
       description: yup.string(),
@@ -136,7 +136,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
           then: yup
             .array()
             .of(customRulesFilesSchema)
-            .min(1, "At least 1 valid custom rule file must be uploaded."),
+            .min(1, t("validation.minOneRequiredRuleFile")),
           otherwise: (schema) => schema,
         }),
       repositoryType: yup.mixed<string>().when("rulesKind", {

--- a/client/src/app/pages/migration-waves/components/export-form.tsx
+++ b/client/src/app/pages/migration-waves/components/export-form.tsx
@@ -73,9 +73,15 @@ export const ExportForm: React.FC<ExportFormProps> = ({
     issueManager: yup
       .mixed<IssueManagerKind>()
       .required("Issue Manager is a required field"),
-    tracker: yup.string().required("Instance is a required field"),
-    project: yup.string().required("Project is a required field"),
-    kind: yup.string().required("Issue type is a required field"),
+    tracker: yup
+      .string()
+      .required(t("validation.requiredField", { field: "Instance" })),
+    project: yup
+      .string()
+      .required(t("validation.requiredField", { field: "Project" })),
+    kind: yup
+      .string()
+      .required(t("validation.requiredField", { field: "Issue type" })),
   });
 
   const {

--- a/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
+++ b/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
@@ -146,31 +146,27 @@ export const WaveForm: React.FC<WaveFormProps> = ({
     name: yup
       .string()
       .defined()
-      .test(
-        "min-char-check",
-        "Name is invalid. The name must be between 3 and 120 characters ",
-        (value) => {
-          if (value) {
-            const schema = yup
-              .string()
-              .min(3, t("validation.minLength", { length: 3 }))
-              .max(120, t("validation.maxLength", { length: 120 }));
-            return schema.isValidSync(value);
-          }
-          return true;
+      .test("min-char-check", t("nameInvalid"), (value) => {
+        if (value) {
+          const schema = yup
+            .string()
+            .min(3, t("validation.minLength", { length: 3 }))
+            .max(120, t("validation.maxLength", { length: 120 }));
+          return schema.isValidSync(value);
         }
-      ),
+        return true;
+      }),
     startDateStr: yup
       .string()
       .required(t("validation.required"))
       .test(
         "isValidFormat",
-        "Date must be formatted as MM/DD/YYYY",
+        t("invalidDateFormat"),
         (value) => !!value && dateStrFormatValidator(value)
       )
       .test(
         "noSoonerThanToday",
-        "Start date can be no sooner than today",
+        t("startDateAfterToday"),
         (value) => !dayjs(value).isBefore(dayjs(), "day")
       ),
     endDateStr: yup
@@ -178,13 +174,13 @@ export const WaveForm: React.FC<WaveFormProps> = ({
       .required(t("validation.required"))
       .test(
         "isValidFormat",
-        "Date must be formatted as MM/DD/YYYY",
+        t("invalidDateFormat"),
         (value) => !!value && dateStrFormatValidator(value)
       )
       .when("startDateStr", (startDateStr, schema: yup.StringSchema) =>
         schema.test(
           "afterStartDate",
-          "End date must be after start date",
+          t("endDateAfterStartDate"),
           (value) =>
             !startDateStr || dayjs(value).isAfter(dayjs(startDateStr), "day")
         )


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
Update validation error messages to ensure all use localization (t())
issue:#213