### PR TITLE
:bug:  [backport release-0.6] Fix questionnaire import row placement issue (#2185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The React and Patternfly based UI is composed of web pages served by an http ser
   such as hot reload. The webpack-dev-server serves the UI on port **9000**. The `/auth` and `/hub`
   routes are forwarded to port **8080** for Express to handle.
 
-The Express [server/src/setupProxy.js](server/src/setupProxy.js) proxies use the environment
+The Express [common/src/proxies.ts](common/src/proxies.ts) proxies use the environment
 variables `TACKLE_HUB_URL` and `SSO_SERVER_URL` to define the backend endpoints:
 
 - If the Tackle Hub variable `TACKLE_HUB_URL` is not defined, the URL `http://localhost:9002` is
@@ -109,7 +109,7 @@ variables `TACKLE_HUB_URL` and `SSO_SERVER_URL` to define the backend endpoints:
 
 ### Running the UI outside the cluster
 
-To enable running the UI outside the cluster, port forwardings must be activated to route
+To enable running the UI outside the cluster, ports forwardings must be activated to route
 the Tackle Keycloak (SSO) and Tackle Hub requests to the services on the cluster. Use
 the script `npm run port-forward` to easily start the forwards. The script `npm run start:dev`
 will also setup port forwarding to all tackle2 services concurrently with starting the dev server.

--- a/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
@@ -250,14 +250,17 @@ const AssessmentSettings: React.FC = () => {
                 }
                 numRenderedColumns={numRenderedColumns}
               >
-                {currentPageItems?.map((questionnaire, rowIndex) => {
-                  const formattedDate = dayjs(questionnaire.createTime)
-                    .utc()
-                    .format("YYYY-MM-DD HH:mm:ss");
+                <Tbody>
+                  {currentPageItems?.map((questionnaire, rowIndex) => {
+                    const formattedDate = dayjs(questionnaire.createTime)
+                      .utc()
+                      .format("YYYY-MM-DD HH:mm:ss");
 
-                  return (
-                    <Tbody key={questionnaire.id}>
-                      <Tr {...getTrProps({ item: questionnaire })}>
+                    return (
+                      <Tr
+                        key={questionnaire.id}
+                        {...getTrProps({ item: questionnaire })}
+                      >
                         <TableRowContentWithControls
                           {...tableControls}
                           item={questionnaire}
@@ -269,7 +272,7 @@ const AssessmentSettings: React.FC = () => {
                           >
                             {questionnaire.required}
                             <Switch
-                              id={`required-switch-${rowIndex.toString()}`}
+                              id={`required-switch-${questionnaire.id}`}
                               label="Yes"
                               labelOff="No"
                               isChecked={questionnaire.required}
@@ -376,9 +379,9 @@ const AssessmentSettings: React.FC = () => {
                           </Td>
                         </TableRowContentWithControls>
                       </Tr>
-                    </Tbody>
-                  );
-                })}
+                    );
+                  })}
+                </Tbody>
               </ConditionalTableBody>
             </Table>
             <SimplePagination


### PR DESCRIPTION
Backport-of: (#2185 )
Resolves [MTA-4630](https://issues.redhat.com/browse/MTA-4630)

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
