### PR TITLE
:sparkles: Implement bulk analysis cancellation

### DIFF
--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -371,6 +371,9 @@ export const deleteTask = (id: number) => axios.delete<void>(`${TASKS}/${id}`);
 export const cancelTask = (id: number) =>
   axios.put<void>(`${TASKS}/${id}/cancel`);
 
+export const cancelTasks = (ids: number[]) =>
+  axios.put<void>(`${TASKS}/cancel/list`, ids);
+
 export const getTaskQueue = (addon?: string): Promise<TaskQueue> =>
   axios
     .get<TaskQueue>(`${TASKS}/report/queue`, { params: { addon } })

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -372,7 +372,7 @@ export const cancelTask = (id: number) =>
   axios.put<void>(`${TASKS}/${id}/cancel`);
 
 export const cancelTasks = (ids: number[]) =>
-  axios.put<void>(`${TASKS}/cancel/list`, ids);
+  axios.put<void>(`${TASKS}/cancel?filter=id:(${ids.join("|")})`);
 
 export const getTaskQueue = (addon?: string): Promise<TaskQueue> =>
   axios

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   cancelTask,
+  cancelTasks,
   deleteTask,
   getServerTasks,
   getTaskById,
@@ -182,6 +183,23 @@ export const useCancelTaskMutation = (
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: cancelTask,
+    onSuccess: (response) => {
+      queryClient.invalidateQueries([TasksQueryKey]);
+      onSuccess && onSuccess(response.status);
+    },
+    onError: (err: Error) => {
+      onError && onError(err);
+    },
+  });
+};
+
+export const useCancelTasksMutation = (
+  onSuccess: (statusCode: number) => void,
+  onError: (err: Error | null) => void
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: cancelTasks,
     onSuccess: (response) => {
       queryClient.invalidateQueries([TasksQueryKey]);
       onSuccess && onSuccess(response.status);


### PR DESCRIPTION
Update the backend to implement a bulk cancellation functionality, enabling the cancellation of multiple analyses based on provided IDs in a single request. Modify the existing logic to integrate the new endpoint for handling multiple cancellations simultaneously.

Part of: #2153 
Related to: [tackle2-hub PR #769](https://github.com/konveyor/tackle2-hub/pull/769)