### PR TITLE
:bug: Fix some applications query issues

### DIFF
--- a/client/src/app/pages/applications/application-detail-drawer/components/download-button.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/components/download-button.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { Button } from "@patternfly/react-core";
+import { Alert, Spinner } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { useDownloadStaticReport } from "@app/queries/applications";
-import { Application } from "@app/api/models";
-import { Spinner, Alert } from "@patternfly/react-core";
 
-import { MimeType } from "@app/api/models";
+import { Application, MimeType } from "@app/api/models";
+import { useDownloadStaticReport } from "@app/queries/applications";
 
 interface IDownloadButtonProps {
   application: Application;
@@ -20,8 +19,8 @@ export const DownloadButton: React.FC<IDownloadButtonProps> = ({
   isDownloadEnabled,
 }) => {
   const {
-    mutate: downloadFile,
-    isLoading,
+    mutateAsync: downloadFile,
+    isPending,
     isError,
   } = useDownloadStaticReport();
 
@@ -34,7 +33,7 @@ export const DownloadButton: React.FC<IDownloadButtonProps> = ({
 
   return (
     <>
-      {isLoading ? (
+      {isPending ? (
         <Spinner size="sm" />
       ) : isError ? (
         <Alert variant="warning" isInline title={"Error downloading report"}>

--- a/client/src/app/queries/applications.ts
+++ b/client/src/app/queries/applications.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/api/models";
 import {
   APPLICATIONS,
+  HEADERS,
   createApplication,
   createApplicationDependency,
   deleteApplication,
@@ -207,9 +208,9 @@ export const useDeleteApplicationMutation = (
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id }: { id: number }) => deleteApplication(id),
-    onSuccess: (_res) => {
+    onSuccess: (_res, vars) => {
       queryClient.invalidateQueries({ queryKey: [ApplicationsQueryKey] });
-      onSuccess(1);
+      onSuccess(vars.id);
     },
     onError: onError,
   });
@@ -230,11 +231,10 @@ export const useBulkDeleteApplicationMutation = (
   });
 };
 
-export const downloadStaticReport = async ({
+const downloadStaticReport = async ({
   application,
   mimeType,
 }: DownloadOptions): Promise<void> => {
-  const yamlAcceptHeader = "application/x-yaml";
   let url = `${APPLICATIONS}/${application.id}/analysis/report`;
 
   switch (mimeType) {
@@ -249,11 +249,7 @@ export const downloadStaticReport = async ({
   try {
     const response = await axios.get(url, {
       responseType: "blob",
-      ...(MimeType.YAML && {
-        headers: {
-          Accept: yamlAcceptHeader,
-        },
-      }),
+      ...(mimeType === MimeType.YAML && { headers: HEADERS.yaml }),
     });
 
     if (response.status !== 200) {


### PR DESCRIPTION
Resolves some issues noticed while updating the application form:

- `useDeleteApplicationMutation()` was not sending the correct application id to `onSuccess()`

- `downloadStaticReport()` was not testing for mime type properly when setting the accept headers for yaml types

- `DownloadButton` changed:
  - Using `mutateAsync` instead of `mutate`
  - Use `isPending` instead of `isLoading` as per the deprecation comment



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Improvements
  * Static report downloads now save directly to your device with a clear, descriptive filename.
  * Download button shows a spinner while a download is in progress for clearer feedback.

* Bug Fixes
  * Fixed YAML report downloads so the correct file format is delivered.
  * Application deletion now correctly reflects the deleted item in subsequent actions and UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->