### PR TITLE
:sparkles: create application discovery manifest view and handling

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -414,6 +414,7 @@
     "label": "Label",
     "loading": "Loading",
     "lowRisk": "Low risk",
+    "manifest": "Manifest",
     "manualTags": "Manual Tags",
     "maintainers": "Maintainers",
     "mavenConfig": "Maven configuration",

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -875,6 +875,8 @@ export interface GroupedStakeholderRef extends Ref {
   uniqueId: string;
 }
 
+export interface JsonDocument extends Record<string, unknown> {}
+
 export interface SourcePlatform {
   id: number;
   kind: string;
@@ -882,7 +884,7 @@ export interface SourcePlatform {
   url: string;
   identity?: Ref;
   applications?: Ref[];
-  coordinates?: Record<string, any>;
+  coordinates?: JsonDocument;
   discoverApplicationsState?: TaskState;
 }
 export interface ManifestDeployment {
@@ -894,16 +896,10 @@ export interface ManifestSecret {
   user?: string;
   password?: string;
 }
-export interface ManifestContent {
-  name: string;
-  password?: string;
-  deployment?: ManifestDeployment;
-  service?: { name: string; other?: number };
-}
 
 export interface Manifest {
   id: number;
-  content: ManifestContent;
+  content: JsonDocument;
   secret: ManifestSecret;
   application?: Ref;
 }

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -885,3 +885,25 @@ export interface SourcePlatform {
   coordinates?: Record<string, any>;
   discoverApplicationsState?: TaskState;
 }
+export interface ManifestDeployment {
+  name: string;
+  other?: number;
+}
+
+export interface ManifestSecret {
+  user?: string;
+  password?: string;
+}
+export interface ManifestContent {
+  name: string;
+  password?: string;
+  deployment?: ManifestDeployment;
+  service?: { name: string; other?: number };
+}
+
+export interface Manifest {
+  id: number;
+  content: ManifestContent;
+  secret: ManifestSecret;
+  application?: Ref;
+}

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -47,8 +47,10 @@ import {
   SourcePlatform,
   AnalysisDependency,
   AnalysisAppDependency,
+  Manifest,
 } from "./models";
 import { serializeRequestParamsForHub } from "@app/hooks/table-controls";
+import { template } from "radash";
 
 // endpoint paths
 export const HUB = "/hub";
@@ -88,6 +90,10 @@ export const TICKETS = HUB + "/tickets";
 export const TRACKER_PROJECT_ISSUETYPES = "issuetypes"; // TODO: ????
 export const TRACKER_PROJECTS = "projects"; // TODO: ????
 export const TRACKERS = HUB + "/trackers";
+
+export const MANIFESTS = HUB + "/manifests";
+
+export const APPLICATION_MANIFEST = HUB + "/applications/{{id}}/manifest";
 
 const jsonHeaders: RawAxiosRequestHeaders = {
   Accept: "application/json",
@@ -275,6 +281,13 @@ export const deleteBulkApplications = (ids: number[]): Promise<Application[]> =>
 
 export const getApplicationById = (id: number | string): Promise<Application> =>
   axios.get(`${APPLICATIONS}/${id}`).then((response) => response.data);
+
+export const getApplicationManifest = (
+  applicationId: number | string
+): Promise<Manifest> =>
+  axios
+    .get<Manifest>(template(APPLICATION_MANIFEST, { id: applicationId }))
+    .then((response) => response.data);
 
 export const getApplications = (): Promise<Application[]> =>
   axios.get(APPLICATIONS).then((response) => response.data);

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { CodeEditor, Language } from "@patternfly/react-code-editor"; // Import CodeEditorControl
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
   EmptyState,
   EmptyStateIcon,
@@ -13,32 +13,31 @@ export { Language } from "@patternfly/react-code-editor";
 
 type ControlledEditor = {
   focus: () => void;
-  getPosition: () => object; // Add getPosition if you need to read cursor position
+  getPosition: () => object;
   setPosition: (position: object) => void;
-  getValue: () => string; // Important for getting the current editor content
+  getValue: () => string;
 };
 
 export interface ISchemaDefinedFieldProps {
-  // If you wanted to make it dynamic to load other schemas:
+  className?: string;
   jsonDocument: object | string;
-  jsonSchema: object | string;
+  jsonSchema?: object | string;
   onSchemaSaved?: (newSchemaContent: object) => void;
 }
 
 export const SchemaDefinedField = ({
-  onSchemaSaved = () => {},
+  className = "",
+  onSchemaSaved,
   jsonDocument,
   jsonSchema,
 }: ISchemaDefinedFieldProps) => {
   const editorRef = React.useRef<ControlledEditor>();
 
-  console.log("SchemaDefinedField rendered with jsonDocument:", jsonDocument);
   const initialCode = React.useMemo(
     () => JSON.stringify(jsonDocument, null, 2),
     [jsonDocument]
   );
-  const [currentCode, setCurrentCode] = React.useState(initialCode); // State to hold editable content
-
+  const [currentCode, setCurrentCode] = React.useState(initialCode);
   const focusMovedOnSelectedDocumentChange = React.useRef<boolean>(false);
   React.useEffect(() => {
     if (currentCode && !focusMovedOnSelectedDocumentChange.current) {
@@ -61,19 +60,21 @@ export const SchemaDefinedField = ({
   const handleSave = () => {
     if (editorRef.current) {
       const contentToSave = editorRef.current.getValue();
-      onSchemaSaved(JSON.parse(contentToSave));
+      onSchemaSaved
+        ? onSchemaSaved(JSON.parse(contentToSave))
+        : console.log("No onSchemaSaved handler provided");
     }
   };
 
   return (
     <CodeEditor
-      className="schema-defined-field-viewer-code-editor"
+      className={`schema-defined-field-viewer-code-editor ${className}`}
       isCopyEnabled
       isDarkTheme
       isDownloadEnabled
       isLineNumbersVisible
-      isReadOnly={false}
-      height="sizeToFit"
+      isReadOnly={onSchemaSaved ? false : true}
+      height="600px"
       downloadFileName="my-schema-download.json"
       language={Language.json}
       code={currentCode}

--- a/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/components/application-detail-drawer/application-detail-drawer.tsx
@@ -34,6 +34,7 @@ import {
   Ref,
   Archetype,
   TaskDashboard,
+  Manifest,
 } from "@app/api/models";
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
 import { useFetchFacts } from "@app/queries/facts";
@@ -85,6 +86,8 @@ import {
 } from "@app/components/TableControls";
 import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
 import { taskStateToLabel } from "@app/pages/tasks/tasks-page";
+import { SchemaDefinedField } from "@app/components/schema-defined-fields/SchemaDefinedFields";
+import { useFetchApplicationManifest } from "@app/queries/applications";
 
 export interface IApplicationDetailDrawerProps
   extends Pick<IPageDrawerContentProps, "onCloseClick"> {
@@ -100,6 +103,7 @@ export enum TabKey {
   Facts,
   Reviews,
   Tasks,
+  Manifest,
 }
 
 export const ApplicationDetailDrawer: React.FC<
@@ -110,6 +114,8 @@ export const ApplicationDetailDrawer: React.FC<
   const [activeTabKey, setActiveTabKey] = React.useState<TabKey>(
     TabKey.Details
   );
+
+  const manifest = useFetchApplicationManifest(application?.id).manifest;
 
   return (
     <PageDrawerContent
@@ -180,6 +186,14 @@ export const ApplicationDetailDrawer: React.FC<
               title={<TabTitleText>{t("terms.tasks")}</TabTitleText>}
             >
               <TabTasksContent application={application} task={task} />
+            </Tab>
+          )}
+          {!application || !manifest ? null : (
+            <Tab
+              eventKey={TabKey.Manifest}
+              title={<TabTitleText>{t("terms.manifest")}</TabTitleText>}
+            >
+              <TabManifestContent manifest={manifest} />
             </Tab>
           )}
         </Tabs>
@@ -267,7 +281,7 @@ const TabDetailsContent: React.FC<{
             {application?.archetypes?.length ? (
               <>
                 <DescriptionListDescription>
-                  {application.archetypes.length ?? 0 > 0 ? (
+                  {(application.archetypes.length ?? 0) > 0 ? (
                     <ArchetypeLabels
                       archetypeRefs={application.archetypes as Ref[]}
                     />
@@ -748,5 +762,13 @@ const TabTasksContent: React.FC<{
         paginationProps={paginationProps}
       />
     </>
+  );
+};
+
+const TabManifestContent: React.FC<{
+  manifest: Manifest;
+}> = ({ manifest }) => {
+  return (
+    <SchemaDefinedField className={spacing.mtLg} jsonDocument={manifest} />
   );
 };

--- a/client/src/app/pages/applications/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/useDecoratedApplications.ts
@@ -93,16 +93,16 @@ const chooseApplicationTaskStatus = ({
   return !tasks.exist
     ? "None"
     : tasks.latestHasRunning
-    ? "Running"
-    : tasks.latestHasQueued
-    ? "Queued"
-    : tasks.latestHasFailed
-    ? "Failed"
-    : tasks.latestHasCanceled
-    ? "Canceled"
-    : tasks.latestHasSuccessWithErrors
-    ? "SuccessWithErrors"
-    : "Success";
+      ? "Running"
+      : tasks.latestHasQueued
+        ? "Queued"
+        : tasks.latestHasFailed
+          ? "Failed"
+          : tasks.latestHasCanceled
+            ? "Canceled"
+            : tasks.latestHasSuccessWithErrors
+              ? "SuccessWithErrors"
+              : "Success";
 };
 
 /**

--- a/client/src/app/queries/applications.ts
+++ b/client/src/app/queries/applications.ts
@@ -16,6 +16,7 @@ import {
   deleteBulkApplications,
   getApplicationById,
   getApplicationDependencies,
+  getApplicationManifest,
   getApplications,
   updateAllApplications,
   updateApplication,
@@ -26,7 +27,7 @@ import saveAs from "file-saver";
 export const ApplicationDependencyQueryKey = "applicationdependencies";
 export const ApplicationsQueryKey = "applications";
 export const ReportQueryKey = "report";
-
+export const ApplicationManifestQueryKey = "applicationManifest";
 interface DownloadOptions {
   application: Application;
   mimeType: MimeType;
@@ -66,6 +67,26 @@ export const useFetchApplicationById = (id?: number | string) => {
 
   return {
     application: data,
+    isFetching: isLoading,
+    fetchError: error,
+  };
+};
+
+export const useFetchApplicationManifest = (
+  applicationId?: number | string
+) => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [ApplicationManifestQueryKey, applicationId],
+    queryFn: () =>
+      applicationId === undefined
+        ? Promise.resolve(undefined)
+        : getApplicationManifest(applicationId),
+    onError: (error: AxiosError) => console.log("error, ", error),
+    enabled: applicationId !== undefined,
+  });
+
+  return {
+    manifest: data,
     isFetching: isLoading,
     fetchError: error,
   };


### PR DESCRIPTION
https://issues.redhat.com/browse/MTA-5244
https://issues.redhat.com/browse/MTA-5601

part of: #2285

added the application discovery manifest API endpoints, and the veiw of it inside the application side drawer, as a readonly code editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Manifest" tab to the application detail drawer, displaying the application's manifest in a formatted JSON view.
  * Introduced the ability to fetch and display manifest data for each application.
  * Enhanced translation support with a new "manifest" key in English.

* **Improvements**
  * The SchemaDefinedField component now supports optional class names and improved read-only behavior based on the presence of a save handler.

* **Bug Fixes**
  * Corrected a conditional expression in the application detail drawer for accurate archetype display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->