### PR TITLE
:bug: Fix subversion url verification

### DIFF
--- a/client/src/app/utils/utils.test.ts
+++ b/client/src/app/utils/utils.test.ts
@@ -125,7 +125,13 @@ describe("URL validation tests", () => {
 
   describe("Valid svn URLs", () => {
     const testSvnURLs = [
+      "svn://host.testing",
+      "svn://host.testing/",
+      "svn://host.testing:3690",
+      "svn://host.testing:3690/repo",
       "svn://host.xz/path/to/repo/",
+      "svn://a.b.c.foo",
+      "svn://10.11.12.13",
       "svn://10.11.12.13/repo",
       "svn://10.11.12.13/svn/mtage-svn/book-server",
       "svn://10.11.12.13/svn/mtage-svn/bookserver-no-trunk",
@@ -134,7 +140,10 @@ describe("URL validation tests", () => {
       "https://host.xz/path/to/repo",
       "https://host.xz/path/to/repo/",
       "https://host.xz:/path/to/repo",
+      "https://host.xz:8080/path/to/repo",
+      "http://10.11.12.13",
       "http://10.11.12.13/repo",
+      "http://10.11.12.13:8080/repo",
       "https://10.11.12.13/svn/mtage-svn/book-server",
       "https://10.11.12.13/svn/mtage-svn/bookserver-no-trunk",
     ];
@@ -147,11 +156,48 @@ describe("URL validation tests", () => {
     }
   });
 
+  describe("Invalid svn URLs", () => {
+    const testSvnURLs = [
+      "",
+      "svn:",
+      "svn://",
+      "svn://host", // just a hostname, not FQDN
+      "svn://host/",
+      "svn://-host.testing/", // bad host label
+      "svn://host-.testing/",
+      "svn://host.-testing", // bad tld
+      "svn://host.testing-",
+      "svn://:3690", // no host
+      "svn://10.11.12", // bad IP
+      "svn://-10.11.12.13",
+      "svn://10-.11.12.13/",
+      "svn://foo.bar.ไทย/path", // non latin-1 charset TLD
+    ];
+
+    for (const url of testSvnURLs) {
+      it(`Invalid svn URL: "${url}"`, () => {
+        const result = isValidSvnUrl(url);
+        expect(result).toBe(false);
+      });
+    }
+  });
+
   describe("Valid standard URLs", () => {
     const testStandardURLs = [
+      "https://a.b.c.foo",
+      "http://www.foo",
       "http://www.foo.bar",
-      "www.foo.bar",
+      "http://www.foo.bar/zig",
+      "http://www.foo.bar:/zig",
+      "http://www.foo.bar:8080",
+      "http://www.foo.bar:8080/zig",
       "https://www.github.com/ibolton336/tackle-testapp.git",
+      "http://10.11.12.13",
+      "http://10.11.12.13/",
+      "http://10.11.12.13/path",
+      "http://10.11.12.13:8080",
+      "http://10.11.12.13:8080/",
+      "http://10.11.12.13:8080/path",
     ];
 
     for (const url of testStandardURLs) {
@@ -165,14 +211,25 @@ describe("URL validation tests", () => {
   describe("Invalid standard URLs", () => {
     const testBrokenURLs = [
       "",
+      "http:",
       "http://",
       "https://",
-      "http:",
-      "http://www.foo",
-      "http://wrong",
-      "wwwfoo.bar",
+      "http://host", // just a hostname, not a FQDN
+      "http://www-.foo", // bad host label
+      "http://www.-foo", // bad tld
+      "http://www.foo-", // bad tld
+      "http://foo.bar.ไทย/path", // non latin-1 charset TLD
+      "wwwfoo.bar", // no protocol
       "foo.bar",
       "www.foo.b",
+      "www.-foo.bar",
+      "www.10",
+      "-www.foo",
+      "www-.foo",
+      "www.foo.bar",
+      "www.foo.bar/zig/zag",
+      "www.foo.bar:8080",
+      "www.foo.bar:8080/zig/zag",
     ];
 
     for (const url of testBrokenURLs) {

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -108,13 +108,25 @@ export const getValidatedFromError = (error: unknown | undefined) => {
   return error ? "error" : "default";
 };
 
-const standardURLRegex =
-  /^(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.\S{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.\S{2,}|www\.[a-zA-Z0-9]+\.\S{2,})$/;
-
-export const isValidStandardUrl = (url: string) => standardURLRegex.test(url);
-
 export const standardStrictURLRegex =
   /https:\/\/(www\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)/;
+
+// URLs in Latin-1 (with non-capturing groups)
+//   protocol: https?:\/\/
+//   hostname label: [a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?
+//   hostname labels: [a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9](?:\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*?
+//   tld: (?:\.[a-zA-Z]{2,}?)
+//   ip address (format but not validate): \d{1,3}(?:\.\d{1,3}){3}
+//   port: (?::\d*)?
+//   path: (?:\/.*)?
+// url: {{protocol}}({{hostname labels}}{{tld}})|{{ip address}}{{port}}{{path}}
+const standardUrlRegex =
+  /^https?:\/\/([a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*?(?:\.[a-zA-Z]{2,}?)|\d{1,3}(?:\.\d{1,3}){3})(?::\d*)?(?:\/.*)?$/;
+
+const svnUrlRegex =
+  /^svn:\/\/([a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*?(?:\.[a-zA-Z]{2,}?)|\d{1,3}(?:\.\d{1,3}){3})(?::\d*)?(?:\/.*)?$/;
+
+export const isValidStandardUrl = (url: string) => standardUrlRegex.test(url);
 
 export const isValidGitUrl = (url: string): boolean => {
   try {
@@ -124,8 +136,6 @@ export const isValidGitUrl = (url: string): boolean => {
     return false;
   }
 };
-
-const svnUrlRegex = /^svn:\/\/[\S/$.?#].\S*$/;
 
 export const isValidSvnUrl = (url: string) =>
   svnUrlRegex.test(url) || isValidStandardUrl(url);


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-5629

Subversion URL verification was not allowing URLs that are valid for the svn client to use.  The test and unit tests have been updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL validation to better recognize valid SVN URLs, including both SVN-specific and standard URL formats.

* **Tests**
  * Expanded test coverage to include additional cases for SVN URL validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->