### PR TITLE
:seedling: Update use of MSW in jest tests

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -53,9 +53,7 @@ const taskgroupData = {
 describe("<AnalysisWizard />", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-  afterEach(() => {
-    server.resetHandlers();
+    server.use(rest.get("/hub/identities", (_, res, ctx) => res(ctx.json([]))));
   });
 
   let isAnalyzeModalOpen = true;

--- a/client/src/app/pages/applications/components/application-form/__tests__/application-form.test.tsx
+++ b/client/src/app/pages/applications/components/application-form/__tests__/application-form.test.tsx
@@ -15,20 +15,18 @@ import { rest } from "msw";
 
 describe("Component: application-form", () => {
   const mockChangeValue = jest.fn();
-  beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
-  afterAll(() => server.close());
 
   beforeEach(() => {
     jest.clearAllMocks();
+    server.use(
+      rest.get("/hub/businessservices", (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json([{ id: 1, name: "service" }]));
+      }),
+      rest.get("/hub/stakeholders", (_, res, ctx) => res(ctx.json([]))),
+      rest.get("/hub/applications", (_, res, ctx) => res(ctx.json([]))),
+      rest.get("/hub/tagCategories", (_, res, ctx) => res(ctx.json([])))
+    );
   });
-  afterEach(() => {
-    server.resetHandlers();
-  });
-  server.use(
-    rest.get("/hub/businessservices", (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json([{ id: 1, name: "service" }]));
-    })
-  );
 
   it("Validation tests", async () => {
     render(

--- a/client/src/app/pages/identities/components/identity-form/__tests__/identity-form.test.tsx
+++ b/client/src/app/pages/identities/components/identity-form/__tests__/identity-form.test.tsx
@@ -6,25 +6,22 @@ import {
   fireEvent,
 } from "@app/test-config/test-utils";
 
-import { IdentityForm } from "..";
 import "@testing-library/jest-dom";
 import { server } from "@mocks/server";
 import { rest } from "msw";
 
-describe("Component: identity-form", () => {
-  beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+import { IdentityForm } from "..";
 
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+describe("Component: identity-form", () => {
+  beforeEach(() =>
+    server.use(
+      rest.get("http://localhost/hub/identities", (_req, res, ctx) => {
+        return res(ctx.json([]));
+      })
+    )
+  );
 
   const mockChangeValue = jest.fn();
-  const data: any = [];
-
-  server.use(
-    rest.get("*", (req, res, ctx) => {
-      return res(ctx.json(data));
-    })
-  );
 
   it("Display form on initial load", async () => {
     render(<IdentityForm onClose={mockChangeValue} />);
@@ -40,16 +37,14 @@ describe("Component: identity-form", () => {
     expect(typeSelector).toBeInTheDocument();
   });
 
-  it("Check dynamic form rendering", async () => {
+  it("Check dynamic form rendering - Source Control", async () => {
     render(<IdentityForm onClose={mockChangeValue} />);
     const typeSelector = await screen.findByLabelText(
       "Type select dropdown toggle"
     );
-
     fireEvent.click(typeSelector);
 
     const sourceControlOption = await screen.findByText("Source Control");
-
     fireEvent.click(sourceControlOption);
 
     const userCredentialsSelector = await screen.findByLabelText(
@@ -57,10 +52,9 @@ describe("Component: identity-form", () => {
     );
     expect(userCredentialsSelector).toBeInTheDocument();
 
+    // Check User credentials Username/Password
     fireEvent.click(userCredentialsSelector);
-
     const userPassOption = await screen.findByText("Username/Password");
-
     fireEvent.click(userPassOption);
 
     const userInput = await screen.findByLabelText("Username *");
@@ -69,12 +63,11 @@ describe("Component: identity-form", () => {
     const passwordInput = await screen.findByLabelText("Password *");
     expect(passwordInput).toBeInTheDocument();
 
+    // Check User credentials Source Private Key/Passphrase
     fireEvent.click(userCredentialsSelector);
-
     const sourceOption = await screen.findByText(
       "Source Private Key/Passphrase"
     );
-
     fireEvent.click(sourceOption);
 
     const credentialKeyFileUpload = await screen.findByLabelText(
@@ -86,18 +79,29 @@ describe("Component: identity-form", () => {
       "Private Key Passphrase"
     );
     expect(credentialKeyPassphrase).toBeInTheDocument();
+  });
 
+  it("Check dynamic form rendering - Maven Settings File", async () => {
+    render(<IdentityForm onClose={mockChangeValue} />);
+    const typeSelector = await screen.findByLabelText(
+      "Type select dropdown toggle"
+    );
     fireEvent.click(typeSelector);
 
     const mavenSettingsOption = await screen.findByText("Maven Settings File");
-
     fireEvent.click(mavenSettingsOption);
 
     const mavenSettingsUpload = await screen.findByLabelText(
       "Upload your Settings file or paste its contents below. *"
     );
     expect(mavenSettingsUpload).toBeInTheDocument();
+  });
 
+  it("Check dynamic form rendering - Proxy", async () => {
+    render(<IdentityForm onClose={mockChangeValue} />);
+    const typeSelector = await screen.findByLabelText(
+      "Type select dropdown toggle"
+    );
     fireEvent.click(typeSelector);
 
     const proxyOption = await screen.findByText("Proxy");
@@ -111,56 +115,43 @@ describe("Component: identity-form", () => {
     expect(proxyPasswordInput).toBeInTheDocument();
   });
 
-  it("Identity form validation test - source - username/password", async () => {
+  it("Identity form validation test - Source Control / username/password", async () => {
     render(<IdentityForm onClose={mockChangeValue} />);
-
-    const identityNameInput = await screen.findByLabelText("Name *");
-
-    fireEvent.change(identityNameInput, {
-      target: { value: "identity-name" },
-    });
 
     const typeSelector = await screen.findByLabelText(
       "Type select dropdown toggle"
     );
-
     fireEvent.click(typeSelector);
 
     const sourceControlOption = await screen.findByText("Source Control");
-
     fireEvent.click(sourceControlOption);
 
     const userCredentialsSelector = await screen.findByLabelText(
       "User credentials select dropdown toggle"
     );
-
     fireEvent.click(userCredentialsSelector);
 
     const userPassOption = await screen.findByText("Username/Password");
-
     fireEvent.click(userPassOption);
 
+    const nameInput = await screen.findByLabelText("Name *");
     const userInput = await screen.findByLabelText("Username *");
-
-    await waitFor(
-      () => {
-        fireEvent.change(userInput, {
-          target: { value: "username" },
-        });
-      },
-      {
-        timeout: 3000,
-      }
-    );
-
     const passwordInput = await screen.findByLabelText("Password *");
-
-    const createButton = screen.getByRole("button", { name: /submit/i });
+    const createButton = await screen.findByRole("button", { name: /submit/i });
 
     expect(createButton).not.toBeEnabled();
 
+    // fill out the form
     await waitFor(
       () => {
+        fireEvent.change(nameInput, {
+          target: { value: "identity-name" },
+        });
+
+        fireEvent.change(userInput, {
+          target: { value: "username" },
+        });
+
         fireEvent.change(passwordInput, {
           target: { value: "password" },
         });
@@ -170,6 +161,9 @@ describe("Component: identity-form", () => {
       }
     );
 
+    // verify field contents have enabled the create button
+    expect(nameInput).toHaveValue("identity-name");
+    expect(userInput).toHaveValue("username");
     expect(passwordInput).toHaveValue("password");
     expect(createButton).toBeEnabled();
 

--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -373,7 +373,6 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
     getValues,
     setValue,
     control,
-    watch,
     resetField,
   } = useForm<IdentityFormValues>({
     defaultValues: {
@@ -398,8 +397,6 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
 
   const [isKeyFileRejected, setIsKeyFileRejected] = useState(false);
   const [isSettingsFileRejected, setIsSettingsFileRejected] = useState(false);
-
-  const watchAllFields = watch();
 
   const userCredentialsOptions: OptionWithValue<UserCredentials>[] = [
     {
@@ -724,6 +721,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           />
         </>
       )}
+
       <ActionGroup>
         <Button
           type="submit"

--- a/client/src/app/pages/identities/identities.tsx
+++ b/client/src/app/pages/identities/identities.tsx
@@ -110,8 +110,8 @@ export const Identities: React.FC = () => {
         what: item.name,
       });
     } else if (
-      applications?.some(
-        (app) => app?.identities?.some((id) => id.id === item.id)
+      applications?.some((app) =>
+        app?.identities?.some((id) => id.id === item.id)
       )
     ) {
       return t("message.blockedDeleteApplication", {
@@ -132,9 +132,8 @@ export const Identities: React.FC = () => {
 
   const dependentApplications = React.useMemo(() => {
     if (identityToDelete) {
-      const res = applications?.filter(
-        (app) =>
-          app?.identities?.map((id) => id.id).includes(identityToDelete.id)
+      const res = applications?.filter((app) =>
+        app?.identities?.map((id) => id.id).includes(identityToDelete.id)
       );
       return res;
     }
@@ -343,11 +342,10 @@ export const Identities: React.FC = () => {
                                 (tracker) =>
                                   tracker?.identity?.id === identity.id
                               ) ||
-                              applications?.some(
-                                (app) =>
-                                  app?.identities?.some(
-                                    (id) => id.id === identity.id
-                                  )
+                              applications?.some((app) =>
+                                app?.identities?.some(
+                                  (id) => id.id === identity.id
+                                )
                               ) ||
                               targets?.some(
                                 (target) =>
@@ -375,29 +373,30 @@ export const Identities: React.FC = () => {
             />
           </div>
         </ConditionalRender>
-
-        <Modal
-          id="credential.modal"
-          title={
-            identityToUpdate
-              ? t("dialog.title.update", {
-                  what: t("terms.credential").toLowerCase(),
-                })
-              : t("dialog.title.new", {
-                  what: t("terms.credential").toLowerCase(),
-                })
-          }
-          variant={ModalVariant.medium}
-          isOpen={isCreateUpdateModalOpen}
-          onClose={() => setCreateUpdateModalState(null)}
-        >
-          <IdentityForm
-            identity={identityToUpdate ? identityToUpdate : undefined}
-            onClose={() => setCreateUpdateModalState(null)}
-            xmlValidator={validateXML}
-          />
-        </Modal>
       </PageSection>
+
+      <Modal
+        id="credential.modal"
+        title={
+          identityToUpdate
+            ? t("dialog.title.update", {
+                what: t("terms.credential").toLowerCase(),
+              })
+            : t("dialog.title.new", {
+                what: t("terms.credential").toLowerCase(),
+              })
+        }
+        variant={ModalVariant.medium}
+        isOpen={isCreateUpdateModalOpen}
+        onClose={() => setCreateUpdateModalState(null)}
+      >
+        <IdentityForm
+          identity={identityToUpdate ? identityToUpdate : undefined}
+          onClose={() => setCreateUpdateModalState(null)}
+          xmlValidator={validateXML}
+        />
+      </Modal>
+
       {isConfirmDialogOpen && (
         <ConfirmDialog
           title={t("dialog.title.deleteWithName", {

--- a/client/src/app/pages/proxies/__tests__/proxy-form.test.tsx
+++ b/client/src/app/pages/proxies/__tests__/proxy-form.test.tsx
@@ -15,22 +15,20 @@ import { rest } from "msw";
 describe("Component: proxy-form", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    server.use(
+      rest.get("/hub/proxies", (_, res, ctx) => res(ctx.json([]))),
+      rest.get("/hub/identities", (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json([
+            { id: 0, name: "proxy-cred", kind: "proxy" },
+            { id: 1, name: "maven-cred", kind: "maven" },
+            { id: 2, name: "source-cred", kind: "source" },
+          ])
+        );
+      })
+    );
   });
-  afterEach(() => {
-    server.resetHandlers();
-  });
-  server.use(
-    rest.get("/hub/identities", (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json([
-          { id: 0, name: "proxy-cred", kind: "proxy" },
-          { id: 1, name: "maven-cred", kind: "maven" },
-          { id: 2, name: "source-cred", kind: "source" },
-        ])
-      );
-    })
-  );
 
   it("Display switch statements on initial load", async () => {
     render(<Proxies />);
@@ -66,19 +64,6 @@ describe("Component: proxy-form", () => {
   });
 
   it("Select http proxy identity", async () => {
-    server.use(
-      rest.get("/hub/identities", (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.json([
-            { id: 0, name: "proxy-cred", kind: "proxy" },
-            { id: 1, name: "maven-cred", kind: "maven" },
-            { id: 2, name: "source-cred", kind: "source" },
-          ])
-        );
-      })
-    );
-
     render(<Proxies />);
     const httpProxySwitch = await screen.findByLabelText("HTTP proxy");
     fireEvent.click(httpProxySwitch);
@@ -108,19 +93,6 @@ describe("Component: proxy-form", () => {
   });
 
   it("Select https proxy identity", async () => {
-    server.use(
-      rest.get("/hub/identities", (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.json([
-            { id: 0, name: "proxy-cred", kind: "proxy" },
-            { id: 1, name: "maven-cred", kind: "maven" },
-            { id: 2, name: "source-cred", kind: "source" },
-          ])
-        );
-      })
-    );
-
     render(<Proxies />);
     const httpsProxySwitch = await screen.findByLabelText("HTTPS proxy");
     fireEvent.click(httpsProxySwitch);

--- a/client/src/app/test-config/setupTests.ts
+++ b/client/src/app/test-config/setupTests.ts
@@ -33,6 +33,6 @@ afterAll(() => server.close());
 //   console.log(`Request to ${req.url.href} was matched with a handler`);
 // });
 
-// server.events.on("request:unhandled", (req) => {
-//   console.warn(`Request to ${req.url.href} was not handled`);
-// });
+server.events.on("request:unhandled", (req) => {
+  console.warn(`Request to ${req.url.href} was not handled`);
+});


### PR DESCRIPTION
MSW provides responses to axios calls made in the various react queries used by components being tested in our jest tests.  Global handling of the MSW handlers is setup in `setupTests.ts`.  After each test, the MSW server handlers are globally reset.  Any handlers that are needed need in a test suite either be setup in the test/it block directly, or globally for a suite using `beforeEach()` in the suite's `define()` block.

Tests that use components with queries/axios calls have been updated to this style.  No axios network exception error should be logged to console.

In future, if any axios network exceptions are logged to console, the test should be updated to provide an msw handler as appropriate for the test.
