### PR TITLE
:seedling: Drop codecov from ci

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -114,17 +114,3 @@ jobs:
 
       - name: Test
         run: npm run test -- --coverage --watchAll=false
-
-      - name: Upload to codecov (client)
-        # if: ${{ github.event.pull_request }}
-        uses: codecov/codecov-action@v4
-        with:
-          flags: client
-          directory: ./client/coverage
-
-      - name: Upload to codecov (server)
-        # if: ${{ github.event.pull_request }}
-        uses: codecov/codecov-action@v4
-        with:
-          flags: server
-          directory: ./server/coverage


### PR DESCRIPTION
We don't have any gating or processes that use the reports that codecov generate on PRs.  Dropping the codecov actions from the `ci-repo.yml` to reduce the noise on PRs.