### PR TITLE
:bug: Don't set TargetProfile ids to 0 when changing Archetypes or TargetProfiles in an Archetype

### DIFF
--- a/client/src/app/pages/archetypes/components/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form.tsx
@@ -206,11 +206,7 @@ const ArchetypeFormReady: React.FC<ArchetypeFormProps> = ({
 
     // Note: We need to manually retain the target profiles
     if (archetype?.profiles) {
-      payload.profiles = archetype.profiles.map(({ name, generators }) => ({
-        id: 0,
-        name,
-        generators,
-      }));
+      payload.profiles = archetype.profiles;
     }
 
     if (archetype && !isDuplicating) {

--- a/client/src/app/pages/archetypes/hooks/useArchetypeMutations.ts
+++ b/client/src/app/pages/archetypes/hooks/useArchetypeMutations.ts
@@ -164,9 +164,9 @@ export const useArchetypeMutations = ({
 
   // Target profile function
   const addTargetProfile = (archetype: Archetype, profile: TargetProfile) => {
-    const updatedProfiles = (
-      archetype.profiles ? [...archetype.profiles, profile] : [profile]
-    ).map((p) => ({ ...p, id: 0 })); // TODO: Verify why this is needed.
+    const updatedProfiles = archetype.profiles
+      ? [...archetype.profiles, profile]
+      : [profile];
     updateArchetype({ ...archetype, profiles: updatedProfiles });
   };
 
@@ -174,9 +174,9 @@ export const useArchetypeMutations = ({
     archetype: Archetype,
     profile: TargetProfile
   ) => {
-    const updatedProfiles = archetype.profiles
-      ?.map((p) => (p.id === profile.id ? profile : p))
-      .map((p) => ({ ...p, id: 0 })); // TODO: Verify why this is needed.
+    const updatedProfiles = archetype.profiles?.map((p) =>
+      p.id === profile.id ? profile : p
+    );
     updateArchetype({ ...archetype, profiles: updatedProfiles });
   };
 
@@ -184,9 +184,9 @@ export const useArchetypeMutations = ({
     archetype: Archetype,
     profile: TargetProfile
   ) => {
-    const updatedProfiles = archetype.profiles
-      ?.filter((p) => p.id !== profile.id)
-      .map((p) => ({ ...p, id: 0 })); // TODO: Verify why this is needed.
+    const updatedProfiles = archetype.profiles?.filter(
+      (p) => p.id !== profile.id
+    );
     updateArchetype({ ...archetype, profiles: updatedProfiles });
   };
 


### PR DESCRIPTION
Resolves: #2564
Ref: https://github.com/konveyor/tackle2-hub/issues/883

Leave existing TargetProfile ids untouched when modifiying an Archetype or when modifying an Archetype's TargetProfile.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Archetype profile management now preserves profile IDs during submit and target profile actions (add, update, delete), preventing unintended ID resets.
  - Ensures edits apply to the correct profile, avoiding duplicate entries, misplaced updates, or failed deletions.
  - Improves reliability and consistency of profile lists and details in the UI.
  - Reduces chances of data mismatch between what’s shown and what’s saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->