### PR TITLE
:sparkles: Rename Generator fields

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -933,7 +933,7 @@ export interface Generator {
   name: string;
   description?: string;
   repository?: Repository;
-  parameters?: JsonDocument;
+  params?: JsonDocument;
   values?: JsonDocument;
   identity?: Ref;
   profiles?: Ref[];

--- a/client/src/app/pages/asset-generators/asset-generators.tsx
+++ b/client/src/app/pages/asset-generators/asset-generators.tsx
@@ -299,7 +299,7 @@ const AssetGenerators: React.FC = () => {
                           {generator?.repository?.url}
                         </Td>
                         <Td {...getTdProps({ columnKey: "parameters" })}>
-                          {Object.keys(generator?.parameters || {}).length}
+                          {Object.keys(generator?.params || {}).length}
                         </Td>
                         <Td {...getTdProps({ columnKey: "values" })}>
                           {Object.keys(generator?.values || {}).length}

--- a/client/src/app/pages/asset-generators/components/generator-detail-drawer.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-detail-drawer.tsx
@@ -183,7 +183,7 @@ const ParametersTab: React.FC<{ generator: Generator | null }> = ({
 }) => {
   return (
     <GeneratorCollectionTable
-      collection={parametersToArray(generator?.parameters || {}) || []}
+      collection={parametersToArray(generator?.params || {}) || []}
     />
   );
 };

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form-parameters.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form-parameters.tsx
@@ -13,12 +13,12 @@ const GeneratorFormParametersComponent: React.FC<
 > = () => {
   const { t } = useTranslation();
   const { control } = useFormContext();
-  const parameters = useWatch({
+  const params = useWatch({
     control,
-    name: "parameters",
+    name: "params",
   });
   const addButtonRef = useRef<{ addField: () => void }>(null);
-  const [isExpanded, setIsExpanded] = useState(parameters.length > 0);
+  const [isExpanded, setIsExpanded] = useState(params.length > 0);
 
   const handleAddClick = () => {
     if (!addButtonRef.current) {
@@ -43,7 +43,7 @@ const GeneratorFormParametersComponent: React.FC<
             text: (
               <>
                 {t("terms.parameters")}{" "}
-                <Label color="blue">{parameters.length}</Label>
+                <Label color="blue">{params.length}</Label>
               </>
             ),
             id: "parameters-header",
@@ -65,7 +65,7 @@ const GeneratorFormParametersComponent: React.FC<
         ref={addButtonRef}
         noValuesMessage="No parameters to display"
         removeLabel="Remove this parameter definition"
-        name="parameters"
+        name="params"
       />
     </ControlledFormFieldGroupExpandable>
   );

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form.tsx
@@ -45,7 +45,7 @@ export interface GeneratorFormValues {
   repository: Repository;
   credentials?: string;
   values?: Array<{ key: string; value: string }>;
-  parameters?: Array<{ key: string; value: string }>;
+  params?: Array<{ key: string; value: string }>;
 }
 
 export interface GeneratorFormProps {
@@ -137,7 +137,7 @@ const GeneratorFormRenderer: React.FC<GeneratorFormProps> = ({
             value: yup.string().trim().required("A value is required"),
           })
         ),
-        parameters: yup.array().of(
+        params: yup.array().of(
           yup.object().shape({
             key: yup.string().trim().required("A key is required"),
             value: yup.string().trim().required("A value is required"),
@@ -157,7 +157,7 @@ const GeneratorFormRenderer: React.FC<GeneratorFormProps> = ({
             repository: EMPTY_REPOSITORY,
             credentials: "",
             values: [],
-            parameters: [],
+            params: [],
           }
         : {
             kind: generator.kind,
@@ -166,7 +166,7 @@ const GeneratorFormRenderer: React.FC<GeneratorFormProps> = ({
             repository: generator.repository || EMPTY_REPOSITORY,
             credentials: generator?.identity?.name,
             values: parametersToArray(generator.values),
-            parameters: parametersToArray(generator.parameters),
+            params: parametersToArray(generator.params),
           },
     [generator]
   );
@@ -198,7 +198,7 @@ const GeneratorFormRenderer: React.FC<GeneratorFormProps> = ({
         : undefined,
       identity: identityToRef(values.credentials),
       values: arrayToParameters(values.values),
-      parameters: arrayToParameters(values.parameters),
+      params: arrayToParameters(values.params),
     };
 
     if (generator) {


### PR DESCRIPTION
s/parameters/params/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the "parameters" property to "params" throughout the asset generator interfaces, forms, and display components for consistency.

* **Bug Fixes**
  * Updated all relevant user interface elements and forms to reference "params" instead of "parameters", ensuring accurate display and editing of generator parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->