### PR TITLE
:seedling: [backport release-0.6] Update ci-global.yml (#2179)(#2186)

### DIFF
--- a/.github/workflows/ci-global.yml
+++ b/.github/workflows/ci-global.yml
@@ -39,24 +39,25 @@ concurrency:
 jobs:
   build-and-upload-for-global-ci:
     runs-on: ubuntu-latest
+    outputs:
+      IMG_NAME: ${{ steps.container.outputs.IMG_NAME }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: save tackle2-ui image
+      - id: container
+        name: build the tackle2-ui container
+        env:
+          IMG_NAME: ttl.sh/tackle2-ui-${{ github.sha }}:2h
         run: |
-          docker build . -t quay.io/konveyor/tackle2-ui:latest
-          docker save -o /tmp/tackle2-ui.tar quay.io/konveyor/tackle2-ui:latest
-
-      - name: Upload tackle2-ui image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: tackle2-ui
-          path: /tmp/tackle2-ui.tar
-          retention-days: 1
+          echo "IMG_NAME=${IMG_NAME}" >> "$GITHUB_OUTPUT"
+          docker build . -t ${IMG_NAME}
+          docker push ${IMG_NAME}
 
   run-global-ci:
     needs: build-and-upload-for-global-ci
-    uses: konveyor/ci/.github/workflows/global-ci.yml@main
+    uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main
     with:
-      component_name: tackle2-ui
+      tackle_ui: ${{ needs.build-and-upload-for-global-ci.outputs.IMG_NAME }}
       run_api_tests: false
+      run_ui_tests: true
+      ui_test_tags: "@ci"


### PR DESCRIPTION
Backport of: #2179
Backport of: #2186

With `upload-artifact@v3` deprecated[^1] and shut off, move to use the `global-ci-bundle.yml` workflow for global CI. This change drops the need for artifacts and just uses the ttl.sh service[^2]. This technique is already being used in a few other Konveyor projects as well.

A recent change in the UI tests repo[^3] changed the basic CI testing suite from `@tier0` to `@ci`. Updating the CI workflow to use the new tier.

[^1]: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
[^2]: https://ttl.sh
[^3]: https://github.com/konveyor/tackle-ui-tests/pull/1351

