### PR TITLE
:bug: Discover application filter input for cloud foundry

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -1032,6 +1032,12 @@ export interface JsonSchemaObject {
   /** For type array */
   items?: JsonSchemaObject;
 
+  /** For type array, minimum number of items */
+  minItems?: number;
+
+  /** For type array, maximum number of items */
+  maxItems?: number;
+
   /** For type object, defined properties */
   properties?: { [key: string]: JsonSchemaObject };
 

--- a/client/src/app/components/schema-defined-fields/utils.tsx
+++ b/client/src/app/components/schema-defined-fields/utils.tsx
@@ -1,8 +1,9 @@
-import { JsonSchemaObject } from "@app/api/models";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { TFunction } from "i18next";
 import { unique } from "radash";
 import * as yup from "yup";
+
+import { JsonSchemaObject } from "@app/api/models";
 
 const fallbackT = (k: string, v?: object) => `${k}: ${JSON.stringify(v)}`;
 
@@ -19,7 +20,21 @@ export const jsonSchemaToYupSchema = (
     if (jsonSchema.items) {
       schema = schema.of(jsonSchemaToYupSchema(jsonSchema.items, t));
     }
-    // TODO: minItems, maxItems, uniqueItems
+
+    if (jsonSchema.minItems) {
+      schema = schema.min(
+        jsonSchema.minItems,
+        t("validation.minItems", { count: jsonSchema.minItems })
+      );
+    }
+    if (jsonSchema.maxItems) {
+      schema = schema.max(
+        jsonSchema.maxItems,
+        t("validation.maxItems", { count: jsonSchema.maxItems })
+      );
+    }
+    // TODO: uniqueItems
+
     return schema;
   }
 

--- a/client/src/app/pages/applications/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/application-form/application-form.tsx
@@ -22,6 +22,7 @@ import {
 import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { SchemaDefinedField } from "@app/components/schema-defined-fields";
 import { toOptionLike } from "@app/utils/model-utils";
+import { wrapAsEvent } from "@app/utils/utils";
 
 import { DecoratedApplication } from "../useDecoratedApplications";
 
@@ -409,14 +410,7 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
                   jsonDocument={value ?? {}}
                   jsonSchema={coordinatesSchema.definition}
                   onDocumentChanged={(newJsonDocument) => {
-                    // Note: Since the shape of the json document __could__ look like an event
-                    //       object, we wrap it up so it will always be processed correctly.
-                    onChange({
-                      target: {
-                        name,
-                        value: newJsonDocument,
-                      },
-                    });
+                    onChange(wrapAsEvent(newJsonDocument, name));
                   }}
                 />
               );

--- a/client/src/app/pages/applications/generate-assets-wizard/step-capture-parameters.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/step-capture-parameters.tsx
@@ -23,6 +23,7 @@ import {
   jsonSchemaToYupSchema,
 } from "@app/components/schema-defined-fields/utils";
 import { useFetchGenerators } from "@app/queries/generators";
+import { wrapAsEvent } from "@app/utils/utils";
 
 export interface ParameterState {
   isValid: boolean;
@@ -191,7 +192,7 @@ export const CaptureParameters: React.FC<{
                       jsonDocument={value ?? {}}
                       jsonSchema={schema}
                       onDocumentChanged={(newJsonDocument) => {
-                        onChange(newJsonDocument);
+                        onChange(wrapAsEvent(newJsonDocument, name));
                       }}
                     />
                   )}

--- a/client/src/app/pages/source-platforms/discover-import-wizard/filter-input-cloudfoundry.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/filter-input-cloudfoundry.tsx
@@ -1,0 +1,288 @@
+import * as React from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { Control, useFieldArray, useForm } from "react-hook-form";
+import * as yup from "yup";
+import {
+  Bullseye,
+  Button,
+  FormFieldGroup,
+  FormFieldGroupHeader,
+  Grid,
+  GridItem,
+  Stack,
+  StackItem,
+  Tooltip,
+} from "@patternfly/react-core";
+import { MinusCircleIcon } from "@patternfly/react-icons/dist/js/icons/minus-circle-icon";
+import { PlusCircleIcon } from "@patternfly/react-icons/dist/js/icons/plus-circle-icon";
+import styles from "@patternfly/react-styles/css/components/Form/form";
+
+import { JsonDocument } from "@app/api/models";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+import { HookFormPFTextInput } from "@app/components/HookFormPFFields";
+
+const AddButton = ({
+  label,
+  tooltip,
+  onAdd,
+}: {
+  label: string;
+  tooltip?: string;
+  onAdd: () => void;
+}) => {
+  return (
+    <Bullseye>
+      <Tooltip content={<span>{tooltip ?? label}</span>}>
+        <Button variant="link" icon={<PlusCircleIcon />} onClick={onAdd}>
+          {label}
+        </Button>
+      </Tooltip>
+    </Bullseye>
+  );
+};
+
+const RemoveButton = ({
+  label,
+  tooltip,
+  onRemove,
+}: {
+  label?: string;
+  tooltip: string;
+  onRemove: () => void;
+}) => {
+  return (
+    <Bullseye>
+      <Tooltip content={<span>{tooltip ?? label}</span>}>
+        <Button variant="plain" icon={<MinusCircleIcon />} onClick={onRemove}>
+          {label}
+        </Button>
+      </Tooltip>
+    </Bullseye>
+  );
+};
+
+/*
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "names": {
+      "description": "Application names. Each may be a glob expression.",
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 0,
+      "type": "array"
+    },
+    "spaces": {
+      "description": "Space names.",
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array"
+    }
+  },
+  "required": ["spaces"],
+  "title": "CloudFoundry Discover Filter",
+  "type": "object"
+}
+*/
+
+interface FormValues {
+  names: { value: string }[];
+  spaces: { value: string }[];
+}
+
+const stringsToFormValue = (values?: string[]) =>
+  values?.map((value) => ({ value })) ?? [];
+
+const formValueToStrings = (values?: { value: string }[]) =>
+  values?.map((value) => value.value) ?? [];
+
+export interface FilterInputCloudFoundryProps {
+  id: string;
+  values?: JsonDocument;
+  onDocumentChanged: (newJsonDocument: JsonDocument) => void;
+}
+
+/**
+ * Inputs for CloudFoundry discover applications filter.  This is based on the json schema.
+ */
+export const FilterInputCloudFoundry: React.FC<
+  FilterInputCloudFoundryProps
+> = ({ id, values, onDocumentChanged }) => {
+  const validationSchema = yup.object().shape({
+    names: yup
+      .array()
+      .of(
+        yup.object().shape({
+          value: yup
+            .string()
+            .min(1, "Name must be at least 1 character")
+            .trim(),
+        })
+      )
+      .min(0),
+    spaces: yup
+      .array()
+      .of(
+        yup.object().shape({
+          value: yup
+            .string()
+            .min(1, "Space must be at least 1 character")
+            .trim(),
+        })
+      )
+      .min(1),
+  });
+
+  const form = useForm<FormValues>({
+    defaultValues: {
+      names: stringsToFormValue(values?.names as string[]),
+      spaces: stringsToFormValue(values?.spaces as string[]),
+    },
+    resolver: yupResolver(validationSchema),
+    mode: "all",
+  });
+
+  const { control, subscribe } = form;
+
+  React.useEffect(() => {
+    const subscription = subscribe({
+      formState: { values: true },
+      callback: ({ values }) => {
+        const asDocument = {
+          names: formValueToStrings(values.names),
+          spaces: formValueToStrings(values.spaces),
+        };
+        console.log("subscription document", asDocument);
+        onDocumentChanged(asDocument);
+      },
+    });
+    return () => subscription();
+  }, [subscribe, onDocumentChanged]);
+
+  // useFormUpdateHandler(form, onDocumentChanged);
+
+  // // Initialize from values prop
+  // useEffect(() => {
+  //   reset({
+  //     names: (values?.names as string[]) || [],
+  //     spaces: (values?.spaces as string[]) || [],
+  //   });
+  // }, [values, reset]);
+
+  return (
+    <Stack id={id}>
+      <StackItem>
+        <StringFieldsGroup
+          control={form.control}
+          groupTitle="Names"
+          groupDescription="Enter application name (glob expressions allowed)"
+          fieldName="names"
+          addLabel="Add a name"
+          removeLabel="Remove this name"
+          emptyMessage="No application names specified"
+        />
+      </StackItem>
+
+      <StackItem>
+        <StringFieldsGroup
+          control={form.control}
+          groupTitle="Spaces"
+          groupDescription="Enter space name"
+          fieldName="spaces"
+          addLabel="Add a space"
+          removeLabel="Remove this space"
+          emptyMessage="No spaces specified (at least one space is required)"
+          isRequired={true}
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+interface StringFieldsProps {
+  control: Control<FormValues>;
+  fieldName: keyof FormValues;
+  groupTitle: string;
+  groupDescription?: string;
+  addLabel: string;
+  removeLabel: string;
+  emptyMessage?: string;
+  isRequired?: boolean;
+}
+
+const StringFieldsGroup: React.FC<StringFieldsProps> = ({
+  control,
+  fieldName,
+  groupTitle,
+  groupDescription,
+  addLabel,
+  removeLabel,
+  emptyMessage,
+  isRequired = false,
+}) => {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: fieldName,
+  });
+
+  const handleAddField = () => {
+    append({ value: "" });
+  };
+
+  const handleRemoveField = (index: number) => {
+    remove(index);
+  };
+
+  return (
+    <FormFieldGroup
+      header={
+        <FormFieldGroupHeader
+          titleText={{
+            text: (
+              <>
+                {groupTitle}
+                {isRequired && (
+                  <span className={styles.formLabelRequired}> *</span>
+                )}
+              </>
+            ),
+            id: `${fieldName}-header`,
+          }}
+          titleDescription={groupDescription}
+          actions={<AddButton label={addLabel} onAdd={handleAddField} />}
+        />
+      }
+    >
+      <Grid hasGutter>
+        {fields.length === 0 && (
+          <GridItem span={12}>
+            <EmptyTextMessage message={emptyMessage} />
+          </GridItem>
+        )}
+        {fields.map((field, index) => (
+          <React.Fragment key={`${fieldName}-${index}`}>
+            <GridItem span={11}>
+              <HookFormPFTextInput
+                control={control}
+                name={`${fieldName}.${index}.value`}
+                fieldId={`${fieldName}-${field.id}`}
+                isRequired={isRequired}
+              />
+            </GridItem>
+            <GridItem span={1}>
+              <RemoveButton
+                tooltip={removeLabel}
+                onRemove={() => handleRemoveField(index)}
+              />
+            </GridItem>
+          </React.Fragment>
+        ))}
+      </Grid>
+    </FormFieldGroup>
+  );
+};

--- a/client/src/app/pages/source-platforms/discover-import-wizard/filter-input.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/filter-input.tsx
@@ -10,8 +10,11 @@ import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
 import { SchemaDefinedField } from "@app/components/schema-defined-fields";
 import { jsonSchemaToYupSchema } from "@app/components/schema-defined-fields/utils";
 import { useFetchPlatformDiscoveryFilterSchema } from "@app/queries/schemas";
+import { wrapAsEvent } from "@app/utils/utils";
 
 import { usePlatformKindList } from "../usePlatformKindList";
+
+import { FilterInputCloudFoundry } from "./filter-input-cloudfoundry";
 
 interface FiltersFormValues {
   filterRequired: boolean;
@@ -137,17 +140,28 @@ export const FilterInput: React.FC<{
               platformName: platform.name,
             })}
             fieldId="document"
