### PR TITLE
:sparkles: Update custom migration targets filtering/creation

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -353,7 +353,6 @@
     "credentialType": "Credential type",
     "criticality": "Criticality",
     "currentLandscape": "Current landscape",
-    "customTargetOfType": "custom migration target: {{type}}",
     "customTarget": "Custom migration target",
     "customTargets": "Custom migration targets",
     "customTargetsDetails": "Create and manage custom migration targets. You can also drag and drop the cards to rearrange them. Note that any changes to the layout here will be reflected in the Analysis wizard",

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -843,7 +843,6 @@ export interface Archetype {
   review?: Ref;
   risk?: Risk;
 }
-export type ProviderType = "Java" | "Go";
 
 export interface QuestionWithSectionOrder extends Question {
   sectionOrder: number;

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -1,4 +1,8 @@
-import axios, { AxiosPromise, RawAxiosRequestHeaders } from "axios";
+import axios, {
+  AxiosPromise,
+  AxiosResponse,
+  RawAxiosRequestHeaders,
+} from "axios";
 
 import {
   AnalysisAppDependency,
@@ -441,11 +445,12 @@ export const deleteAllMigrationWaves = (
     .catch((error) => error);
 };
 
-export const updateTarget = (obj: Target): Promise<Target> =>
-  axios.put(`${TARGETS}/${obj.id}`, obj);
+export const updateTarget = (obj: Target) =>
+  axios.put<Target>(`${TARGETS}/${obj.id}`, obj);
 
-export const createTarget = (obj: New<Target>): Promise<Target> =>
-  axios.post(TARGETS, obj);
+export const createTarget = (
+  obj: New<Target>
+): Promise<AxiosResponse<Target>> => axios.post<Target>(TARGETS, obj);
 
 export const deleteTarget = (id: number): Promise<Target> =>
   axios.delete(`${TARGETS}/${id}`);

--- a/client/src/app/pages/migration-targets/components/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/components/custom-target-form.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useState, useMemo } from "react";
 import {
   ActionGroup,
   Alert,
@@ -28,14 +28,7 @@ import {
 } from "@app/components/HookFormPFFields";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 import { useCreateFileMutation } from "@app/queries/targets";
-import {
-  IReadFile,
-  New,
-  ProviderType,
-  Rule,
-  Target,
-  TargetLabel,
-} from "@app/api/models";
+import { IReadFile, New, Rule, Target, TargetLabel } from "@app/api/models";
 import { getParsedLabel, parseRules } from "@app/utils/rules-utils";
 import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { toOptionLike } from "@app/utils/model-utils";
@@ -49,18 +42,23 @@ import {
   useUpdateTargetMutation,
 } from "@app/queries/targets";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import {
+  DEFAULT_PROVIDER,
+  useMigrationProviderList,
+} from "../useMigrationProviderList";
+import { unique } from "radash";
 
 export interface CustomTargetFormProps {
   target?: Target | null;
   onSaved: (response: AxiosResponse<Target>) => void;
   onCancel: () => void;
-  providerType: ProviderType;
 }
 
 export interface CustomTargetFormValues {
   id: number;
   name: string;
   description?: string;
+  providerType?: string;
   imageID: number | null;
   customRulesFiles: IReadFile[];
   rulesKind: string;
@@ -75,9 +73,23 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
   target: initialTarget,
   onSaved,
   onCancel,
-  providerType,
 }) => {
   const { pushNotification } = useContext(NotificationsContext);
+  const baseProviderList = useMigrationProviderList();
+  const providerList = useMemo(
+    () =>
+      unique([initialTarget?.provider, ...baseProviderList]).filter(Boolean),
+    [baseProviderList, initialTarget?.provider]
+  );
+  const providerListOptions = useMemo(
+    () =>
+      providerList.map((provider) => ({
+        value: provider,
+        toString: () => provider,
+      })),
+    [providerList]
+  );
+
   const { t } = useTranslation();
   const [target, setTarget] = useState(initialTarget);
   const [imageRejectedError, setImageRejectedError] = useState<string | null>(
@@ -126,6 +138,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
           (value) => duplicateNameCheck(targets, target || null, value || "")
         ),
       description: yup.string(),
+      providerType: yup.string().oneOf(providerList),
       imageID: yup.number().defined().nullable(),
       rulesKind: yup.string().defined(),
       customRulesFiles: yup
@@ -180,6 +193,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
       id: target?.id || 0,
       name: target?.name || "",
       description: target?.description || "",
+      providerType: target?.provider ?? DEFAULT_PROVIDER,
       imageID: target?.image?.id || null,
       customRulesFiles: getInitialCustomRulesFilesData(),
       rulesKind: !target
@@ -205,7 +219,6 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
     getValues,
     setValue,
     control,
-    watch,
     setFocus,
     clearErrors,
     trigger,
@@ -223,9 +236,8 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
       setTarget(undefined);
       setFilename("default.png");
     };
-  }, []);
+  }, [initialTarget]);
 
