### PR TITLE
:bug: Rename Retrieve configurations kebab menu item for applications

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -53,6 +53,7 @@
     "reset": "Reset",
     "review": "Review",
     "retrieve": "Retrieve",
+    "retrieveConfigurations": "Retrieve configurations",
     "save": "Save",
     "saveAndReview": "Save and review",
     "selectAll": "Select all",


### PR DESCRIPTION
Fixes [Issue](https://github.com/konveyor/tackle2-ui/issues/2554)
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new action label, “Retrieve configurations,” to the English interface. This enables the UI to display the action where applicable, improving clarity and discoverability for users. No existing labels or behaviors were changed, and this addition is backward-compatible with current screens and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->