### PR TITLE
:bug: always refresh the application query on application inventory

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import { AxiosError } from "axios";
 import { useHistory } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
-import dayjs from "dayjs";
 
 // @patternfly
 import {
@@ -183,10 +182,6 @@ export const ApplicationsTable: React.FC = () => {
   const [reviewToDiscard, setReviewToDiscard] =
     useState<DecoratedApplication | null>(null);
 
-  const [endOfAppImportPeriod, setEndOfAppImportPeriod] = useState<dayjs.Dayjs>(
-    dayjs()
-  );
-
   const onChange = (
     _event: React.FormEvent<HTMLSelectElement>,
     value: string
@@ -216,7 +211,7 @@ export const ApplicationsTable: React.FC = () => {
   // ----- Table data fetches and mutations
   const { tagItems } = useFetchTagsWithTagItems();
 
-  const { tasks, hasActiveTasks } = useFetchTaskDashboard(isAnalyzeModalOpen);
+  const { tasks } = useFetchTaskDashboard(isAnalyzeModalOpen);
 
   const completedCancelTask = () => {
     pushNotification({
@@ -311,14 +306,12 @@ export const ApplicationsTable: React.FC = () => {
     return !!task && !TaskStates.Terminal.includes(task?.state ?? "");
   };
 
-  // TODO: Review the refetchInterval calculation for the application list
+  // TODO: Perf concerns for this query: https://github.com/konveyor/tackle2-ui/issues/2350
   const {
     data: baseApplications,
     isFetching: isFetchingApplications,
     error: applicationsFetchError,
-  } = useFetchApplications(() =>
-    hasActiveTasks || dayjs().isBefore(endOfAppImportPeriod) ? 5000 : false
-  );
+  } = useFetchApplications();
 
   const {
     applications,
@@ -1264,7 +1257,6 @@ export const ApplicationsTable: React.FC = () => {
           <ImportApplicationsForm
             onSaved={() => {
               setIsApplicationImportModalOpen(false);
-              setEndOfAppImportPeriod(dayjs().add(15, "s"));
             }}
           />
         </Modal>

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from "react";
 import {
   useInfiniteQuery,
   useMutation,
@@ -26,7 +25,6 @@ import {
   TaskQueue,
   TaskDashboard,
 } from "@app/api/models";
-import { ApplicationsQueryKey } from "./applications";
 
 export const TaskStates = {
   Canceled: ["Canceled"],
@@ -69,9 +67,6 @@ const calculateSyntheticTaskDashboardState = (
 };
 
 export const useFetchTaskDashboard = (refetchDisabled: boolean = false) => {
-  const previousActiveTasks = useRef(false);
-  const queryClient = useQueryClient();
-
   const { isLoading, error, refetch, data } = useQuery({
     queryKey: [TasksQueryKey, "/report/dashboard"],
     queryFn: getTasksDashboard,
@@ -85,13 +80,6 @@ export const useFetchTaskDashboard = (refetchDisabled: boolean = false) => {
 
   const hasActiveTasks =
     data?.some((task) => TaskStates.Queued.includes(task.state ?? "")) ?? false;
-
-  useEffect(() => {
-    if (previousActiveTasks.current && !hasActiveTasks) {
-      queryClient.invalidateQueries([ApplicationsQueryKey]);
-    }
-    previousActiveTasks.current = hasActiveTasks;
-  }, [queryClient, hasActiveTasks]);
 
   return {
     tasks: data || [],


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-5181

Historically and for performance reasons, the application inventory page tried to not always refresh in the background. The approach never really consistently worked, and if hub has a large number of applications, the refresh query logic would almost always run anyway.

The refresh logic has been removed and the page will refresh the applications every 5 seconds.

Performance issues may emerge in a large environment and #2350 was written to capture what is known and have some ideas about how to approach a solution.
