### PR TITLE
:bug: Validate shape of uploaded custom rules files

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -517,17 +517,10 @@ export interface ParsedRule {
   fileID?: number;
 }
 
-export type FileLoadError = {
-  name?: string;
-  message?: string;
-  stack?: string;
-  cause?: {};
-};
-
 export interface IReadFile {
   fileName: string;
   fullFile?: File;
-  loadError?: FileLoadError;
+  loadError?: Error;
   loadPercentage?: number;
   loadResult?: "danger" | "success";
   data?: string;

--- a/client/src/app/api/rest-files.ts
+++ b/client/src/app/api/rest-files.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+
+import { HUB, HEADERS } from "./rest";
+import { HubFile, IReadFile } from "./models";
+
+export const FILES = HUB + "/files";
+
+export const createFile = ({
+  formData,
+  file,
+}: {
+  formData: FormData;
+  file: IReadFile;
+}) =>
+  axios
+    .post<HubFile>(`${FILES}/${file.fileName}`, formData, {
+      headers: HEADERS.file,
+    })
+    .then((response) => response.data);
+
+export const getTextFileById = (id: number) =>
+  axios
+    .get<string>(`${FILES}/${id}`, { headers: HEADERS.plain })
+    .then((response) => response.data);

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -22,12 +22,10 @@ import {
   BaseAnalysisRuleReport,
   BusinessService,
   Cache,
-  HubFile,
   HubPaginatedResult,
   HubRequestParams,
   Identity,
   InitialAssessment,
-  IReadFile,
   JobFunction,
   MigrationWave,
   MimeType,
@@ -88,7 +86,6 @@ export const TICKETS = HUB + "/tickets";
 export const FACTS = HUB + "/facts";
 
 export const TARGETS = HUB + "/targets";
-export const FILES = HUB + "/files";
 export const CACHE = HUB + "/cache/m2";
 
 export const ANALYSIS_DEPENDENCIES = HUB + "/analyses/report/dependencies";
@@ -116,16 +113,25 @@ export const ASSESSMENTS = HUB + "/assessments";
 
 export const PLATFORMS = HUB + "/platforms";
 
-const jsonHeaders: RawAxiosRequestHeaders = {
-  Accept: "application/json",
+export const HEADERS: Record<string, RawAxiosRequestHeaders> = {
+  json: {
+    Accept: "application/json",
+  },
+  form: {
+    Accept: "multipart/form-data",
+  },
+  file: {
+    Accept: "application/json",
+  },
+  yaml: {
+    Accept: "application/x-yaml",
+  },
+  plain: {
+    Accept: "test/plain",
+  },
 };
-const formHeaders: RawAxiosRequestHeaders = {
-  Accept: "multipart/form-data",
-};
-const fileHeaders: RawAxiosRequestHeaders = { Accept: "application/json" };
-const yamlHeaders: RawAxiosRequestHeaders = {
-  Accept: "application/x-yaml",
-};
+
+export * from "./rest-files";
 
 type Direction = "asc" | "desc";
 
@@ -482,26 +488,6 @@ export const deleteTarget = (id: number): Promise<Target> =>
 
 export const getTargets = (): Promise<Target[]> =>
   axios.get(TARGETS).then((response) => response.data);
-
-export const createFile = ({
-  formData,
-  file,
-}: {
-  formData: FormData;
-  file: IReadFile;
-}) =>
-  axios
-    .post<HubFile>(`${FILES}/${file.fileName}`, formData, {
-      headers: fileHeaders,
-    })
-    .then((response) => {
-      return response.data;
-    });
-
-export const getTextFile = (id: number): Promise<string> =>
-  axios
-    .get(`${FILES}/${id}`, { headers: { Accept: "text/plain" } })
-    .then((response) => response.data);
 
 export const getSettingById = <K extends keyof SettingTypes>(
   id: K

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -154,7 +154,7 @@ export const getApplicationDependencies = (
   return axios
     .get(`${APPLICATION_DEPENDENCY}`, {
       params,
-      headers: jsonHeaders,
+      headers: HEADERS.json,
     })
     .then((response) => response.data);
 };
@@ -260,7 +260,7 @@ export const deleteAssessment = (id: number) => {
 };
 
 export const getIdentities = () => {
-  return axios.get<Identity[]>(`${IDENTITIES}`, { headers: jsonHeaders });
+  return axios.get<Identity[]>(`${IDENTITIES}`, { headers: HEADERS.json });
 };
 
 export const createIdentity = (obj: New<Identity>) => {
@@ -337,7 +337,7 @@ export const getApplicationImports = (
 export function getTaskById(id: number): Promise<Task> {
   return axios
     .get(`${TASKS}/${id}`, {
-      headers: { ...jsonHeaders },
+      headers: { ...HEADERS.json },
       responseType: "json",
     })
     .then((response) => {
@@ -351,7 +351,7 @@ export function getTaskByIdAndFormat(
   merged: boolean = false
 ): Promise<string> {
   const isYaml = format === "yaml";
-  const headers = isYaml ? { ...yamlHeaders } : { ...jsonHeaders };
+  const headers = isYaml ? { ...HEADERS.yaml } : { ...HEADERS.json };
   const responseType = isYaml ? "text" : "json";
 
   let url = `${TASKS}/${id}`;
@@ -376,7 +376,7 @@ export function getTasksByIds(
   format: "json" | "yaml" = "json"
 ): Promise<Task[]> {
   const isYaml = format === "yaml";
-  const headers = isYaml ? { ...yamlHeaders } : { ...jsonHeaders };
+  const headers = isYaml ? { ...HEADERS.yaml } : { ...HEADERS.json };
   const responseType = isYaml ? "text" : "json";
   const filterParam = `id:(${ids.join("|")})`;
 
@@ -440,7 +440,7 @@ export const uploadFileTaskgroup = ({
   file: any;
 }) => {
   return axios.post<Taskgroup>(`${TASKGROUPS}/${id}/bucket/${path}`, formData, {
-    headers: formHeaders,
+    headers: HEADERS.form,
   });
 };
 

--- a/client/src/app/components/CustomRuleFilesUpload.tsx
+++ b/client/src/app/components/CustomRuleFilesUpload.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import {
+  Alert,
+  MultipleFileUpload,
+  MultipleFileUploadMain,
+  MultipleFileUploadStatus,
+  MultipleFileUploadStatusItem,
+} from "@patternfly/react-core";
+import UploadIcon from "@patternfly/react-icons/dist/esm/icons/upload-icon";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import useRuleFiles from "@app/hooks/useRuleFiles";
+import { IReadFile } from "@app/api/models";
+import { counting } from "radash";
+
+export interface CustomRuleFilesUploadProps {
+  /** Set of rule files that have already been uploaded. */
+  ruleFiles: IReadFile[];
+
+  onAddRuleFiles: (ruleFiles: IReadFile[]) => void;
+  onRemoveRuleFiles: (ruleFiles: IReadFile[]) => void;
+  onChangeRuleFile: (ruleFile: IReadFile) => void;
+
+  /** When provided, if a file name already exists, block the upload and display an error. */
+  fileExists?: (filename: string) => boolean;
+
+  /**
+   * If working with custom rules in a Taskgroup (for Analysis), provide the taskgroup id.  Files
+   * will be uploaded to the Taskgroup instead of a standard hub file.
+   */
+  taskgroupId?: number;
+}
+
+export const CustomRuleFilesUpload: React.FC<CustomRuleFilesUploadProps> = ({
+  ruleFiles,
+  onAddRuleFiles,
+  onRemoveRuleFiles,
+  onChangeRuleFile,
+  fileExists,
+  taskgroupId,
+}) => {
+  const { handleFileDrop, handleFile } = useRuleFiles({
+    ruleFiles,
+    fileExists,
+    onAddRuleFiles,
+    onRemoveRuleFiles,
+    onChangeRuleFile,
+    taskgroupId,
+  });
+
+  const showStatus = ruleFiles.length > 0;
+  const filesInError = ruleFiles.filter((file) => !!file.loadError);
+
+  const results = counting(ruleFiles, (r) => r.loadResult ?? "inProgress");
+
+  const ruleFilesStatusText = `${results.success} of ${ruleFiles.length} files uploaded`;
+  const ruleFilesStatusIcon =
+    results.inProgress > 0
+      ? "inProgress"
+      : results.danger > 0
+        ? "danger"
+        : "success";
+
+  return (
+    <>
+      {filesInError.map((file) => (
+        <Alert
+          key={file.fileName}
+          className={`${spacing.mtMd} ${spacing.mbMd}`}
+          variant="danger"
+          isInline
+          title={file.loadError?.message}
+        />
+      ))}
+
+      <MultipleFileUpload
+        onFileDrop={handleFileDrop}
+        dropzoneProps={{
+          accept: {
+            "text/xml": [".xml"],
+            "text/yaml": [".yml", ".yaml"],
+          },
+        }}
+      >
+        <MultipleFileUploadMain
+          titleIcon={<UploadIcon />}
+          titleText="Drag and drop files here"
+          titleTextSeparator="or"
+          infoText="Accepted file types: .yml, .yaml, .xml"
+        />
+        {showStatus && (
+          <MultipleFileUploadStatus
+            statusToggleText={ruleFilesStatusText}
+            statusToggleIcon={ruleFilesStatusIcon}
+          >
+            {ruleFiles.map((ruleFile) => (
+              <MultipleFileUploadStatusItem
+                key={ruleFile.fileName}
+                file={ruleFile.fullFile}
+                customFileHandler={(file) => handleFile(ruleFile, file)}
+                onClearClick={() => onRemoveRuleFiles([ruleFile])}
+                progressValue={ruleFile.loadPercentage}
+                progressVariant={ruleFile.loadResult}
+              />
+            ))}
+          </MultipleFileUploadStatus>
+        )}
+      </MultipleFileUpload>
+    </>
+  );
+};

--- a/client/src/app/components/HookFormPFFields/HookFormPFGroupController.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormPFGroupController.tsx
@@ -18,7 +18,7 @@ import {
 // Generic type params here are the same as the ones used by react-hook-form's <Controller>.
 export interface BaseHookFormPFGroupControllerProps<
   TFieldValues extends FieldValues,
-  TName extends Path<TFieldValues>
+  TName extends Path<TFieldValues>,
 > {
   control: Control<TFieldValues>;
   label?: React.ReactNode;
@@ -34,14 +34,14 @@ export interface BaseHookFormPFGroupControllerProps<
 
 export interface HookFormPFGroupControllerProps<
   TFieldValues extends FieldValues,
-  TName extends Path<TFieldValues>
+  TName extends Path<TFieldValues>,
 > extends BaseHookFormPFGroupControllerProps<TFieldValues, TName> {
   renderInput: ControllerProps<TFieldValues, TName>["render"];
 }
 
 export const HookFormPFGroupController = <
   TFieldValues extends FieldValues = FieldValues,
-  TName extends Path<TFieldValues> = Path<TFieldValues>
+  TName extends Path<TFieldValues> = Path<TFieldValues>,
 >({
   control,
   label,
@@ -94,7 +94,7 @@ export const HookFormPFGroupController = <
 export const extractGroupControllerProps = <
   TFieldValues extends FieldValues,
   TName extends Path<TFieldValues>,
-  TProps extends BaseHookFormPFGroupControllerProps<TFieldValues, TName>
+  TProps extends BaseHookFormPFGroupControllerProps<TFieldValues, TName>,
 >(
   props: TProps
 ): {

--- a/client/src/app/components/HookFormPFFields/HookFormPFTextInput.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormPFTextInput.tsx
@@ -10,12 +10,12 @@ import {
 
 export type HookFormPFTextInputProps<
   TFieldValues extends FieldValues,
-  TName extends Path<TFieldValues>
+  TName extends Path<TFieldValues>,
 > = TextInputProps & BaseHookFormPFGroupControllerProps<TFieldValues, TName>;
 
 export const HookFormPFTextInput = <
   TFieldValues extends FieldValues = FieldValues,
-  TName extends Path<TFieldValues> = Path<TFieldValues>
+  TName extends Path<TFieldValues> = Path<TFieldValues>,
 >(
   props: HookFormPFTextInputProps<TFieldValues, TName>
 ) => {

--- a/client/src/app/hooks/useRuleFiles.tsx
+++ b/client/src/app/hooks/useRuleFiles.tsx
@@ -1,4 +1,4 @@
-import { useContext, useReducer } from "react";
+import { useContext } from "react";
 import { HubFile, IReadFile, Taskgroup } from "@app/api/models";
 import { NotificationsContext } from "@app/components/NotificationsContext";
 import { AxiosError, AxiosResponse } from "axios";
@@ -101,7 +101,7 @@ export default function useRuleFiles({
   taskgroupId,
 }: UseRuleFilesParams) {
   const { pushNotification } = useContext(NotificationsContext);
-  const [state, dispatch] = useReducer(fileSetReducer, {});
+  // const [state, dispatch] = useReducer(fileSetReducer, {});
 
   const notifyOnUploadFail = (error: AxiosError) => {
     pushNotification({

--- a/client/src/app/hooks/useRuleFiles.tsx
+++ b/client/src/app/hooks/useRuleFiles.tsx
@@ -1,62 +1,109 @@
-import { useContext, useState } from "react";
-import { FileLoadError, IReadFile } from "@app/api/models";
+import { useContext, useReducer } from "react";
+import { HubFile, IReadFile, Taskgroup } from "@app/api/models";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { AxiosError } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 import { useUploadFileMutation } from "@app/queries/taskgroups";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 import { useCreateFileMutation } from "@app/queries/targets";
-import { CustomTargetFormValues } from "@app/pages/migration-targets/components/custom-target-form";
-import { UseFormReturn } from "react-hook-form";
 import { XMLValidator } from "fast-xml-parser";
 import XSDSchema from "./windup-jboss-ruleset.xsd";
 import { checkRuleFileType } from "../utils/rules-utils";
 import { DropEvent } from "@patternfly/react-core";
+import { load as loadYaml, YAMLException } from "js-yaml";
+
+// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
+import type { MultipleFileUploadStatusProps } from "@patternfly/react-core";
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const xmllint = require("xmllint");
 
-export default function useRuleFiles(
-  taskgroupID: number | null | undefined,
-  existingRuleFiles: IReadFile[] = [],
-  methods?: UseFormReturn<CustomTargetFormValues>
-) {
-  const { pushNotification } = useContext(NotificationsContext);
-  const [uploadError, setUploadError] = useState("");
-  const [ruleFiles, setRuleFiles] = useState<IReadFile[]>(
-    taskgroupID ? [] : existingRuleFiles
-  );
-  const [showStatus, setShowStatus] = useState(true);
+export interface ValidationFunctionResult {
+  state: "valid" | "error";
+  message?: string;
+}
 
-  const onUploadError = (error: AxiosError) =>
-    console.log("File upload failed: ", error);
+const validateXmlFile = (data: string): ValidationFunctionResult => {
+  // Filter out "data:text/xml;base64," from data
+  const validationObject = XMLValidator.validate(data, {
+    allowBooleanAttributes: true,
+  });
 
-  const onCreateRuleFileSuccess = (
-    response: any,
-    formData: FormData,
-    file: IReadFile
-  ) => {
-    setRuleFiles((oldRuleFiles) => {
-      const fileWithID: IReadFile = {
-        ...file,
-        ...{ responseID: response?.id },
-      };
-      const updatedFiles = [...oldRuleFiles];
-      const ruleFileToUpdate = ruleFiles.findIndex(
-        (ruleFile) => ruleFile.fileName === file.fileName
-      );
-      updatedFiles[ruleFileToUpdate] = fileWithID;
+  // If xml is valid, check against schema
+  if (validationObject === true) {
+    const currentSchema = XSDSchema;
 
-      if (methods) {
-        methods.setValue(
-          "customRulesFiles",
-          updatedFiles.filter((ruleFile) => ruleFile.loadResult === "success"),
-          { shouldDirty: true, shouldValidate: true }
-        );
-      }
-      return updatedFiles;
+    const validationResult = xmllint.xmllint.validateXML({
+      xml: data,
+      schema: currentSchema,
     });
-  };
 
-  const onCreateRuleFileFailure = (error: AxiosError) => {
+    if (validationResult.errors)
+      return {
+        state: "error",
+        message: validationResult?.errors?.toString(),
+      };
+    else return { state: "valid" };
+  } else
+    return {
+      state: "error",
+      message: validationObject?.err?.msg?.toString(),
+    };
+};
+
+const validateYamlFile = (data: string): ValidationFunctionResult => {
+  try {
+    loadYaml(data);
+    return {
+      state: "valid",
+    };
+  } catch (err) {
+    const yamlException = err as YAMLException;
+    return {
+      state: "error",
+      message: `${yamlException.reason} (ln: ${yamlException.mark.line}, col: ${yamlException.mark.column})`,
+    };
+  }
+};
+
+export interface UseRuleFilesParams {
+  ruleFiles: IReadFile[];
+  onAddRuleFiles: (ruleFile: IReadFile[]) => void;
+  onRemoveRuleFiles: (ruleFile: IReadFile[]) => void;
+  onChangeRuleFile: (ruleFile: IReadFile) => void;
+  fileExists?: (fileName: string) => boolean;
+  taskgroupId?: number;
+}
+
+// function fileSetReducer(state, action: { type: string, payload: unknown }): Record<string, IReadFile> {
+//   const actions = {
+//     startFile(payload) {
+
+//     },
+
+//     removeFile(payload) {
+
+//     },
+
+//     fileLoaded(payload) {
+
+//     },
+//   };
+
+//   return actions[action.type]?.(action);
+// }
+
+export default function useRuleFiles({
+  ruleFiles,
+  onAddRuleFiles,
+  onRemoveRuleFiles,
+  onChangeRuleFile,
+  fileExists,
+  taskgroupId,
+}: UseRuleFilesParams) {
+  const { pushNotification } = useContext(NotificationsContext);
+  const [state, dispatch] = useReducer(fileSetReducer, {});
+
+  const notifyOnUploadFail = (error: AxiosError) => {
     pushNotification({
       title: getAxiosErrorMessage(error),
       variant: "danger",
@@ -64,271 +111,161 @@ export default function useRuleFiles(
   };
 
   const { mutate: createRuleFile } = useCreateFileMutation(
-    onCreateRuleFileSuccess,
-    onCreateRuleFileFailure
-  );
-
-  const onUploadFileSuccess = (
-    response: any,
-    id: number,
-    path: string,
-    formData: IReadFile,
-    file: IReadFile
-  ) => {
-    //Set file ID for use in form submit
-    setRuleFiles((oldRuleFiles) => {
-      const fileWithID: IReadFile = {
+    (response: HubFile, _formData: FormData, file: IReadFile) => {
+      onChangeRuleFile({
         ...file,
-        ...{ responseID: response?.id },
-      };
-      const updatedFiles = [...oldRuleFiles];
-      const ruleFileToUpdate = ruleFiles.findIndex(
-        (ruleFile) => ruleFile.fileName === file.fileName
-      );
-      updatedFiles[ruleFileToUpdate] = fileWithID;
-
-      return updatedFiles;
-    });
-  };
-
-  const { mutate: uploadFile } = useUploadFileMutation(
-    onUploadFileSuccess,
-    onUploadError
+        responseID: response?.id,
+      });
+    },
+    notifyOnUploadFail
   );
 
-  const setStatus = () => {
-    if (ruleFiles.length < existingRuleFiles.length) {
-      return "inProgress";
-    } else if (ruleFiles.every((file) => file.loadResult === "success")) {
-      return "success";
-    } else {
-      return "danger";
-    }
-  };
+  const { mutate: uploadTaskgroupFile } = useUploadFileMutation(
+    (
+      response: AxiosResponse<Taskgroup>,
+      _id: number,
+      _path: string,
+      _formData: IReadFile,
+      file: IReadFile
+    ) => {
+      onChangeRuleFile({
+        ...file,
+        responseID: response?.data?.id,
+      });
+    },
+    notifyOnUploadFail
+  );
 
-  const isFileIncluded = (name: string) =>
-    existingRuleFiles.some((file) => file.fileName === name);
-
-  const successfullyReadFileCount = ruleFiles.filter(
-    (fileData) => fileData.loadResult === "success"
-  ).length;
-
-  const getloadPercentage = (filename: string) => {
-    const readFile = ruleFiles.find((file) => file.fileName === filename);
-    if (readFile) return readFile.loadPercentage;
-    return 0;
-  };
-
-  const getloadResult = (filename: string) => {
-    const readFile = ruleFiles.find((file) => file.fileName === filename);
-    if (readFile) return readFile.loadResult;
-    return undefined;
-  };
-
-  const readFile = (file: File) => {
-    return new Promise<string | null>((resolve, reject) => {
+  const readFile = (ruleFile: IReadFile, file: File) => {
+    return new Promise<string>((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(reader.result as string);
       reader.onerror = () => reject(reader.error);
       reader.onprogress = (data) => {
         if (data.lengthComputable) {
-          // setLoadPercentage((data.loaded / data.total) * 100);
+          onChangeRuleFile({
+            ...ruleFile,
+            loadPercentage: (data.loaded / data.total) * 100,
+          });
         }
       };
       reader.readAsText(file);
     });
   };
 
-  // callback that will be called by the react dropzone with the newly dropped file objects
-  const handleFileDrop = (event: DropEvent, droppedFiles: File[]) => {
+  const handleFileDrop = (_event: DropEvent, droppedFiles: File[]) => {
     // identify what, if any, files are re-uploads of already uploaded files
-    const currentFileNames = ruleFiles.map((file) => file.fileName);
-    const reUploads = droppedFiles.filter((droppedFile) =>
-      currentFileNames.includes(droppedFile.name)
+    const droppedFileNames = droppedFiles.map(({ name }) => name);
+    const ruleFilesToRemove = ruleFiles.filter(({ fileName }) =>
+      droppedFileNames.includes(fileName)
     );
-    /** this promise chain is needed because if the file removal is done at the same time as the file adding react
-     * won't realize that the status items for the re-uploaded files needs to be re-rendered */
+
+    // this promise chain is needed because if the file removal is done at the same time as the
+    // file adding react won't realize that the status items for the re-uploaded files needs to
+    // be re-rendered
     Promise.resolve()
-      .then(() => removeFiles(reUploads.map((file) => file.name)))
+      .then(() => onRemoveRuleFiles(ruleFilesToRemove))
       .then(() => {
-        const droppedReadFiles: IReadFile[] = droppedFiles.map(
-          (droppedFile) => {
-            return {
-              fileName: droppedFile.name,
-              fullFile: droppedFile,
-            };
-          }
-        );
-        setRuleFiles((prevRuleFiles) => [
-          ...prevRuleFiles,
-          ...droppedReadFiles,
-        ]);
+        const newRuleFiles: IReadFile[] = droppedFiles.map((droppedFile) => ({
+          fileName: droppedFile.name,
+          fullFile: droppedFile,
+        }));
+        onAddRuleFiles(newRuleFiles);
       });
   };
 
-  const removeFiles = (namesOfFilesToRemove: string[]) => {
-    const updatedRuleFilesList = ruleFiles.filter(
-      (currentFile) =>
-        !namesOfFilesToRemove.some(
-          (fileName) => fileName === currentFile.fileName
-        )
-    );
-    setRuleFiles(updatedRuleFilesList);
-    if (!updatedRuleFilesList.some((file) => file.loadResult === "danger")) {
-      setUploadError("");
+  const handleFile = (ruleFile: IReadFile, file: File) => {
+    // Don't do anything for a File that already loaded or is just a
+    // placeholder for an existing hub file
+    if (
+      ruleFile.loadResult === "success" ||
+      ruleFile.loadPercentage === 100 ||
+      file.type === "placeholder"
+    ) {
+      return;
     }
-    if (methods) {
-      methods.setValue(
-        "customRulesFiles",
-        updatedRuleFilesList.filter(
-          (ruleFile) => ruleFile.loadResult === "success"
-        ),
-        { shouldDirty: true, shouldValidate: true }
-      );
-      methods.trigger("customRulesFiles");
-    }
-  };
 
-  const handleFile = (file: File) => {
-    readFile(file)
-      .then((data) => {
-        if (isFileIncluded(file.name) && !taskgroupID) {
-          //If existing file loaded in edit mode, add placeholder file for custom target form
-          handleReadSuccess(data || "", file);
-        } else {
-          if (isFileIncluded(file.name)) {
-            const error = new Error(`File "${file.name}" is already uploaded`);
-            handleReadFail(error, 100, file);
-          } else {
-            if (data) {
-              if (checkRuleFileType(file.name) === "XML") {
-                const validatedXMLResult = validateXMLFile(data);
-                if (validatedXMLResult.state === "valid") {
-                  handleReadSuccess(data, file);
-                } else {
-                  const error = new Error(
-                    `File "${file.name}" is not a valid XML: ${validatedXMLResult.message}`
-                  );
-                  handleReadFail(error, 100, file);
-                }
-              } else {
-                handleReadSuccess(data, file);
-              }
-            } else {
-              const error = new Error("error");
-              handleReadFail(error, 100, file);
-            }
+    readFile(ruleFile, file)
+      .then(async (fileContents) => {
+        console.log("successfully read", file.name);
+        ruleFile.loadPercentage = 100;
+
+        // Block duplicate file name uploads if a Taskgroup is available
+        if (fileExists && fileExists(file.name)) {
+          throw new Error(`File "${file.name}" is already uploaded`);
+        }
+
+        // Verify/lint the contents of an XML file
+        if (checkRuleFileType(file.name) === "XML") {
+          const result = validateXmlFile(fileContents);
+          if (result.state === "error") {
+            throw new Error(
+              `File "${file.name}" is not valid XML: ${result.message}`
+            );
           }
         }
+
+        // Verify/lint the contents of a YAML file
+        if (checkRuleFileType(file.name) === "YAML") {
+          const result = validateYamlFile(fileContents);
+          if (result.state === "error") {
+            throw new Error(
+              `File "${file.name}" is not valid YAML: ${result.message}`
+            );
+          }
+        }
+
+        handleReadSuccess(ruleFile, file, fileContents);
       })
       .catch((error) => {
-        handleReadFail(error, 0, file);
+        handleReadFail(ruleFile, file, error);
       });
   };
 
-  const handleReadSuccess = (data: string, file: File) => {
-    if (taskgroupID) {
-      // Upload file to bucket if bucket exists / in analysis wizard mode
-      const newFile: IReadFile = {
-        data,
-        fileName: file.name,
-        loadResult: "success",
-        loadPercentage: 100,
-        fullFile: file,
-      };
-      const formFile = new FormData();
-      newFile.fullFile && formFile.append("file", newFile.fullFile);
-      uploadFile({
-        id: taskgroupID as number,
+  const handleReadSuccess = (ruleFile: IReadFile, file: File, data: string) => {
+    console.log("reading SUCCESS", file.name);
+    const newFile: IReadFile = {
+      ...ruleFile,
+      data,
+      fullFile: file,
+      loadResult: "success",
+      loadPercentage: 100,
+    };
+
+    const formFile = new FormData();
+    formFile.append("file", file);
+
+    if (taskgroupId) {
+      uploadTaskgroupFile({
+        id: taskgroupId,
         path: `rules/${newFile.fileName}`,
         formData: formFile,
         file: newFile,
       });
     } else {
-      const newFile: IReadFile = {
-        data,
-        fileName: file.name,
-        loadResult: "success",
-        loadPercentage: 100,
-        fullFile: file,
-      };
-      const formFile = new FormData();
-      newFile.fullFile && formFile.append("file", newFile?.fullFile);
       createRuleFile({
         formData: formFile,
         file: newFile,
       });
     }
+
+    // Note: The ruleFile will be updated by the onSuccess handlers of the mutations
   };
 
-  const handleReadFail = (error: Error, percentage: number, file: File) => {
-    setUploadError(error.toString());
+  const handleReadFail = (ruleFile: IReadFile, file: File, error: Error) => {
+    console.log("reading FAIL", file.name, ", Error: ", error.message);
     const fileWithErrorState: IReadFile = {
-      loadError: error as FileLoadError,
-      fileName: file.name,
-      loadResult: "danger",
-      loadPercentage: percentage,
+      ...ruleFile,
       fullFile: file,
+      loadResult: "danger",
+      loadError: error,
     };
-    const updatedFiles = [...ruleFiles];
-    const ruleFileToUpdate = ruleFiles.findIndex(
-      (ruleFile) => ruleFile.fileName === file.name
-    );
-    updatedFiles[ruleFileToUpdate] = fileWithErrorState;
-
-    setRuleFiles(updatedFiles);
-  };
-
-  // only show the status component once a file has been uploaded, but keep the status list component itself even if all files are removed
-  if (!showStatus && existingRuleFiles.length > 0) {
-    setShowStatus(true);
-  }
-  interface IParsedXMLFileStatus {
-    state: "valid" | "error";
-    message?: string;
-  }
-
-  const validateXMLFile = (data: string): IParsedXMLFileStatus => {
-    // Filter out "data:text/xml;base64," from data
-    const validationObject = XMLValidator.validate(data, {
-      allowBooleanAttributes: true,
-    });
-
-    // If xml is valid, check against schema
-    if (validationObject === true) {
-      const currentSchema = XSDSchema;
-
-      const validationResult = xmllint.xmllint.validateXML({
-        xml: data,
-        schema: currentSchema,
-      });
-
-      if (validationResult.errors)
-        return {
-          state: "error",
-          message: validationResult?.errors?.toString(),
-        };
-      else return { state: "valid" };
-    } else
-      return {
-        state: "error",
-        message: validationObject?.err?.msg?.toString(),
-      };
+    onChangeRuleFile(fileWithErrorState);
   };
 
   return {
+    /** Manage the set of files when a new file is dropped or uploaded. */
     handleFileDrop,
-    removeFiles,
-    existingRuleFiles,
-    setRuleFiles,
-    ruleFiles,
-    showStatus,
-    uploadError,
-    setUploadError,
-    successfullyReadFileCount,
-    getloadPercentage,
-    getloadResult,
-    setStatus,
     handleFile,
   };
 }

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -1,11 +1,5 @@
 import * as yup from "yup";
-import {
-  Application,
-  IReadFile,
-  FileLoadError,
-  TargetLabel,
-  Target,
-} from "@app/api/models";
+import { Application, IReadFile, TargetLabel, Target } from "@app/api/models";
 import { useTranslation } from "react-i18next";
 import { useAnalyzableApplicationsByMode } from "./utils";
 
@@ -108,7 +102,7 @@ export interface CustomRulesStepValues {
 export const customRulesFilesSchema: yup.SchemaOf<IReadFile> = yup.object({
   fileName: yup.string().required(),
   fullFile: yup.mixed<File>(),
-  loadError: yup.mixed<FileLoadError>(),
+  loadError: yup.mixed<Error>(),
   loadPercentage: yup.number(),
   loadResult: yup.mixed<"danger" | "success" | undefined>(),
   data: yup.string(),

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -14,7 +14,7 @@ import {
   getTaskByIdAndFormat,
   getTaskQueue,
   getTasksDashboard,
-  getTextFile,
+  getTextFileById,
   updateTask,
 } from "@app/api/rest";
 import { universalComparator } from "@app/utils/utils";
@@ -262,7 +262,7 @@ export const useFetchTaskAttachmentById = ({
 }) => {
   const { isLoading, error, data, refetch } = useQuery({
     queryKey: [TaskAttachmentByIDQueryKey, attachmentId],
-    queryFn: () => (attachmentId ? getTextFile(attachmentId) : undefined),
+    queryFn: () => (attachmentId ? getTextFileById(attachmentId) : undefined),
     enabled,
   });
 

--- a/client/src/app/utils/rules-utils.ts
+++ b/client/src/app/utils/rules-utils.ts
@@ -13,6 +13,7 @@ export const checkRuleFileType = (filename: string): RuleFileType => {
     return null;
   }
 };
+
 type ParsedYamlElement = { labels?: string[] };
 type ParsedYaml = ParsedYamlElement[] | {};
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-4749

When uploading custom rule files aw YAML or XML, make sure that the file can be read as a YAML or XML file before the file is accepted.  If a file cannot be validated, display an error and flag the file as in error.  These files will not pass to further processing.  Upload forms will not be able to be submitted with an invalid file.

Supporting changes:
  - Add `CustomRuleFilesUpload` component to share rule file upload behavior in multiple places

  - Refactor `useRuleFiles()` hook to work well with `CustomRuleFilesUpload` and not keep internal state beyond what is necessary.  All basic file validation is done within this hook.

  - Refactor `CustomRules` (analysis wizard, advanced / custom targets step) to use `CustomRulesFilesUploads`

  - Refactor `CustomTargetForm` (create/edit custom migration target modal) to use `CustomRulesFilesUploads`, reduce default image upload to a single place, and rename some state and functions to have more accurate names.
