### PR TITLE
:seedling: Update global-ci testing tag to `@ci`

### DIFF
--- a/.github/workflows/ci-global.yml
+++ b/.github/workflows/ci-global.yml
@@ -60,4 +60,4 @@ jobs:
       tackle_ui: ${{ needs.build-and-upload-for-global-ci.outputs.IMG_NAME }}
       run_api_tests: false
       run_ui_tests: true
-      ui_test_tags: "@tier0"
+      ui_test_tags: "@ci"


### PR DESCRIPTION
A recent change in the UI tests repo [1] changed the basic CI testing suite from `@tier0` to `@ci`. Updating the CI workflow to use the new tier.

[1]: https://github.com/konveyor/tackle-ui-tests/pull/1351
