### PR TITLE
:bug: Remove save button and functionality from SchemaAsCodeEditor

### DIFF
--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -24,7 +24,6 @@ export interface ISchemaAsCodeEditorProps {
   id: string;
   jsonDocument: object;
   jsonSchema?: JsonSchemaObject;
-  onDocumentSaved?: (newSchemaContent: object) => void;
   onDocumentChanged?: (newSchemaContent: object) => void;
   isReadOnly?: boolean;
   /**
@@ -38,7 +37,6 @@ export const SchemaAsCodeEditor = ({
   id,
   jsonDocument,
   jsonSchema,
-  onDocumentSaved,
   onDocumentChanged,
   isReadOnly = false,
   height = "600px",
@@ -48,7 +46,7 @@ export const SchemaAsCodeEditor = ({
   const [currentCode, setCurrentCode] = React.useState(
     JSON.stringify(jsonDocument, null, 2)
   );
-  const [okToSave, setOkToSave] = React.useState(true);
+  // const [documentIsValid, setDocumentIsValid] = React.useState(true);
 
   const focusMovedOnSelectedDocumentChange = React.useRef<boolean>(false);
   React.useEffect(() => {
@@ -61,7 +59,7 @@ export const SchemaAsCodeEditor = ({
   const focusAndHomePosition = () => {
     if (editorRef.current) {
       editorRef.current.focus();
-      editorRef.current.setPosition({ column: 0, lineNumber: 1 });
+      editorRef.current.setPosition({ column: 1, lineNumber: 1 });
     }
   };
 
@@ -113,11 +111,13 @@ export const SchemaAsCodeEditor = ({
           });
         }
       }}
-      editorProps={{
-        onValidate: (markers) => {
-          setOkToSave(markers.every(({ severity }) => severity !== 8));
-        },
-      }}
+      // editorProps={{
+      //   onValidate: (markers) => {
+      //     setDocumentIsValid(
+      //       markers.every(({ severity }) => severity !== MarkerSeverity.Error)
+      //     );
+      //   },
+      // }}
       showEditor={!!currentCode}
       emptyState={
         <div className="simple-task-viewer-empty-state">

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -7,7 +7,6 @@ import {
   Spinner,
   Title,
 } from "@patternfly/react-core";
-import { SaveControl } from "./SaveControl";
 import { JsonSchemaObject } from "@app/api/models";
 import { jsonSchemaToYupSchema } from "./utils";
 import { useMemo } from "react";
@@ -84,20 +83,6 @@ export const SchemaAsCodeEditor = ({
     }
   };
 
-  const handleSave = () => {
-    if (editorRef.current && okToSave && onDocumentSaved) {
-      try {
-        const asJson = JSON.parse(editorRef.current.getValue());
-        if (!validator || validator.isValidSync(asJson)) {
-          onDocumentSaved(asJson);
-        }
-      } catch (error) {
-        console.error("Invalid JSON:", error);
-        // TODO: Use useNotify() to toast the save error to the user
-      }
-    }
-  };
-
   return (
     <CodeEditor
       id={id}
@@ -108,7 +93,7 @@ export const SchemaAsCodeEditor = ({
       isLineNumbersVisible
       isReadOnly={isReadOnly}
       height={height}
-      downloadFileName="my-schema-download.json"
+      downloadFileName="my-schema-download"
       language={Language.json}
       code={currentCode}
       onChange={handleCodeChange}
@@ -144,15 +129,6 @@ export const SchemaAsCodeEditor = ({
           </EmptyState>
         </div>
       }
-      customControls={[
-        !isReadOnly && (
-          <SaveControl
-            key="save-json"
-            onSave={handleSave}
-            isDisabled={!okToSave}
-          />
-        ),
-      ].filter(Boolean)}
     />
   );
 };

--- a/client/src/app/components/schema-defined-fields/SchemaAsFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsFields.tsx
@@ -20,7 +20,6 @@ export interface SchemaAsFieldsProps {
   id: string;
   jsonDocument: object;
   jsonSchema: JsonSchemaObject;
-  onDocumentSaved?: (newJsonDocument: object) => void;
   onDocumentChanged?: (newJsonDocument: object) => void;
   isReadOnly?: boolean;
 }
@@ -222,7 +221,6 @@ export const SchemaAsFields: React.FC<SchemaAsFieldsProps> = ({
   jsonDocument,
   jsonSchema,
   onDocumentChanged,
-  // Note: onDocumentSaved doesn't make sense for this component
   isReadOnly = false,
 }) => {
   const { t } = useTranslation();

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -12,7 +12,6 @@ export interface ISchemaDefinedFieldProps {
   className?: string;
   jsonDocument: object;
   jsonSchema?: JsonSchemaObject;
-  onDocumentSaved?: (newJsonDocument: object) => void;
   onDocumentChanged?: (newJsonDocument: object) => void;
   isReadOnly?: boolean;
 }
@@ -22,19 +21,12 @@ export const SchemaDefinedField = ({
   className,
   jsonDocument,
   jsonSchema,
-  onDocumentSaved,
   onDocumentChanged,
   isReadOnly = false,
 }: ISchemaDefinedFieldProps) => {
   const [isJsonView, setIsJsonView] = React.useState<boolean>(
     !jsonSchema || isComplexSchema(jsonSchema)
   );
-
-  const onSavedHandler = !onDocumentSaved
-    ? undefined
-    : (newJsonDocument: object) => {
-        onDocumentSaved?.(newJsonDocument);
-      };
 
   const onChangeHandler = (newJsonDocument: object) => {
     onDocumentChanged?.(newJsonDocument);
@@ -66,7 +58,6 @@ export const SchemaDefinedField = ({
             isReadOnly={isReadOnly}
             jsonDocument={jsonDocument}
             jsonSchema={jsonSchema}
-            onDocumentSaved={onSavedHandler}
             onDocumentChanged={onChangeHandler}
           />
         ) : (
@@ -75,7 +66,6 @@ export const SchemaDefinedField = ({
             isReadOnly={isReadOnly}
             jsonDocument={jsonDocument}
             jsonSchema={jsonSchema}
-            onDocumentSaved={onSavedHandler}
             onDocumentChanged={onChangeHandler}
           />
         )}


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-6025
Resolves: https://issues.redhat.com/browse/MTA-6024
Resolves: #2592 
Resolves: #2591

Before:
<img width="1236" height="845" alt="Screenshot_20250902_160539" src="https://github.com/user-attachments/assets/58e598b4-b1c9-45ee-a3bd-9784961ba50c" />

After:
<img width="1236" height="845" alt="Screenshot_20250902_160602" src="https://github.com/user-attachments/assets/1779c64d-f2ac-4ea3-9ad0-da1688568390" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the editor’s Save button and manual save flow; edits are now applied automatically when valid JSON is detected and propagated immediately.
  * Download behavior updated: exported schema uses the base name "my-schema-download" without a preset file extension.

* **Documentation**
  * Clarified that changes save automatically on valid edits and downloads no longer append “.json” by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->