### PR TITLE
:bug: Add insights link to application detail drawer

### DIFF
--- a/client/src/app/pages/applications/application-detail-drawer/tab-details-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-details-content.tsx
@@ -38,6 +38,7 @@ import {
 import { useFetchTickets } from "@app/queries/tickets";
 import { useDeleteTicketMutation } from "@app/queries/migration-waves";
 import ExternalLink from "@app/components/ExternalLink";
+import { getInsightsSingleAppSelectedLocation } from "@app/pages/insights/helpers";
 
 const ApplicationArchetypesLabels: React.FC<{
   application: DecoratedApplication;
@@ -73,6 +74,11 @@ export const TabDetailsContent: React.FC<{
           <ListItem>
             <Link to={getIssuesSingleAppSelectedLocation(application.id)}>
               {t("terms.issues")}
+            </Link>
+          </ListItem>
+          <ListItem>
+            <Link to={getInsightsSingleAppSelectedLocation(application.id)}>
+              {t("terms.insights")}
             </Link>
           </ListItem>
           <ListItem>

--- a/client/src/app/pages/insights/helpers.ts
+++ b/client/src/app/pages/insights/helpers.ts
@@ -1,4 +1,4 @@
-import { Location } from "history";
+import { Location, LocationDescriptor } from "history";
 import {
   AnalysisInsight,
   UiAnalysisReportInsight,
@@ -181,6 +181,27 @@ export const getBackToAllInsightsUrl = ({
         .filters,
     },
   })}`;
+};
+
+// When selecting an application, we want to preserve any issue filters that might be present.
+export const getInsightsSingleAppSelectedLocation = (
+  applicationId: number,
+  fromLocation?: Location
+): LocationDescriptor => {
+  const existingFiltersParam =
+    fromLocation &&
+    new URLSearchParams(fromLocation.search).get(
+      `${TablePersistenceKeyPrefix.insights}:filters`
+    );
+  return {
+    pathname: Paths.insightsSingleAppSelected.replace(
+      ":applicationId",
+      String(applicationId)
+    ),
+    search: existingFiltersParam
+      ? new URLSearchParams({ filters: existingFiltersParam }).toString()
+      : undefined,
+  };
 };
 
 export const getInsightTitle = (


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-5899

When viewing an application's details in the detail drawer, we want to show a link to the insights page for that application. This follows the pattern for issues and dependencies.

Screenshot:
<img width="1636" height="922" alt="image" src="https://github.com/user-attachments/assets/f6bc68dc-5153-4c39-9032-736d4dcd4c9d" />
