### PR TITLE
:bug: Fix handling of source platform coordinates on application form

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -291,6 +291,11 @@
     "retain": "Retain",
     "retire": "Retire"
   },
+  "repositoryKind": {
+    "git": "Git",
+    "subversion": "Subversion",
+    "none": "None"
+  },
   "risks": {
     "high": "High",
     "low": "Low",

--- a/client/src/app/hooks/useRepositoryKind.ts
+++ b/client/src/app/hooks/useRepositoryKind.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { OptionWithValue } from "@app/components/SimpleSelect";
+
+export type RepositoryKind = "git" | "subversion" | "" | null;
+
+export const KIND_META: Map<RepositoryKind, { i18nKey: string }> = new Map([
+  ["git", { i18nKey: "repositoryKind.git" }],
+  ["subversion", { i18nKey: "repositoryKind.subversion" }],
+]);
+
+export const useRepositoryKind = () => {
+  const { t } = useTranslation();
+
+  const kindOptions: OptionWithValue<RepositoryKind>[] = useMemo(
+    () =>
+      Array.from(KIND_META.entries()).map(([key, meta]) => ({
+        value: key,
+        toString: () => t(meta.i18nKey),
+      })),
+    [t]
+  );
+
+  return {
+    kindOptions,
+  };
+};

--- a/client/src/app/pages/applications/application-form/__tests__/application-form.test.tsx
+++ b/client/src/app/pages/applications/application-form/__tests__/application-form.test.tsx
@@ -1,17 +1,17 @@
 import React from "react";
+import { server } from "@mocks/server";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { rest } from "msw";
+
 import {
-  render,
-  waitFor,
-  screen,
   fireEvent,
+  render,
+  screen,
+  waitFor,
 } from "@app/test-config/test-utils";
 
-import userEvent from "@testing-library/user-event";
-
-import "@testing-library/jest-dom";
 import { ApplicationFormModal } from "../application-form-modal";
-import { server } from "@mocks/server";
-import { rest } from "msw";
 
 describe("Component: application-form", () => {
   const mockChangeValue = jest.fn();
@@ -33,7 +33,7 @@ describe("Component: application-form", () => {
     const data = {
       name: "app-name",
       businessService: "service",
-      repoType: "Git",
+      repoType: "repositoryKind.git", // display name or i18n key if i18n is disabled
       repoUrl: "https://github.com/username/tackle-testapp.git",
     };
 

--- a/client/src/app/pages/applications/application-form/application-form-modal.tsx
+++ b/client/src/app/pages/applications/application-form/application-form-modal.tsx
@@ -2,13 +2,14 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Button, ButtonVariant, Modal } from "@patternfly/react-core";
 
-import { Application } from "@app/api/models";
+import { DecoratedApplication } from "../useDecoratedApplications";
+
 import { ApplicationForm } from "./application-form";
 import { useApplicationForm } from "./useApplicationForm";
 import { useApplicationFormData } from "./useApplicationFormData";
 
 export interface ApplicationFormModalProps {
-  application: Application | null;
+  application: DecoratedApplication | null;
   onClose: () => void;
   isOpen?: boolean;
 }
@@ -17,6 +18,25 @@ export const ApplicationFormModal: React.FC<ApplicationFormModalProps> = ({
   application,
   onClose,
   isOpen = true,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <ApplicationFormModalInner
+      key={!isOpen ? "closed" : (application?.id ?? "new")}
+      application={application}
+      onClose={onClose}
+      isOpen={isOpen}
+    />
+  );
+};
+
+const ApplicationFormModalInner: React.FC<ApplicationFormModalProps> = ({
+  application,
+  onClose,
+  isOpen,
 }) => {
   const { t } = useTranslation();
   const data = useApplicationFormData({
@@ -27,10 +47,6 @@ export const ApplicationFormModal: React.FC<ApplicationFormModalProps> = ({
       application,
       data,
     });
-
-  if (!isOpen) {
-    return null;
-  }
 
   return (
     <Modal

--- a/client/src/app/pages/applications/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/application-form/application-form.tsx
@@ -51,14 +51,15 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
     repositoryKindOptions,
     stakeholders,
     businessServiceOptions,
-    sourcePlatformFromName,
-    sourcePlatformOptions,
+    platformFromName,
+    platformOptions,
   },
   application,
 }) => {
   const { t } = useTranslation();
   const watchKind = useWatch({ control, name: "kind" });
   const watchAssetKind = useWatch({ control, name: "assetKind" });
+  const watchSourcePlatform = useWatch({ control, name: "sourcePlatform" });
   const values = getValues();
 
   const [isBasicExpanded, setBasicExpanded] = React.useState(true);
@@ -366,10 +367,8 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
                 id="source-platform-select"
                 toggleAriaLabel="Source platform select dropdown toggle"
                 aria-label={name}
-                value={
-                  value ? toOptionLike(value, sourcePlatformOptions) : undefined
-                }
-                options={sourcePlatformOptions}
+                value={value ? toOptionLike(value, platformOptions) : undefined}
+                options={platformOptions}
                 onChange={(selection) => {
                   const name = (selection as OptionWithValue<string>).value;
                   if (name !== value) {
@@ -394,21 +393,21 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
             label={t("terms.sourcePlatformCoordinates")}
             fieldId="coordinatesDocument"
             renderInput={({ field: { value, name, onChange } }) => {
-              const sp = values.sourcePlatform;
-              const cs = sourcePlatformFromName(sp)?.coordinatesSchema;
+              const coordinatesSchema =
+                platformFromName(watchSourcePlatform)?.coordinatesSchema;
 
-              return !sp ? (
+              return !watchSourcePlatform ? (
                 <i>Select a source platform to setup the coordinates.</i>
-              ) : !cs ? (
+              ) : !coordinatesSchema ? (
                 <i>
                   No coordinates are available for the selected source platform.
                 </i>
               ) : (
                 <SchemaDefinedField
-                  key={`${application?.id ?? -1}-${values.sourcePlatform}`}
+                  key={`${application?.id ?? -1}-${watchSourcePlatform}`}
                   id={name}
                   jsonDocument={value ?? {}}
-                  jsonSchema={cs.definition}
+                  jsonSchema={coordinatesSchema.definition}
                   onDocumentChanged={(newJsonDocument) => {
                     // Note: Since the shape of the json document __could__ look like an event
                     //       object, we wrap it up so it will always be processed correctly.

--- a/client/src/app/pages/applications/application-form/useApplicationFormData.ts
+++ b/client/src/app/pages/applications/application-form/useApplicationFormData.ts
@@ -1,21 +1,22 @@
-import React from "react";
-import { useTranslation } from "react-i18next";
+import React, { useCallback, useMemo } from "react";
 import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
 
 import { Application } from "@app/api/models";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { matchItemsToRef, matchItemsToRefs } from "@app/utils/model-utils";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { OptionWithValue } from "@app/components/SimpleSelect";
+import { useRepositoryKind } from "@app/hooks/useRepositoryKind";
 import {
   useCreateApplicationMutation,
   useFetchApplications,
   useUpdateApplicationMutation,
 } from "@app/queries/applications";
 import { useFetchBusinessServices } from "@app/queries/businessservices";
-import { useFetchTagsWithTagItems } from "@app/queries/tags";
+import { useFetchPlatformsWithCoordinatesSchemas } from "@app/queries/platforms";
 import { useFetchStakeholders } from "@app/queries/stakeholders";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { useFetchPlatforms } from "@app/queries/platforms";
-import { OptionWithValue } from "@app/components/SimpleSelect";
+import { useFetchTagsWithTagItems } from "@app/queries/tags";
+import { matchItemsToRef, matchItemsToRefs } from "@app/utils/model-utils";
+import { getAxiosErrorMessage } from "@app/utils/utils";
 
 const entityToOptionWithValue = <T extends { name: string }>(
   entity: T
@@ -24,83 +25,105 @@ const entityToOptionWithValue = <T extends { name: string }>(
   toString: () => entity.name,
 });
 
-const repositoryKindOptions: OptionWithValue<string>[] = [
-  {
-    value: "git",
-    toString: () => `Git`,
-  },
-  {
-    value: "subversion",
-    toString: () => `Subversion`,
-  },
-];
-
 export const useApplicationFormData = ({
   onActionSuccess = () => {},
   onActionFail = () => {},
 }: {
   onActionSuccess?: () => void;
   onActionFail?: () => void;
-}) => {
+} = {}) => {
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
 
   // Fetch data
-  const { tags, tagItems } = useFetchTagsWithTagItems();
-  const { businessServices } = useFetchBusinessServices();
-  const { stakeholders } = useFetchStakeholders();
-  const { data: existingApplications } = useFetchApplications();
-  const { platforms: sourcePlatforms } = useFetchPlatforms();
+  const { tags, tagItems, isSuccess: is1 } = useFetchTagsWithTagItems();
+  const { businessServices, isSuccess: is2 } = useFetchBusinessServices();
+  const { stakeholders, isSuccess: is3 } = useFetchStakeholders();
+  const { data: existingApplications, isSuccess: is4 } = useFetchApplications();
+  const { platforms, isSuccess: is5 } =
+    useFetchPlatformsWithCoordinatesSchemas();
+  const { kindOptions } = useRepositoryKind();
+
+  const isDataReady = useMemo(() => {
+    return is1 && is2 && is3 && is4 && is5;
+  }, [is1, is2, is3, is4, is5]);
 
   // Helpers
-  const idsToTagRefs = (ids: number[] | undefined | null) =>
-    matchItemsToRefs(tags, (i) => i.id, ids);
+  const idsToTagRefs = useCallback(
+    (ids: number[] | undefined | null) =>
+      matchItemsToRefs(tags, (i) => i.id, ids),
+    [tags]
+  );
 
-  const businessServiceToRef = (name: string | undefined | null) =>
-    matchItemsToRef(businessServices, (i) => i.name, name);
+  const businessServiceToRef = useCallback(
+    (name: string | undefined | null) =>
+      matchItemsToRef(businessServices, (i) => i.name, name),
+    [businessServices]
+  );
 
-  const sourcePlatformToRef = (name: string | undefined | null) =>
-    matchItemsToRef(sourcePlatforms, (i) => i.name, name);
+  const sourcePlatformToRef = useCallback(
+    (name: string | undefined | null) =>
+      matchItemsToRef(platforms, (i) => i.name, name),
+    [platforms]
+  );
 
-  const sourcePlatformFromName = (name?: string) =>
-    name ? sourcePlatforms.find((p) => p.name === name) : undefined;
+  const sourcePlatformFromName = useCallback(
+    (name?: string) =>
+      name ? platforms.find((p) => p.name === name) : undefined,
+    [platforms]
+  );
 
-  const stakeholderToRef = (name: string | undefined | null) =>
-    matchItemsToRef(stakeholders, (i) => i.name, name);
+  const stakeholderToRef = useCallback(
+    (name: string | undefined | null) =>
+      matchItemsToRef(stakeholders, (i) => i.name, name),
+    [stakeholders]
+  );
 
-  const stakeholdersToRefs = (names: string[] | undefined | null) =>
-    matchItemsToRefs(stakeholders, (i) => i.name, names);
+  const stakeholdersToRefs = useCallback(
+    (names: string[] | undefined | null) =>
+      matchItemsToRefs(stakeholders, (i) => i.name, names),
+    [stakeholders]
+  );
 
   // Mutation notification handlers
-  const onCreateApplicationSuccess = (application: Application) => {
-    pushNotification({
-      title: t("toastr.success.createWhat", {
-        type: t("terms.application"),
-        what: application.name,
-      }),
-      variant: "success",
-    });
-    onActionSuccess();
-  };
+  const onCreateApplicationSuccess = useCallback(
+    (application: Application) => {
+      pushNotification({
+        title: t("toastr.success.createWhat", {
+          type: t("terms.application"),
+          what: application.name,
+        }),
+        variant: "success",
+      });
+      onActionSuccess();
+    },
+    [pushNotification, t, onActionSuccess]
+  );
 
-  const onUpdateApplicationSuccess = (payload: Application) => {
-    pushNotification({
-      title: t("toastr.success.saveWhat", {
-        type: t("terms.application"),
-        what: payload.name,
-      }),
-      variant: "success",
-    });
-    onActionSuccess();
-  };
+  const onUpdateApplicationSuccess = useCallback(
+    (payload: Application) => {
+      pushNotification({
+        title: t("toastr.success.saveWhat", {
+          type: t("terms.application"),
+          what: payload.name,
+        }),
+        variant: "success",
+      });
+      onActionSuccess();
+    },
+    [pushNotification, t, onActionSuccess]
+  );
 
-  const onCreateUpdateApplicationError = (error: AxiosError) => {
-    pushNotification({
-      title: getAxiosErrorMessage(error),
-      variant: "danger",
-    });
-    onActionFail();
-  };
+  const onCreateUpdateApplicationError = useCallback(
+    (error: AxiosError) => {
+      pushNotification({
+        title: getAxiosErrorMessage(error),
+        variant: "danger",
+      });
+      onActionFail();
+    },
+    [pushNotification, onActionFail]
+  );
 
   // Mutations
   const { mutate: createApplication } = useCreateApplicationMutation(
@@ -115,6 +138,7 @@ export const useApplicationFormData = ({
 
   // Send back source data and action that are needed by the ApplicationForm
   return {
+    isDataReady,
     businessServices,
     businessServiceOptions: businessServices.map(entityToOptionWithValue),
     businessServiceToRef,
@@ -128,10 +152,10 @@ export const useApplicationFormData = ({
     idsToTagRefs,
     createApplication,
     updateApplication,
-    sourcePlatforms,
-    sourcePlatformOptions: sourcePlatforms.map(entityToOptionWithValue),
+    sourcePlatforms: platforms,
+    sourcePlatformOptions: platforms.map(entityToOptionWithValue),
     sourcePlatformFromName,
     sourcePlatformToRef,
-    repositoryKindOptions,
+    repositoryKindOptions: kindOptions,
   };
 };

--- a/client/src/app/pages/applications/application-form/useApplicationFormData.ts
+++ b/client/src/app/pages/applications/application-form/useApplicationFormData.ts
@@ -68,7 +68,7 @@ export const useApplicationFormData = ({
   );
 
   const sourcePlatformFromName = useCallback(
-    (name?: string) =>
+    (name?: string | null) =>
       name ? platforms.find((p) => p.name === name) : undefined,
     [platforms]
   );

--- a/client/src/app/pages/applications/application-form/useApplicationFormData.ts
+++ b/client/src/app/pages/applications/application-form/useApplicationFormData.ts
@@ -61,13 +61,7 @@ export const useApplicationFormData = ({
     [businessServices]
   );
 
-  const sourcePlatformToRef = useCallback(
-    (name: string | undefined | null) =>
-      matchItemsToRef(platforms, (i) => i.name, name),
-    [platforms]
-  );
-
-  const sourcePlatformFromName = useCallback(
+  const platformFromName = useCallback(
     (name?: string | null) =>
       name ? platforms.find((p) => p.name === name) : undefined,
     [platforms]
@@ -152,10 +146,9 @@ export const useApplicationFormData = ({
     idsToTagRefs,
     createApplication,
     updateApplication,
-    sourcePlatforms: platforms,
-    sourcePlatformOptions: platforms.map(entityToOptionWithValue),
-    sourcePlatformFromName,
-    sourcePlatformToRef,
+    platforms,
+    platformOptions: platforms.map(entityToOptionWithValue),
+    platformFromName,
     repositoryKindOptions: kindOptions,
   };
 };

--- a/client/src/app/pages/source-platforms/source-platforms.tsx
+++ b/client/src/app/pages/source-platforms/source-platforms.tsx
@@ -19,20 +19,25 @@ import {
   ToolbarItem,
   Tooltip,
 } from "@patternfly/react-core";
+import { CubesIcon, PencilAltIcon } from "@patternfly/react-icons";
 import {
+  ActionsColumn,
   Table,
   Tbody,
+  Td,
   Th,
   Thead,
   Tr,
-  Td,
-  ActionsColumn,
 } from "@patternfly/react-table";
-import { CubesIcon, PencilAltIcon } from "@patternfly/react-icons";
+
+import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { SourcePlatform } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
@@ -40,18 +45,14 @@ import {
 } from "@app/components/TableControls";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useDeletePlatformMutation } from "@app/queries/platforms";
-import { SourcePlatform } from "@app/api/models";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { getAxiosErrorMessage } from "@app/utils/utils";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
-import { SimplePagination } from "@app/components/SimplePagination";
 
+import { ColumnPlatformName } from "./components/column-platform-name";
 import LinkToPlatformApplications from "./components/link-to-platform-applications";
 import PlatformDetailDrawer from "./components/platform-detail-drawer";
 import { PlatformForm } from "./components/platform-form";
 import { DiscoverImportWizard } from "./discover-import-wizard/discover-import-wizard";
 import { useFetchPlatformsWithTasks } from "./useFetchPlatformsWithTasks";
-import { ColumnPlatformName } from "./components/column-platform-name";
 import { usePlatformKindList } from "./usePlatformKindList";
 
 export const SourcePlatforms: React.FC = () => {
@@ -81,7 +82,7 @@ export const SourcePlatforms: React.FC = () => {
 
   const {
     platforms,
-    isFetching,
+    isLoading,
     error: fetchError,
   } = useFetchPlatformsWithTasks(isModalOpen);
 
@@ -109,7 +110,7 @@ export const SourcePlatforms: React.FC = () => {
     idProperty: "id",
     dataNameProperty: "name",
     items: platforms || [],
-    isLoading: isFetching,
+    isLoading,
     hasActionsColumn: true,
 
     columnNames: {
@@ -210,7 +211,7 @@ export const SourcePlatforms: React.FC = () => {
       </PageSection>
       <PageSection>
         <ConditionalRender
-          when={isFetching && !(platforms || fetchError)}
+          when={isLoading && !(platforms || fetchError)}
           then={<AppPlaceholder />}
         >
           <div
@@ -253,7 +254,7 @@ export const SourcePlatforms: React.FC = () => {
                 </Tr>
               </Thead>
               <ConditionalTableBody
-                isLoading={isFetching}
+                isLoading={isLoading}
                 isError={!!fetchError}
                 isNoData={currentPageItems.length === 0}
                 noDataEmptyState={

--- a/client/src/app/pages/source-platforms/useFetchPlatformsWithTasks.ts
+++ b/client/src/app/pages/source-platforms/useFetchPlatformsWithTasks.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 import { group, listify, mapEntries } from "radash";
+
 import { SourcePlatform, TaskDashboard } from "@app/api/models";
-import { TaskStates, useFetchTaskDashboard } from "@app/queries/tasks";
 import { useFetchPlatforms } from "@app/queries/platforms";
+import { TaskStates, useFetchTaskDashboard } from "@app/queries/tasks";
 
 export interface TasksGroupedByKind {
   [key: string]: TaskDashboard[];
@@ -130,7 +131,7 @@ const decoratePlatforms = (
 };
 
 export const useFetchPlatformsWithTasks = (refetchDisabled: boolean) => {
-  const { platforms, isFetching, isSuccess, error } = useFetchPlatforms();
+  const { platforms, isLoading, isSuccess, error } = useFetchPlatforms();
   const { tasks } = useFetchTaskDashboard(refetchDisabled);
 
   const decoratedPlatforms = useMemo(
@@ -146,7 +147,7 @@ export const useFetchPlatformsWithTasks = (refetchDisabled: boolean) => {
   return {
     platforms: decoratedPlatforms,
     // platformNames,
-    isFetching,
+    isLoading,
     isSuccess,
     error,
   };

--- a/client/src/app/queries/applications.ts
+++ b/client/src/app/queries/applications.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios, { AxiosError, AxiosResponse } from "axios";
+import saveAs from "file-saver";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import {
   Application,
   ApplicationDependency,
@@ -20,9 +22,8 @@ import {
   getApplications,
   updateApplication,
 } from "@app/api/rest";
+
 import { assessmentsByItemIdQueryKey } from "./assessments";
-import saveAs from "file-saver";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const ApplicationDependencyQueryKey = "applicationdependencies";
 export const ApplicationsQueryKey = "applications";
@@ -40,7 +41,7 @@ export const useFetchApplications = (
     | (() => number | false) = DEFAULT_REFETCH_INTERVAL
 ) => {
   const queryClient = useQueryClient();
-  const { isLoading, error, refetch, data } = useQuery({
+  const { isLoading, isSuccess, error, refetch, data } = useQuery({
     queryKey: [ApplicationsQueryKey],
     queryFn: getApplications,
     onSuccess: () => {
@@ -54,6 +55,8 @@ export const useFetchApplications = (
   return {
     data: data || [],
     isFetching: isLoading,
+    isLoading,
+    isSuccess,
     error,
     refetch,
   };
@@ -65,7 +68,7 @@ export const useFetchApplicationById = (
   id?: number | string,
   refetchInterval: number | false = DEFAULT_REFETCH_INTERVAL
 ) => {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isSuccess, error } = useQuery({
     queryKey: [ApplicationQueryKey, id],
     queryFn: () =>
       id === undefined ? Promise.resolve(undefined) : getApplicationById(id),
@@ -77,6 +80,8 @@ export const useFetchApplicationById = (
   return {
     application: data,
     isFetching: isLoading,
+    isLoading,
+    isSuccess,
     fetchError: error,
   };
 };
@@ -85,7 +90,7 @@ export const useFetchApplicationManifest = (
   applicationId?: number | string,
   refetchInterval: number | false = DEFAULT_REFETCH_INTERVAL * 2
 ) => {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isSuccess, error } = useQuery({
     queryKey: [ApplicationManifestQueryKey, applicationId],
     queryFn: () =>
       applicationId === undefined
@@ -99,6 +104,8 @@ export const useFetchApplicationManifest = (
   return {
     manifest: data,
     isFetching: isLoading,
+    isLoading,
+    isSuccess,
     fetchError: error,
   };
 };

--- a/client/src/app/queries/businessservices.ts
+++ b/client/src/app/queries/businessservices.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { BusinessService, New } from "@app/api/models";
 import {
   createBusinessService,
   deleteBusinessService,
@@ -8,8 +10,6 @@ import {
   getBusinessServices,
   updateBusinessService,
 } from "@app/api/rest";
-import { BusinessService, New } from "@app/api/models";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const BusinessServicesQueryKey = "businessservices";
 export const BusinessServiceQueryKey = "businessservice";
@@ -17,7 +17,7 @@ export const BusinessServiceQueryKey = "businessservice";
 export const useFetchBusinessServices = (
   refetchInterval: number | false = DEFAULT_REFETCH_INTERVAL
 ) => {
-  const { data, isLoading, error, refetch } = useQuery({
+  const { data, isLoading, isSuccess, error, refetch } = useQuery({
     queryKey: [BusinessServicesQueryKey],
     queryFn: getBusinessServices,
     onError: (error: AxiosError) => console.log("error, ", error),
@@ -26,6 +26,8 @@ export const useFetchBusinessServices = (
   return {
     businessServices: data || [],
     isFetching: isLoading,
+    isLoading,
+    isSuccess,
     fetchError: error as AxiosError,
     refetch,
   };

--- a/client/src/app/queries/platforms.ts
+++ b/client/src/app/queries/platforms.ts
@@ -65,13 +65,14 @@ export const useFetchPlatformsWithCoordinatesSchemas = (
       queryKey: [PLATFORM_COORDINATES_SCHEMA_QUERY_KEY, kind],
       queryFn: () => getPlatformCoordinatesSchema(kind),
       refetchInterval: false,
+      staleTime: Infinity,
     })),
   });
 
   const aggregatedSchemaResults = useMemo(
     () => ({
       isLoading: schemaResults.some((result) => result.isLoading),
-      isFetching: schemaResults.every((result) => result.isFetching),
+      isFetching: schemaResults.some((result) => result.isFetching),
       isSuccess: schemaResults.every((result) => result.isSuccess),
       errors: schemaResults.map(({ error }) => error).filter(Boolean),
       schemasByKind: Object.fromEntries(

--- a/client/src/app/queries/platforms.ts
+++ b/client/src/app/queries/platforms.ts
@@ -68,8 +68,8 @@ export const useFetchPlatformsWithCoordinatesSchemas = (
     })),
   });
 
-  const aggregatedSchemaResults = useMemo(() => {
-    const r = {
+  const aggregatedSchemaResults = useMemo(
+    () => ({
       isLoading: schemaResults.some((result) => result.isLoading),
       isFetching: schemaResults.every((result) => result.isFetching),
       isSuccess: schemaResults.every((result) => result.isSuccess),
@@ -77,10 +77,9 @@ export const useFetchPlatformsWithCoordinatesSchemas = (
       schemasByKind: Object.fromEntries(
         uniqueKinds.map((kind, index) => [kind, schemaResults[index].data])
       ),
-    };
-    console.log("aggregatedSchemaResults", r);
-    return r;
-  }, [schemaResults, uniqueKinds]);
+    }),
+    [schemaResults, uniqueKinds]
+  );
 
   const platformsWithSchemas = useMemo(() => {
     const { schemasByKind } = aggregatedSchemaResults;

--- a/client/src/app/queries/platforms.ts
+++ b/client/src/app/queries/platforms.ts
@@ -1,15 +1,26 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-
+import { useMemo } from "react";
+import {
+  UseQueryOptions,
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { AxiosError } from "axios";
-import { SourcePlatform } from "@app/api/models";
+import { unique } from "radash";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { SourcePlatform, TargetedSchema } from "@app/api/models";
 import {
   createPlatform,
   deletePlatform,
   getPlatformById,
+  getPlatformCoordinatesSchema,
   getPlatforms,
   updatePlatform,
 } from "@app/api/rest";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+
+import { PLATFORM_COORDINATES_SCHEMA_QUERY_KEY } from "./schemas";
 
 export const PLATFORMS_QUERY_KEY = "platforms";
 export const PLATFORM_QUERY_KEY = "platform";
@@ -27,9 +38,67 @@ export const useFetchPlatforms = (
   return {
     platforms: data || [],
     isFetching: isLoading,
+    isLoading,
     isSuccess,
     error,
     refetch,
+  };
+};
+
+export const useFetchPlatformsWithCoordinatesSchemas = (
+  refetchInterval: number | false = false
+) => {
+  const {
+    platforms,
+    isLoading: isPlatformsLoading,
+    isSuccess: isPlatformsSuccess,
+    error: platformsError,
+  } = useFetchPlatforms(refetchInterval);
+
+  const uniqueKinds = useMemo(
+    () => unique(platforms.map((platform) => platform.kind)),
+    [platforms]
+  );
+
+  const schemaResults = useQueries({
+    queries: uniqueKinds.map<UseQueryOptions<TargetedSchema>>((kind) => ({
+      queryKey: [PLATFORM_COORDINATES_SCHEMA_QUERY_KEY, kind],
+      queryFn: () => getPlatformCoordinatesSchema(kind),
+      refetchInterval: false,
+    })),
+  });
+
+  const aggregatedSchemaResults = useMemo(() => {
+    const r = {
+      isLoading: schemaResults.some((result) => result.isLoading),
+      isFetching: schemaResults.every((result) => result.isFetching),
+      isSuccess: schemaResults.every((result) => result.isSuccess),
+      errors: schemaResults.map(({ error }) => error).filter(Boolean),
+      schemasByKind: Object.fromEntries(
+        uniqueKinds.map((kind, index) => [kind, schemaResults[index].data])
+      ),
+    };
+    console.log("aggregatedSchemaResults", r);
+    return r;
+  }, [schemaResults, uniqueKinds]);
+
+  const platformsWithSchemas = useMemo(() => {
+    const { schemasByKind } = aggregatedSchemaResults;
+    return platforms.map((platform) => ({
+      ...platform,
+      coordinatesSchema: schemasByKind[platform.kind],
+    }));
+  }, [platforms, aggregatedSchemaResults]);
+
+  return {
+    platforms: platformsWithSchemas,
+    isLoading: isPlatformsLoading || aggregatedSchemaResults.isLoading,
+    isSuccess: isPlatformsSuccess && aggregatedSchemaResults.isSuccess,
+    error:
+      platformsError ||
+      (aggregatedSchemaResults.errors.length > 0
+        ? aggregatedSchemaResults.errors[0]
+        : null),
   };
 };
 
@@ -37,7 +106,7 @@ export const useFetchPlatformById = (
   id?: number | string,
   refetchInterval: number | false = DEFAULT_REFETCH_INTERVAL
 ) => {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isSuccess, error } = useQuery({
     queryKey: [PLATFORM_QUERY_KEY, id],
     queryFn: () =>
       id === undefined ? Promise.resolve(undefined) : getPlatformById(id),
@@ -48,7 +117,8 @@ export const useFetchPlatformById = (
 
   return {
     platform: data,
-    isFetching: isLoading,
+    isLoading,
+    isSuccess,
     fetchError: error,
   };
 };

--- a/client/src/app/queries/schemas.ts
+++ b/client/src/app/queries/schemas.ts
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-
 import { AxiosError } from "axios";
+
 import {
-  getSchemas,
-  getSchemaByName,
   getPlatformCoordinatesSchema,
   getPlatformDiscoveryFilterSchema,
+  getSchemaByName,
+  getSchemas,
 } from "@app/api/rest";
 
 export const SCHEMAS_QUERY_KEY = "schemas";
@@ -33,7 +33,7 @@ export const useFetchSchemas = (refetchInterval: number | false = false) => {
 };
 
 export const useFetchSchemaByName = (name?: string) => {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isSuccess, error } = useQuery({
     queryKey: [SCHEMA_QUERY_KEY, name],
     queryFn: () =>
       name === undefined ? Promise.resolve(undefined) : getSchemaByName(name),
@@ -44,12 +44,13 @@ export const useFetchSchemaByName = (name?: string) => {
   return {
     schema: data,
     isLoading,
+    isSuccess,
     fetchError: error,
   };
 };
 
 export const useFetchPlatformCoordinatesSchema = (platformKind?: string) => {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isSuccess, error } = useQuery({
     queryKey: [PLATFORM_COORDINATES_SCHEMA_QUERY_KEY, platformKind],
     queryFn: () =>
       platformKind === undefined
@@ -62,6 +63,7 @@ export const useFetchPlatformCoordinatesSchema = (platformKind?: string) => {
   return {
     coordinatesSchema: data,
     isLoading,
+    isSuccess,
     fetchError: error,
   };
 };

--- a/client/src/app/queries/stakeholders.ts
+++ b/client/src/app/queries/stakeholders.ts
@@ -1,17 +1,19 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { Role, Stakeholder, StakeholderWithRole } from "@app/api/models";
 import {
   createStakeholder,
   deleteStakeholder,
   getStakeholders,
   updateStakeholder,
 } from "@app/api/rest";
-import { AxiosError } from "axios";
-import { Role, Stakeholder, StakeholderWithRole } from "@app/api/models";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+
+import { ARCHETYPES_QUERY_KEY } from "./archetypes";
+import { assessmentsQueryKey } from "./assessments";
 import { BusinessServicesQueryKey } from "./businessservices";
 import { MigrationWavesQueryKey } from "./migration-waves";
-import { assessmentsQueryKey } from "./assessments";
-import { ARCHETYPES_QUERY_KEY } from "./archetypes";
 
 export const StakeholdersQueryKey = "stakeholders";
 
@@ -45,6 +47,7 @@ export const useFetchStakeholders = (
   return {
     stakeholders: data || [],
     isFetching: isLoading,
+    isLoading,
     isSuccess,
     fetchError: error,
     refetch,


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-6100
Resolves: #2563

Change the source platform data flow such that the source platform coordinates schemas are available prior to the selection of the source platform.  This way, there is no delay in applying the initial schema or changing the schema on selection/clearing of the source platform.

Now form validation works as expected and when a source platform is selected, and coordinates are entered, changes in other fields will enable the save button.

Related changes:
- Add `useRepositoryKind` hook for reuse

  Even though the hook only holds static data, keeping it as a hook allows for reuse in other components.

- Update a lot of queries to report isLoading and isSuccess instead of isFetching

  isLoading, isSuccess, and isError are all data related.

  The isFetching status is based on when the fetch is actually running and may not result in any updates.  We really care more about having data than the fetch status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added UI labels/options for repository kinds (Git, Subversion, None).
  - Added Application detail drawer, import/retrieve wizards, and persistent Platforms table settings.
  - Enabled saving downloaded application reports to files.

- Improvements
  - Application form delays rendering until data is ready and handles platform/coordinates selection more reliably.
  - More consistent loading indicators and status flags across lists and forms.
  - Toolbar actions visually separated for clarity.

- Bug Fixes
  - Fixed dependencies management by passing the correct application to the dependency form.

- Tests
  - Added API-mocking scaffolding to application form tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->