### PR TITLE
:bug: Update the application-import task payload

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -374,7 +374,10 @@ export interface ApplicationManifestTask
 }
 
 export interface PlatformApplicationImportTask
-  extends Omit<Task<{ filter: JsonDocument }>, "application" | "platform"> {
+  extends Omit<
+    Task<PlatformApplicationImportTaskData>,
+    "application" | "platform"
+  > {
   kind: "application-import";
   platform: Ref;
 }
@@ -463,6 +466,10 @@ export interface AnalysisTaskData {
     };
     ruleSets?: Ref[]; // Target.ruleset.{ id, name }
   };
+}
+
+export interface PlatformApplicationImportTaskData {
+  filter: JsonDocument;
 }
 
 export interface TaskgroupTask {

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -374,7 +374,7 @@ export interface ApplicationManifestTask
 }
 
 export interface PlatformApplicationImportTask
-  extends Omit<Task<JsonDocument>, "application" | "platform"> {
+  extends Omit<Task<{ filter: JsonDocument }>, "application" | "platform"> {
   kind: "application-import";
   platform: Ref;
 }

--- a/client/src/app/pages/source-platforms/discover-import-wizard/useStartPlatformApplicationImport.ts
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/useStartPlatformApplicationImport.ts
@@ -32,7 +32,7 @@ export const useStartPlatformApplicationImport = () => {
       kind: "application-import",
       platform: { id: platform.id, name: platform.name },
       state: "Ready",
-      data: filters || {},
+      data: filters ? { filter: filters } : undefined,
     };
 
     try {

--- a/client/src/app/pages/source-platforms/discover-import-wizard/useStartPlatformApplicationImport.ts
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/useStartPlatformApplicationImport.ts
@@ -2,13 +2,14 @@ import {
   JsonDocument,
   New,
   PlatformApplicationImportTask,
+  PlatformApplicationImportTaskData,
   SourcePlatform,
 } from "@app/api/models";
 import { useCreateTaskMutation } from "@app/queries/tasks";
 
 export const useStartPlatformApplicationImport = () => {
   const { mutateAsync: createTask } = useCreateTaskMutation<
-    JsonDocument,
+    PlatformApplicationImportTaskData,
     PlatformApplicationImportTask
   >();
 


### PR DESCRIPTION
The data payload needed the filters to be under a key `filter`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import wizard now correctly applies selected filters when starting platform application imports.
  * Starting an import without filters is handled reliably, avoiding unintended empty payloads.

* **Refactor**
  * Standardized import task payload to wrap filters under a single field and make payload absent when no filters are provided, improving consistency and future compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->