### PR TITLE
:sparkles: Refactor RetrieveConfigWizard to be inline with DiscoverImportWizard

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -53,7 +53,6 @@
     "reset": "Reset",
     "review": "Review",
     "retrieve": "Retrieve",
-    "retrieveConfigurations": "Retrieve configurations",
     "save": "Save",
     "saveAndReview": "Save and review",
     "selectAll": "Select all",
@@ -167,7 +166,6 @@
       "newStakeholderGroup": "New stakeholder group",
       "newTag": "New Tag",
       "newTagCategory": "New tag category",
-      "retrieveConfigurations": "Retrieve configurations",
       "update": "Update {{what}}",
       "updateArchetype": "Update archetype",
       "updateApplication": "Update application",
@@ -669,9 +667,10 @@
     }
   },
   "retrieveConfigWizard": {
+    "title": "Retrieve Configurations",
+    "description": "Retrieve configurations from the selected applications.",
     "selectedCount": "{{count}} of {{total}} applications selected",
     "noApplicationsWithSourcePlatforms": "No applications with source platforms selected.",
-    "noTasksSubmitted": "No tasks were submitted.",
     "toast": {
       "submittedOk": "Application manifest fetches submitted",
       "submittedFailed": "Application manifest fetches failed"
@@ -680,10 +679,11 @@
       "title": "Configuration Retrieval Results",
       "summary": "Summary of configuration retrieval task submissions.",
       "noResults": "No results available.",
+      "noTasksSubmitted": "No tasks were submitted.",
       "failedSubmissions_one": "Failed Submission",
       "failedSubmissions_other": "Failed Submissions ({{count}})",
-      "successSubmissions_one": "Success Submission",
-      "successSubmissions_other": "Success Submissions ({{count}})"
+      "successSubmissions_one": "Successful Submission",
+      "successSubmissions_other": "Successful Submissions ({{count}})"
     },
     "review": {
       "description_one": "This application is ready to retrieve configurations from its source platform. The application's platform coordinates will be used to connect to the platform and build the application's discovery manifest.",

--- a/client/src/app/pages/applications/retrieve-config-wizard/results.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/results.tsx
@@ -9,7 +9,7 @@ import {
   TextVariants,
   Grid,
   GridItem,
-  Button,
+  Icon,
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import { useTranslation } from "react-i18next";
@@ -70,15 +70,30 @@ export const Results: React.FC<ResultsProps> = ({ results }) => {
       </TextContent>
 
       <Grid hasGutter>
+        {success.length === 0 && failure.length === 0 && (
+          <GridItem span={12}>
+            <Card>
+              <CardBody>
+                <Text>
+                  {t("retrieveConfigWizard.results.noTasksSubmitted")}
+                </Text>
+              </CardBody>
+            </Card>
+          </GridItem>
+        )}
+
         {success.length > 0 && (
           <GridItem span={12}>
             <Card>
               <CardHeader>
                 <CardTitle>
-                  <CheckCircleIcon
-                    color="var(--pf-global--success-color--100)"
+                  <Icon
+                    status="success"
+                    isInline
                     style={{ marginRight: "8px" }}
-                  />
+                  >
+                    <CheckCircleIcon />
+                  </Icon>
                   {t("retrieveConfigWizard.results.successSubmissions", {
                     count: success.length,
                   })}
@@ -90,7 +105,6 @@ export const Results: React.FC<ResultsProps> = ({ results }) => {
                     <Tr>
                       <Th>{t("terms.application")}</Th>
                       <Th>{t("terms.task")}</Th>
-                      <Th>{t("actions.actions")}</Th>
                     </Tr>
                   </Thead>
                   <Tbody>
@@ -108,19 +122,10 @@ export const Results: React.FC<ResultsProps> = ({ results }) => {
                             )}
                           </div>
                         </Td>
-                        <Td>{result.task.id}</Td>
                         <Td>
-                          <Button
-                            variant="link"
-                            component={(props) => (
-                              <Link
-                                {...props}
-                                to={`/tasks/${result.task.id}`}
-                              />
-                            )}
-                          >
-                            View Task
-                          </Button>
+                          <Link to={`/tasks/${result.task.id}`}>
+                            {result.task.id}
+                          </Link>
                         </Td>
                       </Tr>
                     ))}
@@ -136,10 +141,9 @@ export const Results: React.FC<ResultsProps> = ({ results }) => {
             <Card>
               <CardHeader>
                 <CardTitle>
-                  <ExclamationTriangleIcon
-                    color="var(--pf-global--danger-color--100)"
-                    style={{ marginRight: "8px" }}
-                  />
+                  <Icon status="danger" isInline style={{ marginRight: "8px" }}>
+                    <ExclamationTriangleIcon />
+                  </Icon>
                   {t("retrieveConfigWizard.results.failedSubmissions", {
                     count: failure.length,
                   })}
@@ -192,16 +196,6 @@ export const Results: React.FC<ResultsProps> = ({ results }) => {
                     ))}
                   </Tbody>
                 </Table>
-              </CardBody>
-            </Card>
-          </GridItem>
-        )}
-
-        {success.length === 0 && failure.length === 0 && (
-          <GridItem span={12}>
-            <Card>
-              <CardBody>
-                <Text>{t("retrieveConfigWizard.noTasksSubmitted")}</Text>
               </CardBody>
             </Card>
           </GridItem>

--- a/client/src/app/pages/applications/retrieve-config-wizard/useStartFetchApplicationManifest.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/useStartFetchApplicationManifest.tsx
@@ -1,0 +1,73 @@
+import { EmptyObject, ApplicationManifestTask, New } from "@app/api/models";
+import { useCreateTaskMutation } from "@app/queries/tasks";
+import { DecoratedApplication } from "../useDecoratedApplications";
+
+export const useStartFetchApplicationManifest = () => {
+  const { mutateAsync: createTask } = useCreateTaskMutation<
+    EmptyObject,
+    ApplicationManifestTask
+  >();
+
+  const createAndSubmitTask = async (
+    application: DecoratedApplication
+  ): Promise<{
+    success?: {
+      task: ApplicationManifestTask;
+      application: DecoratedApplication;
+    };
+    failure?: {
+      message: string;
+      cause: Error;
+      application: DecoratedApplication;
+      newTask: New<ApplicationManifestTask>;
+    };
+  }> => {
+    const newTask: New<ApplicationManifestTask> = {
+      name: `${application.name}.${application.id}.application-manifest`,
+      kind: "application-manifest",
+      application: { id: application.id, name: application.name },
+      state: "Ready",
+      data: {},
+    };
+
+    try {
+      const task = await createTask(newTask);
+      return { success: { task, application } };
+    } catch (error) {
+      return {
+        failure: {
+          message: "Failed to submit the application manifest fetch task",
+          cause: error as Error,
+          application,
+          newTask,
+        },
+      };
+    }
+  };
+
+  const submitTasks = async (applications: DecoratedApplication[]) => {
+    const results = await Promise.allSettled(
+      applications.map(createAndSubmitTask)
+    );
+
+    const success = [];
+    const failure = [];
+
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        if (result.value.success) {
+          success.push(result.value.success);
+        }
+        if (result.value.failure) {
+          failure.push(result.value.failure);
+        }
+      }
+    }
+
+    return { success, failure };
+  };
+
+  return {
+    submitTasks,
+  };
+};


### PR DESCRIPTION
Apply the same kind of changes made to hooks and views with the `DiscoverImportWizard` to the older `RetrieveConfigWizard`.  This will help keep the structure and layout the same.

Needs #2545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve Configurations wizard updated with a clearer title, description and improved flow.
  * Results view refined: status icons, task IDs link directly to task details, and a single “No tasks were submitted” message appears at the top when applicable.

* **Style**
  * Wording revised to “Successful Submission(s)” and translations reorganized for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->