### PR TITLE
:bug: Enable the description field on Generators

### DIFF
--- a/client/src/app/api/rest/generators.ts
+++ b/client/src/app/api/rest/generators.ts
@@ -13,21 +13,14 @@ export const getGeneratorById = (id: number | string) =>
 
 // success with code 201 and created entity as response data
 export const createGenerator = (generator: New<Generator>) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { description, ...generatorWithoutDescription } = generator; //TODO: Remove this when the backend is updated with description support
   return axios
-    .post<Generator>(ASSET_GENERATORS, generatorWithoutDescription)
+    .post<Generator>(ASSET_GENERATORS, generator)
     .then((res) => res.data);
 };
 
 // success with code 204 and therefore no response content
 export const updateGenerator = (generator: Generator) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { description, ...generatorWithoutDescription } = generator; //TODO: Remove this when the backend is updated with description support
-  return axios.put<void>(
-    `${ASSET_GENERATORS}/${generator.id}`,
-    generatorWithoutDescription
-  );
+  return axios.put<void>(`${ASSET_GENERATORS}/${generator.id}`, generator);
 };
 
 // success with code 204 and therefore no response content


### PR DESCRIPTION
Follow-up: #2482, #2499
Ref: https://github.com/konveyor/tackle2-hub/pull/860

Enable saving the description field when Creating/Updating Generators


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generator descriptions are now included when creating or updating generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->