### PR TITLE
:seedling: Update keycloak-js to 26.1.0

### DIFF
--- a/client/config/jest.config.ts
+++ b/client/config/jest.config.ts
@@ -46,6 +46,9 @@ const config: JestConfigWithTsJest = {
   transform: {
     "^.+\\.(js|mjs|ts|mts)x?$": "ts-jest",
   },
+  transformIgnorePatterns: [
+    "node_modules/(?!(keycloak-js)/)", // Ensure Jest processes keycloak-js
+  ],
 
   // Code to set up the testing framework before each test file in the suite is executed
   setupFilesAfterEnv: ["<rootDir>/src/app/test-config/setupTests.ts"],

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
     "i18next": "^19.8.4",
     "i18next-http-backend": "^1.0.22",
     "js-yaml": "^4.1.0",
-    "keycloak-js": "^18.0.1",
+    "keycloak-js": "^26.1.0",
     "radash": "^12.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "i18next": "^19.8.4",
         "i18next-http-backend": "^1.0.22",
         "js-yaml": "^4.1.0",
-        "keycloak-js": "^18.0.1",
+        "keycloak-js": "^26.1.0",
         "radash": "^12.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -1854,6 +1854,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@react-keycloak/core/-/core-3.2.0.tgz",
       "integrity": "sha512-1yzU7gQzs+6E1v6hGqxy0Q+kpMHg9sEcke2yxZR29WoU8KNE8E50xS6UbI8N7rWsgyYw8r9W1cUPCOF48MYjzw==",
+      "license": "MIT",
       "dependencies": {
         "react-fast-compare": "^3.2.0"
       },
@@ -1869,6 +1870,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@react-keycloak/web/-/web-3.4.0.tgz",
       "integrity": "sha512-yKKSCyqBtn7dt+VckYOW1IM5NW999pPkxDZOXqJ6dfXPXstYhOQCkTZqh8l7UL14PkpsoaHDh7hSJH8whah01g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.0",
         "@react-keycloak/core": "^3.2.0",
@@ -3949,6 +3951,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10371,11 +10374,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10518,13 +10516,10 @@
       }
     },
     "node_modules/keycloak-js": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-18.0.1.tgz",
-      "integrity": "sha512-IRXToYpbIrkyfLeNNJly2OjUCf11ncx2Sdsg257NVDwjOYE923osu47w8pfxEVWpTaS14/Y2QjbTHciuBK0RBQ==",
-      "dependencies": {
-        "base64-js": "^1.5.1",
-        "js-sha256": "^0.9.0"
-      }
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.1.1.tgz",
+      "integrity": "sha512-vz1QZvg7YlytdUMiafaFDkmd4iWPEcYjSwlkFLmc6DaRtAiGjS65nTfzls9ph5bI0lMWjDjkpyZa5+J/t9+kGQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.3",


### PR DESCRIPTION
Related hub PR:  https://github.com/konveyor/tackle2-hub/pull/780

No breaking changes were observed in our implementation, and login flows remain functional.
