### PR TITLE
:seedling: Dependabot - do weekly checks, group changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,52 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: ":ghost: "
-
-    groups:
-      patternfly:
-        patterns:
-          - "@patternfly/*"
-        update-types:
-          - minor
-          - patch
-
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: daily
     commit-message:
       prefix: ":seedling: "
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: thursday
+    commit-message:
+      prefix: ":ghost: "
+
+    allow:
+      - dependency-type: direct
+
+    ignore:
+      - dependency-name: "@patternfly/*"
+      - update-types:
+          - version-update:semver-major
+
+    groups:
+      patternfly:
+        patterns:
+          - "@patternfly/*"
+
+      "server dependencies":
+        patterns:
+          - cookie
+          - ejs
+          - express
+          - http-proxy-middleware
+          - http-terminator
+
+      rollup:
+        patterns:
+          - "@rollup/*"
+          - "rollup"
+          - "rollup-*"
+
+      linting:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+          - prettier
+          - lint-staged
+          - husky
+          - "*eslint-plugin-*"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "lint-staged": {
     "package-lock.json": "./scripts/verify_lock.mjs",
-    "!(package-lock.json)*": "prettier --ignore-unknown --write"
+    "!(package-lock.json)*": "prettier --ignore-unknown --write",
+    ".github/**/*.{yaml,yml}": "prettier --ignore-unknown --write"
   },
   "workspaces": [
     "common",


### PR DESCRIPTION
Change from daily to weekly to reduce disturbance and keep dep updates to Thursdays.

Add more groups to keep some like things together as best as possible.

Have prettier format yaml files under `.github/` via `lint-staged`.