### PR TITLE
:seedling: Bump actions/upload-artifact@v3 -> v4

### DIFF
--- a/.github/workflows/ci-global.yml
+++ b/.github/workflows/ci-global.yml
@@ -48,7 +48,7 @@ jobs:
           docker save -o /tmp/tackle2-ui.tar quay.io/konveyor/tackle2-ui:latest
 
       - name: Upload tackle2-ui image as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tackle2-ui
           path: /tmp/tackle2-ui.tar


### PR DESCRIPTION
- actions/upload-artifact@v3 has been deprecated as of April 16, 2024