### PR TITLE
:sparkles: Source platform render updates

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -449,6 +449,7 @@
     "other": "Other",
     "owner": "Owner",
     "platform": "Platform",
+    "platformKind": "Type",
     "pod": "Pod",
     "parameters": "Parameters",
     "path": "Path",

--- a/client/src/app/pages/source-platforms/components/link-to-platform-applications.tsx
+++ b/client/src/app/pages/source-platforms/components/link-to-platform-applications.tsx
@@ -36,13 +36,9 @@ const LinkToPlatformApplications: React.FC<{
     <Text>{t("message.platformNoApplications")}</Text>
   ) : (
     <Link to={getApplicationsUrl(platform?.name)}>
-      {platform?.applications?.length === 1
-        ? t("message.platformApplicationCount_one", {
-            count: platform?.applications?.length,
-          })
-        : t("message.platformApplicationCount_other", {
-            count: platform?.applications?.length ?? 0,
-          })}
+      {t("message.platformApplicationCount", {
+        count: platform?.applications?.length ?? 0,
+      })}
     </Link>
   );
 };

--- a/client/src/app/pages/source-platforms/components/platform-applications-table.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-applications-table.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { Ref } from "@app/api/models";
 import {
   useTableControlState,
@@ -109,11 +108,7 @@ const PlatformAppsTable: React.FC<IPlatformAppsTableProps> = ({
   };
   return (
     <>
-      <Toolbar
-        {...toolbarProps}
-        className={spacing.mtSm}
-        clearAllFilters={clearFilters}
-      >
+      <Toolbar {...toolbarProps} clearAllFilters={clearFilters}>
         <ToolbarContent>
           <FilterToolbar {...filterToolbarProps} />
           <ToolbarItem {...paginationToolbarItemProps}>

--- a/client/src/app/pages/source-platforms/components/platform-detail-drawer.css
+++ b/client/src/app/pages/source-platforms/components/platform-detail-drawer.css
@@ -1,7 +1,3 @@
 .platform-detail-drawer-list {
-  --pf-v5-c-description-list__term--FontSize: var(--pf-v5-global--FontSize--lg);
-  --pf-v5-c-description-list__description--FontSize: var(
-    --pf-v5-global--FontSize--md
-  );
-  margin-top: 1.4em;
+  margin-top: var(--pf-v5-global--spacer--md);
 }

--- a/client/src/app/pages/source-platforms/components/platform-detail-drawer.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-detail-drawer.tsx
@@ -19,6 +19,11 @@ import { SourcePlatform } from "@app/api/models";
 
 import { PageDrawerContent } from "@app/components/PageDrawerContext";
 import PlatformAppsTable from "./platform-applications-table";
+import {
+  DrawerTabContent,
+  DrawerTabsContainer,
+} from "@app/components/detail-drawer";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 
 export interface IPlatformDetailDrawerProps {
   onCloseClick: () => void;
@@ -58,7 +63,7 @@ const PlatformDetailDrawer: React.FC<IPlatformDetailDrawerProps> = ({
         </TextContent>
       }
     >
-      <div>
+      <DrawerTabsContainer>
         <Tabs
           activeKey={activeTabKey}
           onSelect={(_event, tabKey) => setActiveTabKey(tabKey as TabKey)}
@@ -67,49 +72,74 @@ const PlatformDetailDrawer: React.FC<IPlatformDetailDrawerProps> = ({
             eventKey={TabKey.Details}
             title={<TabTitleText>{t("terms.details")}</TabTitleText>}
           >
-            <DescriptionList className="platform-detail-drawer-list">
-              <DescriptionListGroup>
-                <DescriptionListTerm>{t("terms.name")}</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {platform?.name}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>
-                  {t("terms.providerType")}
-                </DescriptionListTerm>
-                <DescriptionListDescription>
-                  {platform?.kind}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>{t("terms.url")}</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {platform?.url}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-            </DescriptionList>
+            <DrawerTabContent>
+              <DescriptionList className="platform-detail-drawer-list">
+                <DescriptionListGroup>
+                  <DescriptionListTerm>{t("terms.name")}</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {platform?.name}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>
+                    {t("terms.platformKind")}
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {platform?.kind}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>{t("terms.url")}</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {platform?.url}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>
+                    {t("terms.credentials")}
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {/* TODO: Add a link to the identity when identity page can filter by urlParams */}
+                    {platform?.identity ? (
+                      platform.identity.name
+                    ) : (
+                      <EmptyTextMessage message={t("terms.none")} />
+                    )}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              </DescriptionList>
+            </DrawerTabContent>
           </Tab>
+
           {/* TODO: Add this back if Platforms need schema defined coordinates */}
           {/*
           <Tab
             eventKey={TabKey.Coordinates}
             title={<TabTitleText>{t("terms.coordinates")}</TabTitleText>}
           >
-            <SchemaDefinedField
-              baseJsonDocument={myJson}
-              jsonSchema={mySchema as JsonSchemaObject}
-            />
+            <DrawerTabContent>
+              <DrawerTabContentSection label={t("terms.coordinates")}>
+                <SchemaDefinedField
+                  jsonDocument={platform?.coordinates ?? {}}
+                  jsonSchema={undefined}
+                />
+              </DrawerTabContentSection>
+            </DrawerTabContent>
           </Tab>
           */}
+
           <Tab
             eventKey={TabKey.Applications}
             title={<TabTitleText>{t("terms.applications")}</TabTitleText>}
           >
-            <PlatformAppsTable platformApplications={platform?.applications} />
+            <DrawerTabContent>
+              <PlatformAppsTable
+                platformApplications={platform?.applications}
+              />
+            </DrawerTabContent>
           </Tab>
         </Tabs>
-      </div>
+      </DrawerTabsContainer>
     </PageDrawerContent>
   );
 };

--- a/client/src/app/pages/source-platforms/components/platform-form.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-form.tsx
@@ -30,7 +30,7 @@ import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { SimpleSelect } from "@app/components/SimpleSelect";
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { useFetchIdentities } from "@app/queries/identities";
-import { usePlatformProviderList } from "../../usePlatformProviderList";
+import { usePlatformKindList } from "../usePlatformKindList";
 
 export interface PlatformFormValues {
   kind: string;
@@ -59,7 +59,7 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
   onClose,
 }) => {
   const { t } = useTranslation();
-  const { providers: providersList } = usePlatformProviderList();
+  const { kinds: platformKindList } = usePlatformKindList();
 
   const { existingPlatforms, createPlatform, updatePlatform } =
     usePlatformFormData({
@@ -67,7 +67,9 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
     });
 
   const { identities } = useFetchIdentities();
-  const identitiesOptions = identities.map((identity) => identity.name);
+  const identitiesOptions = identities
+    .filter(({ kind }) => kind === "source")
+    .map((identity) => identity.name);
 
   const validationSchema = yup.object().shape({
     kind: yup
@@ -113,11 +115,6 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
     handleSubmit,
     formState: { isSubmitting, isValidating, isValid, isDirty },
     control,
-
-    // for debugging
-    // getValues,
-    // getFieldState,
-    // formState,
   } = useForm<PlatformFormValues>({
     defaultValues: !platform
       ? {
@@ -157,7 +154,6 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
     if (platform) {
       updatePlatform({
         id: platform.id,
-        applications: platform.applications,
         ...payload,
       });
     } else {
@@ -178,7 +174,7 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
       <HookFormPFGroupController
         control={control}
         name="kind"
-        label={t("terms.providerType")}
+        label={t("terms.platformKind")}
         fieldId="kind"
         isRequired
         renderInput={({ field: { value, name, onChange } }) => (
@@ -186,15 +182,15 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
             <SimpleSelect
               maxHeight={DEFAULT_SELECT_MAX_HEIGHT}
               placeholderText={t("composed.selectOne", {
-                what: t("terms.providerType").toLowerCase(),
+                what: t("terms.platformKind").toLowerCase(),
               })}
               variant="typeahead"
-              toggleId="provider-type-toggle"
-              id="provider-type-select"
-              toggleAriaLabel="Provider type select dropdown toggle"
+              toggleId="platform-kind-toggle"
+              id="platform-kind-select"
+              toggleAriaLabel="Platform kind select dropdown toggle"
               aria-label={name}
               value={value}
-              options={providersList || []}
+              options={platformKindList || []}
               onChange={(selection) => {
                 onChange(selection);
               }}

--- a/client/src/app/pages/source-platforms/components/platform-form/index.ts
+++ b/client/src/app/pages/source-platforms/components/platform-form/index.ts
@@ -1,1 +1,0 @@
-export { PlatformForm as default } from "./platform-form";

--- a/client/src/app/pages/source-platforms/source-platforms.tsx
+++ b/client/src/app/pages/source-platforms/source-platforms.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {
@@ -47,11 +48,10 @@ import {
 
 import LinkToPlatformApplications from "./components/link-to-platform-applications";
 import PlatformDetailDrawer from "./components/platform-detail-drawer";
-import PlatformForm from "./components/platform-form";
+import { PlatformForm } from "./components/platform-form";
 import { SourcePlatform, TaskState } from "@app/api/models";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { getAxiosErrorMessage } from "@app/utils/utils";
-import { AxiosError } from "axios";
 import { SimplePagination } from "@app/components/SimplePagination";
 import { TablePersistenceKeyPrefix } from "@app/Constants";
 import { TaskStateIcon } from "@app/components/Icons";
@@ -122,7 +122,7 @@ const SourcePlatforms: React.FC = () => {
 
     columnNames: {
       name: t("terms.name"),
-      providerType: t("terms.providerType"),
+      platformKind: t("terms.platformKind"),
       applications: t("terms.applications"),
     },
 
@@ -145,12 +145,12 @@ const SourcePlatforms: React.FC = () => {
         },
       },
       {
-        categoryKey: "providerType",
-        title: t("terms.providerType"),
+        categoryKey: "platformKind",
+        title: t("terms.platformKind"),
         type: FilterType.search,
         placeholderText:
           t("actions.filterBy", {
-            what: t("terms.providerType").toLowerCase(),
+            what: t("terms.platformKind").toLowerCase(),
           }) + "...",
         getItemValue: (platform) => {
           return platform?.kind ?? "";
@@ -158,10 +158,10 @@ const SourcePlatforms: React.FC = () => {
       },
     ],
 
-    sortableColumns: ["name", "providerType", "applications"],
+    sortableColumns: ["name", "platformKind", "applications"],
     getSortValues: (platform) => ({
       name: platform.name ?? "",
-      providerType: platform.kind ?? "",
+      platformKind: platform.kind ?? "",
       applications: platform.applications?.length ?? 0,
     }),
     initialSort: { columnKey: "name", direction: "asc" },
@@ -203,32 +203,12 @@ const SourcePlatforms: React.FC = () => {
     filterToolbarProps.setFilterValues({});
   };
 
-  const changeTaskStatus = (platformId: number, newStatus: TaskState) => {
-    setPlatforms(
-      platforms?.map((platform) =>
-        platform.id === platformId
-          ? { ...platform, discoverApplicationsState: newStatus }
-          : platform
-      )
-    );
-  };
-
-  const discoverApplications = (platformId: number) => {
-    const platform = platforms?.find((p) => p.id === platformId);
+  const discoverApplications = (platform: SourcePlatform) => {
     if (platform) {
-      changeTaskStatus(platformId, "Pending");
-      // Simulate a task status change, in a real application this would be an API call
-      setTimeout(() => {
-        changeTaskStatus(platformId, "Succeeded");
-        pushNotification({
-          title: t("toastr.success.discoverApplications", {
-            platformName: platform.name,
-          }),
-          variant: "success",
-        });
-      }, 2000); // Simulate a delay for the task completion
+      console.log("discoverApplications", platform);
     }
   };
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -273,7 +253,7 @@ const SourcePlatforms: React.FC = () => {
                 <Tr>
                   <TableHeaderContentWithControls {...tableControls}>
                     <Th {...getThProps({ columnKey: "name" })} />
-                    <Th {...getThProps({ columnKey: "providerType" })} />
+                    <Th {...getThProps({ columnKey: "platformKind" })} />
                     <Th {...getThProps({ columnKey: "applications" })} />
                     <Th screenReaderText="primary action" />
                     <Th screenReaderText="secondary actions" />
@@ -322,7 +302,7 @@ const SourcePlatforms: React.FC = () => {
                             <Text>{platform.name}</Text>
                           </Popover>
                         </Td>
-                        <Td {...getTdProps({ columnKey: "providerType" })}>
+                        <Td {...getTdProps({ columnKey: "platformKind" })}>
                           {platform.kind}
                         </Td>
                         <Td {...getTdProps({ columnKey: "applications" })}>
@@ -346,8 +326,7 @@ const SourcePlatforms: React.FC = () => {
                               ...[
                                 {
                                   title: t("actions.discoverApplications"),
-                                  onClick: () =>
-                                    discoverApplications(platform.id),
+                                  onClick: () => discoverApplications(platform),
                                 },
                               ],
                               { isSeparator: true },

--- a/client/src/app/pages/source-platforms/usePlatformKindList.ts
+++ b/client/src/app/pages/source-platforms/usePlatformKindList.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_KIND = "cloudfoundry";
+
+const KIND_LIST = [DEFAULT_KIND]; // Add more provider kinds here, or use a list from the API
+
+export const usePlatformKindList = (): { kinds: string[] } => {
+  return { kinds: KIND_LIST };
+};

--- a/client/src/app/pages/source-platforms/usePlatformProviderList.ts
+++ b/client/src/app/pages/source-platforms/usePlatformProviderList.ts
@@ -1,7 +1,0 @@
-export const DEFAULT_PROVIDER = "cloud-foundry";
-
-const PROVIDER_LIST = ["cloud-foundry"].sort();
-
-export const usePlatformProviderList = (): { providers: string[] } => {
-  return { providers: PROVIDER_LIST };
-};

--- a/client/src/app/queries/identities.ts
+++ b/client/src/app/queries/identities.ts
@@ -52,6 +52,7 @@ export const useCreateIdentityMutation = (
   };
 };
 
+// TODO: Add a filter to the query to only return identities of given kind
 export const useFetchIdentities = (refetchInterval: number | false = false) => {
   const { data, isLoading, isSuccess, error, refetch } = useQuery({
     queryKey: [IdentitiesQueryKey],


### PR DESCRIPTION
Changes:
  - Rename `providerType` to `platformKind` across the components
  - `platformKind` is labeled as `Type` in the UI
  - Only show source identities in the source platform form
  - Add credentials to the source platform detail drawer
  - Rename `usePlatformProviderList` to `usePlatformKindList`
  - Minor rendering changes

Screenshots:
<img width="1503" height="978" alt="image" src="https://github.com/user-attachments/assets/f9bc6027-9654-41ff-acd7-b3ca78824fce" />

<img width="1503" height="978" alt="image" src="https://github.com/user-attachments/assets/2c4b6bf0-da86-44ed-af2a-dfe129f0b295" />

<img width="1503" height="978" alt="image" src="https://github.com/user-attachments/assets/188fbc71-4322-40ed-b89d-6fcb03581ec7" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "platformKind" translation key for improved labeling.
  * Introduced a credentials field in the platform details view.

* **Refactor**
  * Replaced "providerType" terminology with "platformKind" across the user interface.
  * Updated platform kind selection and labeling in forms and tables.
  * Simplified application count display and UI layout in platform details.
  * Streamlined styling for the platform detail drawer.
  * Improved component structure for platform detail tabs.

* **Chores**
  * Removed unused files and replaced internal logic for listing platform kinds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->