-            renderInput={({ field: { value, name, onChange } }) => (
-              <SchemaDefinedField
-                key={platform.kind}
-                id={name}
-                jsonDocument={value ?? {}}
-                jsonSchema={filtersSchema.definition}
-                onDocumentChanged={(newJsonDocument) => {
-                  onChange(newJsonDocument);
-                }}
-              />
-            )}
+            renderInput={({ field: { value, name, onChange } }) =>
+              platform.kind === "cloudfoundry" ? (
+                <FilterInputCloudFoundry
+                  key={platform.kind}
+                  id={name}
+                  values={value ?? {}}
+                  onDocumentChanged={(newJsonDocument) => {
+                    onChange(wrapAsEvent(newJsonDocument, name));
+                  }}
+                />
+              ) : (
+                <SchemaDefinedField
+                  key={platform.kind}
+                  id={name}
+                  jsonDocument={value ?? {}}
+                  jsonSchema={filtersSchema.definition}
+                  onDocumentChanged={(newJsonDocument) => {
+                    onChange(wrapAsEvent(newJsonDocument, name));
+                  }}
+                />
+              )
+            }
           />
         </Form>
       )}

--- a/client/src/app/pages/source-platforms/discover-import-wizard/review-input-cloudfoundry.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/review-input-cloudfoundry.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+
+import { JsonDocument } from "@app/api/models";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+
+export interface ReviewInputCloudFoundryProps {
+  id: string;
+  values?: JsonDocument;
+}
+
+/**
+ * Inputs for CloudFoundry discover applications filter.  This is based on the json schema.
+ */
+export const ReviewInputCloudFoundry: React.FC<
+  ReviewInputCloudFoundryProps
+> = ({ id, values }) => {
+  if (!values) {
+    return <EmptyTextMessage message="No filter values to display" />;
+  }
+
+  const names = (values.names as string[]) ?? [];
+  const spaces = (values.spaces as string[]) ?? [];
+
+  return (
+    <DescriptionList isHorizontal isCompact id={id}>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Names</DescriptionListTerm>
+        <DescriptionListDescription>
+          {names.length === 0 ? (
+            <EmptyTextMessage message="No names specified" />
+          ) : (
+            <List isPlain>
+              {names.map((name) => (
+                <ListItem key={name}>{name}</ListItem>
+              ))}
+            </List>
+          )}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Spaces</DescriptionListTerm>
+        <DescriptionListDescription>
+          {spaces.length === 0 ? (
+            <EmptyTextMessage message="No spaces specified" />
+          ) : (
+            <List isPlain>
+              {spaces.map((space) => (
+                <ListItem key={space}>{space}</ListItem>
+              ))}
+            </List>
+          )}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+    </DescriptionList>
+  );
+};

