### PR TITLE
:bug: Source Platform toast messages

### DIFF
--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -717,7 +717,7 @@ export const getPlatformById = (id: number | string) =>
 
 // success with code 201 and created entity as response data
 export const createPlatform = (platform: New<SourcePlatform>) =>
-  axios.post<void>(PLATFORMS, platform).then((res) => res.data);
+  axios.post<SourcePlatform>(PLATFORMS, platform).then((res) => res.data);
 
 // success with code 204 and therefore no response content
 export const updatePlatform = (platform: SourcePlatform) =>

--- a/client/src/app/pages/source-platforms/components/platform-form.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-form.tsx
@@ -276,20 +276,22 @@ const usePlatformFormData = ({
     useFetchPlatforms();
 
   // Mutation notification handlers
-  const onCreateSuccess = () => {
+  const onCreateSuccess = (platform: SourcePlatform) => {
     pushNotification({
       title: t("toastr.success.createWhat", {
-        type: t("terms.platform").toLocaleLowerCase(),
+        type: t("terms.sourcePlatform"),
+        what: platform.name,
       }),
       variant: "success",
     });
     onActionSuccess();
   };
 
-  const onUpdateSuccess = (_id: number) => {
+  const onUpdateSuccess = (platform: SourcePlatform) => {
     pushNotification({
-      title: t("toastr.success.save", {
-        type: t("terms.platform").toLocaleLowerCase(),
+      title: t("toastr.success.saveWhat", {
+        type: t("terms.sourcePlatform"),
+        what: platform.name,
       }),
       variant: "success",
     });

--- a/client/src/app/queries/platforms.ts
+++ b/client/src/app/queries/platforms.ts
@@ -54,33 +54,35 @@ export const useFetchPlatformById = (
 };
 
 export const useCreatePlatformMutation = (
-  onSuccess: () => void,
+  onSuccess: (platform: SourcePlatform) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: createPlatform,
-    onSuccess: () => {
-      onSuccess();
+    onSuccess: (platform, _variables) => {
       queryClient.invalidateQueries({ queryKey: [PLATFORMS_QUERY_KEY] });
+      onSuccess(platform);
     },
     onError: onError,
   });
 };
 
 export const useUpdatePlatformMutation = (
-  onSuccess: (id: number) => void,
+  onSuccess: (platform: SourcePlatform) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: updatePlatform,
-    onSuccess: (_, { id }) => {
-      onSuccess(id);
+    onSuccess: (_, platform) => {
       queryClient.invalidateQueries({ queryKey: [PLATFORMS_QUERY_KEY] });
-      queryClient.invalidateQueries({ queryKey: [PLATFORM_QUERY_KEY, id] });
+      queryClient.invalidateQueries({
+        queryKey: [PLATFORM_QUERY_KEY, platform.id],
+      });
+      onSuccess(platform);
     },
     onError: onError,
   });
@@ -95,11 +97,11 @@ export const useDeletePlatformMutation = (
   return useMutation({
     mutationFn: (platform: SourcePlatform) => deletePlatform(platform.id),
     onSuccess: (_, platform) => {
-      onSuccess(platform);
       queryClient.invalidateQueries({ queryKey: [PLATFORMS_QUERY_KEY] });
       queryClient.invalidateQueries({
         queryKey: [PLATFORM_QUERY_KEY, platform.id],
       });
+      onSuccess(platform);
     },
     onError: onError,
   });


### PR DESCRIPTION
Resolves: #2552

The toast messages for source platform creation and update were not using the correct translation keys and data.


## Screenshots
Create toast:
<img width="1676" height="1087" alt="image" src="https://github.com/user-attachments/assets/4a59c449-f4a3-4175-8b7b-bdc2f9b16937" />

Change toast:
<img width="1676" height="1087" alt="image" src="https://github.com/user-attachments/assets/58dc7fd1-f814-4e9d-97c8-56ea0828509b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Success notifications for creating and updating source platforms now show the platform name and a more specific label for clearer feedback.

* **Bug Fixes**
  * Improved reliability of UI updates after creating, updating, or deleting source platforms, reducing chances of stale data in lists and details.
  * Consistent post-action handling ensures notifications and refreshes occur in the correct order for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->