### PR TITLE
:sparkles:Build presets & map analysis state functions

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -502,7 +502,8 @@
     "user": "User",
     "version": "Version",
     "workPriority": "Work priority",
-    "YAMLTemplate": "YAML template"
+    "YAMLTemplate": "YAML template",
+    "ok": "OK"
   },
   "titles": {
     "archetypeDrawer": "Archetype details",

--- a/client/src/app/components/Icons/IconedStatus.tsx
+++ b/client/src/app/components/Icons/IconedStatus.tsx
@@ -13,7 +13,6 @@ import {
   UnknownIcon,
   TopologyIcon,
 } from "@patternfly/react-icons";
-import { buildPresetLabels } from "@app/pages/applications/components/application-analysis-status";
 
 export type IconedStatusPreset =
   | "InheritedReviews"
@@ -164,3 +163,22 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
     />
   );
 };
+
+export const buildPresetLabels = (
+  t: (key: string) => string
+): Record<IconedStatusPreset, { label: string }> => ({
+  InProgressInheritedReviews: { label: t("terms.inProgress") },
+  InProgressInheritedAssessments: { label: t("terms.inProgress") },
+  InheritedReviews: { label: t("terms.completed") },
+  InheritedAssessments: { label: t("terms.completed") },
+  Canceled: { label: t("terms.canceled") },
+  Completed: { label: t("terms.completed") },
+  CompletedWithErrors: { label: t("terms.completedWithErrors") },
+  Error: { label: t("terms.error") },
+  Failed: { label: t("terms.failed") },
+  InProgress: { label: t("terms.inProgress") },
+  NotStarted: { label: t("terms.notStarted") },
+  Scheduled: { label: t("terms.scheduled") },
+  Ok: { label: t("terms.ok") }, // Add Ok with a label
+  Unknown: { label: t("terms.unknown") }, // Add Unknown with a label
+});

--- a/client/src/app/components/Icons/IconedStatus.tsx
+++ b/client/src/app/components/Icons/IconedStatus.tsx
@@ -13,6 +13,7 @@ import {
   UnknownIcon,
   TopologyIcon,
 } from "@patternfly/react-icons";
+import { buildPresetLabels } from "@app/pages/applications/components/application-analysis-status";
 
 export type IconedStatusPreset =
   | "InheritedReviews"
