### PR TITLE
:bug: Fix wizard back button in first step

### DIFF
--- a/client/src/app/pages/applications/generate-assets-wizard/generate-assets-wizard.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/generate-assets-wizard.tsx
@@ -145,6 +145,8 @@ const GenerateAssetsWizardInner: React.FC<IGenerateAssetsWizard> = ({
           id="select-target-profile"
           name={t("generateAssetsWizard.selectTargetProfile.stepTitle")}
           footer={{
+            nextButtonText: t("actions.next"),
+            backButtonText: t("actions.back"),
             isNextDisabled: !state.profile,
           }}
         >
@@ -159,6 +161,8 @@ const GenerateAssetsWizardInner: React.FC<IGenerateAssetsWizard> = ({
           id="capture-parameters"
           name={t("generateAssetsWizard.captureParameters.stepTitle")}
           footer={{
+            nextButtonText: t("actions.next"),
+            backButtonText: t("actions.back"),
             isNextDisabled: !state.parameters.isValid,
           }}
         >
@@ -176,10 +180,11 @@ const GenerateAssetsWizardInner: React.FC<IGenerateAssetsWizard> = ({
             nextButtonText: results
               ? t("actions.close")
               : t("actions.generateAssets"),
-            onNext: results ? handleCancel : submitTasksAndSaveResults,
+            backButtonText: t("actions.back"),
             isNextDisabled: !state.isReady && !results,
             isBackDisabled: !!results,
             isCancelHidden: !!results,
+            onNext: results ? handleCancel : submitTasksAndSaveResults,
           }}
         >
           {!results ? (

--- a/client/src/app/pages/applications/retrieve-config-wizard/retrieve-config-wizard.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/retrieve-config-wizard.tsx
@@ -164,9 +164,9 @@ const RetrieveConfigWizardInner: React.FC<IRetrieveConfigWizard> = ({
               nextButtonText: showResults
                 ? t("actions.close")
                 : t("actions.retrieve"),
-              onNext: showResults ? handleCancel : handleSubmit(onSubmit),
-              isBackDisabled: showResults,
+              isBackHidden: true, // one step wizard, no back button needed
               isCancelHidden: showResults,
+              onNext: showResults ? handleCancel : handleSubmit(onSubmit),
             }}
           >
             {!showResults ? (

--- a/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
@@ -133,6 +133,7 @@ const DiscoverImportWizardInner: React.FC<IDiscoverImportWizard> = ({
           name={t("platformDiscoverWizard.filterInput.stepTitle")}
           footer={{
             nextButtonText: t("actions.next"),
+            backButtonText: t("actions.back"),
             isNextDisabled: !filters.isValid,
           }}
         >
@@ -150,11 +151,11 @@ const DiscoverImportWizardInner: React.FC<IDiscoverImportWizard> = ({
             nextButtonText: results
               ? t("actions.close")
               : t("actions.discoverApplications"),
-            onNext: results ? handleCancel : onSubmitTask,
-            isNextDisabled: !state.isReady && !results,
             backButtonText: t("actions.back"),
+            isNextDisabled: !state.isReady && !results,
             isBackDisabled: !!results,
             isCancelHidden: !!results,
+            onNext: results ? handleCancel : onSubmitTask,
           }}
         >
           {!results ? (


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-6037

In the first step of a wizard, if there is only one step, the back button should be hidden.  If there is more than one step, the back button on the first step should be disabled.