--- a/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/review.tsx
@@ -16,6 +16,7 @@ import { SchemaDefinedField } from "@app/components/schema-defined-fields";
 import { usePlatformKindList } from "../usePlatformKindList";
 
 import { FilterState } from "./filter-input";
+import { ReviewInputCloudFoundry } from "./review-input-cloudfoundry";
 
 export const Review: React.FC<{
   platform: SourcePlatform;
@@ -81,12 +82,19 @@ export const Review: React.FC<{
                   padding: "16px",
                 }}
               >
-                <SchemaDefinedField
-                  id="platform-discovery-filters-review"
-                  jsonDocument={filters.document ?? {}}
-                  jsonSchema={filters.schema?.definition}
-                  isReadOnly={true}
-                />
+                {platform.kind === "cloudfoundry" ? (
+                  <ReviewInputCloudFoundry
+                    id="platform-discovery-filters-review"
+                    values={filters.document}
+                  />
+                ) : (
+                  <SchemaDefinedField
+                    id="platform-discovery-filters-review"
+                    jsonDocument={filters.document ?? {}}
+                    jsonSchema={filters.schema?.definition}
+                    isReadOnly={true}
+                  />
+                )}
               </div>
             </DescriptionListDescription>
           </DescriptionListGroup>

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from "axios";
-import { ToolbarChip } from "@patternfly/react-core";
 import gitUrlParse from "git-url-parse";
