### PR TITLE
:seedling: Update dependabot configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,14 @@ updates:
       interval: "daily"
     commit-message:
       prefix: ":ghost: "
-    allow:
-      - dependency-name: "@patternfly/*"
-        dependency-type: "direct"
+
+    groups:
+      patternfly:
+        patterns:
+          - "@patternfly/*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
For the npm package checking, update the configs so all patternfly changes are grouped in a single PR and that only minor and patch level changes are considered.  Having dependabot attempt to upgrade a major version number of patternfly will never work.
