### PR TITLE
:sparkles: Workflow - Source platform discover and import applications wizard

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -34,6 +34,7 @@
     "discardAssessment": "Discard assessment(s)",
     "discardReview": "Discard review",
     "discoverApplications": "Discover applications",
+    "discoverImport": "Discover & Import",
     "downloadCsvTemplate": "Download CSV template",
     "download": "Download {{what}}",
     "duplicate": "Duplicate",
@@ -135,7 +136,8 @@
       "dragAndDropFile": "Drag and drop your file here or upload one.",
       "uploadYamlFile": "Upload your YAML file",
       "deleteQuestionnaire": "Deleting a questionnaire will cascade into the deletion of all answered questionnaires associated to applications and/or archetypes.",
-      "confirmDeletion": "Confirm deletion by typing <strong>{{nameToDelete}}</strong> below:"
+      "confirmDeletion": "Confirm deletion by typing <strong>{{nameToDelete}}</strong> below:",
+      "discoverApplications": "Discover and import applications from the selected platform."
     },
     "title": {
       "applicationAnalysis": "Application analysis",
@@ -177,7 +179,8 @@
       "updateStakeholder": "Update stakeholder",
       "updateStakeholderGroup": "Update stakeholder group",
       "updateTag": "Update tag",
-      "updateTagCategory": "Update tag category"
+      "updateTagCategory": "Update tag category",
+      "discoverApplications": "Discover Applications"
     }
   },
   "efforts": {
@@ -689,6 +692,26 @@
       "description_other": "These applications are ready to retrieve configurations from their source platforms. The applications' platform coordinates will be used to connect to the platform and build the applications' discovery manifests.",
       "selectedApplications_one": "Selected application",
       "selectedApplications_other": "Selected applications ({{count}})"
+    }
+  },
+  "platformDiscoverWizard": {
+    "noPlatformSelected": "No platform selected for discovery.",
+    "toast": {
+      "submittedOk": "Platform application discovery task submitted",
+      "submittedFailed": "Platform application discovery task failed"
+    },
+    "results": {
+      "title": "Platform Discovery Results",
+      "summary": "Summary of platform application discovery task submissions.",
+      "noResults": "No results available.",
+      "failedSubmissions_one": "Failed Submission",
+      "failedSubmissions_other": "Failed Submissions ({{count}})",
+      "successSubmissions_one": "Success Submission",
+      "successSubmissions_other": "Success Submissions ({{count}})"
+    },
+    "review": {
+      "title": "Review Platform Discovery",
+      "description": "This will start application discovery on platform {{platformName}}. The platform credentials will be used to connect and discover applications."
     }
   },
   "credentials": {

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -700,6 +700,11 @@
       "submittedOk": "Platform application discovery task submitted",
       "submittedFailed": "Platform application discovery task failed"
     },
+    "filterInput": {
+      "title": "Configure Discovery Filters",
+      "description": "Configure the filters for discovering applications on platform {{platformName}} ({{platformKind}}). These filters will determine which applications are discovered and imported.",
+      "noFiltersAvailable": "No discovery filters are available for platform kind {{platformKind}}."
+    },
     "results": {
       "title": "Platform Discovery Results",
       "summary": "Summary of platform application discovery task submissions.",
@@ -711,7 +716,8 @@
     },
     "review": {
       "title": "Review Platform Discovery",
-      "description": "This will start application discovery on platform {{platformName}}. The platform credentials will be used to connect and discover applications."
+      "description": "Review the platform and discovery filters before starting application discovery on {{platformName}}.",
+      "discoveryFilters": "Discovery Filters"
     }
   },
   "credentials": {

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -136,8 +136,7 @@
       "dragAndDropFile": "Drag and drop your file here or upload one.",
       "uploadYamlFile": "Upload your YAML file",
       "deleteQuestionnaire": "Deleting a questionnaire will cascade into the deletion of all answered questionnaires associated to applications and/or archetypes.",
-      "confirmDeletion": "Confirm deletion by typing <strong>{{nameToDelete}}</strong> below:",
-      "discoverApplications": "Discover and import applications from the selected platform."
+      "confirmDeletion": "Confirm deletion by typing <strong>{{nameToDelete}}</strong> below:"
     },
     "title": {
       "applicationAnalysis": "Application analysis",
@@ -179,8 +178,7 @@
       "updateStakeholder": "Update stakeholder",
       "updateStakeholderGroup": "Update stakeholder group",
       "updateTag": "Update tag",
-      "updateTagCategory": "Update tag category",
-      "discoverApplications": "Discover Applications"
+      "updateTagCategory": "Update tag category"
     }
   },
   "efforts": {
@@ -695,15 +693,25 @@
     }
   },
   "platformDiscoverWizard": {
+    "title": "Discover Applications",
+    "description": "Discover and import applications from the selected platform.",
     "noPlatformSelected": "No platform selected for discovery.",
     "toast": {
       "submittedOk": "Platform application discovery task submitted",
       "submittedFailed": "Platform application discovery task failed"
     },
     "filterInput": {
+      "stepTitle": "Filters",
       "title": "Configure Discovery Filters",
       "description": "Configure the filters for discovering applications on platform {{platformName}} ({{platformKind}}). These filters will determine which applications are discovered and imported.",
+      "filtersLabel": "{{platformName}} discovery filters",
       "noFiltersAvailable": "No discovery filters are available for platform kind {{platformKind}}."
+    },
+    "review": {
+      "stepTitle": "Review",
+      "title": "Review Platform Discovery",
+      "description": "Review the platform and discovery filters before starting application discovery on {{platformName}}.",
+      "discoveryFilters": "Discovery Filters"
     },
     "results": {
       "title": "Platform Discovery Results",
@@ -711,13 +719,8 @@
       "noResults": "No results available.",
       "failedSubmissions_one": "Failed Submission",
       "failedSubmissions_other": "Failed Submissions ({{count}})",
-      "successSubmissions_one": "Success Submission",
-      "successSubmissions_other": "Success Submissions ({{count}})"
-    },
-    "review": {
-      "title": "Review Platform Discovery",
-      "description": "Review the platform and discovery filters before starting application discovery on {{platformName}}.",
-      "discoveryFilters": "Discovery Filters"
+      "successSubmissions_one": "Successful Submission",
+      "successSubmissions_other": "Successful Submissions ({{count}})"
     }
   },
   "credentials": {

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -717,6 +717,7 @@
       "title": "Platform Discovery Results",
       "summary": "Summary of platform application discovery task submissions.",
       "noResults": "No results available.",
+      "noTasksSubmitted": "No tasks were submitted.",
       "failedSubmissions_one": "Failed Submission",
       "failedSubmissions_other": "Failed Submissions ({{count}})",
       "successSubmissions_one": "Successful Submission",

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -364,6 +364,8 @@ export interface ApplicationTask<DataType>
   application: Ref;
 }
 
