### PR TITLE
:bug: In the task drawer, show task kind instead of addon

### DIFF
--- a/client/src/app/components/task-manager/TaskManagerDrawer.tsx
+++ b/client/src/app/components/task-manager/TaskManagerDrawer.tsx
@@ -152,8 +152,8 @@ const TaskItem: React.FC<{
 }) => {
   const starttime = dayjs(task.started ?? task.createTime);
   const title = expanded
-    ? `${task.id} (${task.addon})`
-    : `${task.id} (${task.addon}) - ${task.applicationName} - ${
+    ? `${task.id} (${task.kind})`
+    : `${task.id} (${task.kind}) - ${task.applicationName} - ${
         task.priority ?? 0
       }`;
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-6046
Fixes: #2589 

UI tests PR: 1663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Task Manager task titles: both expanded and collapsed states now display task ID and Kind, replacing the previous Add-on label.
  * In the collapsed view, app name and priority continue to appear alongside the new fields.
  * This is a UI text update only; no changes to task behavior, interactions, sorting, or filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->