### PR TITLE
:bug: Fix breadcrumbs for questionnaire summary page

### DIFF
--- a/client/src/app/components/questionnaire-summary/questionnaire-summary.tsx
+++ b/client/src/app/components/questionnaire-summary/questionnaire-summary.tsx
@@ -49,10 +49,7 @@ const QuestionnaireSummary: React.FC<QuestionnaireSummaryProps> = ({
     "all"
   );
 
-  const handleTabClick = (
-    _event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
-    tabKey: string | number
-  ) => {
+  const handleTabClick = (_event: unknown, tabKey: string | number) => {
     setActiveSectionIndex(tabKey as "all" | number);
   };
 
@@ -88,6 +85,16 @@ const QuestionnaireSummary: React.FC<QuestionnaireSummaryProps> = ({
         applicationId: (summaryData as Assessment)?.application?.id,
       });
 
+  // questionnaire is the base definition
+  // assessment is the answers to a questionnaire for an application or archetype
+  const summaryName = !summaryData
+    ? ""
+    : summaryType === SummaryType.Questionnaire
+      ? (summaryData as Questionnaire).name
+      : summaryType === SummaryType.Assessment
+        ? (summaryData as Assessment).questionnaire.name
+        : "";
+
   const BreadcrumbPath =
     summaryType === SummaryType.Assessment ? (
       <Breadcrumb>
@@ -95,7 +102,7 @@ const QuestionnaireSummary: React.FC<QuestionnaireSummaryProps> = ({
           <Link to={dynamicPath}>Assessment</Link>
         </BreadcrumbItem>
         <BreadcrumbItem to="#" isActive>
-          {summaryData?.name}
+          {summaryName}
         </BreadcrumbItem>
       </Breadcrumb>
     ) : (
@@ -104,7 +111,7 @@ const QuestionnaireSummary: React.FC<QuestionnaireSummaryProps> = ({
           <Link to={Paths.assessment}>Assessment</Link>
         </BreadcrumbItem>
         <BreadcrumbItem to="#" isActive>
-          {summaryData?.name}
+          {summaryName}
         </BreadcrumbItem>
       </Breadcrumb>
     );

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Questionnaire } from "@app/api/models";
 import { useParams } from "react-router-dom";
 import "./questionnaire-page.css";
 import QuestionnaireSummary, {
@@ -11,7 +10,7 @@ interface QuestionnairePageParams {
   questionnaireId: string;
 }
 
-const Questionnaire: React.FC = () => {
+const QuestionnairePage: React.FC = () => {
   const { questionnaireId } = useParams<QuestionnairePageParams>();
 
   const {
@@ -30,4 +29,4 @@ const Questionnaire: React.FC = () => {
   );
 };
 
-export default Questionnaire;
+export default QuestionnairePage;


### PR DESCRIPTION
Improve the breadcrumb text for the questionnaire summary page. Depending on the specific summaryData type, the breadcrumb text needs to be accessed from the questionnaire or assessment object.

Resolves: #2574

<img width="1676" height="913" alt="image" src="https://github.com/user-attachments/assets/f903019b-db92-41cf-b891-0b9118701916" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Breadcrumbs now consistently display the correct name for questionnaires and assessments.

- Refactor
  - Renamed the questionnaire page component for clarity.
  - Simplified internal event handling and replaced direct name references with a unified computed display value.
  - Removed an unused import.

- Documentation
  - Added clarifying comments distinguishing questionnaires (definitions) from assessments (answers).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->