+export interface PlatformDiscoveryImportData extends JsonDocument {}
+
 export interface PlatformTask<DataType>
   extends Omit<Task<DataType>, "application" | "platform"> {
   platform: Ref;

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -389,7 +389,7 @@ export interface TaskDashboard {
   kind?: string;
   addon?: string;
   state: TaskState;
-  application: Ref;
+  application?: Ref;
   started?: string; // ISO-8601
   terminated?: string; // ISO-8601
 

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -16,6 +16,10 @@ export type New<T extends { id: number }> = Omit<T, "id">;
  */
 export type WithUiId<T> = T & { _ui_unique_id: string };
 
+export interface EmptyObject extends Record<string, never> {}
+
+export interface JsonDocument extends Record<string, unknown> {}
+
 export interface HubFilter {
   field: string;
   operator?: "=" | "!=" | "~" | ">" | ">=" | "<" | "<=";
@@ -328,14 +332,14 @@ export type TaskState =
   | "Postponed"
   | "SucceededWithErrors"; // synthetic state for ease-of-use in UI;
 
-export interface Task<DataType = AnalysisTaskData> {
+export interface Task<DataType> {
   id: number;
   createUser?: string;
   updateUser?: string;
   createTime?: string;
 
   name?: string;
-  kind?: string;
+  kind: string;
   addon?: string;
   extensions?: string[];
   state?: TaskState;
@@ -344,7 +348,7 @@ export interface Task<DataType = AnalysisTaskData> {
   policy?: TaskPolicy;
   ttl?: TTL;
   data?: DataType;
-  application: Ref;
+  application?: Ref;
   platform?: Ref;
   bucket?: Ref;
   pod?: string;
@@ -357,17 +361,21 @@ export interface Task<DataType = AnalysisTaskData> {
   attached?: TaskAttachment[];
 }
 
-export type EmptyTaskData = Record<string, never>;
-
-export interface ApplicationTask<DataType>
-  extends Omit<Task<DataType>, "application" | "platform"> {
+export interface AnalysisTask
+  extends Omit<Task<AnalysisTaskData>, "application" | "platform"> {
+  kind: "analysis";
   application: Ref;
 }
 
-export interface PlatformDiscoveryImportData extends JsonDocument {}
+export interface ApplicationManifestTask
+  extends Omit<Task<EmptyObject>, "application" | "platform"> {
+  kind: "application-manifest";
+  application: Ref;
+}
 
-export interface PlatformTask<DataType>
-  extends Omit<Task<DataType>, "application" | "platform"> {
+export interface PlatformApplicationImportTask
+  extends Omit<Task<JsonDocument>, "application" | "platform"> {
+  kind: "application-import";
   platform: Ref;
 }
 
@@ -937,8 +945,6 @@ export interface GroupedStakeholderRef extends Ref {
   group: StakeholderType.Stakeholder | StakeholderType.StakeholderGroup;
   uniqueId: string;
 }
-
-export interface JsonDocument extends Record<string, unknown> {}
 
 export interface SourcePlatform {
   id: number;

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -390,6 +390,7 @@ export interface TaskDashboard {
   addon?: string;
   state: TaskState;
   application?: Ref;
+  platform?: Ref;
   started?: string; // ISO-8601
   terminated?: string; // ISO-8601
 

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -328,7 +328,7 @@ export type TaskState =
   | "Postponed"
   | "SucceededWithErrors"; // synthetic state for ease-of-use in UI;
 
-export interface Task<DataType = TaskData> {
+export interface Task<DataType = AnalysisTaskData> {
   id: number;
   createUser?: string;
   updateUser?: string;
@@ -419,7 +419,7 @@ export interface TaskAttachment {
   activity?: number;
 }
 
-export interface TaskData {
+export interface AnalysisTaskData {
   tagger: {
     enabled: boolean;
   };
@@ -465,7 +465,7 @@ export interface Taskgroup {
   name: string;
   kind?: string;
   addon?: string;
-  data: TaskData;
+  data: AnalysisTaskData;
   tasks: TaskgroupTask[];
 }
 

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -34,10 +34,7 @@ import {
   Tag,
   TagCategory,
   Target,
-  Task,
   Taskgroup,
-  TaskQueue,
-  TaskDashboard,
   Ticket,
   Tracker,
   TrackerProject,
@@ -96,7 +93,6 @@ export const TAG_CATEGORIES = hub`/tagcategories`;
 export const TAGS = hub`/tags`;
 export const TARGETS = hub`/targets`;
 export const TASKGROUPS = hub`/taskgroups`;
-export const TASKS = hub`/tasks`;
 export const TICKETS = hub`/tickets`;
 export const TRACKER_PROJECT_ISSUETYPES = "issuetypes"; // TODO: ????
 export const TRACKER_PROJECTS = "projects"; // TODO: ????
@@ -122,8 +118,9 @@ export const HEADERS: Record<string, RawAxiosRequestHeaders> = {
 
 export * from "./rest/analysis";
 export * from "./rest/files";
-export * from "./rest/schemas";
 export * from "./rest/generators";
+export * from "./rest/schemas";
+export * from "./rest/tasks";
 
 /**
  * Provide consistent fetch and processing for server side filtering and sorting with
@@ -377,101 +374,6 @@ export const getApplicationSummaryCSV = (id: string) => {
     }
   );
 };
-
-// ---------------------------------------
-// Tasks
-//
-export function getTaskById(id: number) {
-  return axios
-    .get<Task>(`${TASKS}/${id}`, {
-      headers: { ...HEADERS.json },
-      responseType: "json",
-    })
-    .then((response) => {
-      return response.data;
-    });
-}
-
-export function getTaskByIdAndFormat(
-  id: number,
-  format: "json" | "yaml",
-  merged: boolean = false
-): Promise<string> {
-  const isYaml = format === "yaml";
-  const headers = isYaml ? { ...HEADERS.yaml } : { ...HEADERS.json };
-  const responseType = isYaml ? "text" : "json";
-
-  let url = `${TASKS}/${id}`;
-  if (merged) {
-    url += "?merged=1";
-  }
-
-  return axios
-    .get<Task | string>(url, {
-      headers: headers,
-      responseType: responseType,
-    })
-    .then((response) => {
-      return isYaml
-        ? String(response.data ?? "")
-        : JSON.stringify(response.data, undefined, 2);
-    });
-}
-
-export function getTasksByIds(
-  ids: number[],
-  format: "json" | "yaml" = "json"
-): Promise<Task[]> {
-  const isYaml = format === "yaml";
-  const headers = isYaml ? { ...HEADERS.yaml } : { ...HEADERS.json };
-  const responseType = isYaml ? "text" : "json";
-  const filterParam = `id:(${ids.join("|")})`;
-
-  return axios
-    .get<Task[]>(`${TASKS}`, {
-      headers,
-      responseType,
-      params: {
-        filter: filterParam,
-      },
-    })
-    .then((response) => {
-      return response.data;
-    });
-}
-
-export const getTasksDashboard = () =>
-  axios
-    .get<TaskDashboard[]>(`${TASKS}/report/dashboard`)
-    .then((response) => response.data);
-
-export const getServerTasks = (params: HubRequestParams = {}) =>
-  getHubPaginatedResult<Task>(TASKS, params);
-
-export const deleteTask = (id: number) => axios.delete<void>(`${TASKS}/${id}`);
-
-export const cancelTask = (id: number) =>
-  axios.put<void>(`${TASKS}/${id}/cancel`);
-
-export const cancelTasks = (ids: number[]) =>
-  axios.put<void>(`${TASKS}/cancel?filter=id:(${ids.join("|")})`);
-
-export const getTaskQueue = (addon?: string): Promise<TaskQueue> =>
-  axios
-    .get<TaskQueue>(`${TASKS}/report/queue`, { params: { addon } })
-    .then(({ data }) => data);
-
-export const createTask = <TaskData, TaskType extends Task<TaskData>>(
-  task: New<TaskType>
-) => axios.post<TaskType>(TASKS, task).then((response) => response.data);
-
-export const updateTask = <TaskData, TaskType extends Task<TaskData>>(
-  task: Partial<TaskType> & { id: number }
-) => axios.patch<TaskType>(`${TASKS}/${task.id}`, task);
-
-export const submitTask = <TaskData, TaskType extends Task<TaskData>>(
-  task: TaskType
-) => axios.put<void>(`${TASKS}/${task.id}/submit`, { id: task.id });
 
 // ---------------------------------------
 // Task Groups

--- a/client/src/app/api/rest/schemas.ts
+++ b/client/src/app/api/rest/schemas.ts
@@ -23,13 +23,13 @@ export const getPlatformCoordinatesSchema = (platformKind: string) =>
     )
     .then(({ data }) => data);
 
-export const getPlatformDiscoveryImportSchema = (platformKind: string) =>
+export const getPlatformDiscoveryFilterSchema = (platformKind: string) =>
   axios
     .get<TargetedSchema>(
       template(TARGETED_SCHEMA, {
         domain: "platform",
         variant: platformKind,
-        subject: "import",
+        subject: "filter",
       })
     )
     .then(({ data }) => data);

--- a/client/src/app/api/rest/schemas.ts
+++ b/client/src/app/api/rest/schemas.ts
@@ -23,13 +23,13 @@ export const getPlatformCoordinatesSchema = (platformKind: string) =>
     )
     .then(({ data }) => data);
 
-export const getPlatformDiscoveryFiltersSchema = (platformKind: string) =>
+export const getPlatformDiscoveryImportSchema = (platformKind: string) =>
   axios
     .get<TargetedSchema>(
       template(TARGETED_SCHEMA, {
         domain: "platform",
         variant: platformKind,
-        subject: "filters",
+        subject: "import",
       })
     )
     .then(({ data }) => data);

--- a/client/src/app/api/rest/tasks.ts
+++ b/client/src/app/api/rest/tasks.ts
@@ -1,0 +1,114 @@
+import axios from "axios";
+
+import {
+  HubRequestParams,
+  New,
+  Task,
+  TaskDashboard,
+  TaskQueue,
+} from "../models";
+import { getHubPaginatedResult, HEADERS, hub } from "../rest";
+
+export const TASKS = hub`/tasks`;
+
+// ---------------------------------------
+// Fetch hub paginated, sorted, filtered Tasks
+//
+export const getServerTasks = <D extends object>(
+  params: HubRequestParams = {}
+) => getHubPaginatedResult<Task<D>>(TASKS, params);
+
+export function getTaskById<D extends object>(id: number) {
+  return axios
+    .get<Task<D>>(`${TASKS}/${id}`, {
+      headers: { ...HEADERS.json },
+      responseType: "json",
+    })
+    .then((response) => {
+      return response.data;
+    });
+}
+
+// ---------------------------------------
+// Tasks functions
+//
+export function getTaskByIdAndFormat(
+  id: number,
+  format: "json" | "yaml",
+  merged: boolean = false
+): Promise<string> {
+  const isYaml = format === "yaml";
+  const headers = isYaml ? { ...HEADERS.yaml } : { ...HEADERS.json };
+  const responseType = isYaml ? "text" : "json";
+
+  let url = `${TASKS}/${id}`;
+  if (merged) {
+    url += "?merged=1";
+  }
+
+  return axios
+    .get<Task<object> | string>(url, {
+      headers: headers,
+      responseType: responseType,
+    })
+    .then((response) => {
+      return isYaml
+        ? String(response.data ?? "")
+        : JSON.stringify(response.data, undefined, 2);
+    });
+}
+
+export function getTasksByIds<D extends object>(
+  ids: number[],
+  format: "json" | "yaml" = "json"
+): Promise<Task<D>[]> {
+  const isYaml = format === "yaml";
+  const headers = isYaml ? { ...HEADERS.yaml } : { ...HEADERS.json };
+  const responseType = isYaml ? "text" : "json";
+  const filterParam = `id:(${ids.join("|")})`;
+
+  return axios
+    .get<Task<D>[]>(`${TASKS}`, {
+      headers,
+      responseType,
+      params: {
+        filter: filterParam,
+      },
+    })
+    .then((response) => {
+      return response.data;
+    });
+}
+
+export const deleteTask = (id: number) => axios.delete<void>(`${TASKS}/${id}`);
+
+export const cancelTask = (id: number) =>
+  axios.put<void>(`${TASKS}/${id}/cancel`);
+
+export const cancelTasks = (ids: number[]) =>
+  axios.put<void>(`${TASKS}/cancel?filter=id:(${ids.join("|")})`);
+
+export const createTask = <D, TaskType extends Task<D> = Task<D>>(
+  task: New<TaskType>
+) => axios.post<TaskType>(TASKS, task).then((response) => response.data);
+
+export const updateTask = <D, TaskType extends Task<D> = Task<D>>(
+  task: Partial<TaskType> & { id: number }
+) => axios.patch<TaskType>(`${TASKS}/${task.id}`, task);
+
+export const submitTask = <D, TaskType extends Task<D> = Task<D>>(
+  task: TaskType
+) => axios.put<void>(`${TASKS}/${task.id}/submit`, { id: task.id });
+
+// ---------------------------------------
+// Task Reports
+//
+export const getTasksDashboard = () =>
+  axios
+    .get<TaskDashboard[]>(`${TASKS}/report/dashboard`)
+    .then((response) => response.data);
+
+export const getTaskQueue = (addon?: string): Promise<TaskQueue> =>
+  axios
+    .get<TaskQueue>(`${TASKS}/report/queue`, { params: { addon } })
+    .then(({ data }) => data);

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -28,6 +28,11 @@ export interface ISchemaAsCodeEditorProps {
   onDocumentSaved?: (newSchemaContent: object) => void;
   onDocumentChanged?: (newSchemaContent: object) => void;
   isReadOnly?: boolean;
+  /**
+   * Height of the editor. Defaults to 600px. Use "sizeToFit" to size editor to fit content.
+   * Set to "100%" to make the editor take up the full height of its container.
+   */
+  height?: string;
 }
 
 export const SchemaAsCodeEditor = ({
@@ -37,6 +42,7 @@ export const SchemaAsCodeEditor = ({
   onDocumentSaved,
   onDocumentChanged,
   isReadOnly = false,
+  height = "600px",
 }: ISchemaAsCodeEditorProps) => {
   const editorRef = React.useRef<ControlledEditor>();
 
@@ -101,7 +107,7 @@ export const SchemaAsCodeEditor = ({
       isDownloadEnabled
       isLineNumbersVisible
       isReadOnly={isReadOnly}
-      height="600px"
+      height={height}
       downloadFileName="my-schema-download.json"
       language={Language.json}
       code={currentCode}

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -42,7 +42,7 @@ export const SchemaDefinedField = ({
 
   const isComplex = React.useMemo(() => {
     const isComplex = jsonSchema && isComplexSchema(jsonSchema);
-    console.log("jsonSchema", jsonSchema, "isComplex?", isComplex);
+    // console.log("jsonSchema", jsonSchema, "isComplex?", isComplex);
     return isComplex;
   }, [jsonSchema]);
 

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -26,7 +26,9 @@ export const SchemaDefinedField = ({
   onDocumentChanged,
   isReadOnly = false,
 }: ISchemaDefinedFieldProps) => {
-  const [isJsonView, setIsJsonView] = React.useState<boolean>(!jsonSchema);
+  const [isJsonView, setIsJsonView] = React.useState<boolean>(
+    !jsonSchema || isComplexSchema(jsonSchema)
+  );
 
   const onSavedHandler = !onDocumentSaved
     ? undefined
@@ -38,22 +40,27 @@ export const SchemaDefinedField = ({
     onDocumentChanged?.(newJsonDocument);
   };
 
+  const isComplex = React.useMemo(() => {
+    const isComplex = jsonSchema && isComplexSchema(jsonSchema);
+    console.log("jsonSchema", jsonSchema, "isComplex?", isComplex);
+    return isComplex;
+  }, [jsonSchema]);
+
   return (
     <Panel className={className} id={id}>
-      {jsonSchema ? (
+      {jsonSchema && !isComplex ? (
         <PanelHeader>
           <Switch
             id={`${id}-json-toggle`}
             label="JSON"
             isChecked={isJsonView}
             onChange={() => setIsJsonView(!isJsonView)}
-            isDisabled={!jsonSchema || isComplexSchema(jsonSchema)}
           />
         </PanelHeader>
       ) : null}
 
       <PanelMain maxHeight="100%">
-        {isJsonView || !jsonSchema ? (
+        {!jsonSchema || isComplex || isJsonView ? (
           <SchemaAsCodeEditor
             id={`${id}-as-code-editor`}
             isReadOnly={isReadOnly}

--- a/client/src/app/components/task-manager/TaskManagerDrawer.tsx
+++ b/client/src/app/components/task-manager/TaskManagerDrawer.tsx
@@ -49,12 +49,12 @@ interface TaskManagerTask {
   extensions: string[];
   state: TaskState;
   priority: number;
-  applicationId: number;
-  applicationName: string;
+  applicationName?: string;
+  platformName?: string;
   preemptEnabled: boolean;
 
   // full object to be used with library functions
-  _: Task;
+  _: Task<unknown>;
 }
 
 const PAGE_SIZE = 20;
@@ -215,10 +215,12 @@ const TaskItem: React.FC<{
             </Tooltip>
           }
         >
-          <div>{task.applicationName}</div>
-          {/* TODO: Link to /applications with filter applied? */}
-          <div>Priority {task.priority}</div>
+          {/* TODO: Link to /applications or /platforms with filter applied? */}
+          {task.applicationName && <div>{task.applicationName}</div>}
+          {task.platformName && <div>{task.platformName}</div>}
+
           {/* TODO: Bucket to Low, Medium, High? */}
+          <div>Priority {task.priority}</div>
         </NotificationDrawerListItemBody>
       ) : undefined}
     </NotificationDrawerListItem>
@@ -266,8 +268,8 @@ const useTaskManagerData = () => {
               extensions: task.extensions,
               state: task.state ?? "",
               priority: task.priority ?? 0,
-              applicationId: task.application.id,
-              applicationName: task.application.name,
+              applicationName: task.application?.name,
+              platformName: task.platform?.name,
               preemptEnabled: task?.policy?.preemptEnabled ?? false,
 
               _: task,

--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -16,7 +16,7 @@ import {
   Application,
   New,
   Ref,
-  TaskData,
+  AnalysisTaskData,
   Taskgroup,
   TaskgroupTask,
 } from "@app/api/models";
@@ -51,7 +51,7 @@ interface IAnalysisWizard {
   isOpen: boolean;
 }
 
-const defaultTaskData: TaskData = {
+const defaultTaskData: AnalysisTaskData = {
   tagger: {
     enabled: true,
   },

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -334,6 +334,7 @@ export const ApplicationsTable: React.FC = () => {
     applicationNames,
     referencedArchetypeRefs,
     referencedBusinessServiceRefs,
+    referencedPlatformRefs,
   } = useDecoratedApplications(baseApplications, tasks);
 
   const onDeleteApplicationSuccess = (appIDCount: number) => {
@@ -496,6 +497,21 @@ export const ApplicationsTable: React.FC = () => {
         },
       },
       {
+        categoryKey: "platforms",
+        title: t("terms.sourcePlatforms"),
+        type: FilterType.multiselect,
+        placeholderText:
+          t("actions.filterBy", {
+            what: t("terms.sourcePlatforms").toLowerCase(),
+          }) + "...",
+        selectOptions: referencedPlatformRefs.map(({ name }) => ({
+          key: name,
+          value: name,
+        })),
+        logicOperator: "OR",
+        getItemValue: (app) => app.platform?.name ?? "",
+      },
+      {
         categoryKey: "businessService",
         title: t("terms.businessService"),
         type: FilterType.multiselect,
@@ -612,7 +628,6 @@ export const ApplicationsTable: React.FC = () => {
         ],
         getItemValue: (item) => normalizeRisk(item.risk) ?? "",
       },
-
       {
         categoryKey: "analysis",
         title: t("terms.analysis"),

--- a/client/src/app/pages/applications/retrieve-config-wizard/results.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/results.tsx
@@ -19,12 +19,12 @@ import {
   ExclamationTriangleIcon,
 } from "@patternfly/react-icons";
 
-import { ApplicationTask, EmptyTaskData } from "@app/api/models";
+import { ApplicationManifestTask } from "@app/api/models";
 import { DecoratedApplication } from "../useDecoratedApplications";
 
 export interface ResultsData {
   success: {
-    task: ApplicationTask<EmptyTaskData>;
+    task: ApplicationManifestTask;
     application: DecoratedApplication;
   }[];
   failure: {

--- a/client/src/app/pages/applications/retrieve-config-wizard/retrieve-config-wizard.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/retrieve-config-wizard.tsx
@@ -14,7 +14,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { group } from "radash";
 
-import { ApplicationTask, EmptyTaskData, New } from "@app/api/models";
+import { ApplicationManifestTask, EmptyObject, New } from "@app/api/models";
 import { NotificationsContext } from "@app/components/NotificationsContext";
 import { useCreateTaskMutation } from "@app/queries/tasks";
 import { DecoratedApplication } from "../useDecoratedApplications";
@@ -61,7 +61,7 @@ const RetrieveConfigWizardInner: React.FC<IRetrieveConfigWizard> = ({
 }: IRetrieveConfigWizard) => {
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
-  const { submitTasks } = useFetchApplicationManifest();
+  const { submitTasks } = useStartFetchApplicationManifest();
 
   // State to track submission results and current step
   const [submissionResults, setSubmissionResults] =
@@ -186,27 +186,27 @@ const RetrieveConfigWizardInner: React.FC<IRetrieveConfigWizard> = ({
   );
 };
 
-const useFetchApplicationManifest = () => {
+const useStartFetchApplicationManifest = () => {
   const { mutateAsync: createTask } = useCreateTaskMutation<
-    EmptyTaskData,
-    ApplicationTask<EmptyTaskData>
+    EmptyObject,
+    ApplicationManifestTask
   >();
 
   const createAndSubmitTask = async (
     application: DecoratedApplication
   ): Promise<{
     success?: {
-      task: ApplicationTask<EmptyTaskData>;
+      task: ApplicationManifestTask;
       application: DecoratedApplication;
     };
     failure?: {
       message: string;
       cause: Error;
       application: DecoratedApplication;
-      newTask: New<ApplicationTask<EmptyTaskData>>;
+      newTask: New<ApplicationManifestTask>;
     };
   }> => {
-    const newTask: New<ApplicationTask<EmptyTaskData>> = {
+    const newTask: New<ApplicationManifestTask> = {
       name: `${application.name}.${application.id}.application-manifest`,
       kind: "application-manifest",
       application: { id: application.id, name: application.name },

--- a/client/src/app/pages/applications/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/useDecoratedApplications.ts
@@ -241,10 +241,20 @@ export const useDecoratedApplications = (
     [applications]
   );
 
+  const referencedPlatformRefs = useMemo(
+    () =>
+      unique(
+        applications.flatMap((app) => app.platform).filter(Boolean),
+        ({ id, name }) => `${id}:${name}`
+      ).sort((a, b) => universalComparator(a.name, b.name)),
+    [applications]
+  );
+
   return {
     applications: decoratedApplications,
     applicationNames,
     referencedArchetypeRefs,
     referencedBusinessServiceRefs,
+    referencedPlatformRefs,
   };
 };

--- a/client/src/app/pages/applications/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/useDecoratedApplications.ts
@@ -71,11 +71,11 @@ export interface DecoratedApplication extends Application {
 /**
  * Take an array of `Tasks`, group by application id and then by task kind.
  */
-const groupTasks = (tasks: TaskDashboard[]) => {
-  const byApplicationId = group(tasks, (task) => task.application.id) as Record<
-    number,
-    TaskDashboard[]
-  >;
+const groupApplicationTasks = (tasks: TaskDashboard[]) => {
+  const byApplicationId = group(
+    tasks.filter((task) => task.application),
+    (task) => task.application!.id
+  ) as Record<number, TaskDashboard[]>;
 
   const groupedByIdByKind = mapEntries(byApplicationId, (id, tasks) => [
     id,
@@ -123,7 +123,7 @@ const decorateApplications = (
   assessments: AssessmentWithSectionOrder[],
   businessServices: BusinessService[]
 ) => {
-  const { tasksById, tasksByIdByKind } = groupTasks(tasks);
+  const { tasksById, tasksByIdByKind } = groupApplicationTasks(tasks);
 
   const decorated = applications.map((app: Application) => {
     const tasksByKind = tasksByIdByKind[app.id] ?? [];

--- a/client/src/app/pages/source-platforms/components/column-platform-name.css
+++ b/client/src/app/pages/source-platforms/components/column-platform-name.css
@@ -1,0 +1,11 @@
+.platform-name-popover {
+  --pf-v5-c-popover__header--MarginBottom: 1rem;
+}
+
+.platform-name-popover .pf-v5-c-popover__title {
+  flex-grow: 1;
+}
+
+.platform-name-popover .pf-v5-c-popover__title-text {
+  flex-grow: 1;
+}

--- a/client/src/app/pages/source-platforms/components/column-platform-name.tsx
+++ b/client/src/app/pages/source-platforms/components/column-platform-name.tsx
@@ -1,0 +1,192 @@
+import "./column-platform-name.css";
+
+import React from "react";
+import { Link } from "react-router-dom";
+import dayjs from "dayjs";
+
+import {
+  Alert,
+  Icon,
+  Popover,
+  PopoverProps,
+  Tooltip,
+} from "@patternfly/react-core";
+import {
+  CheckCircleIcon,
+  TimesCircleIcon,
+  InProgressIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  PendingIcon,
+  ResourcesEmptyIcon,
+} from "@patternfly/react-icons";
+import { Table, Tbody, Td, Thead, Tr } from "@patternfly/react-table";
+
+import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
+import { Paths } from "@app/Paths";
+import { formatPath, universalComparator } from "@app/utils/utils";
+import { TaskDashboard } from "@app/api/models";
+import {
+  SourcePlatformTasksStatus,
+  SourcePlatformWithTasks,
+} from "../useFetchPlatformsWithTasks";
+
+interface StatusData {
+  popoverVariant: PopoverProps["alertSeverityVariant"];
+  icon: React.FunctionComponent;
+  headerText: string;
+}
+
+/* TODO: This can be better aligned with `TaskStateIcon` in future. */
+const statusMap: Record<SourcePlatformTasksStatus, StatusData> = {
+  None: {
+    popoverVariant: undefined,
+    headerText: "This source platform has no tasks",
+    icon: () => (
+      <Icon status="custom">
+        <ResourcesEmptyIcon />
+      </Icon>
+    ),
+  },
+  Running: {
+    popoverVariant: "info",
+    headerText: "One or more tasks are running",
+    icon: () => (
+      <Icon status="info">
+        <InProgressIcon />
+      </Icon>
+    ),
+  },
+  Queued: {
+    popoverVariant: "info",
+    headerText: "One or more tasks are queued to run",
+    icon: () => (
+      <Icon status="info">
+        <PendingIcon />
+      </Icon>
+    ),
+  },
+  Failed: {
+    popoverVariant: "danger",
+    headerText: "One or more tasks failed",
+    icon: () => (
+      <Icon status="danger">
+        <ExclamationCircleIcon />
+      </Icon>
+    ),
+  },
+  Canceled: {
+    popoverVariant: "info",
+    headerText: "One of more tasks were canceled",
+    icon: () => (
+      <Icon status="info">
+        <TimesCircleIcon />
+      </Icon>
+    ),
+  },
+  Success: {
+    popoverVariant: "success",
+    headerText: "All tasks succeeded",
+    icon: () => (
+      <Icon status="success">
+        <CheckCircleIcon />
+      </Icon>
+    ),
+  },
+  SuccessWithErrors: {
+    popoverVariant: "warning",
+    headerText: "All tasks succeeded, but some errors occurred",
+    icon: () => (
+      <Icon status="warning">
+        <ExclamationTriangleIcon />
+      </Icon>
+    ),
+  },
+};
+
+const linkToTasks = (platformName: string) => {
+  const search = `t:filters={"platform":["${platformName}"]}`;
+  return `${formatPath(Paths.tasks, {})}?${search}`;
+};
+
+const linkToDetails = (task: TaskDashboard) => {
+  return formatPath(Paths.taskDetails, {
+    taskId: task.id,
+  });
+};
+
+export const ColumnPlatformName: React.FC<{
+  platform: SourcePlatformWithTasks;
+}> = ({ platform }) => {
+  const status = statusMap[platform.tasks.tasksStatus];
+  const StatusIcon = status.icon;
+
+  const bodyContent = (
+    <div>
+      <Alert
+        title={status.headerText}
+        variant={status.popoverVariant}
+        customIcon={<StatusIcon />}
+        isInline
+        isPlain
+      />
+      {platform.tasks.tasksStatus === "None" ? (
+        <></>
+      ) : (
+        <Table variant="compact" borders={false}>
+          <Thead>
+            <Tr>
+              <Td>Id</Td>
+              <Td>Kind</Td>
+              <Td>Started</Td>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {Object.entries(platform.tasks.tasksByKind)
+              .sort((a, b) => universalComparator(a[0], b[0]))
+              .map(([kind, [task]]) => {
+                const startTime = dayjs(task.started ?? task.createTime);
+                return (
+                  <Tr key={`popover-p${platform.id}-k${kind}`}>
+                    <Td>{task.id}</Td>
+                    <Td>
+                      <IconWithLabel
+                        icon={<TaskStateIcon state={task.state} />}
+                        label={<Link to={linkToDetails(task)}>{kind}</Link>}
+                      />
+                    </Td>
+                    <Td>
+                      <Tooltip content={startTime.format("ll, LTS")}>
+                        <span>{startTime.fromNow()}</span>
+                      </Tooltip>
+                    </Td>
+                  </Tr>
+                );
+              })}
+          </Tbody>
+        </Table>
+      )}
+    </div>
+  );
+
+  return (
+    <Popover
+      className="platform-name-popover"
+      triggerAction="hover"
+      aria-label="application task information popover"
+      // alertSeverityVariant={status.popoverVariant}
+      // headerIcon={<StatusIcon />}
+      // headerContent={status.headerText}
+      headerContent={platform.name}
+      hasAutoWidth
+      bodyContent={bodyContent}
+      footerContent={
+        <Link to={linkToTasks(platform.name)}>
+          View all tasks for the platform
+        </Link>
+      }
+    >
+      <IconWithLabel icon={<StatusIcon />} label={platform.name} />
+    </Popover>
+  );
+};

--- a/client/src/app/pages/source-platforms/components/column-platform-name.tsx
+++ b/client/src/app/pages/source-platforms/components/column-platform-name.tsx
@@ -20,7 +20,7 @@ import {
   PendingIcon,
   ResourcesEmptyIcon,
 } from "@patternfly/react-icons";
-import { Table, Tbody, Td, Thead, Tr } from "@patternfly/react-table";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
 import { Paths } from "@app/Paths";
@@ -105,7 +105,8 @@ const statusMap: Record<SourcePlatformTasksStatus, StatusData> = {
 };
 
 const linkToTasks = (platformName: string) => {
-  const search = `t:filters={"platform":["${platformName}"]}`;
+  const filters = JSON.stringify({ platform: [platformName] });
+  const search = `t:filters=${encodeURIComponent(filters)}`;
   return `${formatPath(Paths.tasks, {})}?${search}`;
 };
 
@@ -136,9 +137,9 @@ export const ColumnPlatformName: React.FC<{
         <Table variant="compact" borders={false}>
           <Thead>
             <Tr>
-              <Td>Id</Td>
-              <Td>Kind</Td>
-              <Td>Started</Td>
+              <Th>Id</Th>
+              <Th>Kind</Th>
+              <Th>Started</Th>
             </Tr>
           </Thead>
           <Tbody>

--- a/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
@@ -1,0 +1,255 @@
+import * as React from "react";
+import {
+  Modal,
+  ModalVariant,
+  Wizard,
+  WizardStep,
+  WizardHeader,
+  Button,
+} from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+
+import { FormProvider, useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+
+import { New, PlatformTask } from "@app/api/models";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { useCreateTaskMutation } from "@app/queries/tasks";
+import { SourcePlatform } from "@app/api/models";
+import { Review } from "./review";
+import { Results, ResultsData } from "./results";
+
+// ImportFilter type for platform discovery tasks
+export interface ImportFilter {
+  // Filter criteria for discovering applications
+  includePatterns?: string[];
+  excludePatterns?: string[];
+  // Additional filter options as needed
+}
+
+export const DiscoverImportWizard: React.FC<IDiscoverImportWizard> = ({
+  isOpen,
+  ...props
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <DiscoverImportWizardInner
+      key={isOpen ? "open" : "closed"}
+      isOpen={isOpen}
+      {...props}
+    />
+  );
+};
+
+interface IDiscoverImportWizard {
+  platform?: SourcePlatform;
+  onClose: () => void;
+  isOpen: boolean;
+}
+
+enum StepId {
+  Review = 1,
+  Results = 2,
+}
+
+export interface FormValues {
+  platform: SourcePlatform;
+  filters: ImportFilter;
+}
+
+const DiscoverImportWizardInner: React.FC<IDiscoverImportWizard> = ({
+  platform,
+  onClose,
+  isOpen,
+}: IDiscoverImportWizard) => {
+  const { t } = useTranslation();
+  const { pushNotification } = React.useContext(NotificationsContext);
+  const { submitTask } = useStartPlatformApplicationDiscover();
+
+  // State to track submission results and current step
+  const [submissionResults, setSubmissionResults] =
+    React.useState<ResultsData | null>(null);
+
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      platform: platform!,
+      filters: {
+        includePatterns: [],
+        excludePatterns: [],
+      },
+    },
+    resolver: yupResolver(
+      yup.object({
+        platform: yup.object().required(),
+        filters: yup.object().shape({
+          includePatterns: yup.array().of(yup.string()),
+          excludePatterns: yup.array().of(yup.string()),
+        }),
+      })
+    ),
+    mode: "all",
+  });
+  const { handleSubmit } = methods;
+
+  const handleCancel = () => {
+    setSubmissionResults(null);
+    onClose();
+  };
+
+  const onSubmit = async ({ platform, filters }: FormValues) => {
+    const { success, failure } = await submitTask(platform, filters);
+
+    // Store results and move to Results step
+    setSubmissionResults({ success, failure });
+
+    if (success.length > 0) {
+      pushNotification({
+        title: t("platformDiscoverWizard.toast.submittedOk"),
+        message: `Task IDs: ${success
+          .map((result) => result.task.id)
+          .sort()
+          .join(", ")}`,
+        variant: "info",
+      });
+    }
+
+    if (failure.length > 0) {
+      pushNotification({
+        title: t("platformDiscoverWizard.toast.submittedFailed"),
+        message: `Platform: ${failure
+          .map((result) => result.platform.name)
+          .join(", ")}`,
+        variant: "danger",
+      });
+    }
+  };
+
+  if (!platform) {
+    return (
+      <Modal
+        variant={ModalVariant.medium}
+        title={t("dialog.title.discoverApplications")}
+        isOpen={isOpen}
+        onClose={handleCancel}
+        footer={
+          <Button variant="primary" onClick={handleCancel}>
+            {t("actions.close")}
+          </Button>
+        }
+      >
+        <div style={{ padding: "20px" }}>
+          <p>{t("platformDiscoverWizard.noPlatformSelected")}</p>
+        </div>
+      </Modal>
+    );
+  }
+
+  const showResults = submissionResults !== null;
+  return (
+    <FormProvider {...methods}>
+      <Modal
+        variant={ModalVariant.large}
+        aria-label={t("dialog.title.discoverApplications")}
+        isOpen={isOpen}
+        showClose={false}
+        hasNoBodyWrapper
+        onEscapePress={handleCancel}
+      >
+        <Wizard
+          onClose={handleCancel}
+          header={
+            <WizardHeader
+              onClose={handleCancel}
+              title={t("dialog.title.discoverApplications")}
+              description={t("dialog.message.discoverApplications")}
+            />
+          }
+        >
+          <WizardStep
+            id={StepId.Review}
+            name="Review"
+            footer={{
+              nextButtonText: showResults
+                ? t("actions.close")
+                : t("actions.discoverApplications"),
+              onNext: showResults ? handleCancel : handleSubmit(onSubmit),
+              isBackDisabled: showResults,
+              isCancelHidden: showResults,
+            }}
+          >
+            {!showResults ? (
+              <Review />
+            ) : (
+              <Results results={submissionResults} />
+            )}
+          </WizardStep>
+        </Wizard>
+      </Modal>
+    </FormProvider>
+  );
+};
+
+const useStartPlatformApplicationDiscover = () => {
+  const { mutateAsync: createTask } = useCreateTaskMutation<
+    ImportFilter,
+    PlatformTask<ImportFilter>
+  >();
+
+  const createAndSubmitTask = async (
+    platform: SourcePlatform,
+    filters: ImportFilter
+  ): Promise<{
+    success?: {
+      task: PlatformTask<ImportFilter>;
+      platform: SourcePlatform;
+    };
+    failure?: {
+      message: string;
+      cause: Error;
+      platform: SourcePlatform;
+      newTask: New<PlatformTask<ImportFilter>>;
+    };
+  }> => {
+    const newTask: New<PlatformTask<ImportFilter>> = {
+      name: `${platform.name}.${platform.id}.platform-discover-import`,
+      kind: "platform-discover-import",
+      platform: { id: platform.id, name: platform.name },
+      state: "Ready",
+      data: filters,
+    };
+
+    try {
+      const task = await createTask(newTask);
+      return { success: { task, platform } };
+    } catch (error) {
+      return {
+        failure: {
+          message: "Failed to submit the platform application discovery task",
+          cause: error as Error,
+          platform,
+          newTask,
+        },
+      };
+    }
+  };
+
+  const submitTask = async (
+    platform: SourcePlatform,
+    filters: ImportFilter
+  ) => {
+    const result = await createAndSubmitTask(platform, filters);
+
+    const success = result.success ? [result.success] : [];
+    const failure = result.failure ? [result.failure] : [];
+
+    return { success, failure };
+  };
+
+  return {
+    submitTask,
+  };
+};

--- a/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
@@ -14,9 +14,9 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
 import {
+  JsonDocument,
   New,
-  PlatformDiscoveryImportData,
-  PlatformTask,
+  PlatformApplicationImportTask,
   TargetedSchema,
 } from "@app/api/models";
 import { NotificationsContext } from "@app/components/NotificationsContext";
@@ -60,7 +60,7 @@ enum StepId {
 export interface FormValues {
   platform: SourcePlatform;
   filtersSchema?: TargetedSchema;
-  filtersDocument?: PlatformDiscoveryImportData;
+  filtersDocument?: JsonDocument;
 }
 
 const DiscoverImportWizardInner: React.FC<IDiscoverImportWizard> = ({
@@ -250,24 +250,27 @@ const DiscoverImportWizardInner: React.FC<IDiscoverImportWizard> = ({
 };
 
 const useStartPlatformApplicationDiscover = () => {
-  const { mutateAsync: createTask } = useCreateTaskMutation();
+  const { mutateAsync: createTask } = useCreateTaskMutation<
+    JsonDocument,
+    PlatformApplicationImportTask
+  >();
 
   const createAndSubmitTask = async (
     platform: SourcePlatform,
-    filters?: PlatformDiscoveryImportData
+    filters?: JsonDocument
   ): Promise<{
     success?: {
-      task: PlatformTask<PlatformDiscoveryImportData>;
+      task: PlatformApplicationImportTask;
       platform: SourcePlatform;
     };
     failure?: {
       message: string;
       cause: Error;
       platform: SourcePlatform;
-      newTask: New<PlatformTask<PlatformDiscoveryImportData>>;
+      newTask: New<PlatformApplicationImportTask>;
     };
   }> => {
-    const newTask: New<PlatformTask<PlatformDiscoveryImportData>> = {
+    const newTask: New<PlatformApplicationImportTask> = {
       name: `${platform.name}.${platform.id}.application-import`,
       kind: "application-import",
       platform: { id: platform.id, name: platform.name },
@@ -292,7 +295,7 @@ const useStartPlatformApplicationDiscover = () => {
 
   const submitTask = async (
     platform: SourcePlatform,
-    filters?: PlatformDiscoveryImportData
+    filters?: JsonDocument
   ) => {
     const result = await createAndSubmitTask(platform, filters);
 

--- a/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
@@ -125,6 +125,7 @@ const DiscoverImportWizardInner: React.FC<IDiscoverImportWizard> = ({
             description={t("platformDiscoverWizard.description")}
           />
         }
+        isVisitRequired
       >
         <WizardStep
           id="filter-input"
@@ -134,7 +135,11 @@ const DiscoverImportWizardInner: React.FC<IDiscoverImportWizard> = ({
             isNextDisabled: !filters.isValid,
           }}
         >
-          <FilterInput platform={platform} onFiltersChanged={setFilters} />
+          <FilterInput
+            platform={platform}
+            onFiltersChanged={setFilters}
+            initialFilters={filters}
+          />
         </WizardStep>
 
         <WizardStep

--- a/client/src/app/pages/source-platforms/discover-import-wizard/filter-input.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/filter-input.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { useFormContext } from "react-hook-form";
+import { TextContent, Text } from "@patternfly/react-core";
+
+import { SchemaDefinedField } from "@app/components/schema-defined-fields/SchemaDefinedFields";
+import { FormValues } from "./discover-import-wizard";
+
+export const FilterInput: React.FC = () => {
+  const { t } = useTranslation();
+  const { watch, setValue } = useFormContext<FormValues>();
+
+  const platform = watch("platform");
+  const filtersSchema = watch("filtersSchema");
+  const filtersDocument = watch("filtersDocument");
+
+  return (
+    <div>
+      <TextContent style={{ marginBottom: "var(--pf-v5-global--spacer--lg)" }}>
+        <Text component="h3">
+          {t("platformDiscoverWizard.filterInput.title")}
+        </Text>
+        <Text component="p">
+          {t("platformDiscoverWizard.filterInput.description", {
+            platformName: platform?.name,
+            platformKind: platform?.kind,
+          })}
+        </Text>
+      </TextContent>
+
+      {!platform ? (
+        <div style={{ padding: "20px" }}>
+          <Text>{t("platformDiscoverWizard.noPlatformSelected")}</Text>
+        </div>
+      ) : !filtersSchema ? (
+        <div style={{ padding: "20px" }}>
+          <Text>
+            {t("platformDiscoverWizard.filterInput.noFiltersAvailable", {
+              platformKind: platform.kind,
+            })}
+          </Text>
+        </div>
+      ) : (
+        <SchemaDefinedField
+          key={platform.kind}
+          id="platform-discovery-filters"
+          jsonDocument={filtersDocument ?? {}}
+          jsonSchema={filtersSchema.definition}
+          onDocumentChanged={(newFiltersDocument) => {
+            setValue("filtersDocument", newFiltersDocument, {
+              shouldValidate: true,
+              shouldDirty: true,
+            });
+          }}
+        />
+      )}
+    </div>
+  );
+};

--- a/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
@@ -48,6 +48,7 @@ export const Results: React.FC<IResultsProps> = ({ results }) => {
     }));
   };
 
+  // TODO: Review the results view.
   return (
     <div>
       <TextContent style={{ marginBottom: "var(--pf-v5-global--spacer--lg)" }}>

--- a/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
@@ -14,19 +14,21 @@ import {
   Text,
 } from "@patternfly/react-core";
 
-import { PlatformTask, SourcePlatform } from "@app/api/models";
-import { ImportFilter } from "./discover-import-wizard";
+import {
+  PlatformDiscoveryImportData,
+  PlatformTask,
+  SourcePlatform,
+} from "@app/api/models";
 
 export interface ResultsData {
   success: Array<{
-    task: PlatformTask<ImportFilter>;
+    task: PlatformTask<PlatformDiscoveryImportData>;
     platform: SourcePlatform;
   }>;
   failure: Array<{
     message: string;
     cause: Error;
     platform: SourcePlatform;
-    newTask: any;
   }>;
 }
 

--- a/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Alert,
+  Button,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  ExpandableSection,
+  List,
+  ListItem,
+  TextContent,
+  Text,
+} from "@patternfly/react-core";
+
+import { PlatformTask, SourcePlatform } from "@app/api/models";
+import { ImportFilter } from "./discover-import-wizard";
+
+export interface ResultsData {
+  success: Array<{
+    task: PlatformTask<ImportFilter>;
+    platform: SourcePlatform;
+  }>;
+  failure: Array<{
+    message: string;
+    cause: Error;
+    platform: SourcePlatform;
+    newTask: any;
+  }>;
+}
+
+interface IResultsProps {
+  results: ResultsData;
+}
+
+export const Results: React.FC<IResultsProps> = ({ results }) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [showErrorDetails, setShowErrorDetails] = React.useState<{
+    [key: number]: boolean;
+  }>({});
+
+  const { success, failure } = results;
+
+  const toggleErrorDetails = (index: number) => {
+    setShowErrorDetails((prev) => ({
+      ...prev,
+      [index]: !prev[index],
+    }));
+  };
+
+  return (
+    <div>
+      <TextContent style={{ marginBottom: "var(--pf-v5-global--spacer--lg)" }}>
+        <Text component="h3">{t("platformDiscoverWizard.results.title")}</Text>
+        <Text component="p">{t("platformDiscoverWizard.results.summary")}</Text>
+      </TextContent>
+
+      {success.length === 0 && failure.length === 0 && (
+        <Alert
+          variant="info"
+          title={t("platformDiscoverWizard.results.noResults")}
+        />
+      )}
+
+      {success.length > 0 && (
+        <Alert
+          variant="success"
+          title={t("platformDiscoverWizard.results.successSubmissions", {
+            count: success.length,
+          })}
+          style={{ marginBottom: "var(--pf-v5-global--spacer--md)" }}
+        >
+          <ExpandableSection
+            toggleText={
+              isExpanded ? t("actions.showLess") : t("actions.showMore")
+            }
+            onToggle={(_event, expanded) => setIsExpanded(expanded)}
+            isExpanded={isExpanded}
+          >
+            <List>
+              {success.map((result, index) => (
+                <ListItem key={index}>
+                  <DescriptionList isHorizontal>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>
+                        {t("terms.platform")}
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {result.platform.name}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>
+                        {t("terms.taskId")}
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {result.task.id}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </DescriptionList>
+                </ListItem>
+              ))}
+            </List>
+          </ExpandableSection>
+        </Alert>
+      )}
+
+      {failure.length > 0 && (
+        <Alert
+          variant="danger"
+          title={t("platformDiscoverWizard.results.failedSubmissions", {
+            count: failure.length,
+          })}
+        >
+          <List>
+            {failure.map((result, index) => (
+              <ListItem key={index}>
+                <div>
+                  <strong>{result.platform.name}:</strong> {result.message}
+                  <br />
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={() => toggleErrorDetails(index)}
+                  >
+                    {showErrorDetails[index]
+                      ? t("actions.hideDetails")
+                      : t("actions.showDetails")}
+                  </Button>
+                  {showErrorDetails[index] && (
+                    <div
+                      style={{ marginTop: "var(--pf-v5-global--spacer--sm)" }}
+                    >
+                      <pre
+                        style={{
+                          fontSize: "var(--pf-v5-global--FontSize--sm)",
+                        }}
+                      >
+                        {result.cause.message}
+                      </pre>
+                    </div>
+                  )}
+                </div>
+              </ListItem>
+            ))}
+          </List>
+        </Alert>
+      )}
+    </div>
+  );
+};

--- a/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
@@ -14,15 +14,11 @@ import {
   Text,
 } from "@patternfly/react-core";
 
-import {
-  PlatformDiscoveryImportData,
-  PlatformTask,
-  SourcePlatform,
-} from "@app/api/models";
+import { PlatformApplicationImportTask, SourcePlatform } from "@app/api/models";
 
 export interface ResultsData {
   success: Array<{
-    task: PlatformTask<PlatformDiscoveryImportData>;
+    task: PlatformApplicationImportTask;
     platform: SourcePlatform;
   }>;
   failure: Array<{

--- a/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
@@ -1,18 +1,24 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
 import {
-  Alert,
-  Button,
-  DescriptionList,
-  DescriptionListDescription,
-  DescriptionListGroup,
-  DescriptionListTerm,
-  ExpandableSection,
-  List,
-  ListItem,
   TextContent,
   Text,
+  TextVariants,
+  CardBody,
+  Card,
+  GridItem,
+  Grid,
+  CardTitle,
+  CardHeader,
+  Icon,
 } from "@patternfly/react-core";
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+} from "@patternfly/react-icons";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { PlatformApplicationImportTask, SourcePlatform } from "@app/api/models";
 
@@ -34,119 +40,153 @@ interface IResultsProps {
 
 export const Results: React.FC<IResultsProps> = ({ results }) => {
   const { t } = useTranslation();
-  const [isExpanded, setIsExpanded] = React.useState(false);
-  const [showErrorDetails, setShowErrorDetails] = React.useState<{
-    [key: number]: boolean;
-  }>({});
 
-  const { success, failure } = results;
+  if (!results) {
+    return (
+      <div>
+        <TextContent>
+          <Text component={TextVariants.h3}>
+            {t("platformDiscoverWizard.results.title")}
+          </Text>
+          <Text component={TextVariants.p}>
+            {t("platformDiscoverWizard.results.noResults")}
+          </Text>
+        </TextContent>
+      </div>
+    );
+  }
 
-  const toggleErrorDetails = (index: number) => {
-    setShowErrorDetails((prev) => ({
-      ...prev,
-      [index]: !prev[index],
-    }));
-  };
+  const { success = [], failure = [] } = results;
 
-  // TODO: Review the results view.
   return (
-    <div>
-      <TextContent style={{ marginBottom: "var(--pf-v5-global--spacer--lg)" }}>
-        <Text component="h3">{t("platformDiscoverWizard.results.title")}</Text>
-        <Text component="p">{t("platformDiscoverWizard.results.summary")}</Text>
+    <>
+      <TextContent>
+        <Text component={TextVariants.h3}>
+          {t("platformDiscoverWizard.results.title")}
+        </Text>
+        <Text component={TextVariants.p}>
+          {t("platformDiscoverWizard.results.summary")}
+        </Text>
       </TextContent>
 
-      {success.length === 0 && failure.length === 0 && (
-        <Alert
-          variant="info"
-          title={t("platformDiscoverWizard.results.noResults")}
-        />
-      )}
+      <Grid>
+        {success.length === 0 && failure.length === 0 && (
+          <GridItem span={12}>
+            <Card>
+              <CardBody>
+                <Text>
+                  {t("platformDiscoverWizard.results.noTasksSubmitted")}
+                </Text>
+              </CardBody>
+            </Card>
+          </GridItem>
+        )}
 
-      {success.length > 0 && (
-        <Alert
-          variant="success"
-          title={t("platformDiscoverWizard.results.successSubmissions", {
-            count: success.length,
-          })}
-          style={{ marginBottom: "var(--pf-v5-global--spacer--md)" }}
-        >
-          <ExpandableSection
-            toggleText={
-              isExpanded ? t("actions.showLess") : t("actions.showMore")
-            }
-            onToggle={(_event, expanded) => setIsExpanded(expanded)}
-            isExpanded={isExpanded}
-          >
-            <List>
-              {success.map((result, index) => (
-                <ListItem key={index}>
-                  <DescriptionList isHorizontal>
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>
-                        {t("terms.platform")}
-                      </DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {result.platform.name}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>
-                        {t("terms.taskId")}
-                      </DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {result.task.id}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                  </DescriptionList>
-                </ListItem>
-              ))}
-            </List>
-          </ExpandableSection>
-        </Alert>
-      )}
-
-      {failure.length > 0 && (
-        <Alert
-          variant="danger"
-          title={t("platformDiscoverWizard.results.failedSubmissions", {
-            count: failure.length,
-          })}
-        >
-          <List>
-            {failure.map((result, index) => (
-              <ListItem key={index}>
-                <div>
-                  <strong>{result.platform.name}:</strong> {result.message}
-                  <br />
-                  <Button
-                    variant="link"
+        {success.length > 0 && (
+          <GridItem span={12}>
+            <Card>
+              <CardHeader>
+                <CardTitle>
+                  <Icon
+                    status="success"
                     isInline
-                    onClick={() => toggleErrorDetails(index)}
+                    style={{ marginRight: "8px" }}
                   >
-                    {showErrorDetails[index]
-                      ? t("actions.hideDetails")
-                      : t("actions.showDetails")}
-                  </Button>
-                  {showErrorDetails[index] && (
-                    <div
-                      style={{ marginTop: "var(--pf-v5-global--spacer--sm)" }}
-                    >
-                      <pre
-                        style={{
-                          fontSize: "var(--pf-v5-global--FontSize--sm)",
-                        }}
-                      >
-                        {result.cause.message}
-                      </pre>
-                    </div>
-                  )}
-                </div>
-              </ListItem>
-            ))}
-          </List>
-        </Alert>
-      )}
-    </div>
+                    <CheckCircleIcon />
+                  </Icon>
+                  {t("platformDiscoverWizard.results.successSubmissions", {
+                    count: success.length,
+                  })}
+                </CardTitle>
+              </CardHeader>
+              <CardBody>
+                <Table aria-label="Successful task submissions">
+                  <Thead>
+                    <Tr>
+                      <Th>{t("terms.sourcePlatform")}</Th>
+                      <Th>{t("terms.task")}</Th>
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {success.map((result) => (
+                      <Tr key={result.platform.id}>
+                        <Td>
+                          <div>
+                            <strong>{result.platform.name}</strong>
+                          </div>
+                        </Td>
+                        <Td>
+                          <Link to={`/tasks/${result.task.id}`}>
+                            {result.task.id}
+                          </Link>
+                        </Td>
+                      </Tr>
+                    ))}
+                  </Tbody>
+                </Table>
+              </CardBody>
+            </Card>
+          </GridItem>
+        )}
+
+        {failure.length > 0 && (
+          <GridItem span={12}>
+            <Card>
+              <CardHeader>
+                <CardTitle>
+                  <Icon status="danger" isInline style={{ marginRight: "8px" }}>
+                    <ExclamationTriangleIcon />
+                  </Icon>
+                  {t("platformDiscoverWizard.results.failedSubmissions", {
+                    count: failure.length,
+                  })}
+                </CardTitle>
+              </CardHeader>
+              <CardBody>
+                <Table aria-label="Failed task submissions">
+                  <Thead>
+                    <Tr>
+                      <Th>{t("terms.sourcePlatform")}</Th>
+                      <Th>{t("terms.error")}</Th>
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {failure.map((result) => (
+                      <Tr key={result.platform.id}>
+                        <Td>
+                          <div>
+                            <strong>{result.platform.name}</strong>
+                          </div>
+                        </Td>
+                        <Td>
+                          <div
+                            style={{
+                              color: "var(--pf-global--danger-color--100)",
+                            }}
+                          >
+                            {result.message}
+                          </div>
+                          {result.cause?.message && (
+                            <div
+                              style={{
+                                fontSize: "0.8em",
+                                color: "#6a6e73",
+                                marginTop: "4px",
+                              }}
+                            >
+                              {result.cause.message}
+                            </div>
+                          )}
+                        </Td>
+                      </Tr>
+                    ))}
+                  </Tbody>
+                </Table>
+              </CardBody>
+            </Card>
+          </GridItem>
+        )}
+      </Grid>
+    </>
   );
 };

--- a/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
@@ -35,7 +35,7 @@ export interface ResultsData {
 }
 
 interface IResultsProps {
-  results: ResultsData;
+  results?: ResultsData;
 }
 
 export const Results: React.FC<IResultsProps> = ({ results }) => {

--- a/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useFormContext } from "react-hook-form";
 import {
   DescriptionList,
   DescriptionListDescription,
@@ -11,15 +10,17 @@ import {
 } from "@patternfly/react-core";
 
 import { SchemaDefinedField } from "@app/components/schema-defined-fields/SchemaDefinedFields";
-import { FormValues } from "./discover-import-wizard";
+import { SourcePlatform } from "@app/api/models";
+import { FilterState } from "./filter-input";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 
-export const Review: React.FC = () => {
+export const Review: React.FC<{
+  platform: SourcePlatform;
+  filters: FilterState;
+}> = ({ platform, filters }) => {
   const { t } = useTranslation();
-  const { watch } = useFormContext<FormValues>();
-
-  const platform = watch("platform");
-  const filtersSchema = watch("filtersSchema");
-  const filtersDocument = watch("filtersDocument");
+  const showFilters =
+    filters.filterRequired && filters.schema && filters.document;
 
   return (
     <div>
@@ -32,7 +33,7 @@ export const Review: React.FC = () => {
         </Text>
       </TextContent>
 
-      <DescriptionList>
+      <DescriptionList isHorizontal>
         <DescriptionListGroup>
           <DescriptionListTerm>{t("terms.platform")}</DescriptionListTerm>
           <DescriptionListDescription>
@@ -50,18 +51,20 @@ export const Review: React.FC = () => {
         <DescriptionListGroup>
           <DescriptionListTerm>{t("terms.url")}</DescriptionListTerm>
           <DescriptionListDescription>
-            {platform?.url || t("terms.notAvailable")}
+            {platform?.url || <EmptyTextMessage />}
           </DescriptionListDescription>
         </DescriptionListGroup>
 
         <DescriptionListGroup>
           <DescriptionListTerm>{t("terms.credentials")}</DescriptionListTerm>
           <DescriptionListDescription>
-            {platform?.identity?.name || t("terms.none")}
+            {platform?.identity?.name || (
+              <EmptyTextMessage message={t("terms.none")} />
+            )}
           </DescriptionListDescription>
         </DescriptionListGroup>
 
-        {filtersSchema && (
+        {showFilters && (
           <DescriptionListGroup>
             <DescriptionListTerm>
               {t("platformDiscoverWizard.review.discoveryFilters")}
@@ -76,8 +79,8 @@ export const Review: React.FC = () => {
               >
                 <SchemaDefinedField
                   id="platform-discovery-filters-review"
-                  jsonDocument={filtersDocument ?? {}}
-                  jsonSchema={filtersSchema.definition}
+                  jsonDocument={filters.document ?? {}}
+                  jsonSchema={filters.schema?.definition}
                   isReadOnly={true}
                 />
               </div>

--- a/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from "@patternfly/react-core";
 
+import { SchemaDefinedField } from "@app/components/schema-defined-fields/SchemaDefinedFields";
 import { FormValues } from "./discover-import-wizard";
 
 export const Review: React.FC = () => {
@@ -17,6 +18,8 @@ export const Review: React.FC = () => {
   const { watch } = useFormContext<FormValues>();
 
   const platform = watch("platform");
+  const filtersSchema = watch("filtersSchema");
+  const filtersDocument = watch("filtersDocument");
 
   return (
     <div>
@@ -57,6 +60,30 @@ export const Review: React.FC = () => {
             {platform?.identity?.name || t("terms.none")}
           </DescriptionListDescription>
         </DescriptionListGroup>
+
+        {filtersSchema && (
+          <DescriptionListGroup>
+            <DescriptionListTerm>
+              {t("platformDiscoverWizard.review.discoveryFilters")}
+            </DescriptionListTerm>
+            <DescriptionListDescription>
+              <div
+                style={{
+                  border: "1px solid var(--pf-v5-global--BorderColor--100)",
+                  borderRadius: "3px",
+                  padding: "16px",
+                }}
+              >
+                <SchemaDefinedField
+                  id="platform-discovery-filters-review"
+                  jsonDocument={filtersDocument ?? {}}
+                  jsonSchema={filtersSchema.definition}
+                  isReadOnly={true}
+                />
+              </div>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        )}
       </DescriptionList>
     </div>
   );

--- a/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { useFormContext } from "react-hook-form";
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  TextContent,
+  Text,
+} from "@patternfly/react-core";
+
+import { FormValues } from "./discover-import-wizard";
+
+export const Review: React.FC = () => {
+  const { t } = useTranslation();
+  const { watch } = useFormContext<FormValues>();
+
+  const platform = watch("platform");
+
+  return (
+    <div>
+      <TextContent style={{ marginBottom: "var(--pf-v5-global--spacer--lg)" }}>
+        <Text component="h3">{t("platformDiscoverWizard.review.title")}</Text>
+        <Text component="p">
+          {t("platformDiscoverWizard.review.description", {
+            platformName: platform?.name,
+          })}
+        </Text>
+      </TextContent>
+
+      <DescriptionList>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{t("terms.platform")}</DescriptionListTerm>
+          <DescriptionListDescription>
+            {platform?.name}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+
+        <DescriptionListGroup>
+          <DescriptionListTerm>{t("terms.platformKind")}</DescriptionListTerm>
+          <DescriptionListDescription>
+            {platform?.kind}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+
+        <DescriptionListGroup>
+          <DescriptionListTerm>{t("terms.url")}</DescriptionListTerm>
+          <DescriptionListDescription>
+            {platform?.url || t("terms.notAvailable")}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+
+        <DescriptionListGroup>
+          <DescriptionListTerm>{t("terms.credentials")}</DescriptionListTerm>
+          <DescriptionListDescription>
+            {platform?.identity?.name || t("terms.none")}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    </div>
+  );
+};

--- a/client/src/app/pages/source-platforms/discover-import-wizard/useStartPlatformApplicationImport.ts
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/useStartPlatformApplicationImport.ts
@@ -54,11 +54,23 @@ export const useStartPlatformApplicationImport = () => {
     platform: SourcePlatform,
     filters?: JsonDocument
   ) => {
-    const result = await createAndSubmitTask(platform, filters);
+    const results = await Promise.allSettled(
+      [platform].map(async (p) => createAndSubmitTask(p, filters))
+    );
 
-    const success = result.success ? [result.success] : [];
-    const failure = result.failure ? [result.failure] : [];
+    const success = [];
+    const failure = [];
 
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        if (result.value.success) {
+          success.push(result.value.success);
+        }
+        if (result.value.failure) {
+          failure.push(result.value.failure);
+        }
+      }
+    }
     return { success, failure };
   };
 

--- a/client/src/app/pages/source-platforms/discover-import-wizard/useStartPlatformApplicationImport.ts
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/useStartPlatformApplicationImport.ts
@@ -1,0 +1,68 @@
+import {
+  JsonDocument,
+  New,
+  PlatformApplicationImportTask,
+  SourcePlatform,
+} from "@app/api/models";
+import { useCreateTaskMutation } from "@app/queries/tasks";
+
+export const useStartPlatformApplicationImport = () => {
+  const { mutateAsync: createTask } = useCreateTaskMutation<
+    JsonDocument,
+    PlatformApplicationImportTask
+  >();
+
+  const createAndSubmitTask = async (
+    platform: SourcePlatform,
+    filters?: JsonDocument
+  ): Promise<{
+    success?: {
+      task: PlatformApplicationImportTask;
+      platform: SourcePlatform;
+    };
+    failure?: {
+      message: string;
+      cause: Error;
+      platform: SourcePlatform;
+      newTask: New<PlatformApplicationImportTask>;
+    };
+  }> => {
+    const newTask: New<PlatformApplicationImportTask> = {
+      name: `${platform.name}.${platform.id}.application-import`,
+      kind: "application-import",
+      platform: { id: platform.id, name: platform.name },
+      state: "Ready",
+      data: filters || {},
+    };
+
+    try {
+      const task = await createTask(newTask);
+      return { success: { task, platform } };
+    } catch (error) {
+      return {
+        failure: {
+          message: "Failed to submit the platform application import task",
+          cause: error as Error,
+          platform,
+          newTask,
+        },
+      };
+    }
+  };
+
+  const submitTask = async (
+    platform: SourcePlatform,
+    filters?: JsonDocument
+  ) => {
+    const result = await createAndSubmitTask(platform, filters);
+
+    const success = result.success ? [result.success] : [];
+    const failure = result.failure ? [result.failure] : [];
+
+    return { success, failure };
+  };
+
+  return {
+    submitTask,
+  };
+};

--- a/client/src/app/pages/source-platforms/discover-import-wizard/useWizardReducer.ts
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/useWizardReducer.ts
@@ -51,16 +51,23 @@ export const useWizardReducer = () => {
     validateWizardState
   );
 
+  // Create stable callbacks using useCallback
+  const setFilters = React.useCallback((filters: FilterState) => {
+    dispatch({ type: "SET_FILTERS", payload: filters });
+  }, []);
+
+  const setResults = React.useCallback((results: ResultsData | null) => {
+    dispatch({ type: "SET_RESULTS", payload: results });
+  }, []);
+
+  const reset = React.useCallback(() => {
+    dispatch({ type: "RESET" });
+  }, []);
+
   return {
     state,
-    setFilters(filters: FilterState) {
-      dispatch({ type: "SET_FILTERS", payload: filters });
-    },
-    setResults(results: ResultsData | null) {
-      dispatch({ type: "SET_RESULTS", payload: results });
-    },
-    reset() {
-      dispatch({ type: "RESET" });
-    },
+    setFilters,
+    setResults,
+    reset,
   };
 };

--- a/client/src/app/pages/source-platforms/discover-import-wizard/useWizardReducer.ts
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/useWizardReducer.ts
@@ -1,0 +1,66 @@
+import * as React from "react";
+import { FilterState } from "./filter-input";
+import { ResultsData } from "./results";
+
+export interface WizardState {
+  filters: FilterState;
+  isReady: boolean;
+  results: ResultsData | null;
+}
+
+const INITIAL_WIZARD_STATE: WizardState = {
+  filters: {
+    filterRequired: true,
+    isValid: false,
+  },
+  isReady: false,
+  results: null,
+};
+
+type WizardReducer = (state: WizardState, action: WizardAction) => WizardState;
+type WizardAction =
+  | { type: "SET_FILTERS"; payload: FilterState }
+  | { type: "SET_RESULTS"; payload: ResultsData | null }
+  | { type: "RESET" };
+
+const validateWizardState = (state: WizardState): WizardState => {
+  const isReady = state.filters.isValid;
+  return { ...state, isReady };
+};
+
+const wizardReducer: WizardReducer = (state, action) => {
+  switch (action.type) {
+    case "SET_FILTERS":
+      return { ...state, filters: action.payload };
+    case "SET_RESULTS":
+      return { ...state, results: action.payload };
+    case "RESET":
+      return INITIAL_WIZARD_STATE;
+    default:
+      return state;
+  }
+};
+
+const validatedReducer: WizardReducer = (state, action) =>
+  validateWizardState(wizardReducer(state, action));
+
+export const useWizardReducer = () => {
+  const [state, dispatch] = React.useReducer(
+    validatedReducer,
+    INITIAL_WIZARD_STATE,
+    validateWizardState
+  );
+
+  return {
+    state,
+    setFilters(filters: FilterState) {
+      dispatch({ type: "SET_FILTERS", payload: filters });
+    },
+    setResults(results: ResultsData | null) {
+      dispatch({ type: "SET_RESULTS", payload: results });
+    },
+    reset() {
+      dispatch({ type: "RESET" });
+    },
+  };
+};

--- a/client/src/app/pages/source-platforms/useFetchPlatformsWithTasks.ts
+++ b/client/src/app/pages/source-platforms/useFetchPlatformsWithTasks.ts
@@ -1,0 +1,153 @@
+import { useMemo } from "react";
+import { group, listify, mapEntries } from "radash";
+import { SourcePlatform, TaskDashboard } from "@app/api/models";
+import { TaskStates, useFetchTaskDashboard } from "@app/queries/tasks";
+import { useFetchPlatforms } from "@app/queries/platforms";
+
+export interface TasksGroupedByKind {
+  [key: string]: TaskDashboard[];
+}
+
+/**
+ * Characterize the status of set of the most current task for each kinds of task
+ * associated with a platform.
+ */
+export type SourcePlatformTasksStatus =
+  | "None"
+  | "Running"
+  | "Queued"
+  | "Failed"
+  | "Canceled"
+  | "Success"
+  | "SuccessWithErrors";
+
+export interface SourcePlatformWithTasks extends SourcePlatform {
+  tasks: {
+    tasksByKind: TasksGroupedByKind;
+    tasksStatus: SourcePlatformTasksStatus;
+    exist: boolean;
+
+    latestHasCanceled: boolean;
+    latestHasFailed: boolean;
+    latestHasQueued: boolean;
+    latestHasRunning: boolean;
+    latestHasSuccess: boolean;
+    latestHasSuccessWithErrors: boolean;
+  };
+}
+
+/**
+ * Take an array of `Tasks`, group by platform id and then by task kind.
+ */
+const groupPlatformTasks = (tasks: TaskDashboard[]) => {
+  const byPlatformId = group(
+    tasks.filter((task) => task.platform),
+    (task) => task.platform!.id
+  ) as Record<number, TaskDashboard[]>;
+
+  const groupedByIdByKind = mapEntries(byPlatformId, (id, tasks) => [
+    id,
+    {
+      ...group(tasks, (task) => task.kind ?? task.addon ?? ""),
+    } as TasksGroupedByKind,
+  ]);
+
+  return {
+    tasksById: byPlatformId,
+    tasksByIdByKind: groupedByIdByKind,
+  };
+};
+
+/**
+ * Step through the task data of a platform and return its summarized task status.
+ */
+const choosePlatformTaskStatus = ({
+  tasks,
+}: SourcePlatformWithTasks): SourcePlatformTasksStatus => {
+  return !tasks.exist
+    ? "None"
+    : tasks.latestHasRunning
+      ? "Running"
+      : tasks.latestHasQueued
+        ? "Queued"
+        : tasks.latestHasFailed
+          ? "Failed"
+          : tasks.latestHasCanceled
+            ? "Canceled"
+            : tasks.latestHasSuccessWithErrors
+              ? "SuccessWithErrors"
+              : "Success";
+};
+
+/**
+ * Decorate a set of REST Platforms with information useful to the components on the
+ * platform table.
+ */
+const decoratePlatforms = (
+  platforms: SourcePlatform[],
+  tasks: TaskDashboard[]
+) => {
+  const { tasksById, tasksByIdByKind } = groupPlatformTasks(tasks);
+
+  const decorated = platforms.map((platform: SourcePlatform) => {
+    const tasksByKind = tasksByIdByKind[platform.id] ?? [];
+    const latest = listify(tasksByKind, (_kind, tasks) => tasks[0]);
+
+    const da: SourcePlatformWithTasks = {
+      ...platform,
+
+      tasks: {
+        tasksByKind,
+        tasksStatus: "None",
+        exist: (tasksById[platform.id]?.length ?? 0) > 0,
+
+        latestHasCanceled: latest.some((task) =>
+          TaskStates.Canceled.includes(task.state ?? "")
+        ),
+        latestHasFailed: latest.some((task) =>
+          TaskStates.Failed.includes(task.state ?? "")
+        ),
+        latestHasQueued: latest.some((task) =>
+          TaskStates.Queued.includes(task.state ?? "")
+        ),
+        latestHasRunning: latest.some((task) =>
+          TaskStates.Running.includes(task.state ?? "")
+        ),
+        latestHasSuccess: latest.some((task) =>
+          TaskStates.Success.includes(task.state ?? "")
+        ),
+        latestHasSuccessWithErrors: latest.some((task) =>
+          TaskStates.SuccessWithErrors.includes(task.state ?? "")
+        ),
+      },
+    };
+
+    da.tasks.tasksStatus = choosePlatformTaskStatus(da);
+    return da;
+  });
+
+  return decorated;
+};
+
+export const useFetchPlatformsWithTasks = (refetchDisabled: boolean) => {
+  const { platforms, isFetching, isSuccess, error } = useFetchPlatforms();
+  const { tasks } = useFetchTaskDashboard(refetchDisabled);
+
+  const decoratedPlatforms = useMemo(
+    () => decoratePlatforms(platforms, tasks),
+    [platforms, tasks]
+  );
+
+  // const platformNames = useMemo(
+  //   () => platforms.map((platform) => platform.name).sort(universalComparator),
+  //   [platforms]
+  // );
+
+  return {
+    platforms: decoratedPlatforms,
+    // platformNames,
+    isFetching,
+    isSuccess,
+    error,
+  };
+};

--- a/client/src/app/pages/source-platforms/useFetchPlatformsWithTasks.ts
+++ b/client/src/app/pages/source-platforms/useFetchPlatformsWithTasks.ts
@@ -41,7 +41,7 @@ export interface SourcePlatformWithTasks extends SourcePlatform {
  */
 const groupPlatformTasks = (tasks: TaskDashboard[]) => {
   const byPlatformId = group(
-    tasks.filter((task) => task.platform),
+    tasks.filter((task) => !!task.platform),
     (task) => task.platform!.id
   ) as Record<number, TaskDashboard[]>;
 

--- a/client/src/app/pages/tasks/TaskActionColumn.tsx
+++ b/client/src/app/pages/tasks/TaskActionColumn.tsx
@@ -4,7 +4,7 @@ import { Task } from "@app/api/models";
 import { ActionsColumn } from "@patternfly/react-table";
 import { useTaskActions } from "./useTaskActions";
 
-export const TaskActionColumn: FC<{ task: Task }> = ({ task }) => {
+export const TaskActionColumn: FC<{ task: Task<unknown> }> = ({ task }) => {
   const actions = useTaskActions(task);
   return <ActionsColumn items={actions} />;
 };

--- a/client/src/app/pages/tasks/TaskDetails.tsx
+++ b/client/src/app/pages/tasks/TaskDetails.tsx
@@ -17,7 +17,6 @@ export const TaskDetails = () => {
   const { application } = useFetchApplicationById(applicationId);
 
   const appName: string = application?.name ?? t("terms.unknown");
-  console.log(appName);
   const detailsPath = isFromApplication
     ? formatPath(Paths.applicationsTaskDetails, {
         applicationId: applicationId,

--- a/client/src/app/pages/tasks/tasks-page.tsx
+++ b/client/src/app/pages/tasks/tasks-page.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 import { Link, useHistory } from "react-router-dom";
 import {
@@ -34,17 +35,17 @@ import {
 } from "@app/hooks/table-controls";
 
 import { SimplePagination } from "@app/components/SimplePagination";
+import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { TablePersistenceKeyPrefix } from "@app/Constants";
 
 import { useServerTasks } from "@app/queries/tasks";
 import { Task, TaskState } from "@app/api/models";
-import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
-import { ManageColumnsToolbar } from "../applications/applications-table/components/manage-columns-toolbar";
-import dayjs from "dayjs";
 import { formatPath } from "@app/utils/utils";
 import { Paths } from "@app/Paths";
+import { ManageColumnsToolbar } from "../applications/applications-table/components/manage-columns-toolbar";
 import { TaskActionColumn } from "./TaskActionColumn";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 
 export const taskStateToLabel: Record<TaskState, string> = {
   "No task": "taskState.NoTask",
@@ -228,9 +229,9 @@ export const TasksPage: React.FC = () => {
     pod,
     started,
     terminated,
-  }: Task) => ({
+  }: Task<unknown>) => ({
     id,
-    application: application.name,
+    application: application?.name ?? <EmptyTextMessage />,
     kind: kind ?? addon,
     state: (
       <IconWithLabel
@@ -315,7 +316,7 @@ export const TasksPage: React.FC = () => {
             >
               <Tbody>
                 {currentPageItems
-                  ?.map((task): [Task, { [p: string]: ReactNode }] => [
+                  ?.map((task): [Task<unknown>, { [p: string]: ReactNode }] => [
                     task,
                     toCells(task),
                   ])

--- a/client/src/app/pages/tasks/useTaskActions.tsx
+++ b/client/src/app/pages/tasks/useTaskActions.tsx
@@ -20,6 +20,7 @@ const canTogglePreemption = (state: TaskState = "No task") =>
 const useAsyncTaskActions = () => {
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
+
   const { mutate: cancelTask } = useCancelTaskMutation(
     () =>
       pushNotification({
@@ -50,7 +51,7 @@ const useAsyncTaskActions = () => {
       })
   );
 
-  const togglePreemption = (task: Task) =>
+  const togglePreemption = (task: Task<unknown>) =>
     updateTask({
       id: task.id,
       policy: {
@@ -61,7 +62,7 @@ const useAsyncTaskActions = () => {
   return { cancelTask, togglePreemption };
 };
 
-export const useTaskActions = (task: Task) => {
+export const useTaskActions = (task: Task<unknown>) => {
   const { cancelTask, togglePreemption } = useAsyncTaskActions();
   const { t } = useTranslation();
   const history = useHistory();

--- a/client/src/app/queries/schemas.ts
+++ b/client/src/app/queries/schemas.ts
@@ -5,15 +5,15 @@ import {
   getSchemas,
   getSchemaByName,
   getPlatformCoordinatesSchema,
-  getPlatformDiscoveryFiltersSchema,
+  getPlatformDiscoveryImportSchema,
 } from "@app/api/rest";
 
 export const SCHEMAS_QUERY_KEY = "schemas";
 export const SCHEMA_QUERY_KEY = "schema";
 export const PLATFORM_COORDINATES_SCHEMA_QUERY_KEY =
   "platformCoordinatesSchema";
-export const PLATFORM_DISCOVERY_FILTERS_SCHEMA_QUERY_KEY =
-  "platformDiscoveryFiltersSchema";
+export const PLATFORM_DISCOVERY_IMPORT_SCHEMA_QUERY_KEY =
+  "platformDiscoveryImportSchema";
 
 export const useFetchSchemas = (refetchInterval: number | false = false) => {
   const { isLoading, isSuccess, error, refetch, data } = useQuery({
@@ -66,15 +66,15 @@ export const useFetchPlatformCoordinatesSchema = (platformKind?: string) => {
   };
 };
 
-export const useFetchPlatformDiscoveryFiltersSchema = (
+export const useFetchPlatformDiscoveryImportSchema = (
   platformKind?: string
 ) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: [PLATFORM_DISCOVERY_FILTERS_SCHEMA_QUERY_KEY, platformKind],
+    queryKey: [PLATFORM_DISCOVERY_IMPORT_SCHEMA_QUERY_KEY, platformKind],
     queryFn: () =>
       platformKind === undefined
         ? Promise.resolve(undefined)
-        : getPlatformDiscoveryFiltersSchema(platformKind),
+        : getPlatformDiscoveryImportSchema(platformKind),
     onError: (error: AxiosError) => console.log("error, ", error),
     enabled: platformKind !== undefined,
   });

--- a/client/src/app/queries/schemas.ts
+++ b/client/src/app/queries/schemas.ts
@@ -5,15 +5,15 @@ import {
   getSchemas,
   getSchemaByName,
   getPlatformCoordinatesSchema,
-  getPlatformDiscoveryImportSchema,
+  getPlatformDiscoveryFilterSchema,
 } from "@app/api/rest";
 
 export const SCHEMAS_QUERY_KEY = "schemas";
 export const SCHEMA_QUERY_KEY = "schema";
 export const PLATFORM_COORDINATES_SCHEMA_QUERY_KEY =
   "platformCoordinatesSchema";
-export const PLATFORM_DISCOVERY_IMPORT_SCHEMA_QUERY_KEY =
-  "platformDiscoveryImportSchema";
+export const PLATFORM_DISCOVERY_FILTER_SCHEMA_QUERY_KEY =
+  "platformDiscoveryFilterSchema";
 
 export const useFetchSchemas = (refetchInterval: number | false = false) => {
   const { isLoading, isSuccess, error, refetch, data } = useQuery({
@@ -66,15 +66,15 @@ export const useFetchPlatformCoordinatesSchema = (platformKind?: string) => {
   };
 };
 
-export const useFetchPlatformDiscoveryImportSchema = (
+export const useFetchPlatformDiscoveryFilterSchema = (
   platformKind?: string
 ) => {
-  const { data, isLoading, error } = useQuery({
-    queryKey: [PLATFORM_DISCOVERY_IMPORT_SCHEMA_QUERY_KEY, platformKind],
+  const { data, isLoading, isSuccess, error } = useQuery({
+    queryKey: [PLATFORM_DISCOVERY_FILTER_SCHEMA_QUERY_KEY, platformKind],
     queryFn: () =>
       platformKind === undefined
         ? Promise.resolve(undefined)
-        : getPlatformDiscoveryImportSchema(platformKind),
+        : getPlatformDiscoveryFilterSchema(platformKind),
     onError: (error: AxiosError) => console.log("error, ", error),
     enabled: platformKind !== undefined,
   });
@@ -82,6 +82,7 @@ export const useFetchPlatformDiscoveryImportSchema = (
   return {
     filtersSchema: data,
     isLoading,
+    isSuccess,
     fetchError: error,
   };
 };


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-5249
Resolves: https://github.com/konveyor/tackle2-ui/issues/2289

Adds a wizard to discover and import applications from a source platform:
- The wizard captures discover and import filter data from the user
- The filters are added to the import task
- The set of filters are defined by a schema
- The schema is pulled from domain, variant, subject "platform", "cloudfoundry", "filter"
- `SchemaDefinedFields` to be used to input the schema data
- Task summary data for platforms are displayed in a popover on the source platform table's name column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Discover & Import wizard for source platforms (filters, review, results and submit flow) and a hook to start platform imports.
  - Platform name popover showing status and recent tasks with quick links.

- **Enhancements**
  - Platform-aware import flow on Source Platforms page and a new Platforms filter in Applications table.
  - Schema editor accepts configurable height; complex schemas default to JSON view.
  - Tasks table shows fallback when application is missing and improved deletion error notifications.

- **Localization**
  - Added "Discover & Import" and full platform discovery wizard translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->