### PR TITLE
:sparkles: Refactor issues api to insights api

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -616,8 +616,8 @@ export interface AnalysisIssue extends AnalysisIssuesCommonFields {
   id: number;
 }
 
-// Hub type: AppReport - Issues collated by application (but filtered by ruleset/rule)
-// When filtered by ruleset/rule, this object matches exactly one issue and includes that issue's details
+// Hub type: AppReport - Insights collated by application (but filtered by ruleset/rule)
+// When filtered by ruleset/rule, this object matches exactly one insight and includes that insight's details
 export interface AnalysisAppReport extends AnalysisIssue {
   id: number; // Application id
   name: string;
@@ -626,7 +626,7 @@ export interface AnalysisAppReport extends AnalysisIssue {
   businessService: string;
   incidents: number;
   files: number;
-  issue: {
+  insight: {
     id: number;
     name: string;
     ruleset: string;
@@ -658,7 +658,7 @@ export type AnalysisIssueReport = WithUiId<BaseAnalysisIssueReport>;
 
 // Hub type: FileReport - Incidents collated by file
 export interface AnalysisFileReport {
-  issueId: number;
+  insightId: number;
   file: string;
   incidents: number;
   effort: number;

--- a/client/src/app/api/rest/analysis.ts
+++ b/client/src/app/api/rest/analysis.ts
@@ -1,0 +1,63 @@
+import axios from "axios";
+import { template } from "radash";
+import { getHubPaginatedResult } from "../rest";
+import {
+  HubRequestParams,
+  BaseAnalysisRuleReport,
+  AnalysisAppReport,
+  AnalysisIncident,
+  AnalysisFileReport,
+  AnalysisIssue,
+  BaseAnalysisIssueReport,
+} from "../models";
+
+const ANALYSIS_ISSUE = "/hub/analyses/insights/{{id}}";
+const ANALYSIS_ISSUE_INCIDENTS = "/hub/analyses/insights/{{id}}/incidents";
+const ANALYSIS_RULES = "/hub/analyses/report/rules?filter=effort>0";
+const ANALYSIS_APP_ISSUES =
+  "/hub/analyses/report/applications/{{id}}/insights?filter=effort>0";
+const ANALYSIS_ISSUES_APPS =
+  "/hub/analyses/report/insights/applications?filter=effort>0";
+const ANALYSIS_ISSUE_FILES = "/hub/analyses/report/insights/{{id}}/files";
+
+export const getRuleReports = (params: HubRequestParams = {}) =>
+  getHubPaginatedResult<BaseAnalysisRuleReport>(ANALYSIS_RULES, params);
+
+export const getAppReports = (params: HubRequestParams = {}) =>
+  getHubPaginatedResult<AnalysisAppReport>(ANALYSIS_ISSUES_APPS, params);
+
+export const getIssueReports = (
+  applicationId?: number,
+  params: HubRequestParams = {}
+) =>
+  getHubPaginatedResult<BaseAnalysisIssueReport>(
+    template(ANALYSIS_APP_ISSUES, { id: applicationId }),
+    params
+  );
+
+export const getIssue = (issueId: number) =>
+  axios
+    .get<AnalysisIssue>(template(ANALYSIS_ISSUE, { id: issueId }))
+    .then((response) => response.data);
+
+export const getFileReports = (
+  issueId?: number,
+  params: HubRequestParams = {}
+) =>
+  issueId
+    ? getHubPaginatedResult<AnalysisFileReport>(
+        template(ANALYSIS_ISSUE_FILES, { id: issueId }),
+        params
+      )
+    : Promise.reject();
+
+export const getIncidents = (
+  issueId?: number,
+  params: HubRequestParams = {}
+) =>
+  issueId
+    ? getHubPaginatedResult<AnalysisIncident>(
+        template(ANALYSIS_ISSUE_INCIDENTS, { id: issueId }),
+        params
+      )
+    : Promise.reject();

--- a/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
+++ b/client/src/app/pages/applications/components/import-applications-form/import-applications-form.tsx
@@ -14,7 +14,7 @@ import {
   HelperTextItem,
 } from "@patternfly/react-core";
 
-import { UPLOAD_FILE } from "@app/api/rest";
+import { APP_IMPORTS_SUMMARY_UPLOAD } from "@app/api/rest";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 import { NotificationsContext } from "@app/components/NotificationsContext";
 
@@ -57,7 +57,7 @@ export const ImportApplicationsForm: React.FC<ImportApplicationsFormProps> = ({
     };
     setIsSubmitting(true);
     axios
-      .post(UPLOAD_FILE, formData, config)
+      .post(APP_IMPORTS_SUMMARY_UPLOAD, formData, config)
       .then((response) => {
         pushNotification({
           title: t("toastr.success.fileSavedToBeProcessed"),

--- a/client/src/app/pages/issues/affected-applications/affected-applications.tsx
+++ b/client/src/app/pages/issues/affected-applications/affected-applications.tsx
@@ -81,12 +81,12 @@ export const AffectedApplications: React.FC = () => {
       ...tableControlState,
       implicitFilters: [
         {
-          field: "issue.ruleset",
+          field: "insight.ruleset",
           operator: "=",
           value: ruleset || "",
         },
         {
-          field: "issue.rule",
+          field: "insight.rule",
           operator: "=",
           value: rule || "",
         },
@@ -238,7 +238,7 @@ export const AffectedApplications: React.FC = () => {
         </ConditionalRender>
       </PageSection>
       <IssueDetailDrawer
-        issueId={activeItem?.issue.id || null}
+        issueId={activeItem?.insight.id || null}
         applicationName={activeItem?.name || null}
         onCloseClick={clearActiveItem}
       />

--- a/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-all-incidents-table.tsx
+++ b/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-all-incidents-table.tsx
@@ -45,7 +45,7 @@ export const FileAllIncidentsTable: React.FC<
     isFetching,
     fetchError,
   } = useFetchIncidents(
-    fileReport.issueId,
+    fileReport.insightId,
     getHubRequestParams({
       ...tableControlState,
       hubSortFieldKeys: { line: "line", message: "message" },

--- a/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/issue-detail-drawer/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -40,7 +40,7 @@ export const FileIncidentsDetailModal: React.FC<
     result: { data: firstFiveIncidents, total: totalNumIncidents },
     isFetching,
     fetchError,
-  } = useFetchIncidents(fileReport.issueId, {
+  } = useFetchIncidents(fileReport.insightId, {
     filters: [{ field: "file", operator: "=", value: fileReport.file }],
     page: { pageNumber: 1, itemsPerPage: 5 },
   });

--- a/client/src/app/pages/issues/issues-table.tsx
+++ b/client/src/app/pages/issues/issues-table.tsx
@@ -33,7 +33,10 @@ import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { TablePersistenceKeyPrefix, UI_UNIQUE_ID } from "@app/Constants";
+
 import { useFetchIssueReports, useFetchRuleReports } from "@app/queries/issues";
+import { useFetchApplications } from "@app/queries/applications";
+
 import {
   FilterType,
   FilterToolbar,
@@ -63,7 +66,6 @@ import {
   AnalysisRuleReport,
   Application,
 } from "@app/api/models";
-import { useFetchApplications } from "@app/queries/applications";
 import { Paths } from "@app/Paths";
 import { AffectedAppsLink } from "./affected-apps-link";
 import { ConditionalTooltip } from "@app/components/ConditionalTooltip";

--- a/client/src/app/queries/issues.ts
+++ b/client/src/app/queries/issues.ts
@@ -8,7 +8,6 @@ import {
 } from "@app/api/models";
 import {
   getRuleReports,
-  getIssues,
   getAppReports,
   getFileReports,
   getIncidents,
@@ -100,21 +99,6 @@ export const useFetchIssueReports = (
       total: issueReport?.total ?? 0,
       params: issueReport?.params ?? params,
     } as HubPaginatedResult<AnalysisIssueReport>,
-    isFetching: isLoading,
-    fetchError: error,
-    refetch,
-  };
-};
-
-export const useFetchIssues = (params: HubRequestParams = {}) => {
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [IssuesQueryKey, params],
-    queryFn: () => getIssues(params),
-    onError: (error) => console.log("error, ", error),
-    keepPreviousData: true,
-  });
-  return {
-    result: data || { data: [], total: 0, params },
     isFetching: isLoading,
     fetchError: error,
     refetch,


### PR DESCRIPTION
Changes needed to
  - URL endpoints
  - URL endpoint default filters (issues = insights.effort>0)
  - Model field renames `s/issue/insight`
  - Implicit filters for affected applications query

Refactoring:
  - Update `rest.ts`
  - Extract and clean up analysis related rest functions

Resolves: #2444
Part of: https://issues.redhat.com/browse/MTA-5459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated terminology in the user interface from "Issues" to "Insights" across analysis reports and related components.
  * Adjusted identifiers and property names to match the new "Insight" terminology for improved consistency.
  * Reorganized and streamlined API client modules for better maintainability and clarity.
  * Moved analysis-related API functions to a dedicated module.

* **Bug Fixes**
  * Removed duplicate imports in the issues table component.

* **Chores**
  * Removed deprecated and unused code related to fetching issues.
  * Updated internal references to align with new API endpoints and naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->