@@ -62,11 +63,12 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
   tooltipCount = 0,
 }: IIconedStatusProps) => {
   const { t } = useTranslation();
+  const messages = buildPresetLabels(t);
   const presets: IconedStatusPresetType = {
     InProgressInheritedReviews: {
       icon: <InProgressIcon />,
       status: "info",
-      label: t("terms.inProgress"),
+      label: messages.InProgressInheritedReviews.label,
       tooltipMessage: t("message.inheritedReviewTooltip", {
         count: tooltipCount,
       }),
@@ -75,7 +77,7 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
     InProgressInheritedAssessments: {
       icon: <InProgressIcon />,
       status: "info",
-      label: t("terms.inProgress"),
+      label: messages.InProgressInheritedAssessments.label,
       tooltipMessage: t("message.inheritedAssessmentTooltip", {
         count: tooltipCount,
       }),
@@ -84,7 +86,7 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
     InheritedReviews: {
       icon: <CheckCircleIcon />,
       status: "success",
-      label: t("terms.completed"),
+      label: messages.InheritedReviews.label,
       tooltipMessage: t("message.inheritedReviewTooltip", {
         count: tooltipCount,
       }),
@@ -93,7 +95,7 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
     InheritedAssessments: {
       icon: <CheckCircleIcon />,
       status: "success",
-      label: t("terms.completed"),
+      label: messages.InheritedAssessments.label,
       tooltipMessage: t("message.inheritedAssessmentTooltip", {
         count: tooltipCount,
       }),
@@ -102,36 +104,36 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
     Canceled: {
       icon: <TimesCircleIcon />,
       status: "info",
-      label: t("terms.canceled"),
+      label: messages.Canceled.label,
     },
     Completed: {
       icon: <CheckCircleIcon />,
       status: "success",
-      label: t("terms.completed"),
+      label: messages.Completed.label,
     },
     CompletedWithErrors: {
       icon: <ExclamationTriangleIcon />,
       status: "warning",
-      label: t("terms.completedWithErrors"),
+      label: messages.CompletedWithErrors.label,
     },
     Error: {
       icon: <ExclamationCircleIcon />,
       status: "danger",
-      label: t("terms.error"),
+      label: messages.Error.label,
     },
     Failed: {
       icon: <ExclamationCircleIcon />,
       status: "danger",
-      label: t("terms.failed"),
+      label: messages.Failed.label,
     },
     InProgress: {
       icon: <InProgressIcon />,
       status: "info",
-      label: t("terms.inProgress"),
+      label: messages.InProgress.label,
     },
     NotStarted: {
       icon: <TimesCircleIcon />,
-      label: t("terms.notStarted"),
+      label: messages.NotStarted.label,
     },
     Ok: {
       icon: <CheckCircleIcon />,
@@ -140,7 +142,7 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
     Scheduled: {
       icon: <InProgressIcon />,
       status: "info",
-      label: t("terms.scheduled"),
+      label: messages.Scheduled.label,
     },
     Unknown: {
       icon: <UnknownIcon />,

--- a/client/src/app/pages/applications/components/application-analysis-status.tsx
+++ b/client/src/app/pages/applications/components/application-analysis-status.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 
 import { TaskState } from "@app/api/models";
-import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";
+import {
+  buildPresetLabels,
+  IconedStatus,
+  IconedStatusPreset,
+} from "@app/components/Icons";
 export interface ApplicationAnalysisStatusProps {
   state: TaskState;
 }
@@ -43,22 +47,3 @@ export const mapAnalysisStateToLabel = (
   const label = presets[presetKey]?.label ?? presets.Unknown.label;
   return label;
 };
-
-export const buildPresetLabels = (
-  t: (key: string) => string
-): Record<IconedStatusPreset, { label: string }> => ({
-  InProgressInheritedReviews: { label: t("terms.inProgress") },
-  InProgressInheritedAssessments: { label: t("terms.inProgress") },
-  InheritedReviews: { label: t("terms.completed") },
-  InheritedAssessments: { label: t("terms.completed") },
-  Canceled: { label: t("terms.canceled") },
-  Completed: { label: t("terms.completed") },
-  CompletedWithErrors: { label: t("terms.completedWithErrors") },
-  Error: { label: t("terms.error") },
-  Failed: { label: t("terms.failed") },
-  InProgress: { label: t("terms.inProgress") },
-  NotStarted: { label: t("terms.notStarted") },
-  Scheduled: { label: t("terms.scheduled") },
-  Ok: { label: t("terms.ok") }, // Add Ok with a label
-  Unknown: { label: t("terms.unknown") }, // Add Unknown with a label
-});

--- a/client/src/app/pages/applications/components/application-analysis-status.tsx
+++ b/client/src/app/pages/applications/components/application-analysis-status.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { TaskState } from "@app/api/models";
 import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";
-
+import { useTranslation } from "react-i18next";
 export interface ApplicationAnalysisStatusProps {
   state: TaskState;
 }
@@ -34,3 +34,30 @@ export const ApplicationAnalysisStatus: React.FC<
 > = ({ state }) => {
   return <IconedStatus preset={getTaskStatus(state)} />;
 };
+export const mapAnalysisStateToLabel = (value: TaskState) => {
+  const presetKey: IconedStatusPreset = getTaskStatus(value);
+  const { t } = useTranslation();
+  const presets = buildPresets(t);
+  const label = presets[presetKey]?.label ?? t("terms.unknown");
+  return label;
+};
+export const buildPresets = (
+  t: (key: string) => string
+): Record<IconedStatusPreset, { label: string }> => ({
+  Canceled: { label: t("terms.canceled") },
+  Scheduled: { label: t("terms.scheduled") },
+  Completed: { label: t("terms.completed") },
+  CompletedWithErrors: { label: t("terms.completedWithErrors") },
+  Failed: { label: t("terms.failed") },
+  InProgress: { label: t("terms.inProgress") },
+  NotStarted: { label: t("terms.notStarted") },
+  InheritedReviews: { label: t("terms.inheritedReviews") },
+  InProgressInheritedReviews: { label: t("terms.inProgressInheritedReviews") },
+  InProgressInheritedAssessments: {
+    label: t("terms.inProgressInheritedAssessments"),
+  },
+  InheritedAssessments: { label: t("terms.inheritedAssessments") },
+  Error: { label: t("terms.error") }, // Add Error with a label
+  Ok: { label: t("terms.ok") }, // Add Ok with a label
+  Unknown: { label: t("terms.unknown") }, // Add Unknown with a label
+});

--- a/client/src/app/pages/applications/components/application-analysis-status.tsx
+++ b/client/src/app/pages/applications/components/application-analysis-status.tsx
@@ -39,12 +39,12 @@ export const mapAnalysisStateToLabel = (
   t: (key: string) => string
 ) => {
   const presetKey: IconedStatusPreset = getTaskStatus(value);
-  const presets = buildPresets(t);
-  const label = presets[presetKey]?.label ?? t("terms.unknown");
+  const presets = buildPresetLabels(t);
+  const label = presets[presetKey]?.label ?? presets.Unknown.label;
   return label;
 };
 
-export const buildPresets = (
+export const buildPresetLabels = (
   t: (key: string) => string
 ): Record<IconedStatusPreset, { label: string }> => ({
   InProgressInheritedReviews: { label: t("terms.inProgress") },

--- a/client/src/app/pages/applications/components/application-analysis-status.tsx
+++ b/client/src/app/pages/applications/components/application-analysis-status.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { TaskState } from "@app/api/models";
 import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";
-import { useTranslation } from "react-i18next";
 export interface ApplicationAnalysisStatusProps {
   state: TaskState;
 }
@@ -34,30 +33,32 @@ export const ApplicationAnalysisStatus: React.FC<
 > = ({ state }) => {
   return <IconedStatus preset={getTaskStatus(state)} />;
 };
-export const mapAnalysisStateToLabel = (value: TaskState) => {
+
+export const mapAnalysisStateToLabel = (
+  value: TaskState,
+  t: (key: string) => string
+) => {
   const presetKey: IconedStatusPreset = getTaskStatus(value);
-  const { t } = useTranslation();
   const presets = buildPresets(t);
   const label = presets[presetKey]?.label ?? t("terms.unknown");
   return label;
 };
+
 export const buildPresets = (
   t: (key: string) => string
 ): Record<IconedStatusPreset, { label: string }> => ({
+  InProgressInheritedReviews: { label: t("terms.inProgress") },
+  InProgressInheritedAssessments: { label: t("terms.inProgress") },
+  InheritedReviews: { label: t("terms.completed") },
+  InheritedAssessments: { label: t("terms.completed") },
   Canceled: { label: t("terms.canceled") },
-  Scheduled: { label: t("terms.scheduled") },
   Completed: { label: t("terms.completed") },
   CompletedWithErrors: { label: t("terms.completedWithErrors") },
+  Error: { label: t("terms.error") },
   Failed: { label: t("terms.failed") },
   InProgress: { label: t("terms.inProgress") },
   NotStarted: { label: t("terms.notStarted") },
-  InheritedReviews: { label: t("terms.inheritedReviews") },
-  InProgressInheritedReviews: { label: t("terms.inProgressInheritedReviews") },
-  InProgressInheritedAssessments: {
-    label: t("terms.inProgressInheritedAssessments"),
-  },
-  InheritedAssessments: { label: t("terms.inheritedAssessments") },
-  Error: { label: t("terms.error") }, // Add Error with a label
+  Scheduled: { label: t("terms.scheduled") },
   Ok: { label: t("terms.ok") }, // Add Ok with a label
   Unknown: { label: t("terms.unknown") }, // Add Unknown with a label
 });


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
refactoring code according to comments in issue #2100
these functions are used in the PR there