### PR TITLE
:ghost: Add project level cspell dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,17 @@
+{
+  "language": "en",
+  "words": [
+    "cancelation",
+    "colour",
+    "coreutils",
+    "iconed",
+    "konveyor",
+    "ouia",
+    "ruleset",
+    "rulesets",
+    "radash",
+    "taskgroup",
+    "taskgroups",
+    "toastr"
+  ]
+}


### PR DESCRIPTION
By having a project level cspell dictionary we can avoid words that are spelled project local correctly from being flagged as incorrect.  The dictionary can be updated over time.

vscode extension `streetsidesoftware.code-spell-checker` is recommended to keep spelling in sources nice and clean.