+import { ToolbarChip } from "@patternfly/react-core";
 
 import { AdminPathValues, DevPathValues } from "@app/Paths";
 import i18n from "@app/i18n";
@@ -247,4 +247,19 @@ export function intersection<T>(
         ),
       uniqueFirst
     );
+}
+
+/**
+ * When working with react-hook-form, we may need to wrap a value in an event object to make
+ * sure it is processed correctly.  The shape of an object __could__ look like an event and
+ * that would cause issues with how react-hook-form handles the value.  Best to remove all
+ * doubt.
+ */
+export function wrapAsEvent(value: unknown, name: string = "wrapped-as-event") {
+  return {
+    target: {
+      name,
+      value,
+    },
+  };
 }


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-6121

Create a form specifically for cloud foundry discover application filters as the schema currently exists.  The shape and format of the filter document will still be validated against the live schema fetched from the hub.  Any schema changes will require code changes to accommodate.

Starting:
<img width="1686" height="1254" alt="image" src="https://github.com/user-attachments/assets/99ded62e-cf86-4a1e-9a1f-12b08c67aef7" />

With data:
<img width="1686" height="1254" alt="image" src="https://github.com/user-attachments/assets/21014bea-286e-4ed1-9760-2191784b8c51" />

On review:
<img width="1686" height="1254" alt="image" src="https://github.com/user-attachments/assets/bd1f4713-5c50-47b4-ac4b-754244c70778" />

