### PR TITLE
:sparkles: Add advanced options to generate assets wizard

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -806,10 +806,7 @@
       "description_one": "This application is ready to use {{targetProfile}} to generate assets. Assets will be generated based on the application's discovery manifest, target profile, input parameters, and generator settings.",
       "description_other": "These applications are ready to use {{targetProfile}} to generate assets. Assets will be generated based on the applications' discovery manifests, target profile, input parameters, and generator settings.",
       "selectedApplications_one": "Selected application",
-      "selectedApplications_other": "Selected applications ({{count}})",
-      "renderTemplates": "Output rendering",
-      "renderTemplates-true": "Render asset templates",
-      "renderTemplates-false": "Render to helm charts and values.yaml"
+      "selectedApplications_other": "Selected applications ({{count}})"
     },
     "results": {
       "title": "Asset Generation Results",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -791,13 +791,25 @@
       "noParametersRequired": "No user input parameters are required for this target profile.",
       "parametersLabel": "Parameters"
     },
+    "advancedOptions": {
+      "stepTitle": "Advanced",
+      "title": "Advanced options",
+      "description": "Select advanced options here.",
+      "renderTemplatesLabel": "Output rendering",
+      "renderTemplatesPopover": "When generating assets, each generator can output a helm chart and values.yaml file or a set of assets from the templates. This selection allows you to choose the output of the generators.",
+      "renderTemplates-true": "Render asset templates",
+      "renderTemplates-false": "Render to helm charts and values.yaml"
+    },
     "review": {
       "stepTitle": "Review",
       "title": "Review details",
       "description_one": "This application is ready to use {{targetProfile}} to generate assets. Assets will be generated based on the application's discovery manifest, target profile, input parameters, and generator settings.",
       "description_other": "These applications are ready to use {{targetProfile}} to generate assets. Assets will be generated based on the applications' discovery manifests, target profile, input parameters, and generator settings.",
       "selectedApplications_one": "Selected application",
-      "selectedApplications_other": "Selected applications ({{count}})"
+      "selectedApplications_other": "Selected applications ({{count}})",
+      "renderTemplates": "Output rendering",
+      "renderTemplates-true": "Render asset templates",
+      "renderTemplates-false": "Render to helm charts and values.yaml"
     },
     "results": {
       "title": "Asset Generation Results",

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -483,6 +483,7 @@ export interface PlatformApplicationImportTaskData {
 export interface AssetGenerationTaskData {
   profiles: Ref[];
   params: JsonDocument;
+  render: boolean;
 }
 
 export interface TaskgroupTask {

--- a/client/src/app/pages/applications/generate-assets-wizard/generate-assets-wizard.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/generate-assets-wizard.tsx
@@ -18,6 +18,7 @@ import { useWizardReducer } from "./useWizardReducer";
 import { SelectTargetProfile } from "./step-select-target-profile";
 import { Review } from "./step-review";
 import { Results } from "./step-results";
+import { AdvancedOptions } from "./step-advanced-options";
 
 export const GenerateAssetsWizard: React.FC<IGenerateAssetsWizard> = ({
   isOpen,
@@ -50,8 +51,14 @@ const GenerateAssetsWizardInner: React.FC<IGenerateAssetsWizard> = ({
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
   const { submitTasks } = useStartApplicationAssetGeneration();
-  const { state, setProfile, setParameters, setResults, reset } =
-    useWizardReducer();
+  const {
+    state,
+    setProfile,
+    setParameters,
+    setAdvancedOptions,
+    setResults,
+    reset,
+  } = useWizardReducer();
   const { results } = state;
 
   // TODO: Capture notReady when bulk generate assets is implemented
@@ -65,14 +72,20 @@ const GenerateAssetsWizardInner: React.FC<IGenerateAssetsWizard> = ({
   };
 
   const submitTasksAndSaveResults = async () => {
-    if (ready.length === 0 || !state.profile || !state.parameters.isValid) {
+    if (
+      ready.length === 0 ||
+      !state.profile ||
+      !state.parameters.isValid ||
+      !state.advancedOptions.isValid
+    ) {
       return;
     }
 
     const { success, failure } = await submitTasks(
       ready,
       state.profile,
-      state.parameters.parameters
+      state.parameters.parameters,
+      state.advancedOptions.renderTemplates
     );
     setResults({ success, failure });
 
@@ -175,6 +188,21 @@ const GenerateAssetsWizardInner: React.FC<IGenerateAssetsWizard> = ({
         */}
 
         <WizardStep
+          id="advanced-options"
+          name={t("generateAssetsWizard.advancedOptions.stepTitle")}
+          footer={{
+            nextButtonText: t("actions.next"),
+            backButtonText: t("actions.back"),
+            isNextDisabled: !state.advancedOptions.isValid,
+          }}
+        >
+          <AdvancedOptions
+            onStateChanged={setAdvancedOptions}
+            initialState={state.advancedOptions}
+          />
+        </WizardStep>
+
+        <WizardStep
           id="review"
           name={t("generateAssetsWizard.review.stepTitle")}
           footer={{
@@ -193,6 +221,7 @@ const GenerateAssetsWizardInner: React.FC<IGenerateAssetsWizard> = ({
               applications={ready}
               targetProfile={state.profile!}
               parameters={state.parameters}
+              advancedOptions={state.advancedOptions}
             />
           ) : (
             <Results results={results} />

--- a/client/src/app/pages/applications/generate-assets-wizard/step-advanced-options.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/step-advanced-options.tsx
@@ -1,0 +1,150 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { useForm, useWatch, UseFormReturn } from "react-hook-form";
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+
+import {
+  Form,
+  TextContent,
+  Text,
+  PanelMainBody,
+  PanelMain,
+  Panel,
+  Popover,
+  Icon,
+  Radio,
+} from "@patternfly/react-core";
+import { QuestionCircleIcon } from "@patternfly/react-icons";
+
+import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
+
+export interface AdvancedOptionsState {
+  isValid: boolean;
+  renderTemplates: boolean;
+}
+
+interface AdvancedOptionsFormValues {
+  renderTemplates: boolean;
+}
+
+const useAdvancedOptionsStateChangeHandler = (
+  form: UseFormReturn<AdvancedOptionsFormValues>,
+  onChanged: (parameterState: AdvancedOptionsState) => void
+) => {
+  const {
+    control,
+    formState: { isValid },
+  } = form;
+
+  const watchedValues = useWatch({
+    control,
+    name: ["renderTemplates"],
+  });
+
+  const parameterState = React.useMemo((): AdvancedOptionsState => {
+    const [renderTemplates] = watchedValues;
+    return {
+      renderTemplates,
+      isValid,
+    };
+  }, [watchedValues, isValid]);
+
+  React.useEffect(() => {
+    onChanged(parameterState);
+  }, [onChanged, parameterState]);
+};
+
+export const AdvancedOptions: React.FC<{
+  onStateChanged: (parameters: AdvancedOptionsState) => void;
+  initialState?: AdvancedOptionsState;
+}> = ({ onStateChanged, initialState }) => {
+  const { t } = useTranslation();
+
+  const validationSchema = yup.object().shape({
+    renderTemplates: yup.boolean().required(),
+  });
+
+  const form = useForm<AdvancedOptionsFormValues>({
+    defaultValues: {
+      renderTemplates: initialState?.renderTemplates ?? true,
+    },
+    resolver: yupResolver(validationSchema),
+    mode: "all",
+  });
+  const { control } = form;
+
+  useAdvancedOptionsStateChangeHandler(form, onStateChanged);
+
+  return (
+    <>
+      <TextContent style={{ marginBottom: "var(--pf-v5-global--spacer--lg)" }}>
+        <Text component="h3">
+          {t("generateAssetsWizard.advancedOptions.title")}
+        </Text>
+
+        <Text component="p">
+          {t("generateAssetsWizard.advancedOptions.description")}
+        </Text>
+      </TextContent>
+
+      <Panel>
+        <PanelMain>
+          <PanelMainBody>
+            <Form isHorizontal>
+              <HookFormPFGroupController
+                control={control}
+                name="renderTemplates"
+                fieldId="renderTemplates"
+                label={t(
+                  "generateAssetsWizard.advancedOptions.renderTemplatesLabel"
+                )}
+                labelIcon={
+                  <Popover
+                    triggerAction="hover"
+                    aria-label="render templates description popover"
+                    bodyContent={t(
+                      "generateAssetsWizard.advancedOptions.renderTemplatesPopover"
+                    )}
+                  >
+                    <Icon isInline size="md">
+                      <QuestionCircleIcon />
+                    </Icon>
+                  </Popover>
+                }
+                formGroupProps={{
+                  isStack: true,
+                  hasNoPaddingTop: true,
+                }}
+                renderInput={({ field: { value, name, onChange } }) => (
+                  <>
+                    <Radio
+                      isChecked={value}
+                      onChange={() => onChange(true)}
+                      id={`${name}-true`}
+                      name={name}
+                      isLabelWrapped
+                      label={t(
+                        "generateAssetsWizard.advancedOptions.renderTemplates-true"
+                      )}
+                    />
+                    <Radio
+                      isChecked={!value}
+                      onChange={() => onChange(false)}
+                      id={`${name}-false`}
+                      name={name}
+                      isLabelWrapped
+                      label={t(
+                        "generateAssetsWizard.advancedOptions.renderTemplates-false"
+                      )}
+                    />
+                  </>
+                )}
+              />
+            </Form>
+          </PanelMainBody>
+        </PanelMain>
+      </Panel>
+    </>
+  );
+};

--- a/client/src/app/pages/applications/generate-assets-wizard/step-review.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/step-review.tsx
@@ -21,12 +21,14 @@ import { ParameterState } from "./step-capture-parameters";
 import { SchemaDefinedField } from "@app/components/schema-defined-fields/SchemaDefinedFields";
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { RepositoryDetails } from "@app/components/detail-drawer";
+import { AdvancedOptionsState } from "./step-advanced-options";
 
 export const Review: React.FC<{
   applications: DecoratedApplication[];
   targetProfile: TargetProfile;
   parameters: ParameterState;
-}> = ({ applications, targetProfile, parameters }) => {
+  advancedOptions: AdvancedOptionsState;
+}> = ({ applications, targetProfile, parameters, advancedOptions }) => {
   const { t } = useTranslation();
   const showParameters = parameters.parametersRequired && parameters.parameters;
 
@@ -48,7 +50,7 @@ export const Review: React.FC<{
         <PanelMain>
           <PanelMainBody>
             {applications.map((application) => (
-              <DescriptionList isHorizontal key={application.id} isCompact>
+              <DescriptionList isHorizontal key={application.id}>
                 <DescriptionListGroup>
                   <DescriptionListTerm>
                     {t("terms.targetProfile")}
@@ -109,6 +111,21 @@ export const Review: React.FC<{
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                 )}
+
+                <DescriptionListGroup>
+                  <DescriptionListTerm>
+                    {t(
+                      "generateAssetsWizard.advancedOptions.renderTemplatesLabel"
+                    )}
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {t(
+                      advancedOptions.renderTemplates
+                        ? "generateAssetsWizard.advancedOptions.renderTemplates-true"
+                        : "generateAssetsWizard.advancedOptions.renderTemplates-false"
+                    )}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
               </DescriptionList>
             ))}
           </PanelMainBody>

--- a/client/src/app/pages/applications/generate-assets-wizard/useStartApplicationAssetGeneration.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/useStartApplicationAssetGeneration.tsx
@@ -18,7 +18,8 @@ export const useStartApplicationAssetGeneration = () => {
   const createAndSubmitTask = async (
     application: DecoratedApplication,
     targetProfile: TargetProfile,
-    parameters?: JsonDocument
+    parameters?: JsonDocument,
+    renderTemplates?: boolean
   ): Promise<{
     success?: {
       task: ApplicationAssetGenerationTask;
@@ -39,6 +40,7 @@ export const useStartApplicationAssetGeneration = () => {
       data: {
         profiles: toRefs([targetProfile]),
         params: parameters ?? {},
+        render: renderTemplates ?? false,
       },
     };
 
@@ -60,11 +62,12 @@ export const useStartApplicationAssetGeneration = () => {
   const submitTasks = async (
     applications: DecoratedApplication[],
     targetProfile: TargetProfile,
-    parameters?: JsonDocument
+    parameters?: JsonDocument,
+    renderTemplates?: boolean
   ) => {
     const results = await Promise.allSettled(
       applications.map(async (a) =>
-        createAndSubmitTask(a, targetProfile, parameters)
+        createAndSubmitTask(a, targetProfile, parameters, renderTemplates)
       )
     );
 

--- a/client/src/app/pages/applications/generate-assets-wizard/useWizardReducer.ts
+++ b/client/src/app/pages/applications/generate-assets-wizard/useWizardReducer.ts
@@ -1,11 +1,14 @@
 import * as React from "react";
+
+import { TargetProfile } from "@app/api/models";
+import { AdvancedOptionsState } from "./step-advanced-options";
 import { ParameterState } from "./step-capture-parameters";
 import { ResultsData } from "./step-results";
-import { TargetProfile } from "@app/api/models";
 
 export interface WizardState {
   profile?: TargetProfile;
   parameters: ParameterState;
+  advancedOptions: AdvancedOptionsState;
   isReady: boolean;
   results: ResultsData | null;
 }
@@ -16,6 +19,10 @@ const INITIAL_WIZARD_STATE: WizardState = {
     isValid: true, // TODO: Restore to false with #2498
     parametersRequired: false,
   },
+  advancedOptions: {
+    isValid: true,
+    renderTemplates: true,
+  },
   isReady: false,
   results: null,
 };
@@ -24,11 +31,15 @@ type WizardReducer = (state: WizardState, action: WizardAction) => WizardState;
 type WizardAction =
   | { type: "SET_PROFILE"; payload: TargetProfile }
   | { type: "SET_PARAMETERS"; payload: ParameterState }
+  | { type: "SET_ADVANCED_OPTIONS"; payload: AdvancedOptionsState }
   | { type: "SET_RESULTS"; payload: ResultsData | null }
   | { type: "RESET" };
 
 const validateWizardState = (state: WizardState): WizardState => {
-  const isReady = !!state.profile && state.parameters.isValid;
+  const isReady =
+    !!state.profile &&
+    state.parameters.isValid &&
+    state.advancedOptions.isValid;
   return { ...state, isReady };
 };
 
@@ -38,6 +49,8 @@ const wizardReducer: WizardReducer = (state, action) => {
       return { ...state, profile: action.payload };
     case "SET_PARAMETERS":
       return { ...state, parameters: action.payload };
+    case "SET_ADVANCED_OPTIONS":
+      return { ...state, advancedOptions: action.payload };
     case "SET_RESULTS":
       return { ...state, results: action.payload };
     case "RESET":
@@ -66,6 +79,13 @@ export const useWizardReducer = () => {
     dispatch({ type: "SET_PARAMETERS", payload: parameters });
   }, []);
 
+  const setAdvancedOptions = React.useCallback(
+    (advancedOptions: AdvancedOptionsState) => {
+      dispatch({ type: "SET_ADVANCED_OPTIONS", payload: advancedOptions });
+    },
+    []
+  );
+
   const setResults = React.useCallback((results: ResultsData | null) => {
     dispatch({ type: "SET_RESULTS", payload: results });
   }, []);
@@ -78,6 +98,7 @@ export const useWizardReducer = () => {
     state,
     setProfile,
     setParameters,
+    setAdvancedOptions,
     setResults,
     reset,
   };


### PR DESCRIPTION
Resolves: #2542

Add an Advanced Options step to the generate assets wizard to allow the user to select whether to render asset templates or to helm charts and values.yaml.

New step:
<img width="1608" height="1163" alt="image" src="https://github.com/user-attachments/assets/b80a8046-ec9a-4afc-9f3c-40a8d250d94f" />

Review step with the selection showing:
<img width="1608" height="1163" alt="image" src="https://github.com/user-attachments/assets/da81e15d-67be-4172-af9a-9a5eabb83f6c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Advanced Options step to the Generate Assets wizard with an "Output rendering" toggle; wizard validates this step and includes the choice in task submission and the Review screen.

* **Localization**
  * Added English translations for the Advanced Options step, labels, popover help, and rendering true/false values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->