### PR TITLE
:bug: Add "select all filtered" to bulk selection MTA-4886

### DIFF
--- a/client/src/app/hooks/selection/useBulkSelection.ts
+++ b/client/src/app/hooks/selection/useBulkSelection.ts
@@ -8,21 +8,23 @@ export interface BulkSelectionArgs<ItemType> {
    */
   isEqual?: (a: ItemType, b: ItemType) => boolean;
   /**
-   * The full set of items that may be selected.  If this contains more items than in
-   * `currentPageItems`, then selection across multiple pages is possible.
+   * The full list of items that may be selected.  Providing this list will enable "Select All"
+   * functionality.
    */
   items?: ItemType[];
   /**
-   * The subset of `items` that satisfy the current filter state.
+   * The subset of `items` that satisfy the current filter state.  Providing this list will
+   * enable "Select All Filtered" functionality.
    */
   filteredItems?: ItemType[];
   /**
-   * Current set of items being displayed from either derived state pagination
-   * or server side pagination.
+   * Current list of items being displayed from either derived state pagination
+   * or server side pagination.  This list is required and enables "Select Current Page"
+   * functionality.
    */
   currentPageItems: ItemType[];
   /**
-   * Set of items to initially set as selected.
+   * List of items to initially set as selected.
    */
   initialSelected?: ItemType[];
 }

--- a/client/src/app/hooks/table-controls/index.ts
+++ b/client/src/app/hooks/table-controls/index.ts
@@ -2,7 +2,7 @@ export * from "./types";
 export * from "./utils";
 export * from "./useTableControlState";
 export * from "./useTableControlProps";
-export * from "./getLocalTableControlDerivedState";
+export * from "./useLocalTableControlDerivedState";
 export * from "./useLocalTableControls";
 export * from "./getHubRequestParams";
 export * from "./filtering";

