### PR TITLE
:bug: Controls Tag table reflects changes when they happen

### DIFF
--- a/client/src/app/pages/controls/ControlTableActionsColumn.tsx
+++ b/client/src/app/pages/controls/ControlTableActionsColumn.tsx
@@ -5,15 +5,15 @@ import { ActionsColumn, Td } from "@patternfly/react-table";
 import { Button, OverflowMenu, Tooltip } from "@patternfly/react-core";
 import { PencilAltIcon } from "@patternfly/react-icons";
 
-export interface ControlTableActionButtonsProps {
+export interface ControlTableActionsColumnProps {
   isDeleteEnabled?: boolean;
   deleteTooltipMessage?: string;
   onEdit: () => void;
   onDelete: () => void;
 }
 
-export const ControlTableActionButtons: React.FC<
-  ControlTableActionButtonsProps
+export const ControlTableActionsColumn: React.FC<
+  ControlTableActionsColumnProps
 > = ({
   isDeleteEnabled = false,
   deleteTooltipMessage = "",

--- a/client/src/app/pages/controls/business-services/business-services.tsx
+++ b/client/src/app/pages/controls/business-services/business-services.tsx
@@ -38,7 +38,7 @@ import {
 } from "@app/components/TableControls";
 import { CubesIcon } from "@patternfly/react-icons";
 import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
-import { ControlTableActionButtons } from "../ControlTableActionButtons";
+import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
 
 export const BusinessServices: React.FC = () => {
   const { t } = useTranslation();
@@ -271,7 +271,7 @@ export const BusinessServices: React.FC = () => {
                         <Td width={10} {...getTdProps({ columnKey: "owner" })}>
                           {businessService.owner?.name}
                         </Td>
-                        <ControlTableActionButtons
+                        <ControlTableActionsColumn
                           isDeleteEnabled={isAssignedToApplication}
                           deleteTooltipMessage={t(
                             "message.cannotRemoveBusinessServiceAssociatedWithApplication"

--- a/client/src/app/pages/controls/job-functions/job-functions.tsx
+++ b/client/src/app/pages/controls/job-functions/job-functions.tsx
@@ -36,7 +36,7 @@ import {
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { CubesIcon } from "@patternfly/react-icons";
 import { RBAC, RBAC_TYPE, controlsWriteScopes } from "@app/rbac";
-import { ControlTableActionButtons } from "../ControlTableActionButtons";
+import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const JobFunctions: React.FC = () => {
@@ -217,7 +217,7 @@ export const JobFunctions: React.FC = () => {
                         <Td width={90} {...getTdProps({ columnKey: "name" })}>
                           {jobFunction.name}
                         </Td>
-                        <ControlTableActionButtons
+                        <ControlTableActionsColumn
                           isDeleteEnabled={!!jobFunction.stakeholders}
                           deleteTooltipMessage={t(
                             "message.cannotDeleteJobFunctionWithStakeholders"

--- a/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
@@ -51,7 +51,7 @@ import {
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import CubesIcon from "@patternfly/react-icons/dist/js/icons/cubes-icon";
-import { ControlTableActionButtons } from "../ControlTableActionButtons";
+import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
 
 export const StakeholderGroups: React.FC = () => {
   const { t } = useTranslation();
@@ -284,7 +284,7 @@ export const StakeholderGroups: React.FC = () => {
                           >
                             {stakeholderGroup.stakeholders?.length}
                           </Td>
-                          <ControlTableActionButtons
+                          <ControlTableActionsColumn
                             onEdit={() =>
                               setCreateUpdateModalState(stakeholderGroup)
                             }

--- a/client/src/app/pages/controls/stakeholders/stakeholders.tsx
+++ b/client/src/app/pages/controls/stakeholders/stakeholders.tsx
@@ -51,7 +51,7 @@ import {
 } from "@app/components/TableControls";
 import { StakeholderForm } from "./components/stakeholder-form";
 import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
-import { ControlTableActionButtons } from "../ControlTableActionButtons";
+import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
 
 export const Stakeholders: React.FC = () => {
   const { t } = useTranslation();
@@ -305,7 +305,7 @@ export const Stakeholders: React.FC = () => {
                           >
                             {stakeholder.stakeholderGroups?.length}
                           </Td>
-                          <ControlTableActionButtons
+                          <ControlTableActionsColumn
                             onEdit={() =>
                               setCreateUpdateModalState(stakeholder)
                             }

--- a/client/src/app/pages/controls/tags/components/tag-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-form.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { AxiosError, AxiosResponse } from "axios";
 import { object, string, mixed } from "yup";
@@ -42,10 +42,7 @@ export const TagForm: React.FC<TagFormProps> = ({ tag, onClose }) => {
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
 
-  const [error, setError] = useState<AxiosError>();
-
   const { tags } = useFetchTags();
-
   const { tagCategories } = useFetchTagCategories();
 
   const tagCategoryOptions = useMemo(() => {
@@ -101,7 +98,7 @@ export const TagForm: React.FC<TagFormProps> = ({ tag, onClose }) => {
       variant: "success",
     });
 
-  const onTagError = (error: AxiosError) => {
+  const onTagError = (_: AxiosError) => {
     pushNotification({
       title: t("toastr.fail.create", {
         type: t("terms.tag").toLowerCase(),
@@ -120,7 +117,7 @@ export const TagForm: React.FC<TagFormProps> = ({ tag, onClose }) => {
       variant: "success",
     });
 
-  const onUpdateTagError = (error: AxiosError) => {
+  const onUpdateTagError = (_: AxiosError) => {
     pushNotification({
       title: t("toastr.fail.save", {
         type: t("terms.tag").toLowerCase(),

--- a/client/src/app/pages/controls/tags/components/tag-table.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-table.tsx
@@ -4,7 +4,7 @@ import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
 import { Tag, TagCategory } from "@app/api/models";
 import "./tag-table.css";
 import { universalComparator } from "@app/utils/utils";
-import { ControlTableActionButtons } from "../../ControlTableActionButtons";
+import { ControlTableActionsColumn } from "../../ControlTableActionsColumn";
 
 export interface TabTableProps {
   tagCategory: TagCategory;
@@ -33,7 +33,7 @@ export const TagTable: React.FC<TabTableProps> = ({
           .map((tag) => (
             <Tr key={tag.name}>
               <Td>{tag.name}</Td>
-              <ControlTableActionButtons
+              <ControlTableActionsColumn
                 onEdit={() => onEdit(tag)}
                 onDelete={() => onDelete(tag)}
               />

--- a/client/src/app/pages/controls/tags/index.ts
+++ b/client/src/app/pages/controls/tags/index.ts
@@ -1,1 +1,1 @@
-export { Tags as default } from "./tags";
+export { Tags as default } from "./tag-categories-table";

--- a/client/src/app/pages/controls/tags/tag-categories-table.tsx
+++ b/client/src/app/pages/controls/tags/tag-categories-table.tsx
@@ -39,7 +39,10 @@ import {
   useFetchTagCategories,
 } from "@app/queries/tags";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { COLOR_NAMES_BY_HEX_VALUE } from "@app/Constants";
+import {
+  COLOR_NAMES_BY_HEX_VALUE,
+  DEFAULT_REFETCH_INTERVAL,
+} from "@app/Constants";
 import { TagForm } from "./components/tag-form";
 import { TagCategoryForm } from "./components/tag-category-form";
 import { getTagCategoryFallbackColor } from "@app/components/labels/item-tag-label/item-tag-label";
@@ -84,7 +87,6 @@ export const Tags: React.FC = () => {
       title: t("terms.tagDeleted"),
       variant: "success",
     });
-    refetch();
   };
 
   const onDeleteTagError = (error: AxiosError) => {
@@ -114,7 +116,6 @@ export const Tags: React.FC = () => {
       title: t("terms.tagCategoryDeleted"),
       variant: "success",
     });
-    refetch();
   };
 
   const onDeleteTagCategoryError = (error: AxiosError) => {
@@ -139,26 +140,11 @@ export const Tags: React.FC = () => {
     onDeleteTagCategoryError
   );
 
-  const closeTagCategoryModal = () => {
-    setTagCategoryModalState(null);
-    refetch();
-  };
-
-  const closeTagModal = () => {
-    setTagModalState(null);
-    refetch();
-  };
-
   const {
     tagCategories: tagCategories,
     isFetching,
     fetchError,
-    refetch,
-  } = useFetchTagCategories();
-
-  const deleteTagFromTable = (tag: Tag) => {
-    setTagToDelete(tag);
-  };
+  } = useFetchTagCategories(DEFAULT_REFETCH_INTERVAL);
 
   const tableControls = useLocalTableControls({
     tableName: "business-services-table",
@@ -303,13 +289,9 @@ export const Tags: React.FC = () => {
             <Thead>
               <Tr>
                 <TableHeaderContentWithControls {...tableControls}>
-                  <Th
-                    {...getThProps({ columnKey: "tagCategory" })}
-                    width={30}
-                  />
-                  <Th {...getThProps({ columnKey: "color" })} width={20} />
-                  <Th {...getThProps({ columnKey: "tagCount" })} width={20} />
-                  <Th screenReaderText="row actions" width={10} />
+                  <Th {...getThProps({ columnKey: "tagCategory" })} />
+                  <Th {...getThProps({ columnKey: "color" })} />
+                  <Th {...getThProps({ columnKey: "tagCount" })} />
                 </TableHeaderContentWithControls>
               </Tr>
             </Thead>
@@ -335,7 +317,7 @@ export const Tags: React.FC = () => {
               }
               numRenderedColumns={numRenderedColumns}
             >
-              {currentPageItems?.map((tagCategory, rowIndex) => {
+              {currentPageItems.map((tagCategory, rowIndex) => {
                 const hasTags = tagCategory.tags && tagCategory.tags.length > 0;
                 const categoryColor =
                   tagCategory.colour ||
@@ -367,6 +349,7 @@ export const Tags: React.FC = () => {
                         >
                           {tagCategory.tags?.length || 0}
                         </Td>
+                        {/* TODO: Convert to pencil-action / row-actions Td isActionCell */}
                         <ControlTableActionButtons
                           isDeleteEnabled={!!tagCategory.tags?.length}
                           deleteTooltipMessage={t(
@@ -385,7 +368,7 @@ export const Tags: React.FC = () => {
                               <TagTable
                                 tagCategory={tagCategory}
                                 onEdit={setTagModalState}
-                                onDelete={deleteTagFromTable}
+                                onDelete={setTagToDelete}
                               />
                             ) : (
                               <EmptyState variant="sm">
@@ -428,11 +411,11 @@ export const Tags: React.FC = () => {
         }
         variant={ModalVariant.medium}
         isOpen={isTagCategoryModalOpen}
-        onClose={closeTagCategoryModal}
+        onClose={() => setTagCategoryModalState(null)}
       >
         <TagCategoryForm
           tagCategory={tagCategoryToUpdate ? tagCategoryToUpdate : undefined}
-          onClose={closeTagCategoryModal}
+          onClose={() => setTagCategoryModalState(null)}
         />
       </Modal>
 
@@ -449,11 +432,11 @@ export const Tags: React.FC = () => {
         }
         variant={ModalVariant.medium}
         isOpen={isTagModalOpen}
-        onClose={closeTagModal}
+        onClose={() => setTagModalState(null)}
       >
         <TagForm
           tag={tagToUpdate ? tagToUpdate : undefined}
-          onClose={closeTagModal}
+          onClose={() => setTagModalState(null)}
         />
       </Modal>
 

--- a/client/src/app/pages/controls/tags/tag-categories-table.tsx
+++ b/client/src/app/pages/controls/tags/tag-categories-table.tsx
@@ -59,7 +59,7 @@ import {
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { RBAC, controlsWriteScopes, RBAC_TYPE } from "@app/rbac";
 import { TagTable } from "./components/tag-table";
-import { ControlTableActionButtons } from "../ControlTableActionButtons";
+import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
 
 export const Tags: React.FC = () => {
   const { t } = useTranslation();
@@ -350,7 +350,7 @@ export const Tags: React.FC = () => {
                           {tagCategory.tags?.length || 0}
                         </Td>
                         {/* TODO: Convert to pencil-action / row-actions Td isActionCell */}
-                        <ControlTableActionButtons
+                        <ControlTableActionsColumn
                           isDeleteEnabled={!!tagCategory.tags?.length}
                           deleteTooltipMessage={t(
                             "message.cannotDeleteNonEmptyTagCategory"

--- a/client/src/app/queries/tags.ts
+++ b/client/src/app/queries/tags.ts
@@ -32,11 +32,9 @@ export const useFetchTags = (refetchInterval: number | false = false) => {
   };
 };
 
-export const useFetchTagCategories = (
-  refetchInterval: number | false = false
-) => {
+export const useFetchTagCategories = (refetchInterval?: number | false) => {
   const { data, isLoading, isSuccess, error, refetch } = useQuery({
-    queryKey: [TagCategoriesQueryKey, TagsQueryKey],
+    queryKey: [TagCategoriesQueryKey],
     queryFn: getTagCategories,
     onError: (error: AxiosError) => console.log("error, ", error),
     refetchInterval,
@@ -118,16 +116,14 @@ export const useCreateTagMutation = (
   return useMutation({
     mutationFn: createTag,
     onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
       onSuccess(res);
-      queryClient.invalidateQueries({
-        queryKey: [TagCategoriesQueryKey, TagsQueryKey],
-      });
     },
     onError: (err: AxiosError) => {
+      queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
       onError(err);
-      queryClient.invalidateQueries({
-        queryKey: [TagCategoriesQueryKey, TagsQueryKey],
-      });
     },
   });
 };
@@ -141,12 +137,12 @@ export const useCreateTagCategoryMutation = (
   return useMutation({
     mutationFn: createTagCategory,
     onSuccess: (res) => {
-      onSuccess(res);
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      onSuccess(res);
     },
     onError: (err: AxiosError) => {
-      onError(err);
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      onError(err);
     },
   });
 };
@@ -160,16 +156,14 @@ export const useUpdateTagMutation = (
   return useMutation({
     mutationFn: updateTag,
     onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
       onSuccess(res);
-      queryClient.invalidateQueries({
-        queryKey: [TagCategoriesQueryKey, TagsQueryKey],
-      });
     },
     onError: (err: AxiosError) => {
+      queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
       onError(err);
-      queryClient.invalidateQueries({
-        queryKey: [TagCategoriesQueryKey, TagsQueryKey],
-      });
     },
   });
 };
@@ -183,12 +177,14 @@ export const useUpdateTagCategoryMutation = (
   return useMutation({
     mutationFn: updateTagCategory,
     onSuccess: (res) => {
-      onSuccess(res);
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
+      onSuccess(res);
     },
     onError: (err: AxiosError) => {
-      onError(err);
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
+      onError(err);
     },
   });
 };
@@ -201,16 +197,14 @@ export const useDeleteTagMutation = (
   return useMutation({
     mutationFn: deleteTag,
     onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
       onSuccess(res);
-      queryClient.invalidateQueries({
-        queryKey: [TagCategoriesQueryKey, TagsQueryKey],
-      });
     },
     onError: (err: AxiosError) => {
+      queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
       onError(err);
-      queryClient.invalidateQueries({
-        queryKey: [TagCategoriesQueryKey, TagsQueryKey],
-      });
     },
   });
 };
@@ -224,12 +218,14 @@ export const useDeleteTagCategoryMutation = (
   return useMutation({
     mutationFn: deleteTagCategory,
     onSuccess: (res) => {
-      onSuccess(res);
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
+      onSuccess(res);
     },
     onError: (err: AxiosError) => {
-      onError(err);
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
+      onError(err);
     },
   });
 };


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-5884

The controls tag category table was not using the correct technique to reflect changes to tags and tag categories. All of the mutation queries now properly invalidate the fetch queries when any tag changes are made.  The table component no longer has to manually refetch the data.

Changes:
- `tags.tsx` -> `tag-categories-table.tsx`
- dropped use of `refetch`
- fixed some linting errors
- fixed some column rendering errors, widths look better now
- tag mutations now invalidate the tag categories and tags queries as appropriate
- Rename `ControlTableActionButtons` to `ControlTableActionsColumn`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Replaced per-row action buttons with a unified actions column across controls tables.
  - Simplified tag deletion and modal close flows; removed some local error state and redundant fetch calls.
  - Query/mutation behavior updated for more consistent cache invalidation and callback ordering.

- Style
  - Removed fixed column widths in the Tag Categories table for better responsiveness.

- Chores
  - Updated default export to point to the Tag Categories table implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->