### PR TITLE
:bug: Add labels and tooltips per platform kind for Source Platforms

### DIFF
--- a/client/src/app/pages/source-platforms/components/platform-detail-drawer.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-detail-drawer.tsx
@@ -24,6 +24,7 @@ import {
   DrawerTabsContainer,
 } from "@app/components/detail-drawer";
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+import { usePlatformKindList } from "../usePlatformKindList";
 
 export interface IPlatformDetailDrawerProps {
   onCloseClick: () => void;
@@ -41,6 +42,7 @@ const PlatformDetailDrawer: React.FC<IPlatformDetailDrawerProps> = ({
   platform,
 }) => {
   const { t } = useTranslation();
+  const { getDisplayLabel } = usePlatformKindList();
 
   const [activeTabKey, setActiveTabKey] = React.useState<TabKey>(
     TabKey.Details
@@ -85,7 +87,7 @@ const PlatformDetailDrawer: React.FC<IPlatformDetailDrawerProps> = ({
                     {t("terms.platformKind")}
                   </DescriptionListTerm>
                   <DescriptionListDescription>
-                    {platform?.kind}
+                    {getDisplayLabel(platform?.kind)}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>

--- a/client/src/app/pages/source-platforms/components/platform-form.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-form.tsx
@@ -31,6 +31,8 @@ import { SimpleSelect } from "@app/components/SimpleSelect";
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { useFetchIdentities } from "@app/queries/identities";
 import { usePlatformKindList } from "../usePlatformKindList";
+import { OptionWithValue } from "@app/components/SimpleSelect";
+import { toOptionLike } from "@app/utils/model-utils";
 
 export interface PlatformFormValues {
   kind: string;
@@ -189,10 +191,11 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
               id="platform-kind-select"
               toggleAriaLabel="Platform kind select dropdown toggle"
               aria-label={name}
-              value={value}
+              value={value ? toOptionLike(value, platformKindList) : undefined}
               options={platformKindList || []}
               onChange={(selection) => {
-                onChange(selection);
+                const selectionValue = selection as OptionWithValue<string>;
+                onChange(selectionValue.value);
               }}
               onClear={() => onChange("")}
             />

--- a/client/src/app/pages/source-platforms/components/platform-form.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-form.tsx
@@ -10,7 +10,9 @@ import {
   Button,
   ButtonVariant,
   Form,
+  Popover,
 } from "@patternfly/react-core";
+import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
 import type { SourcePlatform, New } from "@app/api/models";
 import {
@@ -61,7 +63,7 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
   onClose,
 }) => {
   const { t } = useTranslation();
-  const { kinds: platformKindList } = usePlatformKindList();
+  const { kinds: platformKindList, getUrlTooltip } = usePlatformKindList();
 
   const { existingPlatforms, createPlatform, updatePlatform } =
     usePlatformFormData({
@@ -209,6 +211,18 @@ const PlatformFormRenderer: React.FC<PlatformFormProps> = ({
         label={t("terms.url")}
         fieldId="url"
         isRequired
+        labelIcon={
+          <Popover bodyContent={<div>{getUrlTooltip(platform?.kind)}</div>}>
+            <button
+              type="button"
+              aria-label="More info for URL field"
+              onClick={(e) => e.preventDefault()}
+              className="pf-v5-c-button pf-m-plain"
+            >
+              <HelpIcon />
+            </button>
+          </Popover>
+        }
       />
 
       <HookFormPFGroupController

--- a/client/src/app/pages/source-platforms/discover-import-wizard/filter-input.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/filter-input.tsx
@@ -11,6 +11,7 @@ import { useFetchPlatformDiscoveryFilterSchema } from "@app/queries/schemas";
 import { SchemaDefinedField } from "@app/components/schema-defined-fields/SchemaDefinedFields";
 import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
 import { jsonSchemaToYupSchema } from "@app/components/schema-defined-fields/utils";
+import { usePlatformKindList } from "../usePlatformKindList";
 
 interface FiltersFormValues {
   filterRequired: boolean;
@@ -60,6 +61,7 @@ export const FilterInput: React.FC<{
   initialFilters?: FilterState;
 }> = ({ platform, onFiltersChanged, initialFilters }) => {
   const { t } = useTranslation();
+  const { getDisplayLabel } = usePlatformKindList();
 
   const validationSchema = yup.object().shape({
     schema: yup.object().nullable(),
@@ -111,7 +113,7 @@ export const FilterInput: React.FC<{
         <Text component="p">
           {t("platformDiscoverWizard.filterInput.description", {
             platformName: platform?.name,
-            platformKind: platform?.kind,
+            platformKind: getDisplayLabel(platform?.kind),
           })}
         </Text>
       </TextContent>
@@ -122,7 +124,7 @@ export const FilterInput: React.FC<{
         <div style={{ padding: "20px" }}>
           <Text>
             {t("platformDiscoverWizard.filterInput.noFiltersAvailable", {
-              platformKind: platform.kind,
+              platformKind: getDisplayLabel(platform?.kind),
             })}
           </Text>
         </div>

--- a/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
@@ -13,12 +13,14 @@ import { SchemaDefinedField } from "@app/components/schema-defined-fields/Schema
 import { SourcePlatform } from "@app/api/models";
 import { FilterState } from "./filter-input";
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+import { usePlatformKindList } from "../usePlatformKindList";
 
 export const Review: React.FC<{
   platform: SourcePlatform;
   filters: FilterState;
 }> = ({ platform, filters }) => {
   const { t } = useTranslation();
+  const { getDisplayLabel } = usePlatformKindList();
   const showFilters =
     filters.filterRequired && filters.schema && filters.document;
 
@@ -44,7 +46,7 @@ export const Review: React.FC<{
         <DescriptionListGroup>
           <DescriptionListTerm>{t("terms.platformKind")}</DescriptionListTerm>
           <DescriptionListDescription>
-            {platform?.kind}
+            {getDisplayLabel(platform?.kind)}
           </DescriptionListDescription>
         </DescriptionListGroup>
 

--- a/client/src/app/pages/source-platforms/source-platforms.tsx
+++ b/client/src/app/pages/source-platforms/source-platforms.tsx
@@ -52,11 +52,14 @@ import { PlatformForm } from "./components/platform-form";
 import { DiscoverImportWizard } from "./discover-import-wizard/discover-import-wizard";
 import { useFetchPlatformsWithTasks } from "./useFetchPlatformsWithTasks";
 import { ColumnPlatformName } from "./components/column-platform-name";
+import { usePlatformKindList } from "./usePlatformKindList";
 
 export const SourcePlatforms: React.FC = () => {
   const { t } = useTranslation();
   const history = useHistory();
   const { pushNotification } = React.useContext(NotificationsContext);
+
+  const { getDisplayLabel } = usePlatformKindList();
 
   const [openCreatePlatform, setOpenCreatePlatform] = useState<boolean>(false);
 
@@ -279,7 +282,7 @@ export const SourcePlatforms: React.FC = () => {
                           <ColumnPlatformName platform={platform} />
                         </Td>
                         <Td {...getTdProps({ columnKey: "platformKind" })}>
-                          {platform.kind}
+                          {getDisplayLabel(platform.kind)}
                         </Td>
                         <Td {...getTdProps({ columnKey: "applications" })}>
                           <LinkToPlatformApplications platform={platform} />

--- a/client/src/app/pages/source-platforms/usePlatformKindList.ts
+++ b/client/src/app/pages/source-platforms/usePlatformKindList.ts
@@ -1,7 +1,37 @@
+import { OptionWithValue } from "@app/components/SimpleSelect";
+import React from "react";
+
 export const DEFAULT_KIND = "cloudfoundry";
 
-const KIND_LIST = [DEFAULT_KIND]; // Add more provider kinds here, or use a list from the API
+// Extend this map as new platform kinds are added
+const KIND_MAP = {
+  cloudfoundry: {
+    label: "Cloud Foundry",
+  },
+} as const;
 
-export const usePlatformKindList = (): { kinds: string[] } => {
-  return { kinds: KIND_LIST };
+export const usePlatformKindList = (): {
+  kinds: OptionWithValue<string>[];
+  getDisplayLabel: (kind?: string | null) => string;
+} => {
+  const kinds: OptionWithValue<string>[] = React.useMemo(
+    () =>
+      Object.entries(KIND_MAP).map(([key, values]) => ({
+        value: key,
+        toString: () => values.label,
+      })),
+    []
+  );
+
+  const getDisplayLabel = React.useCallback((kind?: string | null): string => {
+    if (!kind) return "";
+    const map = KIND_MAP as Record<string, { label: string }>;
+    const entry = map[kind];
+    if (entry?.label) {
+      return entry.label;
+    }
+    return kind;
+  }, []);
+
+  return { kinds, getDisplayLabel };
 };

--- a/client/src/app/pages/source-platforms/usePlatformKindList.ts
+++ b/client/src/app/pages/source-platforms/usePlatformKindList.ts
@@ -5,15 +5,17 @@ import { useTranslation } from "react-i18next";
 export const DEFAULT_KIND = "cloudfoundry";
 
 // Extend this map as new platform kinds are added
-const KIND_MAP: Record<string, { label: string }> = {
+const KIND_MAP: Record<string, { label: string; urlTooltip: string }> = {
   cloudfoundry: {
     label: "Cloud Foundry",
+    urlTooltip: "API URL to Cloud Foundry",
   },
 } as const;
 
 export const usePlatformKindList = (): {
   kinds: OptionWithValue<string>[];
   getDisplayLabel: (kind?: string | null) => string;
+  getUrlTooltip: (kind?: string | null) => string;
 } => {
   const kinds: OptionWithValue<string>[] = React.useMemo(
     () =>
@@ -35,5 +37,15 @@ export const usePlatformKindList = (): {
     [t]
   );
 
-  return { kinds, getDisplayLabel };
+  const getUrlTooltip = React.useCallback(
+    (kind: string | undefined | null): string => {
+      if (kind && kind in KIND_MAP) {
+        return KIND_MAP[kind].urlTooltip;
+      }
+      return "";
+    },
+    []
+  );
+
+  return { kinds, getDisplayLabel, getUrlTooltip };
 };

--- a/client/src/app/pages/source-platforms/usePlatformKindList.ts
+++ b/client/src/app/pages/source-platforms/usePlatformKindList.ts
@@ -1,10 +1,11 @@
 import { OptionWithValue } from "@app/components/SimpleSelect";
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 export const DEFAULT_KIND = "cloudfoundry";
 
 // Extend this map as new platform kinds are added
-const KIND_MAP = {
+const KIND_MAP: Record<string, { label: string }> = {
   cloudfoundry: {
     label: "Cloud Foundry",
   },
@@ -23,15 +24,16 @@ export const usePlatformKindList = (): {
     []
   );
 
-  const getDisplayLabel = React.useCallback((kind?: string | null): string => {
-    if (!kind) return "";
-    const map = KIND_MAP as Record<string, { label: string }>;
-    const entry = map[kind];
-    if (entry?.label) {
-      return entry.label;
-    }
-    return kind;
-  }, []);
+  const { t } = useTranslation();
+  const getDisplayLabel = React.useCallback(
+    (kind: string | undefined | null): string => {
+      if (kind && kind in KIND_MAP) {
+        return KIND_MAP[kind].label;
+      }
+      return t("terms.unknown");
+    },
+    [t]
+  );
 
   return { kinds, getDisplayLabel };
 };


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-6005
Resolves: https://issues.redhat.com/browse/MTA-6023
Resolves: #2576
Resolves: #2588 

<img width="1914" height="903" alt="Screenshot_20250827_144617" src="https://github.com/user-attachments/assets/fd2031e1-5485-4252-b3e2-77867cc45ed0" />

<img width="1225" height="822" alt="Screenshot_20250827_144643" src="https://github.com/user-attachments/assets/b8854367-4ca4-4663-b865-72cba34e174b" />

<img width="1918" height="989" alt="image" src="https://github.com/user-attachments/assets/dca06f7e-48e1-4bde-aff2-c4f7d373adca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform kinds now show friendly labels across Platforms table, Detail drawer, Import Wizard (Filter & Review).
  * URL field now includes a contextual tooltip explaining the expected API URL per platform kind.

* **Refactor**
  * Centralized platform-kind mapping and selection handling for consistent display and reliable form binding.

* **Notes**
  * No user-facing workflow or behavioral changes; display-only improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->