-  const watchAllFields = watch();
   const values = getValues();
 
   const {
@@ -307,7 +319,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
             },
           }),
       },
-      provider: providerType || "Java",
+      provider: formValues.providerType,
     };
 
     if (target) {
@@ -354,7 +366,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
 
   const { mutateAsync: createImageFileAsync } = useCreateFileMutation();
 
-  const onCreateTargetSuccess = (response: any) => {
+  const onCreateTargetSuccess = (response: AxiosResponse<Target>) => {
     onSaved(response);
     reset();
   };
@@ -371,12 +383,12 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
     onCreateTargetFailure
   );
 
-  const onUpdateTargetSuccess = (response: any) => {
+  const onUpdateTargetSuccess = (response: AxiosResponse<Target>) => {
     onSaved(response);
     reset();
   };
 
-  const onUpdateTargetFailure = (error: AxiosError) => {};
+  const onUpdateTargetFailure = (_error: AxiosError) => {};
 
   const { mutate: updateTarget } = useUpdateTargetMutation(
     onUpdateTargetSuccess,
@@ -416,11 +428,32 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
       />
       <HookFormPFGroupController
         control={control}
+        name="providerType"
+        label="Provider"
+        fieldId="provider-type-select"
+        renderInput={({ field: { value, name, onChange } }) => (
+          <SimpleSelect
+            id="provider-type-select"
+            toggleId="provider-type-select-toggle"
+            toggleAriaLabel="Provider type select dropdown toggle"
+            aria-label={name}
+            value={value ? toOptionLike(value, providerListOptions) : undefined}
+            options={providerListOptions}
+            onChange={(selection) => {
+              const selectionValue = selection as OptionWithValue<string>;
+              onChange(selectionValue.value);
+            }}
+          />
+        )}
+      />
+
+      <HookFormPFGroupController
+        control={control}
         name="imageID"
         label={t("terms.image")}
         fieldId="custom-migration-target-upload-image"
         helperText="Upload a png or jpeg file (Max size: 1 MB)"
-        renderInput={({ field: { onChange, name }, fieldState: { error } }) => (
+        renderInput={({ field: { onChange, name } }) => (
           <>
             {imageRejectedError && (
               <Alert
@@ -471,7 +504,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
                     clearErrors("imageID");
                     trigger("imageID");
                   })
-                  .catch((err) => {
+                  .catch(() => {
                     setValue("imageID", null);
                   });
               }}
@@ -493,7 +526,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
         label="Custom rules"
         fieldId="type-select"
         isRequired
-        renderInput={({ field: { value, name, onChange } }) => (
+        renderInput={({ field: { value, onChange } }) => (
           <>
             <Radio
               id="manual"
@@ -573,6 +606,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
           </MultipleFileUpload>
         </>
       )}
+
       {values?.rulesKind === "repository" && (
         <>
           <HookFormPFGroupController
@@ -622,7 +656,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
             name="associatedCredentials"
             label="Associated credentials"
             fieldId="credentials-select"
-            renderInput={({ field: { value, name, onBlur, onChange } }) => (
+            renderInput={({ field: { value, name, onChange } }) => (
               <SimpleSelect
                 variant="typeahead"
                 id="associated-credentials-select"

--- a/client/src/app/pages/migration-targets/migration-targets.tsx
+++ b/client/src/app/pages/migration-targets/migration-targets.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -7,6 +7,8 @@ import {
   useSensor,
   useSensors,
   DragOverlay,
+  DragStartEvent,
+  DragOverEvent,
 } from "@dnd-kit/core";
 import {
   arrayMove,
@@ -17,12 +19,14 @@ import { SortableItem } from "./components/dnd/sortable-item";
 import {
   PageSection,
   PageSectionVariants,
-  Grid,
-  GridItem,
   TextContent,
   Button,
   Text,
   Modal,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { useTranslation } from "react-i18next";
@@ -35,13 +39,19 @@ import { getAxiosErrorMessage } from "@app/utils/utils";
 import { CustomTargetForm } from "./components/custom-target-form";
 import { useSetting, useSettingMutation } from "@app/queries/settings";
 import { useDeleteTargetMutation, useFetchTargets } from "@app/queries/targets";
-import { ProviderType, Target } from "@app/api/models";
-import { SimpleSelect } from "@app/components/SimpleSelect";
+import { Target } from "@app/api/models";
+import { DEFAULT_PROVIDER } from "./useMigrationProviderList";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+import {
+  FilterToolbar,
+  FilterType,
+  FilterValue,
+} from "@app/components/FilterToolbar";
+import { unique } from "radash";
 
 export const MigrationTargets: React.FC = () => {
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
-  const [provider, setProvider] = useState<ProviderType>("Java");
 
   const { targets, refetch: refetchTargets } = useFetchTargets();
 
@@ -62,7 +72,7 @@ export const MigrationTargets: React.FC = () => {
     targetsEndRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
-  const [activeId, setActiveId] = useState(null);
+  const [activeId, setActiveId] = useState<number | null>(null);
 
   const onDeleteTargetSuccess = (target: Target, id: number) => {
     pushNotification({
@@ -124,22 +134,39 @@ export const MigrationTargets: React.FC = () => {
           response.data.id,
         ]);
       }
-    }
 
+      // Make sure the new target's provider is part of the provider's filter so it can be seen
+      if (filterState.filterValues["provider"]) {
+        let newProviderFilter: FilterValue = null;
+
+        const targetProvider = response.data.provider;
+        if (targetProvider) {
+          const fv = filterState.filterValues["provider"];
+          newProviderFilter = fv.includes(targetProvider)
+            ? fv
+            : [...fv, targetProvider];
+        }
+
+        filterState.setFilterValues({
+          name: filterState.filterValues["name"],
+          provider: newProviderFilter,
+        });
+      }
+    }
     setCreateUpdateModalState(null);
     refetchTargets();
   };
 
   const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor));
 
-  function handleDragOver(event: any) {
+  function handleDragOver(event: DragOverEvent) {
     if (targetOrderSetting.isSuccess) {
       const { active, over } = event;
 
-      if (active.id !== over.id) {
+      if (over && active.id !== over.id) {
         const reorderTarget = (items: number[]) => {
-          const oldIndex = items.indexOf(active.id);
-          const newIndex = items.indexOf(over.id);
+          const oldIndex = items.indexOf(active.id as number);
+          const newIndex = items.indexOf(over.id as number);
 
           return arrayMove(items, oldIndex, newIndex);
         };
@@ -151,74 +178,95 @@ export const MigrationTargets: React.FC = () => {
     }
   }
 
-  const handleDragStart = (event: any) => {
+  const handleDragStart = (event: DragStartEvent) => {
     const { active } = event;
-    setActiveId(active.id);
+    setActiveId(active.id as number);
   };
+
+  const tableControls = useLocalTableControls({
+    tableName: "target-cards",
+    items: targets,
+    idProperty: "name",
+    initialFilterValues: { provider: [DEFAULT_PROVIDER] },
+    columnNames: {
+      name: "name",
+      provider: "provider",
+    },
+    isFilterEnabled: true,
+    isPaginationEnabled: false,
+    isSortEnabled: false,
+    // TODO: Add `persistTo` handling if needed.
+    filterCategories: [
+      {
+        selectOptions: unique(
+          targets.map((target) => target.provider).filter(Boolean)
+        ).map((target) => ({ value: target })),
+        placeholderText: "Filter by language...",
+        categoryKey: "provider",
+        title: "Languages",
+        type: FilterType.multiselect,
+        matcher: (filter, target) => !!target.provider?.includes(filter),
+      },
+      {
+        placeholderText: "Filter by name...",
+        categoryKey: "name",
+        title: "Name",
+        type: FilterType.search,
+        matcher: (filter, target) =>
+          !!target.name?.toLowerCase().includes(filter.toLowerCase()),
+      },
+    ],
+  });
+
+  const {
+    filterState,
+    currentPageItems: filteredTargets,
+    propHelpers: { toolbarProps, filterToolbarProps },
+  } = tableControls;
+
+  const filteredTargetsInOrder = useMemo(() => {
+    if (!targetOrderSetting.isSuccess) {
+      return [];
+    }
+
+    return targetOrderSetting.data
+      .map((id) => filteredTargets.find((target) => target.id === id))
+      .filter(Boolean);
+  }, [filteredTargets, targetOrderSetting.data, targetOrderSetting.isSuccess]);
 
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
-        <Grid>
-          <GridItem span={10}>
-            <TextContent>
-              <Text component="h1">{t("terms.customTargets")}</Text>
-            </TextContent>
-          </GridItem>
-          <GridItem span={2}></GridItem>
-          <GridItem span={12}>
-            <TextContent>
-              <Text>{t("terms.customTargetsDetails")}</Text>
-            </TextContent>
-          </GridItem>
-          <GridItem span={2} className={spacing.mtSm}>
-            <SimpleSelect
-              variant="typeahead"
-              id="action-select"
-              toggleId="action-select-toggle"
-              toggleAriaLabel="Action select dropdown toggle"
-              aria-label={"Select provider"}
-              value={provider}
-              options={["Java", "Go"]}
-              onChange={(selection) => {
-                setProvider(selection as ProviderType);
-              }}
-            />
-          </GridItem>
-          <GridItem span={2} className={spacing.mtSm}>
-            <Button
-              id="create-target"
-              isInline
-              className={spacing.mlMd}
-              onClick={() => setCreateUpdateModalState("create")}
-            >
-              Create new
-            </Button>
-          </GridItem>
-        </Grid>
+        <TextContent>
+          <Text component="h1">{t("terms.customTargets")}</Text>
+        </TextContent>
+        <TextContent>
+          <Text>{t("terms.customTargetsDetails")}</Text>
+        </TextContent>
       </PageSection>
+
       <PageSection>
-        <Modal
-          id="create-edit-custom-tarrget-modal"
-          title={t(
-            targetToUpdate ? "dialog.title.update" : "dialog.title.new",
-            {
-              what: `${t("terms.customTargetOfType", {
-                type: provider,
-              })}`,
-            }
-          )}
-          variant="medium"
-          isOpen={isCreateUpdateModalOpen}
-          onClose={() => setCreateUpdateModalState(null)}
+        <Toolbar
+          {...toolbarProps}
+          clearAllFilters={() => filterToolbarProps.setFilterValues({})}
         >
-          <CustomTargetForm
-            providerType={provider}
-            target={targetToUpdate}
-            onSaved={onCustomTargetModalSaved}
-            onCancel={() => setCreateUpdateModalState(null)}
-          />
-        </Modal>
+          <ToolbarContent>
+            <FilterToolbar {...filterToolbarProps} breakpoint="md" />
+            <ToolbarGroup variant="button-group">
+              <ToolbarItem>
+                <Button
+                  id="create-target"
+                  isInline
+                  className={spacing.mlMd}
+                  onClick={() => setCreateUpdateModalState("create")}
+                >
+                  Create new
+                </Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarContent>
+        </Toolbar>
+
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
@@ -230,38 +278,19 @@ export const MigrationTargets: React.FC = () => {
             strategy={rectSortingStrategy}
           >
             <DndGrid>
-              {targetOrderSetting.isSuccess &&
-                targetOrderSetting.data.map((id) => {
-                  const matchingTarget = targets.find(
-                    (target) => target.id === id
-                  );
-                  if (
-                    matchingTarget &&
-                    matchingTarget.provider?.includes(provider)
-                  ) {
-                    return (
-                      <SortableItem
-                        key={id}
-                        id={id}
-                        onEdit={() => {
-                          if (matchingTarget) {
-                            setCreateUpdateModalState(matchingTarget);
-                          }
-                        }}
-                        onDelete={() => {
-                          const matchingTarget = targets.find(
-                            (target) => target.id === id
-                          );
-                          if (matchingTarget?.id) {
-                            deleteTarget(matchingTarget.id);
-                          }
-                        }}
-                      />
-                    );
-                  } else {
-                    return null;
-                  }
-                })}
+              {filteredTargetsInOrder.map((target) => (
+                <SortableItem
+                  key={target.id}
+                  id={target.id}
+                  onEdit={() => {
+                    setCreateUpdateModalState(target);
+                  }}
+                  onDelete={() => {
+                    // TODO: Add a delete confirmation modal.
+                    deleteTarget(target.id);
+                  }}
+                />
+              ))}
               <div ref={targetsEndRef} />
             </DndGrid>
             <DragOverlay>
@@ -270,6 +299,22 @@ export const MigrationTargets: React.FC = () => {
           </SortableContext>
         </DndContext>
       </PageSection>
+
+      <Modal
+        id="create-edit-custom-target-modal"
+        title={t(targetToUpdate ? "dialog.title.update" : "dialog.title.new", {
+          what: `${t("terms.customTarget")}`,
+        })}
+        variant="medium"
+        isOpen={isCreateUpdateModalOpen}
+        onClose={() => setCreateUpdateModalState(null)}
+      >
+        <CustomTargetForm
+          target={targetToUpdate}
+          onSaved={onCustomTargetModalSaved}
+          onCancel={() => setCreateUpdateModalState(null)}
+        />
+      </Modal>
     </>
   );
 };

--- a/client/src/app/pages/migration-targets/useMigrationProviderList.ts
+++ b/client/src/app/pages/migration-targets/useMigrationProviderList.ts
@@ -1,0 +1,12 @@
+export const DEFAULT_PROVIDER = "Java";
+
+const PROVIDER_LIST = ["Java", "Golang", "TypeScript", "Python"].sort();
+
+/**
+ * Provides the list of migration provider names that can be used for custom targets. These names
+ * do not need to match any other names, they are not used in hub. This list is just for UI
+ * filtering and sorting.
+ */
+export const useMigrationProviderList = (): string[] => {
+  return PROVIDER_LIST;
+};

--- a/client/src/app/queries/targets.ts
+++ b/client/src/app/queries/targets.ts
@@ -7,7 +7,7 @@ import {
   getTargets,
   updateTarget,
 } from "@app/api/rest";
-import { AxiosError } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 
 export const TargetsQueryKey = "targets";
 
@@ -28,7 +28,7 @@ export const useFetchTargets = () => {
 };
 
 export const useUpdateTargetMutation = (
-  onSuccess: (res: Target) => void,
+  onSuccess: (res: AxiosResponse<Target>) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
@@ -74,7 +74,7 @@ export const useDeleteTargetMutation = (
 };
 
 export const useCreateTargetMutation = (
-  onSuccess: (res: Target) => void,
+  onSuccess: (res: AxiosResponse<Target>) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();


### PR DESCRIPTION
Resolves: #2176

On the custom migrations target page, update the page to better support provider types. Summary of changes:
  - Add support for target filtering by Name and Provider
  - The filter provider list is pulled from the existing targets' providers so all targets are all always visible to filtering
  - The provider type is now selected on the create modal
  - The provider type can be edited for any custom target
  - The list of providers is contained within the hook `useMigrationProviderList()`.  This allows the list to be changed with little disruption to other components

Other related changes:
  - Resolved linting warnings
  - Fixed types for Target queries
