### PR TITLE
:seedling: Enable import sorting via eslint-plugin-import

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,6 +34,7 @@ module.exports = {
     "react",
     "react-hooks",
     "@tanstack/query",
+    "import",
   ],
 
   // NOTE: Tweak the rules as needed when bulk fixes get merged
@@ -59,10 +60,52 @@ module.exports = {
 
     "@tanstack/query/exhaustive-deps": "error",
     "@tanstack/query/prefer-query-object-syntax": "error",
+
+    // Import ordering rule
+    "import/order": [
+      "warn",
+      {
+        groups: [
+          "builtin", // Node.js built-in modules
+          "external", // 3rd party libraries
+          "internal", // @app imports
+          ["parent", "sibling"], // ../ and ./
+          "index", // ./index
+        ],
+        pathGroups: [
+          {
+            pattern: "@patternfly/**",
+            group: "external",
+            position: "after",
+          },
+          {
+            pattern: "@konveyor-ui/**",
+            group: "internal",
+            position: "before",
+          },
+          {
+            pattern: "@app/**",
+            group: "internal",
+            position: "before",
+          },
+        ],
+        pathGroupsExcludedImportTypes: ["builtin"],
+        "newlines-between": "always",
+        named: true,
+        alphabetize: {
+          order: "asc",
+        },
+      },
+    ],
   },
 
   settings: {
     react: { version: "detect" },
+    "import/resolver": {
+      node: {
+        extensions: [".js", ".jsx", ".ts", ".tsx"],
+      },
+    },
   },
 
   ignorePatterns: [

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -67,12 +67,18 @@ module.exports = {
       {
         groups: [
           "builtin", // Node.js built-in modules
-          "external", // 3rd party libraries
+          "external", // React then 3rd party libraries
           "internal", // @app imports
-          ["parent", "sibling"], // ../ and ./
+          "parent",
+          "sibling", // ../ and ./
           "index", // ./index
         ],
         pathGroups: [
+          {
+            pattern: "react",
+            group: "external",
+            position: "before",
+          },
           {
             pattern: "@patternfly/**",
             group: "external",
@@ -90,6 +96,7 @@ module.exports = {
           },
         ],
         pathGroupsExcludedImportTypes: ["builtin"],
+        distinctGroup: false,
         "newlines-between": "always",
         named: true,
         alphabetize: {

--- a/client/config/webpack.common.ts
+++ b/client/config/webpack.common.ts
@@ -1,10 +1,12 @@
 import path from "path";
-import { Configuration, DefinePlugin } from "webpack";
+
 import CopyPlugin from "copy-webpack-plugin";
-import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin";
 import MonacoWebpackPlugin from "monaco-editor-webpack-plugin";
+import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin";
+import { Configuration, DefinePlugin } from "webpack";
 
 import { brandingAssetPath } from "@konveyor-ui/common";
+
 import { LANGUAGES_BY_FILE_EXTENSION } from "./monacoConstants";
 
 const pathTo = (relativePath: string) => path.resolve(__dirname, relativePath);

--- a/client/config/webpack.dev.ts
+++ b/client/config/webpack.dev.ts
@@ -1,20 +1,22 @@
 import path from "path";
-import { mergeWithRules } from "webpack-merge";
-import type { Configuration as WebpackConfiguration } from "webpack";
-import type { Configuration as DevServerConfiguration } from "webpack-dev-server";
+
+import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
+import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import ReactRefreshTypeScript from "react-refresh-typescript";
-import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
-import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
+import type { Configuration as WebpackConfiguration } from "webpack";
+import type { Configuration as DevServerConfiguration } from "webpack-dev-server";
+import { mergeWithRules } from "webpack-merge";
 
 import {
-  encodeEnv,
   KONVEYOR_ENV,
   SERVER_ENV_KEYS,
-  brandingStrings,
   brandingAssetPath,
+  brandingStrings,
+  encodeEnv,
 } from "@konveyor-ui/common";
+
 import { stylePaths } from "./stylePaths";
 import commonWebpackConfiguration from "./webpack.common";
 

--- a/client/config/webpack.prod.ts
+++ b/client/config/webpack.prod.ts
@@ -1,11 +1,13 @@
 import path from "path";
-import merge from "webpack-merge";
-import webpack, { Configuration } from "webpack";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
+
 import CssMinimizerPlugin from "css-minimizer-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
+import MiniCssExtractPlugin from "mini-css-extract-plugin";
+import webpack, { Configuration } from "webpack";
+import merge from "webpack-merge";
 
 import { brandingAssetPath } from "@konveyor-ui/common";
+
 import { stylePaths } from "./stylePaths";
 import commonWebpackConfiguration from "./webpack.common";
 

--- a/common/rollup.config.js
+++ b/common/rollup.config.js
@@ -1,15 +1,14 @@
 /* eslint-env node */
-
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
 import util from "node:util";
 
-import copy from "rollup-plugin-copy";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import virtual from "@rollup/plugin-virtual";
 import ejs from "ejs";
+import copy from "rollup-plugin-copy";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const pathTo = (...relativePath) => path.resolve(__dirname, ...relativePath);

--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,7 @@
     "radash",
     "taskgroup",
     "taskgroups",
-    "toastr"
+    "toastr",
+    "userpass"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "copyfiles": "^2.4.1",
         "eslint": "^8.47.0",
         "eslint-config-prettier": "^10.1.2",
+        "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.1",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -2328,6 +2329,13 @@
         "win32"
       ]
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -3036,6 +3044,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4138,6 +4153,28 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7171,6 +7208,183 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -13442,6 +13656,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.values": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "lint-staged": {
     "package-lock.json": "./scripts/verify_lock.mjs",
     "!(package-lock.json)*": "prettier --ignore-unknown --write",
-    ".github/**/*.{yaml,yml}": "prettier --ignore-unknown --write"
+    ".github/**/*.{yaml,yml}": "prettier --ignore-unknown --write",
+    "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}": "eslint --fix"
   },
   "workspaces": [
     "common",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "copyfiles": "^2.4.1",
     "eslint": "^8.47.0",
     "eslint-config-prettier": "^10.1.2",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/scripts/verify_lock.mjs
+++ b/scripts/verify_lock.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import process from "node:process";
-import path from "node:path";
 import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
 
 // set the working directory to project root
 // fs.accessSync("./package-lock.json")

--- a/server/rollup.config.js
+++ b/server/rollup.config.js
@@ -1,8 +1,8 @@
 /* eslint-env node */
 
+import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
 import run from "@rollup/plugin-run";
 
 const buildAndRun = process.env?.ROLLUP_RUN === "true";

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,19 +1,19 @@
 /* eslint-env node */
-
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import express from "express";
 import ejs from "ejs";
-import { createHttpTerminator } from "http-terminator";
+import express from "express";
 import { createProxyMiddleware } from "http-proxy-middleware";
+import { createHttpTerminator } from "http-terminator";
 
 import {
-  encodeEnv,
   KONVEYOR_ENV,
   SERVER_ENV_KEYS,
   brandingStrings,
+  encodeEnv,
 } from "@konveyor-ui/common";
+
 import proxies from "./proxies";
 
 const developmentMode = KONVEYOR_ENV.NODE_ENV === "development";

--- a/server/src/proxies.js
+++ b/server/src/proxies.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
-
 /** @import { Logger, Options, OnProxyEvent } from "http-proxy-middleware/dist/types.js" */
 import * as cookie from "cookie";
+
 import { KONVEYOR_ENV } from "@konveyor-ui/common";
 
 /** @type Logger */


### PR DESCRIPTION
File import ordering will now be enforced via eslint rule.  The rule is set to `warn`, and any file that is added to a commit will have its import order rearranged as necessary through the husky managed lint-staged precommit hook.

Import order:
  - React and then other 3rd party libraries first (axios, etc.)
  - PatternFly libraries second (@patternfly/**)
  - `@app` imports third (@app/**)
  - Relative imports last (../, ./)

Within each group, import lines will be alpha sorted by import from name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Standardized import ordering and grouping across the codebase for consistent, readable sources.
- Chores
  - Added import-order linting rules and resolver settings; installed import lint plugin and updated lint-staged to auto-fix JS/TS files.
  - Added a spelling dictionary entry to reduce false-positive spellcheck noise.
  - Enabled dev-time tooling for faster refresh and TypeScript type-check feedback during development.
- Notes
  - No user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->