--- a/client/src/app/hooks/table-controls/types.ts
+++ b/client/src/app/hooks/table-controls/types.ts
@@ -268,6 +268,10 @@ export type ITableControlLocalDerivedStateArgs<
  */
 export type ITableControlDerivedState<TItem> = {
   /**
+   * The unsorted set of items after filtering.
+   */
+  filteredItems?: TItem[];
+  /**
    * The items to be rendered on the current page of the table. These items have already been filtered, sorted and paginated.
    */
   currentPageItems: TItem[];

--- a/client/src/app/hooks/table-controls/useLocalTableControls.ts
+++ b/client/src/app/hooks/table-controls/useLocalTableControls.ts
@@ -1,6 +1,6 @@
 import { useTableControlProps } from "./useTableControlProps";
 import { IUseLocalTableControlsArgs } from "./types";
-import { getLocalTableControlDerivedState } from "./getLocalTableControlDerivedState";
+import { useLocalTableControlDerivedState } from "./useLocalTableControlDerivedState";
 import { useTableControlState } from "./useTableControlState";
 
 /**
@@ -33,7 +33,7 @@ export const useLocalTableControls = <
   >
 > => {
   const state = useTableControlState(args);
-  const derivedState = getLocalTableControlDerivedState({ ...args, ...state });
+  const derivedState = useLocalTableControlDerivedState({ ...args, ...state });
   const { columnState } = state;
 
   return useTableControlProps({

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -599,7 +599,8 @@ export const ApplicationsTable: React.FC = () => {
     propHelpers: { toolbarBulkSelectorProps, getSelectCheckboxTdProps },
   } = useBulkSelection({
     isEqual: (a, b) => a.id === b.id,
-    items: applications,
+    // TODO: Pass `items` to also enable "select all items" if needed
+    // items: applications,
     filteredItems,
     currentPageItems,
   });

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -576,8 +576,8 @@ export const ApplicationsTable: React.FC = () => {
   });
 
   const {
+    filteredItems,
     currentPageItems,
-    totalItemCount,
     numRenderedColumns,
     propHelpers: {
       toolbarProps,
@@ -598,10 +598,10 @@ export const ApplicationsTable: React.FC = () => {
     selectedItems: selectedRows,
     propHelpers: { toolbarBulkSelectorProps, getSelectCheckboxTdProps },
   } = useBulkSelection({
-    items: currentPageItems,
     isEqual: (a, b) => a.id === b.id,
+    items: applications,
+    filteredItems,
     currentPageItems,
-    totalItemCount,
   });
 
   const clearFilters = () => {

--- a/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
+++ b/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
@@ -177,7 +177,7 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
     initialSort: { columnKey: "name", direction: "asc" },
   });
   const {
-    // filteredItems,
+    filteredItems,
     currentPageItems,
     numRenderedColumns,
     propHelpers: {
@@ -198,7 +198,7 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
     propHelpers: { toolbarBulkSelectorProps, getSelectCheckboxTdProps },
   } = useBulkSelection({
     isEqual: (a, b) => a.id === b.id,
-    // filteredItems,
+    filteredItems,
     currentPageItems,
     initialSelected: assignedApplications,
   });

--- a/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
+++ b/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
@@ -177,8 +177,8 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
     initialSort: { columnKey: "name", direction: "asc" },
   });
   const {
+    // filteredItems,
     currentPageItems,
-    totalItemCount,
     numRenderedColumns,
     propHelpers: {
       toolbarProps,
@@ -197,11 +197,10 @@ export const ManageApplicationsForm: React.FC<ManageApplicationsFormProps> = ({
     selectedItems,
     propHelpers: { toolbarBulkSelectorProps, getSelectCheckboxTdProps },
   } = useBulkSelection({
-    items: currentPageItems,
-    initialSelected: assignedApplications,
     isEqual: (a, b) => a.id === b.id,
+    // filteredItems,
     currentPageItems,
-    totalItemCount,
+    initialSelected: assignedApplications,
   });
 
   const onSubmit = () => {

--- a/client/src/app/pages/migration-waves/migration-waves.tsx
+++ b/client/src/app/pages/migration-waves/migration-waves.tsx
@@ -237,7 +237,7 @@ export const MigrationWaves: React.FC = () => {
     isLoading: isFetching,
   });
   const {
-    // filteredItems,
+    filteredItems,
     currentPageItems,
     numRenderedColumns,
     propHelpers: {
@@ -260,7 +260,7 @@ export const MigrationWaves: React.FC = () => {
     propHelpers: { toolbarBulkSelectorProps, getSelectCheckboxTdProps },
   } = useBulkSelection({
     isEqual: (a, b) => a.id === b.id,
-    // filteredItems,
+    filteredItems,
     currentPageItems,
   });
 

--- a/client/src/app/pages/migration-waves/migration-waves.tsx
+++ b/client/src/app/pages/migration-waves/migration-waves.tsx
@@ -237,8 +237,8 @@ export const MigrationWaves: React.FC = () => {
     isLoading: isFetching,
   });
   const {
+    // filteredItems,
     currentPageItems,
-    totalItemCount,
     numRenderedColumns,
     propHelpers: {
       toolbarProps,
@@ -259,10 +259,9 @@ export const MigrationWaves: React.FC = () => {
     selectedItems,
     propHelpers: { toolbarBulkSelectorProps, getSelectCheckboxTdProps },
   } = useBulkSelection({
-    items: currentPageItems,
     isEqual: (a, b) => a.id === b.id,
+    // filteredItems,
     currentPageItems,
-    totalItemCount,
   });
 
   // TODO: Check RBAC access


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-4886

Update the bulk selection hook and component to enable selecting:
  - nothing
  - the current page of items
  - the current set of filtered items (if provided)
  - the full set of items (if provided)

Refactor the `getLocalTableControlDerviedState()` function into a react hook, and apply a memo to each derived state function call.  This will keep the item references stable and allow bulk selection to function properly.

The application inventory table passes in enough items such that the bulk selector can provide selection of: none, page, all filtered.
