### PR TITLE
:bug: Fix archetype assessment/review override message

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -1423,6 +1423,7 @@ export const ApplicationsTable: React.FC = () => {
             what: t("terms.review").toLowerCase(),
           })}
           alertMessage={t("message.overrideArchetypeReviewDescription", {
+            name: applicationToReview?.name,
             what:
               archetypeRefsToOverrideReview
                 ?.map((archetypeRef) => archetypeRef.name)
@@ -1451,6 +1452,7 @@ export const ApplicationsTable: React.FC = () => {
             what: t("terms.assessment").toLowerCase(),
           })}
           alertMessage={t("message.overrideAssessmentDescription", {
+            name: applicationToAssess?.name,
             what:
               archetypeRefsToOverride
                 ?.map((archetypeRef) => archetypeRef.name)


### PR DESCRIPTION
Resolves: #2425

<img width="1532" height="1150" alt="image" src="https://github.com/user-attachments/assets/a82eb808-241c-4940-b299-094a3b8b1b10" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Confirmation dialogs for overriding archetype reviews and assessments now display the name of the relevant application for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->