### PR TITLE
:seedling: Refactor wizard form field name to improve readability

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -605,9 +605,9 @@
       "scope": "Scope",
       "setTargets": "Set targets",
       "source": "Source",
-      "sources": "Sources",
+      "source_plural": "Sources",
       "target": "Target",
-      "targets": "Targets",
+      "target_plural": "Targets",
       "transactionReport": "Transaction Report",
       "autoTagging": "Automated tagging"
     },

--- a/client/src/app/components/target-card/target-card.tsx
+++ b/client/src/app/components/target-card/target-card.tsx
@@ -40,7 +40,7 @@ export interface TargetCardProps {
     target: Target
   ) => void;
   onSelectedCardTargetChange?: (value: string) => void;
-  formLabels?: TargetLabel[];
+  selectedTargetLabels?: TargetLabel[];
   handleProps?: any;
   readOnly?: boolean;
   onEdit?: () => void;
@@ -57,7 +57,7 @@ export const TargetCard: React.FC<TargetCardProps> = ({
   item: target,
   readOnly = false,
   cardSelected = false,
-  formLabels,
+  selectedTargetLabels,
   onCardClick,
   onSelectedCardTargetChange,
   handleProps,
@@ -74,9 +74,9 @@ export const TargetCard: React.FC<TargetCardProps> = ({
   const [selectedLabelName, setSelectedLabelName] = React.useState<string>(
     () => {
       const prevSelectedLabel =
-        formLabels?.find((formLabel) => {
+        selectedTargetLabels?.find((label) => {
           const labelNames = targetLabels.map((label) => label.name);
-          return labelNames?.includes(formLabel.name);
+          return labelNames?.includes(label.name);
         })?.name || "";
 
       return (

--- a/client/src/app/pages/applications/analysis-wizard/__tests__/utils.test.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/__tests__/utils.test.tsx
@@ -1,5 +1,5 @@
 import { Target, TargetLabel } from "@app/api/models";
-import { getUpdatedFormLabels } from "../utils";
+import { updateSelectedTargetLabels } from "../utils";
 
 const TARGET_LABELS: TargetLabel[] = [
   {
@@ -55,9 +55,9 @@ const TARGET_B: Target = {
   ],
 };
 
-describe("analysis-wizard utils", () => {
+describe("analysis-wizard utils - updateSelectedTargetLabels()", () => {
   it("add a label to an empty list", () => {
-    const theResult = getUpdatedFormLabels(
+    const theResult = updateSelectedTargetLabels(
       true,
       TARGET_LABELS[1].name,
       TARGET_A,
@@ -67,7 +67,7 @@ describe("analysis-wizard utils", () => {
   });
 
   it("add a label to a list with a label", () => {
-    const theResult = getUpdatedFormLabels(
+    const theResult = updateSelectedTargetLabels(
       true,
       TARGET_A.labels![1].name,
       TARGET_A,
@@ -77,7 +77,7 @@ describe("analysis-wizard utils", () => {
   });
 
   it("add a label to a list with with multiple labels", () => {
-    const theResult = getUpdatedFormLabels(
+    const theResult = updateSelectedTargetLabels(
       true,
       TARGET_A.labels![2].name,
       TARGET_A,
@@ -94,7 +94,7 @@ describe("analysis-wizard utils", () => {
     const labelA = TARGET_A.labels![0];
     const labelB = TARGET_B.labels![0];
 
-    const theResult = getUpdatedFormLabels(true, labelB.name, TARGET_B, [
+    const theResult = updateSelectedTargetLabels(true, labelB.name, TARGET_B, [
       labelA,
     ]);
     expect(theResult).toStrictEqual([labelA, labelB]);
@@ -103,14 +103,19 @@ describe("analysis-wizard utils", () => {
   it("remove a label from an empty list", () => {
     const label = TARGET_B.labels![0];
 
-    const theResult = getUpdatedFormLabels(false, label.name, TARGET_B, []);
+    const theResult = updateSelectedTargetLabels(
+      false,
+      label.name,
+      TARGET_B,
+      []
+    );
     expect(theResult).toStrictEqual([]);
   });
 
   it("remove a label", () => {
     const label = TARGET_B.labels![0];
 
-    const theResult = getUpdatedFormLabels(false, label.name, TARGET_B, [
+    const theResult = updateSelectedTargetLabels(false, label.name, TARGET_B, [
       TARGET_LABELS[0],
       label,
     ]);
@@ -120,7 +125,7 @@ describe("analysis-wizard utils", () => {
   it("remove a label from the middle of a list", () => {
     const label = TARGET_B.labels![0];
 
-    const theResult = getUpdatedFormLabels(false, label.name, TARGET_B, [
+    const theResult = updateSelectedTargetLabels(false, label.name, TARGET_B, [
       TARGET_LABELS[0],
       label,
       TARGET_LABELS[1],

--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -164,7 +164,7 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
     defaultValues: {
       artifact: null,
       mode: "source-code-deps",
-      formLabels: [],
+      selectedTargetLabels: [],
       selectedTargets: [],
       // defaults will be passed as initialFilterValues to the table hook
       targetFilters: undefined,
@@ -266,7 +266,7 @@ export const AnalysisWizard: React.FC<IAnalysisWizard> = ({
           labels: {
             included: Array.from(
               new Set<string>([
-                ...fieldValues.formLabels
+                ...fieldValues.selectedTargetLabels
                   .filter(
                     (label) =>
                       getParsedLabel(label.label).labelType !== "source"

--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -58,13 +58,13 @@ import { useTaskGroup } from "./components/TaskGroupContext";
 
 export const CustomRules: React.FC = () => {
   const { t } = useTranslation();
-  const { taskGroup, updateTaskGroup } = useTaskGroup();
+  const { taskGroup } = useTaskGroup();
 
   const { watch, setValue, control, getValues } =
     useFormContext<AnalysisWizardFormValues>();
   const values = getValues();
 
-  const { formLabels, customRulesFiles, rulesKind } = watch();
+  const { selectedTargetLabels, customRulesFiles, rulesKind } = watch();
   const initialActiveTabKeyValue = (value: string): number =>
     value === "manual" ? 0 : value === "repository" ? 1 : 0;
 
@@ -191,10 +191,10 @@ export const CustomRules: React.FC = () => {
                 onClick={() => {
                   customRulesFiles.forEach((file) => {
                     const { allLabels } = parseRules(file);
-                    const updatedFormLabels = formLabels.filter(
+                    const updatedFormLabels = selectedTargetLabels.filter(
                       (label) => !allLabels?.includes(label.label)
                     );
-                    setValue("formLabels", [...updatedFormLabels]);
+                    setValue("selectedTargetLabels", [...updatedFormLabels]);
                   });
 
                   // Remove rule file from list
@@ -402,7 +402,7 @@ export const CustomRules: React.FC = () => {
                 !ruleFiles.find((file) => file.loadResult === "success") ||
                 ruleFiles.some((file) => file.loadResult === "danger")
               }
-              onClick={(event) => {
+              onClick={() => {
                 let hasExistingRuleFile = null;
                 const validFiles = ruleFiles.filter(
                   (file) => file.loadResult === "success"
@@ -442,13 +442,13 @@ export const CustomRules: React.FC = () => {
                           label: label,
                         };
                       }) || [];
-                    const newLabels = formLabels.filter((label) => {
+                    const newLabels = selectedTargetLabels.filter((label) => {
                       const newLabelNames = formattedAllLabels.map(
                         (label) => label.name
                       );
                       return !newLabelNames.includes(label.name);
                     });
-                    setValue("formLabels", [
+                    setValue("selectedTargetLabels", [
                       ...newLabels,
                       ...formattedAllLabels,
                     ]);

--- a/client/src/app/pages/applications/analysis-wizard/review.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/review.tsx
@@ -42,7 +42,7 @@ export const Review: React.FC<IReview> = ({ applications, mode }) => {
 
   const { watch } = useFormContext<AnalysisWizardFormValues>();
   const {
-    formLabels,
+    selectedTargetLabels,
     selectedSourceLabels,
     withKnownLibs,
     includedPackages,
@@ -83,13 +83,11 @@ export const Review: React.FC<IReview> = ({ applications, mode }) => {
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>
-            {formLabels.length > 1
-              ? t("wizard.terms.targets")
-              : t("wizard.terms.target")}
+            {t("wizard.terms.target", { count: selectedTargetLabels.length })}
           </DescriptionListTerm>
           <DescriptionListDescription id="targets">
             <List isPlain>
-              {formLabels.map((label, index) => {
+              {selectedTargetLabels.map((label, index) => {
                 const parsedLabel = getParsedLabel(label?.label);
                 if (parsedLabel.labelType === "target") {
                   return (
@@ -102,9 +100,7 @@ export const Review: React.FC<IReview> = ({ applications, mode }) => {
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>
-            {selectedSourceLabels.length > 1
-              ? t("wizard.terms.sources")
-              : t("wizard.terms.source")}
+            {t("wizard.terms.source", { count: selectedSourceLabels.length })}
           </DescriptionListTerm>
           <DescriptionListDescription id="sources">
             <List isPlain>

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -55,14 +55,14 @@ const useModeStepSchema = ({
 };
 
 export interface TargetsStepValues {
-  formLabels: TargetLabel[];
   selectedTargets: Target[];
+  selectedTargetLabels: TargetLabel[];
   targetFilters?: Record<string, string[]>;
 }
 
 const useTargetsStepSchema = (): yup.SchemaOf<TargetsStepValues> => {
   return yup.object({
-    formLabels: yup.array(),
+    selectedTargetLabels: yup.array(),
     selectedTargets: yup.array(),
     targetFilters: yup.object(),
   });
@@ -127,7 +127,7 @@ const useCustomRulesStepSchema = (): yup.SchemaOf<CustomRulesStepValues> => {
         then: yup.array().of(customRulesFilesSchema),
         otherwise: (schema) => schema,
       })
-      .when(["formLabels", "rulesKind", "selectedTargets"], {
+      .when(["selectedTargetLabels", "rulesKind", "selectedTargets"], {
         is: (
           labels: TargetLabel[],
           rulesKind: string,
@@ -168,7 +168,6 @@ export interface OptionsStepValues {
 }
 
 const useOptionsStepSchema = (): yup.SchemaOf<OptionsStepValues> => {
-  const { t } = useTranslation();
   return yup.object({
     excludedRulesTags: yup.array().of(yup.string().defined()),
     autoTaggingEnabled: yup.bool().defined(),

--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -39,7 +39,7 @@ export const SetOptions: React.FC = () => {
     useFormContext<AnalysisWizardFormValues>();
 
   const {
-    formLabels,
+    selectedTargetLabels,
     excludedRulesTags,
     autoTaggingEnabled,
     advancedAnalysisEnabled,
@@ -96,14 +96,14 @@ export const SetOptions: React.FC = () => {
       </TextContent>
       <HookFormPFGroupController
         control={control}
-        name="formLabels"
-        label={t("wizard.terms.targets")}
+        name="selectedTargetLabels"
+        label={t("wizard.terms.target", { count: 2 })}
         fieldId="target-labels"
         renderInput={({
           field: { onChange, onBlur },
           fieldState: { isDirty, error, isTouched },
         }) => {
-          const targetSelections = formLabels
+          const targetSelections = selectedTargetLabels
             .map((formLabel) => {
               const parsedLabel = getParsedLabel(formLabel?.label);
               if (parsedLabel.labelType === "target") {
@@ -126,8 +126,12 @@ export const SetOptions: React.FC = () => {
                   (label) => label.label === selectionLabel
                 );
                 const updatedFormLabels = !matchingLabel
-                  ? formLabels
-                  : toggle(formLabels, matchingLabel, (tl) => tl.label);
+                  ? selectedTargetLabels
+                  : toggle(
+                      selectedTargetLabels,
+                      matchingLabel,
+                      (tl) => tl.label
+                    );
                 onChange(updatedFormLabels);
 
                 const updatedSelectedTargets =
@@ -163,7 +167,7 @@ export const SetOptions: React.FC = () => {
       <HookFormPFGroupController
         control={control}
         name="selectedSourceLabels"
-        label={t("wizard.terms.sources")}
+        label={t("wizard.terms.source", { count: 2 })}
         fieldId="sources"
         renderInput={({
           field: { onChange, onBlur, value },

--- a/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -18,7 +18,7 @@ import { AnalysisWizardFormValues } from "./schema";
 import { useFetchTargets } from "@app/queries/targets";
 import { Application, Target } from "@app/api/models";
 import { useFetchTagCategories } from "@app/queries/tags";
-import { getUpdatedFormLabels, toggleSelectedTargets } from "./utils";
+import { updateSelectedTargetLabels, toggleSelectedTargets } from "./utils";
 import { unique } from "radash";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { useLocalTableControls } from "@app/hooks/table-controls";
@@ -119,11 +119,11 @@ const SetTargetsInternal: React.FC<SetTargetsInternalProps> = ({
     useFormContext<AnalysisWizardFormValues>();
 
   const values = getValues();
-  const formLabels = watch("formLabels");
+  const selectedTargetLabels = watch("selectedTargetLabels");
   const selectedTargets = watch("selectedTargets");
 
   const handleOnSelectedCardTargetChange = (selectedLabelName: string) => {
-    const otherSelectedLabels = formLabels?.filter((formLabel) => {
+    const otherSelectedLabels = selectedTargetLabels?.filter((formLabel) => {
       return formLabel.name !== selectedLabelName;
     });
     const matchingLabel =
@@ -143,7 +143,7 @@ const SetTargetsInternal: React.FC<SetTargetsInternalProps> = ({
         ?.labels?.filter((label) => label.name !== selectedLabelName)
         .map((label) => label.name) || "";
 
-    const isNewLabel = !formLabels
+    const isNewLabel = !selectedTargetLabels
       .map((label) => label.name)
       .includes(selectedLabelName);
     if (isNewLabel) {
@@ -151,7 +151,10 @@ const SetTargetsInternal: React.FC<SetTargetsInternalProps> = ({
         (label) => !matchingOtherLabelNames.includes(label.name)
       );
       matchingLabel &&
-        setValue("formLabels", [...filterConflictingLabels, matchingLabel]);
+        setValue("selectedTargetLabels", [
+          ...filterConflictingLabels,
+          matchingLabel,
+        ]);
     }
   };
 
@@ -166,13 +169,13 @@ const SetTargetsInternal: React.FC<SetTargetsInternalProps> = ({
     );
     setValue("selectedTargets", updatedSelectedTargets);
 
-    const updatedFormLabels = getUpdatedFormLabels(
+    const updatedSelectedTargetLabels = updateSelectedTargetLabels(
       isSelecting,
       selectedLabelName,
       target,
-      formLabels
+      selectedTargetLabels
     );
-    setValue("formLabels", updatedFormLabels);
+    setValue("selectedTargetLabels", updatedSelectedTargetLabels);
   };
 
   const tableControls = useLocalTableControls({
@@ -311,7 +314,7 @@ const SetTargetsInternal: React.FC<SetTargetsInternalProps> = ({
                 onCardClick={(isSelecting, selectedLabelName, target) => {
                   handleOnCardClick(isSelecting, selectedLabelName, target);
                 }}
-                formLabels={formLabels}
+                selectedTargetLabels={selectedTargetLabels}
               />
             </GalleryItem>
           ))}

--- a/client/src/app/pages/applications/analysis-wizard/utils.ts
+++ b/client/src/app/pages/applications/analysis-wizard/utils.ts
@@ -73,34 +73,31 @@ export const toggleSelectedTargets = (
   return toggle(selectedTargets, target, (t) => t.id);
 };
 
-export const getUpdatedFormLabels = (
+export const updateSelectedTargetLabels = (
   isSelecting: boolean,
   selectedLabelName: string,
   target: Target,
-  formLabels: TargetLabel[]
+  currentSelectedTargetLabels: TargetLabel[]
 ) => {
-  if (target.custom) {
-    const customTargetLabelNames = target.labels?.map((label) => label.name);
-    const otherSelectedLabels = formLabels?.filter(
-      (formLabel) => !customTargetLabelNames?.includes(formLabel.name)
-    );
-    return isSelecting && target.labels
-      ? [...otherSelectedLabels, ...target.labels]
-      : otherSelectedLabels;
-  } else {
-    const otherSelectedLabels = formLabels?.filter(
-      (formLabel) => formLabel.name !== selectedLabelName
-    );
-    if (isSelecting) {
-      const matchingLabel = target.labels?.find(
-        (label) => label.name === selectedLabelName
-      );
-      return matchingLabel
-        ? [...otherSelectedLabels, matchingLabel]
-        : otherSelectedLabels;
-    }
+  const testLabelNames = target.custom
+    ? (target.labels?.map((label) => label.name) ?? [])
+    : [selectedLabelName];
+
+  const otherSelectedLabels = currentSelectedTargetLabels.filter(
+    (label) => !testLabelNames.includes(label.name)
+  );
+
+  if (!isSelecting) {
     return otherSelectedLabels;
   }
+
+  const matchingTargetLabels = target.custom
+    ? target.labels
+    : target.labels?.filter((l) => l.name === selectedLabelName);
+
+  return matchingTargetLabels
+    ? [...otherSelectedLabels, ...matchingTargetLabels]
+    : otherSelectedLabels;
 };
 
 /**

--- a/client/src/app/utils/rules-utils.ts
+++ b/client/src/app/utils/rules-utils.ts
@@ -9,7 +9,9 @@ export const checkRuleFileType = (filename: string): RuleFileType => {
     return "YAML";
   } else if (fileExtension === "xml") {
     return "XML";
-  } else return null;
+  } else {
+    return null;
+  }
 };
 type ParsedYamlElement = { labels?: string[] };
 type ParsedYaml = ParsedYamlElement[] | {};


### PR DESCRIPTION
The wizard form field `formLabels` is confusing and misleading. The field has been renamed `selectedTargetLabels`.  Variables have been renamed as appropriate.

Util function `getUpdatedFormLabels()` changed to `updateSelectedTargetLabels()` and refactored to streamline its functionality.

Pre-work for #2198 
Needs #2325 for unit tests
