### PR TITLE
:ghost: Fix lint warnings

### DIFF
--- a/client/__mocks__/react-i18next.js
+++ b/client/__mocks__/react-i18next.js
@@ -46,8 +46,8 @@ module.exports = {
     !children
       ? i18nKey
       : Array.isArray(children)
-      ? renderNodes(children)
-      : renderNodes([children]),
+        ? renderNodes(children)
+        : renderNodes([children]),
 
   Translation: ({ children }) => children((k) => k, { i18n: {} }),
 

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -5,7 +5,11 @@ import axios, {
 } from "axios";
 import { template } from "radash";
 
+import { serializeRequestParamsForHub } from "@app/hooks/table-controls";
+
 import {
+  AnalysisAppDependency,
+  AnalysisDependency,
   Application,
   ApplicationAdoptionPlan,
   ApplicationDependency,
@@ -20,6 +24,7 @@ import {
   Identity,
   InitialAssessment,
   JobFunction,
+  JsonDocument,
   MigrationWave,
   MimeType,
   New,
@@ -29,6 +34,7 @@ import {
   Review,
   Setting,
   SettingTypes,
+  SourcePlatform,
   Stakeholder,
   StakeholderGroup,
   Tag,
@@ -40,12 +46,7 @@ import {
   TrackerProject,
   TrackerProjectIssuetype,
   UnstructuredFact,
-  SourcePlatform,
-  AnalysisDependency,
-  AnalysisAppDependency,
-  JsonDocument,
 } from "./models";
-import { serializeRequestParamsForHub } from "@app/hooks/table-controls";
 
 // endpoint paths
 export { template };

--- a/client/src/app/api/rest/analysis.ts
+++ b/client/src/app/api/rest/analysis.ts
@@ -1,15 +1,15 @@
 import axios from "axios";
 
-import { hub, template, getHubPaginatedResult } from "../rest";
 import {
-  HubRequestParams,
-  AnalysisReportInsight,
-  AnalysisReportInsightApplication,
   AnalysisIncident,
-  AnalysisReportFile,
   AnalysisInsight,
   AnalysisReportApplicationInsight,
+  AnalysisReportFile,
+  AnalysisReportInsight,
+  AnalysisReportInsightApplication,
+  HubRequestParams,
 } from "../models";
+import { getHubPaginatedResult, hub, template } from "../rest";
 
 /*
   - Analysis uses a collection of rulesets containing rules, and activating labels to produce a

--- a/client/src/app/api/rest/files.ts
+++ b/client/src/app/api/rest/files.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosProgressEvent } from "axios";
 
-import { hub, template, HEADERS } from "../rest";
 import { HubFile } from "../models";
+import { HEADERS, hub, template } from "../rest";
 
 export const FILE = hub`/files/{{id}}`;
 

--- a/client/src/app/api/rest/tasks.ts
+++ b/client/src/app/api/rest/tasks.ts
@@ -7,7 +7,7 @@ import {
   TaskDashboard,
   TaskQueue,
 } from "../models";
-import { getHubPaginatedResult, HEADERS, hub } from "../rest";
+import { HEADERS, getHubPaginatedResult, hub } from "../rest";
 
 export const TASKS = hub`/tasks`;
 

--- a/client/src/app/axios-config/apiInit.ts
+++ b/client/src/app/axios-config/apiInit.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+
 import keycloak from "@app/keycloak";
 
 export const initInterceptors = () => {

--- a/client/src/app/code-editor.tsx
+++ b/client/src/app/code-editor.tsx
@@ -2,8 +2,8 @@
 // See: https://github.com/patternfly/patternfly-react/tree/main/packages/react-code-editor
 
 // Use monaco-editor as a packages to avoid using CDN
-import * as monaco from "monaco-editor";
 import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
 loader.config({ monaco });
 
 // TODO: Enable additional YAML syntax highlights?

--- a/client/src/app/components/AppTable.tsx
+++ b/client/src/app/components/AppTable.tsx
@@ -1,18 +1,19 @@
 import React from "react";
-import { Bullseye, Spinner, Skeleton } from "@patternfly/react-core";
+import { Bullseye, Skeleton, Spinner } from "@patternfly/react-core";
 import { IRow } from "@patternfly/react-table";
 import {
   Table,
-  TableHeader,
   TableBody,
+  TableHeader,
   TableProps,
 } from "@patternfly/react-table/deprecated";
 
-import { StateNoData } from "./StateNoData";
-import { StateNoResults } from "./StateNoResults";
-import { StateError } from "./StateError";
 import { Application } from "@app/api/models";
 import { handlePropagatedRowClick } from "@app/hooks/table-controls";
+
+import { StateError } from "./StateError";
+import { StateNoData } from "./StateNoData";
+import { StateNoResults } from "./StateNoResults";
 import "./AppTable.css";
 
 const ENTITY_FIELD = "entity";

--- a/client/src/app/components/AppTableActionButtons.tsx
+++ b/client/src/app/components/AppTableActionButtons.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Flex, FlexItem } from "@patternfly/react-core";
-import { applicationsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
-import { ConditionalTooltip } from "./ConditionalTooltip";
 import { Td } from "@patternfly/react-table";
+
+import { RBAC, RBAC_TYPE, applicationsWriteScopes } from "@app/rbac";
+
+import { ConditionalTooltip } from "./ConditionalTooltip";
 
 export interface AppTableActionButtonsProps {
   isDeleteEnabled?: boolean;

--- a/client/src/app/components/ApplicationDependenciesFormContainer/ApplicationDependenciesForm.tsx
+++ b/client/src/app/components/ApplicationDependenciesFormContainer/ApplicationDependenciesForm.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-
 import {
   ActionGroup,
   Button,
@@ -10,21 +9,19 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
-  Spinner,
   Text,
   TextContent,
 } from "@patternfly/react-core";
 
-import { OptionWithValue } from "@app/components/SimpleSelect";
-
 import { Application, ApplicationDependency } from "@app/api/models";
-
-import { SelectDependency } from "./SelectDependency";
+import { OptionWithValue } from "@app/components/SimpleSelect";
 import {
   useFetchApplicationDependencies,
   useFetchApplications,
 } from "@app/queries/applications";
 import { toRef } from "@app/utils/model-utils";
+
+import { SelectDependency } from "./SelectDependency";
 
 const northToStringFn = (value: ApplicationDependency) => value.from.name;
 const southToStringFn = (value: ApplicationDependency) => value.to.name;
@@ -46,13 +43,8 @@ export const ApplicationDependenciesForm: React.FC<
   ApplicationDependenciesFormProps
 > = ({ application, onCancel }) => {
   const { t } = useTranslation();
-  const {
-    northboundDependencies,
-    southboundDependencies,
-    isFetching,
-    fetchError,
-    refetch,
-  } = useFetchApplicationDependencies(application?.id);
+  const { northboundDependencies, southboundDependencies, isFetching } =
+    useFetchApplicationDependencies(application?.id);
   const [southSaveError, setSouthSaveError] = useState<null | string>(null);
   const [northSaveError, setNorthSaveError] = useState<null | string>(null);
 
@@ -61,11 +53,8 @@ export const ApplicationDependenciesForm: React.FC<
   const [southboundDependenciesOptions, setSouthboundDependenciesOptions] =
     useState<OptionWithValue<ApplicationDependency>[]>([]);
 
-  const {
-    data: applications,
-    isFetching: isFetchingApplications,
-    error: fetchErrorApplications,
-  } = useFetchApplications();
+  const { data: applications, isFetching: isFetchingApplications } =
+    useFetchApplications();
 
   useEffect(() => {
     if (northboundDependencies) {
@@ -85,11 +74,6 @@ export const ApplicationDependenciesForm: React.FC<
     }
   }, [application, southboundDependencies]);
 
-  const savingMsg = (
-    <div className="pf-v5-u-font-size-sm">
-      <Spinner size="sm" /> {`${t("message.savingSelection")}...`}
-    </div>
-  );
   const existingDependencyMappings = southboundDependenciesOptions
     .map((sbd) => sbd.value.to.id)
     .concat(northboundDependenciesOptions.map((nbd) => nbd.value.from.id));

--- a/client/src/app/components/ApplicationDependenciesFormContainer/SelectDependency.tsx
+++ b/client/src/app/components/ApplicationDependenciesFormContainer/SelectDependency.tsx
@@ -1,16 +1,15 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
 import { AxiosError } from "axios";
-
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { useTranslation } from "react-i18next";
 
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { ApplicationDependency } from "@app/api/models";
-import { toRef } from "@app/utils/model-utils";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import {
   useCreateApplicationDependency,
   useDeleteApplicationDependency,
 } from "@app/queries/applications";
+import { toRef } from "@app/utils/model-utils";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 
 const isEqual = (

--- a/client/src/app/components/Autocomplete/Autocomplete.tsx
+++ b/client/src/app/components/Autocomplete/Autocomplete.tsx
@@ -1,22 +1,25 @@
 import React, { useRef } from "react";
 import {
-  Label,
-  LabelProps,
+  Divider,
   Flex,
   FlexItem,
+  Label,
+  LabelProps,
   Menu,
   MenuContent,
+  MenuGroup,
   MenuItem,
   MenuList,
   Popper,
-  Divider,
-  MenuGroup,
 } from "@patternfly/react-core";
-import { LabelToolip } from "../LabelTooltip";
+
 import { getString } from "@app/utils/utils";
-import { useAutocompleteHandlers } from "./useAutocompleteHandlers";
+
+import { LabelToolip } from "../LabelTooltip";
+
 import { SearchInputComponent } from "./SearchInput";
 import { AnyAutocompleteOptionProps, getUniqueId } from "./type-utils";
+import { useAutocompleteHandlers } from "./useAutocompleteHandlers";
 
 export interface AutocompleteOptionProps {
   /** id for the option */
@@ -44,7 +47,6 @@ export interface IAutocompleteProps {
   searchString?: string;
   searchInputAriaLabel?: string;
   labelColor?: LabelProps["color"];
-  menuHeader?: string;
   noResultsMessage?: string;
 }
 
@@ -60,7 +62,6 @@ export const Autocomplete: React.FC<IAutocompleteProps> = ({
   searchInputAriaLabel = "Search input",
   labelColor,
   selections = [],
-  menuHeader = "",
   noResultsMessage = "No results found",
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);

--- a/client/src/app/components/Autocomplete/GroupedAutocomplete.tsx
+++ b/client/src/app/components/Autocomplete/GroupedAutocomplete.tsx
@@ -1,22 +1,25 @@
 import React, { useRef } from "react";
 import {
-  Label,
-  LabelProps,
+  Divider,
   Flex,
   FlexItem,
+  Label,
+  LabelProps,
   Menu,
   MenuContent,
+  MenuGroup,
   MenuItem,
   MenuList,
   Popper,
-  Divider,
-  MenuGroup,
 } from "@patternfly/react-core";
+
 import { getString } from "@app/utils/utils";
+
 import { LabelToolip } from "../LabelTooltip";
+
 import { SearchInputComponent } from "./SearchInput";
-import { useAutocompleteHandlers } from "./useAutocompleteHandlers";
 import { AnyAutocompleteOptionProps, getUniqueId } from "./type-utils";
+import { useAutocompleteHandlers } from "./useAutocompleteHandlers";
 
 export interface GroupedAutocompleteOptionProps {
   /** id for the option - unique id not the ref id */

--- a/client/src/app/components/Autocomplete/SearchInput.tsx
+++ b/client/src/app/components/Autocomplete/SearchInput.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { SearchInput } from "@patternfly/react-core";
+
 import { getString } from "@app/utils/utils";
+
 import { AnyAutocompleteOptionProps } from "./type-utils";
 
 export interface SearchInputProps {

--- a/client/src/app/components/Autocomplete/useAutocompleteHandlers.ts
+++ b/client/src/app/components/Autocomplete/useAutocompleteHandlers.ts
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+
 import {
   AnyAutocompleteOptionProps,
   GroupMap,
@@ -56,7 +57,6 @@ export const useAutocompleteHandlers = ({
 
     return groups;
   }, [options, selections, inputValue]);
-  const allOptions = Object.values(groupedFilteredOptions).flat();
 
   const handleInputChange = (value: string) => {
     setInputValue(value);

--- a/client/src/app/components/Color.tsx
+++ b/client/src/app/components/Color.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-
 import { Split, SplitItem } from "@patternfly/react-core";
 
 import { COLOR_NAMES_BY_HEX_VALUE } from "@app/Constants";

--- a/client/src/app/components/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/client/src/app/components/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -1,14 +1,15 @@
 import React, { FC, useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import {
-  ModalProps,
   Button,
   ButtonVariant,
   Modal,
+  ModalProps,
   ModalVariant,
   Text,
   TextInput,
 } from "@patternfly/react-core";
+
 import { collapseSpacesAndCompare } from "@app/utils/utils";
 
 import "./ConfirmDeleteDialog.css";

--- a/client/src/app/components/ConfirmDialog.tsx
+++ b/client/src/app/components/ConfirmDialog.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import {
-  Button,
-  Modal,
-  ButtonVariant,
-  ModalVariant,
   Alert,
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalVariant,
 } from "@patternfly/react-core";
 
 export interface ConfirmDialogProps {

--- a/client/src/app/components/CustomRuleFilesUpload.tsx
+++ b/client/src/app/components/CustomRuleFilesUpload.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import { AxiosError } from "axios";
+import { counting } from "radash";
 import {
   Alert,
   DropEvent,
@@ -8,15 +9,15 @@ import {
   MultipleFileUploadStatus,
   MultipleFileUploadStatusItem,
 } from "@patternfly/react-core";
-import { counting } from "radash";
 import UploadIcon from "@patternfly/react-icons/dist/esm/icons/upload-icon";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { HubFile, UploadFile } from "@app/api/models";
 import { useCreateFileMutation } from "@app/queries/targets";
 import { useUploadTaskgroupFileMutation } from "@app/queries/taskgroups";
-import { getAxiosErrorMessage } from "@app/utils/utils";
 import { checkRuleFileType, validateYamlFile } from "@app/utils/rules-utils";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
 import { NotificationsContext } from "./NotificationsContext";
 
 export interface CustomRuleFilesUploadProps {

--- a/client/src/app/components/EmptyTextMessage.tsx
+++ b/client/src/app/components/EmptyTextMessage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Text } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
+import { Text } from "@patternfly/react-core";
 
 export interface EmptyTextMessageProps {
   message?: string;

--- a/client/src/app/components/ErrorFallback.tsx
+++ b/client/src/app/components/ErrorFallback.tsx
@@ -1,19 +1,19 @@
-import {
-  Bullseye,
-  EmptyState,
-  EmptyStateVariant,
-  EmptyStateIcon,
-  Title,
-  EmptyStateBody,
-  Button,
-} from "@patternfly/react-core";
 import React, { useEffect, useRef } from "react";
-import UserNinjaIcon from "@patternfly/react-icons/dist/esm/icons/user-ninja-icon";
-import { NotificationsContext } from "@app/components/NotificationsContext";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
-
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+} from "@patternfly/react-core";
+import UserNinjaIcon from "@patternfly/react-icons/dist/esm/icons/user-ninja-icon";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+import { NotificationsContext } from "@app/components/NotificationsContext";
 
 const usePrevious = <T,>(value: T) => {
   const ref = useRef<T>();

--- a/client/src/app/components/FilterToolbar/DateRangeFilter.tsx
+++ b/client/src/app/components/FilterToolbar/DateRangeFilter.tsx
@@ -1,21 +1,20 @@
 import React, { FormEvent, useState } from "react";
-
 import {
   DatePicker,
   InputGroup,
-  isValidDate as isValidJSDate,
   ToolbarChip,
   ToolbarChipGroup,
   ToolbarFilter,
   Tooltip,
+  isValidDate as isValidJSDate,
 } from "@patternfly/react-core";
 
 import { IFilterControlProps } from "./FilterControl";
 import {
-  localizeInterval,
   americanDateFormat,
   isValidAmericanShortDate,
   isValidInterval,
+  localizeInterval,
   parseAmericanDate,
   parseInterval,
   toISODateInterval,

--- a/client/src/app/components/FilterToolbar/FilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/FilterControl.tsx
@@ -1,17 +1,17 @@
 import * as React from "react";
 
+import { DateRangeFilter } from "./DateRangeFilter";
 import {
   FilterCategory,
-  FilterValue,
   FilterType,
-  ISelectFilterCategory,
-  ISearchFilterCategory,
+  FilterValue,
   IMultiselectFilterCategory,
+  ISearchFilterCategory,
+  ISelectFilterCategory,
 } from "./FilterToolbar";
-import { SelectFilterControl } from "./SelectFilterControl";
-import { SearchFilterControl } from "./SearchFilterControl";
 import { MultiselectFilterControl } from "./MultiselectFilterControl";
-import { DateRangeFilter } from "./DateRangeFilter";
+import { SearchFilterControl } from "./SearchFilterControl";
+import { SelectFilterControl } from "./SelectFilterControl";
 
 export interface IFilterControlProps<TItem, TFilterCategoryKey extends string> {
   category: FilterCategory<TItem, TFilterCategoryKey>;

--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import {
   Dropdown,
-  DropdownItem,
   DropdownGroup,
+  DropdownItem,
   DropdownList,
   MenuToggle,
   SelectOptionProps,
-  ToolbarToggleGroup,
   ToolbarItem,
+  ToolbarToggleGroup,
   ToolbarToggleGroupProps,
 } from "@patternfly/react-core";
 import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";

--- a/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -14,12 +14,13 @@ import {
   ToolbarChip,
   ToolbarFilter,
 } from "@patternfly/react-core";
+import { TimesIcon } from "@patternfly/react-icons";
+
 import { IFilterControlProps } from "./FilterControl";
 import {
   FilterSelectOptionProps,
   IMultiselectFilterCategory,
 } from "./FilterToolbar";
-import { TimesIcon } from "@patternfly/react-icons";
 
 import "./select-overrides.css";
 

--- a/client/src/app/components/FilterToolbar/SearchFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/SearchFilterControl.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import {
-  ToolbarFilter,
-  InputGroup,
-  TextInput,
   Button,
   ButtonVariant,
+  InputGroup,
+  TextInput,
+  ToolbarFilter,
 } from "@patternfly/react-core";
 import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
+
 import { IFilterControlProps } from "./FilterControl";
 import { ISearchFilterCategory } from "./FilterToolbar";
 

--- a/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
@@ -8,9 +8,10 @@ import {
   ToolbarChip,
   ToolbarFilter,
 } from "@patternfly/react-core";
+import { css } from "@patternfly/react-styles";
+
 import { IFilterControlProps } from "./FilterControl";
 import { ISelectFilterCategory } from "./FilterToolbar";
-import { css } from "@patternfly/react-styles";
 
 import "./select-overrides.css";
 

--- a/client/src/app/components/FilterToolbar/__tests__/dateUtils.test.ts
+++ b/client/src/app/components/FilterToolbar/__tests__/dateUtils.test.ts
@@ -2,9 +2,9 @@ import {
   isInClosedRange,
   isValidAmericanShortDate,
   isValidInterval,
+  localizeInterval,
   parseInterval,
   toISODateInterval,
-  localizeInterval,
 } from "../dateUtils";
 
 describe("isValidAmericanShortDate", () => {

--- a/client/src/app/components/HookFormPFFields/HookFormAutocomplete.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormAutocomplete.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { Control, FieldValues, Path } from "react-hook-form";
-import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
+
 import {
   Autocomplete,
   AutocompleteOptionProps,
 } from "@app/components/Autocomplete/Autocomplete";
+import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
+
 import {
   GroupedAutocomplete,
   GroupedAutocompleteOptionProps,

--- a/client/src/app/components/HookFormPFFields/HookFormPFGroupController.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormPFGroupController.tsx
@@ -1,18 +1,18 @@
 import * as React from "react";
 import {
-  FormGroup,
-  FormGroupProps,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
-} from "@patternfly/react-core";
-import {
   Control,
   Controller,
   ControllerProps,
   FieldValues,
   Path,
 } from "react-hook-form";
+import {
+  FormGroup,
+  FormGroupProps,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from "@patternfly/react-core";
 
 // We have separate interfaces for these props with and without `renderInput` for convenience.
 // Generic type params here are the same as the ones used by react-hook-form's <Controller>.

--- a/client/src/app/components/HookFormPFFields/HookFormPFTextArea.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormPFTextArea.tsx
@@ -1,21 +1,23 @@
 import * as React from "react";
 import { FieldValues, Path } from "react-hook-form";
 import { TextArea, TextAreaProps } from "@patternfly/react-core";
+
 import { getValidatedFromErrors } from "@app/utils/utils";
+
 import {
-  HookFormPFGroupController,
   BaseHookFormPFGroupControllerProps,
+  HookFormPFGroupController,
   extractGroupControllerProps,
 } from "./HookFormPFGroupController";
 
 export type HookFormPFTextAreaProps<
   TFieldValues extends FieldValues,
-  TName extends Path<TFieldValues>
+  TName extends Path<TFieldValues>,
 > = TextAreaProps & BaseHookFormPFGroupControllerProps<TFieldValues, TName>;
 
 export const HookFormPFTextArea = <
   TFieldValues extends FieldValues = FieldValues,
-  TName extends Path<TFieldValues> = Path<TFieldValues>
+  TName extends Path<TFieldValues> = Path<TFieldValues>,
 >(
   props: HookFormPFTextAreaProps<TFieldValues, TName>
 ) => {

--- a/client/src/app/components/HookFormPFFields/HookFormPFTextInput.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormPFTextInput.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
 import { FieldValues, Path, PathValue } from "react-hook-form";
 import { TextInput, TextInputProps } from "@patternfly/react-core";
+
 import { getValidatedFromErrors } from "@app/utils/utils";
+
 import {
-  extractGroupControllerProps,
-  HookFormPFGroupController,
   BaseHookFormPFGroupControllerProps,
+  HookFormPFGroupController,
+  extractGroupControllerProps,
 } from "./HookFormPFGroupController";
 
 interface WithIntegerType extends Omit<TextInputProps, "type"> {

--- a/client/src/app/components/Icons/IconWithLabel.tsx
+++ b/client/src/app/components/Icons/IconWithLabel.tsx
@@ -1,5 +1,6 @@
 import React, { FC, ReactElement, ReactNode } from "react";
 import { Flex, FlexItem } from "@patternfly/react-core";
+
 import { OptionalTooltip } from "./OptionalTooltip";
 
 export const IconWithLabel: FC<{

--- a/client/src/app/components/Icons/IconedStatus.tsx
+++ b/client/src/app/components/Icons/IconedStatus.tsx
@@ -1,18 +1,18 @@
 import React from "react";
-import { Icon } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import { IconWithLabel } from "./IconWithLabel";
 import { ReactElement } from "react-markdown/lib/react-markdown";
-
+import { Icon } from "@patternfly/react-core";
 import {
   CheckCircleIcon,
-  TimesCircleIcon,
-  InProgressIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
-  UnknownIcon,
+  InProgressIcon,
+  TimesCircleIcon,
   TopologyIcon,
+  UnknownIcon,
 } from "@patternfly/react-icons";
+
+import { IconWithLabel } from "./IconWithLabel";
 
 export type IconedStatusPreset =
   | "InheritedReviews"

--- a/client/src/app/components/Icons/TaskStateIcon.tsx
+++ b/client/src/app/components/Icons/TaskStateIcon.tsx
@@ -1,17 +1,18 @@
-import { TaskState } from "@app/api/models";
 import React, { FC } from "react";
 import { Icon } from "@patternfly/react-core";
 import {
   CheckCircleIcon,
-  TimesCircleIcon,
-  InProgressIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
-  UnknownIcon,
+  InProgressIcon,
+  PauseCircleIcon,
   PendingIcon,
   TaskIcon,
-  PauseCircleIcon,
+  TimesCircleIcon,
+  UnknownIcon,
 } from "@patternfly/react-icons";
+
+import { TaskState } from "@app/api/models";
 
 export const TaskStateIcon: FC<{ state?: TaskState }> = ({ state }) => {
   switch (state) {

--- a/client/src/app/components/InfiniteScroller/InfiniteScroller.tsx
+++ b/client/src/app/components/InfiniteScroller/InfiniteScroller.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+
 import { useVisibilityTracker } from "./useVisibilityTracker";
 import "./InfiniteScroller.css";
 

--- a/client/src/app/components/InfiniteScroller/useVisibilityTracker.tsx
+++ b/client/src/app/components/InfiniteScroller/useVisibilityTracker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useVisibilityTracker({ enable }: { enable: boolean }) {
   const nodeRef = useRef<HTMLDivElement>(null);

--- a/client/src/app/components/KebabDropdown.tsx
+++ b/client/src/app/components/KebabDropdown.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-
 import {
   Dropdown,
   DropdownList,

--- a/client/src/app/components/KeyDisplayToggle.tsx
+++ b/client/src/app/components/KeyDisplayToggle.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Button } from "@patternfly/react-core";
-import EyeSlashIcon from "@patternfly/react-icons/dist/js/icons/eye-slash-icon";
 import EyeIcon from "@patternfly/react-icons/dist/js/icons/eye-icon";
+import EyeSlashIcon from "@patternfly/react-icons/dist/js/icons/eye-slash-icon";
 // TODO this is a good candidate for lib-ui
 
 interface IKeyDisplayToggleProps {

--- a/client/src/app/components/KeycloakProvider.tsx
+++ b/client/src/app/components/KeycloakProvider.tsx
@@ -1,9 +1,11 @@
 import React, { Suspense } from "react";
 import { ReactKeycloakProvider } from "@react-keycloak/web";
-import keycloak from "@app/keycloak";
-import { AppPlaceholder } from "./AppPlaceholder";
+
 import { initInterceptors } from "@app/axios-config";
 import ENV from "@app/env";
+import keycloak from "@app/keycloak";
+
+import { AppPlaceholder } from "./AppPlaceholder";
 
 interface IKeycloakProviderProps {
   children: React.ReactNode;

--- a/client/src/app/components/LabelCustomColor.tsx
+++ b/client/src/app/components/LabelCustomColor.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { Label, LabelProps } from "@patternfly/react-core";
 import tinycolor from "tinycolor2";
+import { Label, LabelProps } from "@patternfly/react-core";
 
 // Omit the variant prop, we won't support the outline variant
 export interface ILabelCustomColorProps

--- a/client/src/app/components/LabelTooltip.tsx
+++ b/client/src/app/components/LabelTooltip.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Tooltip } from "@patternfly/react-core";
+
 import { getString } from "@app/utils/utils";
+
 import { AutocompleteOptionProps } from "./Autocomplete/Autocomplete";
 
 export const LabelToolip: React.FC<{

--- a/client/src/app/components/Notifications.tsx
+++ b/client/src/app/components/Notifications.tsx
@@ -4,6 +4,7 @@ import {
   AlertActionCloseButton,
   AlertGroup,
 } from "@patternfly/react-core";
+
 import { NotificationsContext } from "./NotificationsContext";
 
 export const Notifications: React.FunctionComponent = () => {

--- a/client/src/app/components/PageDrawerContext.tsx
+++ b/client/src/app/components/PageDrawerContext.tsx
@@ -112,7 +112,7 @@ export const PageDrawerContent: React.FC<IPageDrawerContentProps> = ({
   header = null,
   children,
   drawerPanelContentProps,
-  focusKey,
+  focusKey: _focusKey,
   pageKey: localPageKeyProp,
 }) => {
   const {

--- a/client/src/app/components/PageHeader.tsx
+++ b/client/src/app/components/PageHeader.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import {
-  Stack,
-  StackItem,
   Split,
   SplitItem,
-  TextContent,
+  Stack,
+  StackItem,
   Text,
+  TextContent,
 } from "@patternfly/react-core";
+
 import { BreadCrumbPath } from "./BreadCrumbPath";
 import { HorizontalNav } from "./HorizontalNav";
 

--- a/client/src/app/components/RiskLabel.tsx
+++ b/client/src/app/components/RiskLabel.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-
 import { Label } from "@patternfly/react-core";
 
 import { RISK_LIST } from "@app/Constants";

--- a/client/src/app/components/RouteWrapper.tsx
+++ b/client/src/app/components/RouteWrapper.tsx
@@ -1,7 +1,9 @@
-import { isAuthRequired } from "@app/Constants";
-import keycloak from "@app/keycloak";
 import React from "react";
 import { Redirect, Route } from "react-router-dom";
+
+import { isAuthRequired } from "@app/Constants";
+import keycloak from "@app/keycloak";
+
 import { checkAccess } from "../utils/rbac-utils";
 
 interface IRouteWrapperProps {
@@ -18,7 +20,7 @@ export const RouteWrapper = ({
   exact,
 }: IRouteWrapperProps) => {
   const token = keycloak.tokenParsed || undefined;
-  let userRoles = token?.realm_access?.roles || [],
+  const userRoles = token?.realm_access?.roles || [],
     access = checkAccess(userRoles, roles);
 
   if (!token && isAuthRequired) {

--- a/client/src/app/components/SimplePagination.tsx
+++ b/client/src/app/components/SimplePagination.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-
 import { Pagination, PaginationVariant } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
 import { PaginationStateProps } from "@app/hooks/useLegacyPaginationState";
 
 export interface SimplePaginationProps {

--- a/client/src/app/components/SimpleSelect.tsx
+++ b/client/src/app/components/SimpleSelect.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-
 import {
   Select,
   SelectOption,

--- a/client/src/app/components/SimpleSelectBasic.tsx
+++ b/client/src/app/components/SimpleSelectBasic.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from "react";
-
 import {
+  MenuToggle,
+  MenuToggleElement,
   Select,
   SelectList,
   SelectOption,
   SelectOptionProps,
-  MenuToggle,
-  MenuToggleElement,
 } from "@patternfly/react-core";
 
 export interface ISimpleSelectBasicProps {

--- a/client/src/app/components/SimpleSelectCheckbox.tsx
+++ b/client/src/app/components/SimpleSelectCheckbox.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import {
-  Select,
-  SelectOption,
-  SelectList,
-  MenuToggle,
   Badge,
-  SelectOptionProps,
+  MenuToggle,
   MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  SelectOptionProps,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 

--- a/client/src/app/components/SimpleSelectTypeahead.tsx
+++ b/client/src/app/components/SimpleSelectTypeahead.tsx
@@ -1,18 +1,17 @@
 import React from "react";
-
 import {
+  Button,
+  Chip,
+  ChipGroup,
+  MenuToggle,
+  MenuToggleElement,
   Select,
   SelectList,
   SelectOption,
-  MenuToggle,
-  MenuToggleElement,
-  Button,
   SelectOptionProps,
   TextInputGroup,
   TextInputGroupMain,
   TextInputGroupUtilities,
-  ChipGroup,
-  Chip,
 } from "@patternfly/react-core";
 import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 
@@ -134,8 +133,8 @@ export const SimpleSelectTypeahead: React.FC<ISimpleSelectBasicProps> = ({
             ? selectOptions.length - 1
             : currentIndex - 1
           : currentIndex === null || currentIndex === selectOptions.length - 1
-          ? 0
-          : currentIndex + 1;
+            ? 0
+            : currentIndex + 1;
 
       setFocusedItemIndex(indexToFocus);
       const focusedItem = selectOptions[indexToFocus];

--- a/client/src/app/components/SingleLabelWithOverflow.tsx
+++ b/client/src/app/components/SingleLabelWithOverflow.tsx
@@ -1,5 +1,5 @@
-import { Label, LabelGroup, LabelProps, Popover } from "@patternfly/react-core";
 import * as React from "react";
+import { Label, LabelGroup, LabelProps, Popover } from "@patternfly/react-core";
 
 export interface ISingleLabelWithOverflowProps
   extends Omit<LabelProps, "children"> {

--- a/client/src/app/components/StateError.tsx
+++ b/client/src/app/components/StateError.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import {
   EmptyState,
+  EmptyStateBody,
   EmptyStateIcon,
   EmptyStateVariant,
   Title,
-  EmptyStateBody,
 } from "@patternfly/react-core";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 import { global_danger_color_200 as globalDangerColor200 } from "@patternfly/react-tokens";

--- a/client/src/app/components/StateNoData.tsx
+++ b/client/src/app/components/StateNoData.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+
 import { NoDataEmptyState } from "./NoDataEmptyState";
 
 export const StateNoData: React.FC = () => {

--- a/client/src/app/components/StateNoResults.tsx
+++ b/client/src/app/components/StateNoResults.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-
 import {
   EmptyState,
   EmptyStateBody,

--- a/client/src/app/components/StatusIcon.tsx
+++ b/client/src/app/components/StatusIcon.tsx
@@ -2,18 +2,18 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { SpinnerProps, TextContent } from "@patternfly/react-core";
 import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
-import TimesCircleIcon from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
-import InProgressIcon from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
-import { SVGIconProps } from "@patternfly/react-icons/dist/js/createIcon";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import InProgressIcon from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
+import TimesCircleIcon from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
 import UnknownIcon from "@patternfly/react-icons/dist/esm/icons/unknown-icon";
+import { SVGIconProps } from "@patternfly/react-icons/dist/js/createIcon";
 import {
-  global_disabled_color_200 as disabledColor,
-  global_success_color_100 as successColor,
   global_Color_dark_200 as unknownColor,
-  global_info_color_200 as loadingColor,
   global_danger_color_100 as errorColor,
+  global_disabled_color_200 as disabledColor,
   global_info_color_100 as infoColor,
+  global_info_color_200 as loadingColor,
+  global_success_color_100 as successColor,
 } from "@patternfly/react-tokens";
 
 export type StatusIconType =

--- a/client/src/app/components/StringListField.tsx
+++ b/client/src/app/components/StringListField.tsx
@@ -1,15 +1,16 @@
 import * as React from "react";
-import { useTranslation } from "react-i18next";
-import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import * as yup from "yup";
-import { InputGroup, TextInput, Button } from "@patternfly/react-core";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Button, InputGroup, TextInput } from "@patternfly/react-core";
 import TimesCircleIcon from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
-import { getValidatedFromErrors } from "@app/utils/utils";
-import { HookFormPFGroupController } from "./HookFormPFFields";
-
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { Table, Tbody, Td, Tr } from "@patternfly/react-table";
+
+import { getValidatedFromErrors } from "@app/utils/utils";
+
+import { HookFormPFGroupController } from "./HookFormPFFields";
 
 export interface StringListFieldProps {
   listItems: string[];

--- a/client/src/app/components/TableControls/ConditionalTableBody.tsx
+++ b/client/src/app/components/TableControls/ConditionalTableBody.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Bullseye, Spinner } from "@patternfly/react-core";
-import { Tbody, Tr, Td } from "@patternfly/react-table";
+import { Tbody, Td, Tr } from "@patternfly/react-table";
+
 import { StateError } from "../StateError";
 import { StateNoData } from "../StateNoData";
 

--- a/client/src/app/components/TableControls/TableRowContentWithControls.tsx
+++ b/client/src/app/components/TableControls/TableRowContentWithControls.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Td } from "@patternfly/react-table";
-import { ITableControls } from "@app/hooks/table-controls";
+
 import { BulkSelectionValues } from "@app/hooks/selection/useBulkSelection";
+import { ITableControls } from "@app/hooks/table-controls";
 
 export interface ITableRowContentWithControlsProps<
   TItem,

--- a/client/src/app/components/ToolbarBulkExpander.tsx
+++ b/client/src/app/components/ToolbarBulkExpander.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Button, ToolbarItem } from "@patternfly/react-core";
-
 import AngleDownIcon from "@patternfly/react-icons/dist/esm/icons/angle-down-icon";
 import AngleRightIcon from "@patternfly/react-icons/dist/esm/icons/angle-right-icon";
 

--- a/client/src/app/components/ToolbarBulkSelector.tsx
+++ b/client/src/app/components/ToolbarBulkSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dropdown,

--- a/client/src/app/components/answer-table/answer-table.tsx
+++ b/client/src/app/components/answer-table/answer-table.tsx
@@ -1,23 +1,24 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { Label, Text, Tooltip } from "@patternfly/react-core";
+import { List, ListItem } from "@patternfly/react-core";
+import { TimesCircleIcon } from "@patternfly/react-icons";
+import { WarningTriangleIcon } from "@patternfly/react-icons";
+import { InfoCircleIcon } from "@patternfly/react-icons";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { useLocalTableControls } from "@app/hooks/table-controls";
+import { Answer } from "@app/api/models";
+import { IconedStatus } from "@app/components/Icons";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
-import { Answer } from "@app/api/models";
-import { Label, Text, Tooltip } from "@patternfly/react-core";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { IconedStatus } from "@app/components/Icons";
-import { TimesCircleIcon } from "@patternfly/react-icons";
-import { WarningTriangleIcon } from "@patternfly/react-icons";
-import { List, ListItem } from "@patternfly/react-core";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+
 import RiskIcon from "../risk-icon/risk-icon";
-import { InfoCircleIcon } from "@patternfly/react-icons";
 
 export interface IAnswerTableProps {
   answers: Answer[];

--- a/client/src/app/components/application-assessment-donut-chart/application-assessment-donut-chart.tsx
+++ b/client/src/app/components/application-assessment-donut-chart/application-assessment-donut-chart.tsx
@@ -1,15 +1,15 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ChartDonut, ChartLegend } from "@patternfly/react-charts";
+import { global_palette_blue_300 as defaultColor } from "@patternfly/react-tokens";
+
 import { RISK_LIST } from "@app/Constants";
 import {
   Assessment,
-  Section,
-  IdRef,
   AssessmentWithArchetypeApplications,
+  IdRef,
+  Section,
 } from "@app/api/models";
-
-import { global_palette_blue_300 as defaultColor } from "@patternfly/react-tokens";
 import { useFetchAssessmentsWithArchetypeApplications } from "@app/queries/assessments";
 
 export interface ChartData {

--- a/client/src/app/components/detail-drawer/drawer-tabs-container.tsx
+++ b/client/src/app/components/detail-drawer/drawer-tabs-container.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Panel, Title, PanelMain } from "@patternfly/react-core";
+import { Panel, PanelMain, Title } from "@patternfly/react-core";
 import "./drawer-tabs-container.css";
 
 /**

--- a/client/src/app/components/detail-drawer/no-entity.tsx
+++ b/client/src/app/components/detail-drawer/no-entity.tsx
@@ -3,11 +3,11 @@ import "./drawer-tabs-container.css";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import {
-  EmptyStateIcon,
+  EmptyState,
   EmptyStateBody,
   EmptyStateHeader,
+  EmptyStateIcon,
   EmptyStateVariant,
-  EmptyState,
 } from "@patternfly/react-core";
 import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
 

--- a/client/src/app/components/detail-drawer/repository-details.tsx
+++ b/client/src/app/components/detail-drawer/repository-details.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   DescriptionList,
+  DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  DescriptionListDescription,
 } from "@patternfly/react-core";
 
 import { Repository } from "@app/api/models";

--- a/client/src/app/components/detail-drawer/review-fields.tsx
+++ b/client/src/app/components/detail-drawer/review-fields.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import {
+  DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  DescriptionListDescription,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
+import { EFFORT_ESTIMATE_LIST, PROPOSED_ACTION_LIST } from "@app/Constants";
 import { Application, Archetype, Review } from "@app/api/models";
-import { useFetchReviewById } from "@app/queries/reviews";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { useFetchArchetypes } from "@app/queries/archetypes";
+import { useFetchReviewById } from "@app/queries/reviews";
 import { useFetchReviews } from "@app/queries/reviews";
 
-import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
-import { PROPOSED_ACTION_LIST, EFFORT_ESTIMATE_LIST } from "@app/Constants";
 import { ReviewLabel } from "./review-label";
 
 export type ReviewDrawerLabelItem = {

--- a/client/src/app/components/detail-drawer/review-label.tsx
+++ b/client/src/app/components/detail-drawer/review-label.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { Label } from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
 import { ReviewDrawerLabelItem } from "./review-fields";
 
 interface ReviewLabelProps {

--- a/client/src/app/components/insights/components/affected-apps-link.tsx
+++ b/client/src/app/components/insights/components/affected-apps-link.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
 import { Location } from "history";
+import { Link } from "react-router-dom";
 import { Button } from "@patternfly/react-core";
+
 import { UiAnalysisReportInsight } from "@app/api/models";
+
 import { InsightsFilterValuesToCarry, getAffectedAppsUrl } from "../helpers";
 
 export interface IAffectedAppsLinkProps {

--- a/client/src/app/components/insights/components/insight-description-and-links.tsx
+++ b/client/src/app/components/insights/components/insight-description-and-links.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import ReactMarkdown from "react-markdown";
-import { TextContent, List, ListItem } from "@patternfly/react-core";
+import { List, ListItem, TextContent } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { AnalysisInsightLink } from "@app/api/models";
-import { markdownPFComponents } from "@app/components/markdownPFComponents";
 import ExternalLink from "@app/components/ExternalLink";
+import { markdownPFComponents } from "@app/components/markdownPFComponents";
 
 export interface IInsightDescriptionAndLinksProps {
   description: string;

--- a/client/src/app/components/insights/components/insight-expanded-row-content.tsx
+++ b/client/src/app/components/insights/components/insight-expanded-row-content.tsx
@@ -1,21 +1,22 @@
 import * as React from "react";
 import {
-  Text,
   Flex,
   FlexItem,
   Label,
   LabelGroup,
+  Text,
 } from "@patternfly/react-core";
-import { ExpandableRowContent } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
+import { ExpandableRowContent } from "@patternfly/react-table";
 
 import {
   UiAnalysisReportApplicationInsight,
   UiAnalysisReportInsight,
 } from "@app/api/models";
-import { parseReportLabels } from "../helpers";
+
 import { InsightDescriptionAndLinks } from "../components";
+import { parseReportLabels } from "../helpers";
 
 export const ExpandedFieldHeading: React.FC<{
   children: React.ReactNode;

--- a/client/src/app/components/insights/helpers.ts
+++ b/client/src/app/components/insights/helpers.ts
@@ -1,14 +1,15 @@
 import { Location } from "history";
+
+import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Paths } from "@app/Paths";
 import {
   AnalysisInsight,
-  UiAnalysisReportInsight,
   UiAnalysisReportApplicationInsight,
+  UiAnalysisReportInsight,
 } from "@app/api/models";
 import { FilterValue } from "@app/components/FilterToolbar";
 import { serializeFilterUrlParams } from "@app/hooks/table-controls";
 import { trimAndStringifyUrlParams } from "@app/hooks/useUrlParams";
-import { Paths } from "@app/Paths";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
 
 // Certain filters are shared between the Insights page and the Affected Applications Page.
 // We carry these filter values between the two pages when determining the URLs to navigate between them.

--- a/client/src/app/components/insights/tables/all-insights-table.tsx
+++ b/client/src/app/components/insights/tables/all-insights-table.tsx
@@ -1,43 +1,44 @@
 import * as React from "react";
-import { useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
   Tooltip,
 } from "@patternfly/react-core";
-import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
+import { TablePersistenceKeyPrefix, UI_UNIQUE_ID } from "@app/Constants";
+import { Paths } from "@app/Paths";
+import { UiAnalysisReportInsight } from "@app/api/models";
+import { HubRequestParams } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { FilterToolbar } from "@app/components/FilterToolbar";
+import { SimplePagination } from "@app/components/SimplePagination";
+import { SingleLabelWithOverflow } from "@app/components/SingleLabelWithOverflow";
 import {
   ConditionalTableBody,
-  TableRowContentWithControls,
   TableHeaderContentWithControls,
+  TableRowContentWithControls,
 } from "@app/components/TableControls";
 import {
   getHubRequestParams,
   useTableControlProps,
   useTableControlState,
 } from "@app/hooks/table-controls";
-import { TablePersistenceKeyPrefix, UI_UNIQUE_ID } from "@app/Constants";
-import { UiAnalysisReportInsight } from "@app/api/models";
-import { HubRequestParams } from "@app/api/models";
 import { AnalysisQueryResults } from "@app/queries/analysis";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { SingleLabelWithOverflow } from "@app/components/SingleLabelWithOverflow";
-import { FilterToolbar } from "@app/components/FilterToolbar";
-import { SimplePagination } from "@app/components/SimplePagination";
 
-import { parseReportLabels } from "../helpers";
 import { AffectedAppsLink, InsightExpandedRowContent } from "../components";
-import {
-  useInsightsTableFilters,
-  InsightFilterGroups,
-} from "./use-insight-filters";
-import { useDynamicColumns, TableColumns } from "./use-dynamic-columns";
+import { parseReportLabels } from "../helpers";
+
 import { InsightTitleColumn } from "./column-insight-title";
-import { Paths } from "@app/Paths";
+import { TableColumns, useDynamicColumns } from "./use-dynamic-columns";
+import {
+  InsightFilterGroups,
+  useInsightsTableFilters,
+} from "./use-insight-filters";
 
 export interface IAllInsightsTableProps {
   tableAriaLabel?: string;

--- a/client/src/app/components/insights/tables/column-insight-title.tsx
+++ b/client/src/app/components/insights/tables/column-insight-title.tsx
@@ -1,5 +1,6 @@
-import { AnalysisInsight } from "@app/api/models";
 import React from "react";
+
+import { AnalysisInsight } from "@app/api/models";
 
 export const InsightTitleColumn: React.FC<{
   insight: Pick<AnalysisInsight, "description" | "name">;

--- a/client/src/app/components/insights/tables/single-application-insights-table.tsx
+++ b/client/src/app/components/insights/tables/single-application-insights-table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import {
   Button,
   EmptyState,
@@ -12,43 +12,44 @@ import {
   ToolbarItem,
   Tooltip,
 } from "@patternfly/react-core";
-import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
-import {
-  ConditionalTableBody,
-  TableRowContentWithControls,
-  TableHeaderContentWithControls,
-} from "@app/components/TableControls";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import {
-  getHubRequestParams,
-  useTableControlProps,
-  useTableControlState,
-} from "@app/hooks/table-controls";
 import { TablePersistenceKeyPrefix, UI_UNIQUE_ID } from "@app/Constants";
 import {
   Application,
   UiAnalysisReportApplicationInsight,
 } from "@app/api/models";
 import { HubRequestParams } from "@app/api/models";
-import { AnalysisQueryResults } from "@app/queries/analysis";
-import { useFetchApplications } from "@app/queries/applications";
-import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { SingleLabelWithOverflow } from "@app/components/SingleLabelWithOverflow";
+import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
 import { FilterToolbar } from "@app/components/FilterToolbar";
 import { SimplePagination } from "@app/components/SimplePagination";
-
-import { parseReportLabels } from "../helpers";
-import { InsightExpandedRowContent } from "../components";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { SingleLabelWithOverflow } from "@app/components/SingleLabelWithOverflow";
 import {
-  useInsightsTableFilters,
-  InsightFilterGroups,
-} from "./use-insight-filters";
-import { useDynamicColumns, TableColumns } from "./use-dynamic-columns";
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import {
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
+import { AnalysisQueryResults } from "@app/queries/analysis";
+import { useFetchApplications } from "@app/queries/applications";
+
+import { InsightExpandedRowContent } from "../components";
+import { parseReportLabels } from "../helpers";
+
 import { InsightTitleColumn } from "./column-insight-title";
+import { TableColumns, useDynamicColumns } from "./use-dynamic-columns";
+import {
+  InsightFilterGroups,
+  useInsightsTableFilters,
+} from "./use-insight-filters";
 
 const useSelectedApplicationId = (
   pathPattern: string,

--- a/client/src/app/components/insights/tables/use-insight-filters.ts
+++ b/client/src/app/components/insights/tables/use-insight-filters.ts
@@ -6,6 +6,7 @@ import { useFetchArchetypes } from "@app/queries/archetypes";
 import { useFetchBusinessServices } from "@app/queries/businessservices";
 import { useFetchTagsWithTagItems } from "@app/queries/tags";
 import { universalComparator } from "@app/utils/utils";
+
 import { FilterCategory, FilterType } from "../../FilterToolbar";
 
 export const enum InsightFilterGroups {

--- a/client/src/app/components/labels/item-tag-label/item-tag-label.tsx
+++ b/client/src/app/components/labels/item-tag-label/item-tag-label.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { Tag, TagCategory } from "@app/api/models";
+
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
+import { Tag, TagCategory } from "@app/api/models";
 import { LabelCustomColor } from "@app/components/LabelCustomColor";
 
 export const getTagCategoryFallbackColor = (category?: TagCategory | null) => {

--- a/client/src/app/components/labels/labels-from-items/labels-from-items.tsx
+++ b/client/src/app/components/labels/labels-from-items/labels-from-items.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Label, LabelGroup, LabelProps } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
+import { Label, LabelGroup, LabelProps } from "@patternfly/react-core";
 
 export function LabelsFromItems<T extends { name: string }>({
   items,

--- a/client/src/app/components/labels/labels-from-tags/labels-from-tags.tsx
+++ b/client/src/app/components/labels/labels-from-tags/labels-from-tags.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { LabelGroup } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import { ItemTagLabel } from "../item-tag-label/item-tag-label";
+import { LabelGroup } from "@patternfly/react-core";
+
 import { Tag } from "@app/api/models";
 import { useFetchTagCategories } from "@app/queries/tags";
+
+import { ItemTagLabel } from "../item-tag-label/item-tag-label";
 
 export function LabelsFromTags({
   tags,
@@ -16,9 +18,8 @@ export function LabelsFromTags({
   const { tagCategories } = useFetchTagCategories();
 
   const findCategoryForTag = (tagId: number) => {
-    return tagCategories.find(
-      (category) =>
-        category.tags?.some((categoryTag) => categoryTag.id === tagId)
+    return tagCategories.find((category) =>
+      category.tags?.some((categoryTag) => categoryTag.id === tagId)
     );
   };
 

--- a/client/src/app/components/questionnaire-summary/components/questionnaire-section-tab-title.tsx
+++ b/client/src/app/components/questionnaire-summary/components/questionnaire-section-tab-title.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { TabTitleText, Badge } from "@patternfly/react-core";
+import { Badge, TabTitleText } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
 import { Question } from "@app/api/models";
 
 const QuestionnaireSectionTabTitle: React.FC<{

--- a/client/src/app/components/questionnaire-summary/questionnaire-summary.tsx
+++ b/client/src/app/components/questionnaire-summary/questionnaire-summary.tsx
@@ -1,29 +1,31 @@
-import React, { useState, useMemo } from "react";
+import React, { useMemo, useState } from "react";
+import { AxiosError } from "axios";
+import { Link } from "react-router-dom";
 import {
-  Tabs,
-  Tab,
-  SearchInput,
-  Toolbar,
-  ToolbarItem,
-  ToolbarContent,
-  TextContent,
-  PageSection,
-  PageSectionVariants,
   Breadcrumb,
   BreadcrumbItem,
+  PageSection,
+  PageSectionVariants,
+  SearchInput,
+  Tab,
+  Tabs,
   Text,
+  TextContent,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
 } from "@patternfly/react-core";
-import { Link } from "react-router-dom";
-import { Paths } from "@app/Paths";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import QuestionsTable from "@app/components/questions-table/questions-table";
-import { Assessment, Questionnaire } from "@app/api/models";
-import QuestionnaireSectionTabTitle from "./components/questionnaire-section-tab-title";
-import { AxiosError } from "axios";
-import { formatPath } from "@app/utils/utils";
-import useIsArchetype from "@app/hooks/useIsArchetype";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+import { Paths } from "@app/Paths";
+import { Assessment, Questionnaire } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import QuestionsTable from "@app/components/questions-table/questions-table";
+import useIsArchetype from "@app/hooks/useIsArchetype";
+import { formatPath } from "@app/utils/utils";
+
+import QuestionnaireSectionTabTitle from "./components/questionnaire-section-tab-title";
 
 export enum SummaryType {
   Assessment = "Assessment",

--- a/client/src/app/components/questions-table/questions-table.tsx
+++ b/client/src/app/components/questions-table/questions-table.tsx
@@ -1,26 +1,27 @@
 import React from "react";
+import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
+import { Label, List, ListItem, Tooltip } from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import {
+  ExpandableRowContent,
   Table,
-  Thead,
-  Tr,
-  Th,
   Tbody,
   Td,
-  ExpandableRowContent,
+  Th,
+  Thead,
+  Tr,
 } from "@patternfly/react-table";
+
+import { Assessment, Question, Questionnaire } from "@app/api/models";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { useTranslation } from "react-i18next";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { Assessment, Question, Questionnaire } from "@app/api/models";
-import { useLocalTableControls } from "@app/hooks/table-controls";
-import { Label, List, ListItem, Tooltip } from "@patternfly/react-core";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 import AnswerTable from "@app/components/answer-table/answer-table";
-import { AxiosError } from "axios";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 
 const QuestionsTable: React.FC<{
   fetchError: AxiosError | null;

--- a/client/src/app/components/risk-icon/risk-icon.tsx
+++ b/client/src/app/components/risk-icon/risk-icon.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TimesCircleIcon, WarningTriangleIcon } from "@patternfly/react-icons";
+
 import { IconedStatus } from "@app/components/Icons";
 
 interface RiskIconProps {

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useMemo } from "react";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
   EmptyState,
@@ -7,9 +8,10 @@ import {
   Spinner,
   Title,
 } from "@patternfly/react-core";
+
 import { JsonSchemaObject } from "@app/api/models";
+
 import { jsonSchemaToYupSchema } from "./utils";
-import { useMemo } from "react";
 
 export { Language } from "@patternfly/react-code-editor";
 

--- a/client/src/app/components/schema-defined-fields/SchemaAsFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsFields.tsx
@@ -1,7 +1,6 @@
 import React from "react";
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useForm, FormProvider, useFormContext } from "react-hook-form";
-
 import {
   Checkbox,
   FormFieldGroup,
@@ -9,11 +8,12 @@ import {
 } from "@patternfly/react-core";
 import styles from "@patternfly/react-styles/css/components/Form/form";
 
+import { JsonSchemaObject } from "@app/api/models";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
-import { JsonSchemaObject } from "@app/api/models";
+
 import { jsonSchemaToYupResolver } from "./utils";
 
 export interface SchemaAsFieldsProps {

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Panel, PanelHeader, PanelMain, Switch } from "@patternfly/react-core";
+
 import { JsonSchemaObject } from "@app/api/models";
 
 import { SchemaAsCodeEditor } from "./SchemaAsCodeEditor";

--- a/client/src/app/components/schema-defined-fields/utils.test.tsx
+++ b/client/src/app/components/schema-defined-fields/utils.test.tsx
@@ -1,9 +1,10 @@
-import {
-  jsonSchemaToYupSchema,
-  isComplexSchema,
-  combineSchemas,
-} from "./utils";
 import { JsonSchemaObject } from "@app/api/models";
+
+import {
+  combineSchemas,
+  isComplexSchema,
+  jsonSchemaToYupSchema,
+} from "./utils";
 
 describe("jsonSchemaToYupSchema", () => {
   it("should return a yup schema", () => {

--- a/client/src/app/components/simple-document-viewer/AttachmentToggle.tsx
+++ b/client/src/app/components/simple-document-viewer/AttachmentToggle.tsx
@@ -1,12 +1,12 @@
 import React, { FC, useState } from "react";
-
 import {
-  Select,
-  SelectOption,
-  SelectList,
-  MenuToggleElement,
   MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
 } from "@patternfly/react-core";
+
 import { Document } from "./SimpleDocumentViewer";
 import "./SimpleDocumentViewer.css";
 

--- a/client/src/app/components/simple-document-viewer/LanguageToggle.tsx
+++ b/client/src/app/components/simple-document-viewer/LanguageToggle.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { Language } from "@patternfly/react-code-editor";
 import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core";
+import CodeIcon from "@patternfly/react-icons/dist/esm/icons/code-icon";
 import { css } from "@patternfly/react-styles";
 import editorStyles from "@patternfly/react-styles/css/components/CodeEditor/code-editor";
-import CodeIcon from "@patternfly/react-icons/dist/esm/icons/code-icon";
 import "./SimpleDocumentViewer.css";
 
 export const LanguageToggle: React.FC<{

--- a/client/src/app/components/simple-document-viewer/SimpleDocumentViewer.tsx
+++ b/client/src/app/components/simple-document-viewer/SimpleDocumentViewer.tsx
@@ -9,14 +9,15 @@ import {
 } from "@patternfly/react-core";
 
 import "./SimpleDocumentViewer.css";
+import { TaskAttachment } from "@app/api/models";
 import {
   useFetchTaskAttachmentById,
   useFetchTaskByIdAndFormat,
 } from "@app/queries/tasks";
-import { RefreshControl } from "./RefreshControl";
-import { LanguageToggle } from "./LanguageToggle";
+
 import { AttachmentToggle } from "./AttachmentToggle";
-import { TaskAttachment } from "@app/api/models";
+import { LanguageToggle } from "./LanguageToggle";
+import { RefreshControl } from "./RefreshControl";
 
 export { Language } from "@patternfly/react-code-editor";
 

--- a/client/src/app/components/simple-document-viewer/SimpleDocumentViewerModal.tsx
+++ b/client/src/app/components/simple-document-viewer/SimpleDocumentViewerModal.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Button, Modal, ModalProps } from "@patternfly/react-core";
 import { css } from "@patternfly/react-styles";
+
 import {
   ISimpleDocumentViewerProps,
   SimpleDocumentViewer,

--- a/client/src/app/components/target-card/hooks/useFetchImageDataUrl.ts
+++ b/client/src/app/components/target-card/hooks/useFetchImageDataUrl.ts
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import axios from "axios";
-import DefaultImage from "@app/images/Icon-Red_Hat-Virtual_server_stack-A-Black-RGB.svg";
+
 import { Target } from "@app/api/models";
 import { FILES } from "@app/api/rest";
+import DefaultImage from "@app/images/Icon-Red_Hat-Virtual_server_stack-A-Black-RGB.svg";
 
 const useFetchImageDataUrl = (target: Target) => {
   const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);

--- a/client/src/app/components/target-card/target-card.tsx
+++ b/client/src/app/components/target-card/target-card.tsx
@@ -1,33 +1,35 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import {
-  EmptyStateIcon,
-  Title,
+  Bullseye,
   Card,
   CardBody,
+  CardHeader,
   DropdownItem,
+  EmptyStateIcon,
   Flex,
   FlexItem,
   Label,
-  CardHeader,
+  Panel,
   PanelMain,
   PanelMainBody,
-  Panel,
   Stack,
   StackItem,
-  Bullseye,
+  Title,
 } from "@patternfly/react-core";
 import { InfoCircleIcon } from "@patternfly/react-icons";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { useTranslation } from "react-i18next";
 
-import DefaultImage from "@app/images/Icon-Red_Hat-Virtual_server_stack-A-Black-RGB.svg";
 import { Target, TargetLabel } from "@app/api/models";
+import DefaultImage from "@app/images/Icon-Red_Hat-Virtual_server_stack-A-Black-RGB.svg";
+import { localeNumericCompare } from "@app/utils/utils";
+
 import { KebabDropdown } from "../KebabDropdown";
-import useFetchImageDataUrl from "./hooks/useFetchImageDataUrl";
 import { SimpleSelectBasic } from "../SimpleSelectBasic";
 
+import useFetchImageDataUrl from "./hooks/useFetchImageDataUrl";
+
 import "./target-card.css";
-import { localeNumericCompare } from "@app/utils/utils";
 
 export interface TargetCardProps {
   item: Target;

--- a/client/src/app/components/task-manager/TaskManagerContext.tsx
+++ b/client/src/app/components/task-manager/TaskManagerContext.tsx
@@ -1,5 +1,6 @@
-import { useFetchTaskQueue } from "@app/queries/tasks";
 import React, { useContext, useMemo, useState } from "react";
+
+import { useFetchTaskQueue } from "@app/queries/tasks";
 
 interface TaskManagerContextProps {
   /** Count of the currently "queued" Tasks */

--- a/client/src/app/components/task-manager/TaskManagerDrawer.tsx
+++ b/client/src/app/components/task-manager/TaskManagerDrawer.tsx
@@ -1,10 +1,15 @@
 import React, { forwardRef, useCallback, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
 import dayjs from "dayjs";
+import { Link } from "react-router-dom";
 import {
   Dropdown,
   DropdownItem,
   DropdownList,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
   MenuToggle,
   MenuToggleElement,
   NotificationDrawer,
@@ -15,23 +20,19 @@ import {
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
   Tooltip,
-  EmptyState,
-  EmptyStateHeader,
-  EmptyStateIcon,
-  EmptyStateBody,
-  EmptyStateVariant,
 } from "@patternfly/react-core";
-import { EllipsisVIcon, CubesIcon } from "@patternfly/react-icons";
+import { CubesIcon, EllipsisVIcon } from "@patternfly/react-icons";
 import { css } from "@patternfly/react-styles";
 
 import { Task, TaskState } from "@app/api/models";
-import { useTaskManagerContext } from "./TaskManagerContext";
+import { useTaskActions } from "@app/pages/tasks/useTaskActions";
 import { useInfiniteServerTasks } from "@app/queries/tasks";
 
 import "./TaskManagerDrawer.css";
 import { TaskStateIcon } from "../Icons";
-import { useTaskActions } from "@app/pages/tasks/useTaskActions";
 import { InfiniteScroller } from "../InfiniteScroller";
+
+import { useTaskManagerContext } from "./TaskManagerContext";
 
 /** A version of `Task` specific for the task manager drawer components */
 interface TaskManagerTask {

--- a/client/src/app/components/task-manager/TaskNotificaitonBadge.tsx
+++ b/client/src/app/components/task-manager/TaskNotificaitonBadge.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { NotificationBadge } from "@patternfly/react-core";
+
 import { useTaskManagerContext } from "./TaskManagerContext";
 
 export const TaskNotificationBadge: React.FC = () => {

--- a/client/src/app/components/tests/AppPlaceholder.test.tsx
+++ b/client/src/app/components/tests/AppPlaceholder.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { AppPlaceholder } from "../AppPlaceholder";
 
 describe("AppPlaceholder", () => {

--- a/client/src/app/components/tests/AppTable.test.tsx
+++ b/client/src/app/components/tests/AppTable.test.tsx
@@ -1,15 +1,10 @@
 import React from "react";
-import { Label, Skeleton, Spinner } from "@patternfly/react-core";
-import {
-  ICell,
-  IRow,
-  IActions,
-  SortColumn,
-  sortable,
-} from "@patternfly/react-table";
+import { Label } from "@patternfly/react-core";
+import { ICell, IRow, sortable } from "@patternfly/react-table";
+
+import { render, screen } from "@app/test-config/test-utils";
 
 import { AppTable } from "../AppTable";
-import { render, screen } from "@app/test-config/test-utils";
 
 describe("AppTable", () => {
   const columns: ICell[] = [
@@ -24,16 +19,6 @@ describe("AppTable", () => {
       })),
     };
   });
-  const actions: IActions = [
-    {
-      title: "Action1",
-      onClick: jest.fn,
-    },
-    {
-      title: "Action2",
-      onClick: jest.fn,
-    },
-  ];
 
   it("Renders without crashing", () => {
     const wrapper = render(
@@ -90,7 +75,7 @@ describe("AppTable", () => {
   });
 
   it.skip("Renders empty table after applying filters", () => {
-    const wrapper = render(
+    render(
       <AppTable
         cells={columns}
         rows={[]}

--- a/client/src/app/components/tests/BreadCrumbPath.test.tsx
+++ b/client/src/app/components/tests/BreadCrumbPath.test.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, render, screen } from "@app/test-config/test-utils";
 import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
+
+import { fireEvent, render, screen } from "@app/test-config/test-utils";
+
 import { BreadCrumbPath } from "../BreadCrumbPath";
 
 describe("BreadCrumbPath", () => {

--- a/client/src/app/components/tests/ConditionalRender.test.tsx
+++ b/client/src/app/components/tests/ConditionalRender.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { ConditionalRender } from "../ConditionalRender";
+
 import { render, screen } from "@app/test-config/test-utils";
+
+import { ConditionalRender } from "../ConditionalRender";
 
 describe("ConditionalRender", () => {
   it("Renders WHEN=true", () => {

--- a/client/src/app/components/tests/ConfirmDialog.test.tsx
+++ b/client/src/app/components/tests/ConfirmDialog.test.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import { ConfirmDialog } from "../ConfirmDialog";
 import { ButtonVariant } from "@patternfly/react-core";
+
 import { fireEvent, render, screen } from "@app/test-config/test-utils";
+
+import { ConfirmDialog } from "../ConfirmDialog";
 
 describe("ConfirmDialog", () => {
   it("Renders without crashing", () => {

--- a/client/src/app/components/tests/EmptyTextMessage.test.tsx
+++ b/client/src/app/components/tests/EmptyTextMessage.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { EmptyTextMessage } from "../EmptyTextMessage";
 
 describe("EmptyTextMessage", () => {

--- a/client/src/app/components/tests/HorizontalNav.test.tsx
+++ b/client/src/app/components/tests/HorizontalNav.test.tsx
@@ -1,7 +1,9 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
-import { HorizontalNav } from "../HorizontalNav";
 import { BrowserRouter as Router } from "react-router-dom";
+
+import { render } from "@app/test-config/test-utils";
+
+import { HorizontalNav } from "../HorizontalNav";
 
 describe("HorizontalNav", () => {
   it("Renders without crashing", () => {

--- a/client/src/app/components/tests/NoDataEmptyState.test.tsx
+++ b/client/src/app/components/tests/NoDataEmptyState.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { NoDataEmptyState } from "../NoDataEmptyState";
 
 describe("NoDataEmptyState", () => {

--- a/client/src/app/components/tests/PageHeader.test.tsx
+++ b/client/src/app/components/tests/PageHeader.test.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { PageHeader } from "../PageHeader";
-import { Button } from "@patternfly/react-core";
-import { render } from "@app/test-config/test-utils";
 import { BrowserRouter as Router } from "react-router-dom";
+import { Button } from "@patternfly/react-core";
+
+import { render } from "@app/test-config/test-utils";
+
+import { PageHeader } from "../PageHeader";
 
 describe("PageHeader", () => {
   it("Renders without crashing", () => {

--- a/client/src/app/components/tests/RiskLabel.test.tsx
+++ b/client/src/app/components/tests/RiskLabel.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render, screen } from "@app/test-config/test-utils";
+
 import { RiskLabel } from "../RiskLabel";
 
 describe("RiskLabel", () => {

--- a/client/src/app/components/tests/SimpleEmptyState.test.tsx
+++ b/client/src/app/components/tests/SimpleEmptyState.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import AdIcon from "@patternfly/react-icons/dist/esm/icons/ad-icon";
 
-import { SimpleEmptyState } from "../SimpleEmptyState";
 import { render } from "@app/test-config/test-utils";
+
+import { SimpleEmptyState } from "../SimpleEmptyState";
 
 describe("SimpleEmptyState", () => {
   it("Renders without crashing", () => {

--- a/client/src/app/components/tests/SimpleSelect.test.tsx
+++ b/client/src/app/components/tests/SimpleSelect.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { SimpleSelect } from "../SimpleSelect";
+
 import { render } from "@app/test-config/test-utils";
+
+import { SimpleSelect } from "../SimpleSelect";
 
 describe("SimpleSelect", () => {
   it("Renders without crashing", () => {

--- a/client/src/app/components/tests/StateError.test.tsx
+++ b/client/src/app/components/tests/StateError.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { StateError } from "../StateError";
 
 describe("StateError", () => {

--- a/client/src/app/components/tests/StateNoData.test.tsx
+++ b/client/src/app/components/tests/StateNoData.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { StateNoData } from "../StateNoData";
 
 describe("StateNoData", () => {

--- a/client/src/app/components/tests/StateNoResults.test.tsx
+++ b/client/src/app/components/tests/StateNoResults.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { StateNoResults } from "../StateNoResults";
 
 describe("StateNoResults", () => {

--- a/client/src/app/components/tests/StatusIcon.test.tsx
+++ b/client/src/app/components/tests/StatusIcon.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { IconedStatus } from "../Icons";
 
 describe("StatusIcon", () => {

--- a/client/src/app/dayjs.ts
+++ b/client/src/app/dayjs.ts
@@ -1,10 +1,10 @@
 import dayjs from "dayjs";
-import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-import relativeTime from "dayjs/plugin/relativeTime";
+import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import localizedFormat from "dayjs/plugin/localizedFormat";
+import relativeTime from "dayjs/plugin/relativeTime";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);

--- a/client/src/app/hooks/selection/useBulkSelection.ts
+++ b/client/src/app/hooks/selection/useBulkSelection.ts
@@ -1,5 +1,7 @@
 import { TdProps } from "@patternfly/react-table";
+
 import { IToolbarBulkSelectorProps } from "@app/components/ToolbarBulkSelector";
+
 import { useSelectionState } from "../useSelectionState/useSelectionState";
 
 export interface BulkSelectionArgs<ItemType> {

--- a/client/src/app/hooks/table-controls/active-item/getActiveItemDerivedState.ts
+++ b/client/src/app/hooks/table-controls/active-item/getActiveItemDerivedState.ts
@@ -1,4 +1,5 @@
 import { KeyWithValueType } from "@app/utils/type-utils";
+
 import { IActiveItemState } from "./useActiveItemState";
 
 /**

--- a/client/src/app/hooks/table-controls/active-item/useActiveItemEffects.ts
+++ b/client/src/app/hooks/table-controls/active-item/useActiveItemEffects.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { IActiveItemDerivedState } from "./getActiveItemDerivedState";
 import { IActiveItemState } from "./useActiveItemState";
 

--- a/client/src/app/hooks/table-controls/active-item/useActiveItemPropHelpers.ts
+++ b/client/src/app/hooks/table-controls/active-item/useActiveItemPropHelpers.ts
@@ -1,13 +1,14 @@
 import { TrProps } from "@patternfly/react-table";
+
 import {
   IActiveItemDerivedStateArgs,
   getActiveItemDerivedState,
 } from "./getActiveItemDerivedState";
-import { IActiveItemState } from "./useActiveItemState";
 import {
   IUseActiveItemEffectsArgs,
   useActiveItemEffects,
 } from "./useActiveItemEffects";
+import { IActiveItemState } from "./useActiveItemState";
 
 /**
  * Args for useActiveItemPropHelpers that come from outside useTableControlProps

--- a/client/src/app/hooks/table-controls/active-item/useActiveItemState.ts
+++ b/client/src/app/hooks/table-controls/active-item/useActiveItemState.ts
@@ -1,6 +1,7 @@
-import { parseMaybeNumericString } from "@app/utils/utils";
-import { IFeaturePersistenceArgs, isPersistenceProvider } from "../types";
 import { usePersistentState } from "@app/hooks/usePersistentState";
+import { parseMaybeNumericString } from "@app/utils/utils";
+
+import { IFeaturePersistenceArgs, isPersistenceProvider } from "../types";
 
 /**
  * The "source of truth" state for the active item feature.
@@ -72,17 +73,17 @@ export const useActiveItemState = <
           deserialize: ({ activeItem }) => parseMaybeNumericString(activeItem),
         }
       : persistTo === "localStorage" || persistTo === "sessionStorage"
-      ? {
-          persistTo,
-          key: "activeItem",
-        }
-      : isPersistenceProvider(persistTo)
-      ? {
-          persistTo: "provider",
-          serialize: persistTo.write,
-          deserialize: () => persistTo.read() as string | number | null,
-        }
-      : { persistTo: "state" }),
+        ? {
+            persistTo,
+            key: "activeItem",
+          }
+        : isPersistenceProvider(persistTo)
+          ? {
+              persistTo: "provider",
+              serialize: persistTo.write,
+              deserialize: () => persistTo.read() as string | number | null,
+            }
+          : { persistTo: "state" }),
   });
   return { activeItemId, setActiveItemId };
 };

--- a/client/src/app/hooks/table-controls/column/useColumnState.ts
+++ b/client/src/app/hooks/table-controls/column/useColumnState.ts
@@ -1,6 +1,8 @@
-import { useLocalStorage } from "@app/hooks/useStorage";
-import { ColumnSetting } from "../types";
 import { useEffect } from "react";
+
+import { useLocalStorage } from "@app/hooks/useStorage";
+
+import { ColumnSetting } from "../types";
 
 export interface ColumnState<TColumnKey extends string> {
   id: TColumnKey;

--- a/client/src/app/hooks/table-controls/expansion/getExpansionDerivedState.ts
+++ b/client/src/app/hooks/table-controls/expansion/getExpansionDerivedState.ts
@@ -1,4 +1,5 @@
 import { KeyWithValueType } from "@app/utils/type-utils";
+
 import { IExpansionState } from "./useExpansionState";
 
 /**

--- a/client/src/app/hooks/table-controls/expansion/useExpansionPropHelpers.ts
+++ b/client/src/app/hooks/table-controls/expansion/useExpansionPropHelpers.ts
@@ -1,7 +1,9 @@
-import { KeyWithValueType } from "@app/utils/type-utils";
-import { IExpansionState } from "./useExpansionState";
-import { getExpansionDerivedState } from "./getExpansionDerivedState";
 import { TdProps } from "@patternfly/react-table";
+
+import { KeyWithValueType } from "@app/utils/type-utils";
+
+import { getExpansionDerivedState } from "./getExpansionDerivedState";
+import { IExpansionState } from "./useExpansionState";
 
 /**
  * Args for useExpansionPropHelpers that come from outside useTableControlProps

--- a/client/src/app/hooks/table-controls/expansion/useExpansionState.ts
+++ b/client/src/app/hooks/table-controls/expansion/useExpansionState.ts
@@ -1,7 +1,8 @@
 import { usePersistentState } from "@app/hooks/usePersistentState";
-import { objectKeys } from "@app/utils/utils";
-import { IFeaturePersistenceArgs, isPersistenceProvider } from "../types";
 import { DiscriminatedArgs } from "@app/utils/type-utils";
+import { objectKeys } from "@app/utils/utils";
+
+import { IFeaturePersistenceArgs, isPersistenceProvider } from "../types";
 
 /**
  * A map of item ids (strings resolved from `item[idProperty]`) to either:
@@ -109,17 +110,17 @@ export const useExpansionState = <
           },
         }
       : persistTo === "localStorage" || persistTo === "sessionStorage"
-      ? {
-          persistTo,
-          key: "expandedCells",
-        }
-      : isPersistenceProvider(persistTo)
-      ? {
-          persistTo: "provider",
-          serialize: persistTo.write,
-          deserialize: () => persistTo.read() as TExpandedCells<TColumnKey>,
-        }
-      : { persistTo: "state" }),
+        ? {
+            persistTo,
+            key: "expandedCells",
+          }
+        : isPersistenceProvider(persistTo)
+          ? {
+              persistTo: "provider",
+              serialize: persistTo.write,
+              deserialize: () => persistTo.read() as TExpandedCells<TColumnKey>,
+            }
+          : { persistTo: "state" }),
   });
   return { expandedCells, setExpandedCells };
 };

--- a/client/src/app/hooks/table-controls/filtering/__tests__/getLocalFilterDerivedState.test.ts
+++ b/client/src/app/hooks/table-controls/filtering/__tests__/getLocalFilterDerivedState.test.ts
@@ -1,4 +1,5 @@
 import { FilterCategory, FilterType } from "@app/components/FilterToolbar";
+
 import { getLocalFilterDerivedState } from "../getLocalFilterDerivedState";
 
 interface TestItem {

--- a/client/src/app/hooks/table-controls/filtering/getFilterHubRequestParams.ts
+++ b/client/src/app/hooks/table-controls/filtering/getFilterHubRequestParams.ts
@@ -1,9 +1,10 @@
 import { HubFilter, HubRequestParams } from "@app/api/models";
-import { objectKeys } from "@app/utils/utils";
 import {
   FilterCategory,
   getFilterLogicOperator,
 } from "@app/components/FilterToolbar";
+import { objectKeys } from "@app/utils/utils";
+
 import { IFilterState } from "./useFilterState";
 
 /**
@@ -164,10 +165,10 @@ export const serializeFilterForHub = (filter: HubFilter): string => {
     typeof value === "string"
       ? wrapInQuotesAndEscape(value)
       : typeof value === "number"
-      ? `"${value}"`
-      : `(${value.list
-          .map(wrapInQuotesAndEscape)
-          .join(value.operator === "OR" ? "|" : ",")})`;
+        ? `"${value}"`
+        : `(${value.list
+            .map(wrapInQuotesAndEscape)
+            .join(value.operator === "OR" ? "|" : ",")})`;
   return `${field}${operator}${joinedValue}`;
 };
 

--- a/client/src/app/hooks/table-controls/filtering/getLocalFilterDerivedState.ts
+++ b/client/src/app/hooks/table-controls/filtering/getLocalFilterDerivedState.ts
@@ -3,6 +3,7 @@ import {
   FilterValue,
   getFilterLogicOperator,
 } from "@app/components/FilterToolbar";
+
 import { IFilterState } from "./useFilterState";
 
 /**

--- a/client/src/app/hooks/table-controls/filtering/useFilterPropHelpers.ts
+++ b/client/src/app/hooks/table-controls/filtering/useFilterPropHelpers.ts
@@ -1,10 +1,12 @@
+import { useTranslation } from "react-i18next";
+import { ToolbarProps } from "@patternfly/react-core";
+
 import {
   FilterCategory,
   IFilterToolbarProps,
 } from "@app/components/FilterToolbar";
+
 import { IFilterState } from "./useFilterState";
-import { ToolbarProps } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 
 /**
  * Args for useFilterPropHelpers that come from outside useTableControlProps

--- a/client/src/app/hooks/table-controls/filtering/useFilterState.ts
+++ b/client/src/app/hooks/table-controls/filtering/useFilterState.ts
@@ -1,10 +1,13 @@
+import { useEffect, useState } from "react";
+
 import { FilterCategory, IFilterValues } from "@app/components/FilterToolbar";
-import { IFeaturePersistenceArgs, isPersistenceProvider } from "../types";
 import { usePersistentState } from "@app/hooks/usePersistentState";
+import { DiscriminatedArgs } from "@app/utils/type-utils";
+
+import { IFeaturePersistenceArgs, isPersistenceProvider } from "../types";
+
 import { serializeFilterUrlParams } from "./helpers";
 import { deserializeFilterUrlParams } from "./helpers";
-import { DiscriminatedArgs } from "@app/utils/type-utils";
-import { useEffect, useState } from "react";
 
 /**
  * The "source of truth" state for the filter feature.
@@ -72,7 +75,7 @@ export const useFilterState = <
 
   if (isInitialLoad) {
     initialFilterValues = isFilterEnabled
-      ? args?.initialFilterValues ?? {}
+      ? (args?.initialFilterValues ?? {})
       : {};
   }
 
@@ -103,16 +106,18 @@ export const useFilterState = <
           deserialize: deserializeFilterUrlParams,
         }
       : persistTo === "localStorage" || persistTo === "sessionStorage"
-      ? { persistTo, key: "filters", defaultValue: initialFilterValues }
-      : isPersistenceProvider(persistTo)
-      ? {
-          persistTo: "provider",
-          serialize: persistTo.write,
-          deserialize: () =>
-            persistTo.read() as IFilterValues<TFilterCategoryKey>,
-          defaultValue: isFilterEnabled ? args?.initialFilterValues ?? {} : {},
-        }
-      : { persistTo: "state", defaultValue: initialFilterValues }),
+        ? { persistTo, key: "filters", defaultValue: initialFilterValues }
+        : isPersistenceProvider(persistTo)
+          ? {
+              persistTo: "provider",
+              serialize: persistTo.write,
+              deserialize: () =>
+                persistTo.read() as IFilterValues<TFilterCategoryKey>,
+              defaultValue: isFilterEnabled
+                ? (args?.initialFilterValues ?? {})
+                : {},
+            }
+          : { persistTo: "state", defaultValue: initialFilterValues }),
   });
   return { filterValues, setFilterValues };
 };

--- a/client/src/app/hooks/table-controls/getHubRequestParams.ts
+++ b/client/src/app/hooks/table-controls/getHubRequestParams.ts
@@ -2,21 +2,22 @@
 // TODO these could use some unit tests!
 
 import { HubRequestParams } from "@app/api/models";
+
 import {
   IGetFilterHubRequestParamsArgs,
   getFilterHubRequestParams,
   serializeFilterRequestParamsForHub,
 } from "./filtering";
 import {
-  IGetSortHubRequestParamsArgs,
-  getSortHubRequestParams,
-  serializeSortRequestParamsForHub,
-} from "./sorting";
-import {
   IGetPaginationHubRequestParamsArgs,
   getPaginationHubRequestParams,
   serializePaginationRequestParamsForHub,
 } from "./pagination";
+import {
+  IGetSortHubRequestParamsArgs,
+  getSortHubRequestParams,
+  serializeSortRequestParamsForHub,
+} from "./sorting";
 
 // TODO move this outside this directory as part of decoupling Konveyor-specific code from table-controls.
 

--- a/client/src/app/hooks/table-controls/pagination/getPaginationHubRequestParams.ts
+++ b/client/src/app/hooks/table-controls/pagination/getPaginationHubRequestParams.ts
@@ -1,4 +1,5 @@
 import { HubRequestParams } from "@app/api/models";
+
 import { IPaginationState } from "./usePaginationState";
 
 /**

--- a/client/src/app/hooks/table-controls/pagination/usePaginationEffects.ts
+++ b/client/src/app/hooks/table-controls/pagination/usePaginationEffects.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { IPaginationState } from "./usePaginationState";
 
 /**

--- a/client/src/app/hooks/table-controls/pagination/usePaginationPropHelpers.ts
+++ b/client/src/app/hooks/table-controls/pagination/usePaginationPropHelpers.ts
@@ -1,9 +1,10 @@
 import { PaginationProps, ToolbarItemProps } from "@patternfly/react-core";
-import { IPaginationState } from "./usePaginationState";
+
 import {
   IUsePaginationEffectsArgs,
   usePaginationEffects,
 } from "./usePaginationEffects";
+import { IPaginationState } from "./usePaginationState";
 
 /**
  * Args for usePaginationPropHelpers that come from outside useTableControlProps

--- a/client/src/app/hooks/table-controls/pagination/usePaginationState.ts
+++ b/client/src/app/hooks/table-controls/pagination/usePaginationState.ts
@@ -1,6 +1,7 @@
 import { usePersistentState } from "@app/hooks/usePersistentState";
-import { IFeaturePersistenceArgs, isPersistenceProvider } from "../types";
 import { DiscriminatedArgs } from "@app/utils/type-utils";
+
+import { IFeaturePersistenceArgs, isPersistenceProvider } from "../types";
 
 /**
  * The currently applied pagination parameters
@@ -112,17 +113,17 @@ export const usePaginationState = <
           },
         }
       : persistTo === "localStorage" || persistTo === "sessionStorage"
-      ? {
-          persistTo,
-          key: "pagination",
-        }
-      : isPersistenceProvider(persistTo)
-      ? {
-          persistTo: "provider",
-          serialize: persistTo.write,
-          deserialize: () => persistTo.read() as IActivePagination,
-        }
-      : { persistTo: "state" }),
+        ? {
+            persistTo,
+            key: "pagination",
+          }
+        : isPersistenceProvider(persistTo)
+          ? {
+              persistTo: "provider",
+              serialize: persistTo.write,
+              deserialize: () => persistTo.read() as IActivePagination,
+            }
+          : { persistTo: "state" }),
   });
   const { pageNumber, itemsPerPage } = paginationState || defaultValue;
   const setPageNumber = (num: number) =>

--- a/client/src/app/hooks/table-controls/sorting/getLocalSortDerivedState.ts
+++ b/client/src/app/hooks/table-controls/sorting/getLocalSortDerivedState.ts
@@ -1,6 +1,7 @@
 import i18n from "@app/i18n";
-import { ISortState } from "./useSortState";
 import { universalComparator } from "@app/utils/utils";
+
+import { ISortState } from "./useSortState";
 
 /**
  * Args for getLocalSortDerivedState

--- a/client/src/app/hooks/table-controls/sorting/getSortHubRequestParams.ts
+++ b/client/src/app/hooks/table-controls/sorting/getSortHubRequestParams.ts
@@ -1,4 +1,5 @@
 import { HubRequestParams } from "@app/api/models";
+
 import { ISortState } from "./useSortState";
 
 /**

--- a/client/src/app/hooks/table-controls/sorting/useSortPropHelpers.ts
+++ b/client/src/app/hooks/table-controls/sorting/useSortPropHelpers.ts
@@ -1,4 +1,5 @@
 import { ThProps } from "@patternfly/react-table";
+
 import { ISortState } from "./useSortState";
 
 /**

--- a/client/src/app/hooks/table-controls/sorting/useSortState.ts
+++ b/client/src/app/hooks/table-controls/sorting/useSortState.ts
@@ -1,6 +1,7 @@
-import { DiscriminatedArgs } from "@app/utils/type-utils";
-import { IFeaturePersistenceArgs, isPersistenceProvider } from "..";
 import { usePersistentState } from "@app/hooks/usePersistentState";
+import { DiscriminatedArgs } from "@app/utils/type-utils";
+
+import { IFeaturePersistenceArgs, isPersistenceProvider } from "..";
 
 /**
  * The currently applied sort parameters
@@ -111,18 +112,18 @@ export const useSortState = <
               : null,
         }
       : persistTo === "localStorage" || persistTo === "sessionStorage"
-      ? {
-          persistTo,
-          key: "sort",
-        }
-      : isPersistenceProvider(persistTo)
-      ? {
-          persistTo: "provider",
-          serialize: persistTo.write,
-          deserialize: () =>
-            persistTo.read() as IActiveSort<TSortableColumnKey> | null,
-        }
-      : { persistTo: "state" }),
+        ? {
+            persistTo,
+            key: "sort",
+          }
+        : isPersistenceProvider(persistTo)
+          ? {
+              persistTo: "provider",
+              serialize: persistTo.write,
+              deserialize: () =>
+                persistTo.read() as IActiveSort<TSortableColumnKey> | null,
+            }
+          : { persistTo: "state" }),
   });
   return { activeSort, setActiveSort };
 };

--- a/client/src/app/hooks/table-controls/types.ts
+++ b/client/src/app/hooks/table-controls/types.ts
@@ -1,47 +1,49 @@
+import {
+  PaginationProps,
+  ToolbarItemProps,
+  ToolbarProps,
+} from "@patternfly/react-core";
 import { TableProps, TdProps, ThProps, TrProps } from "@patternfly/react-table";
+
+import { IFilterToolbarProps } from "@app/components/FilterToolbar";
+import { ITToolbarBulkExpanderProps } from "@app/components/ToolbarBulkExpander";
 import {
   DisallowCharacters,
   DiscriminatedArgs,
   KeyWithValueType,
 } from "@app/utils/type-utils";
-import {
-  IFilterStateArgs,
-  ILocalFilterDerivedStateArgs,
-  IFilterPropHelpersExternalArgs,
-  IFilterState,
-} from "./filtering";
-import {
-  ILocalSortDerivedStateArgs,
-  ISortPropHelpersExternalArgs,
-  ISortState,
-  ISortStateArgs,
-} from "./sorting";
-import {
-  IPaginationStateArgs,
-  ILocalPaginationDerivedStateArgs,
-  IPaginationPropHelpersExternalArgs,
-  IPaginationState,
-} from "./pagination";
-import {
-  IExpansionDerivedState,
-  IExpansionState,
-  IExpansionStateArgs,
-} from "./expansion";
+
 import {
   IActiveItemDerivedState,
   IActiveItemPropHelpersExternalArgs,
   IActiveItemState,
   IActiveItemStateArgs,
 } from "./active-item";
-import {
-  PaginationProps,
-  ToolbarItemProps,
-  ToolbarProps,
-} from "@patternfly/react-core";
-import { IFilterToolbarProps } from "@app/components/FilterToolbar";
-import { IExpansionPropHelpersExternalArgs } from "./expansion/useExpansionPropHelpers";
 import { IColumnState } from "./column/useColumnState";
-import { ITToolbarBulkExpanderProps } from "@app/components/ToolbarBulkExpander";
+import {
+  IExpansionDerivedState,
+  IExpansionState,
+  IExpansionStateArgs,
+} from "./expansion";
+import { IExpansionPropHelpersExternalArgs } from "./expansion/useExpansionPropHelpers";
+import {
+  IFilterPropHelpersExternalArgs,
+  IFilterState,
+  IFilterStateArgs,
+  ILocalFilterDerivedStateArgs,
+} from "./filtering";
+import {
+  ILocalPaginationDerivedStateArgs,
+  IPaginationPropHelpersExternalArgs,
+  IPaginationState,
+  IPaginationStateArgs,
+} from "./pagination";
+import {
+  ILocalSortDerivedStateArgs,
+  ISortPropHelpersExternalArgs,
+  ISortState,
+  ISortStateArgs,
+} from "./sorting";
 
 // Generic type params used here:
 //   TItem - The actual API objects represented by rows in the table. Can be any object.

--- a/client/src/app/hooks/table-controls/useLocalTableControlDerivedState.ts
+++ b/client/src/app/hooks/table-controls/useLocalTableControlDerivedState.ts
@@ -1,12 +1,13 @@
+import { useMemo } from "react";
+
 import { getLocalFilterDerivedState } from "./filtering";
-import { getLocalSortDerivedState } from "./sorting";
 import { getLocalPaginationDerivedState } from "./pagination";
+import { getLocalSortDerivedState } from "./sorting";
 import {
-  ITableControlLocalDerivedStateArgs,
   ITableControlDerivedState,
+  ITableControlLocalDerivedStateArgs,
   ITableControlState,
 } from "./types";
-import { useMemo } from "react";
 
 /**
  * Returns table-level "derived state" (the results of local/client-computed filtering/sorting/pagination)

--- a/client/src/app/hooks/table-controls/useLocalTableControls.ts
+++ b/client/src/app/hooks/table-controls/useLocalTableControls.ts
@@ -1,6 +1,6 @@
-import { useTableControlProps } from "./useTableControlProps";
 import { IUseLocalTableControlsArgs } from "./types";
 import { useLocalTableControlDerivedState } from "./useLocalTableControlDerivedState";
+import { useTableControlProps } from "./useTableControlProps";
 import { useTableControlState } from "./useTableControlState";
 
 /**

--- a/client/src/app/hooks/table-controls/useTableControlProps.ts
+++ b/client/src/app/hooks/table-controls/useTableControlProps.ts
@@ -1,12 +1,13 @@
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { objectKeys } from "@app/utils/utils";
-import { ITableControls, IUseTableControlPropsArgs } from "./types";
-import { useFilterPropHelpers } from "./filtering";
-import { useSortPropHelpers } from "./sorting";
-import { usePaginationPropHelpers } from "./pagination";
+
 import { useActiveItemPropHelpers } from "./active-item";
 import { useExpansionPropHelpers } from "./expansion";
+import { useFilterPropHelpers } from "./filtering";
+import { usePaginationPropHelpers } from "./pagination";
+import { useSortPropHelpers } from "./sorting";
+import { ITableControls, IUseTableControlPropsArgs } from "./types";
 import { handlePropagatedRowClick } from "./utils";
 
 /**

--- a/client/src/app/hooks/table-controls/useTableControlState.ts
+++ b/client/src/app/hooks/table-controls/useTableControlState.ts
@@ -1,3 +1,9 @@
+import { useActiveItemState } from "./active-item";
+import { useColumnState } from "./column/useColumnState";
+import { useExpansionState } from "./expansion";
+import { useFilterState } from "./filtering";
+import { usePaginationState } from "./pagination";
+import { useSortState } from "./sorting";
 import {
   IFeaturePersistenceArgs,
   ITableControlState,
@@ -5,12 +11,6 @@ import {
   IUseTableControlStateArgs,
   TableFeature,
 } from "./types";
-import { useFilterState } from "./filtering";
-import { useSortState } from "./sorting";
-import { usePaginationState } from "./pagination";
-import { useActiveItemState } from "./active-item";
-import { useExpansionState } from "./expansion";
-import { useColumnState } from "./column/useColumnState";
 
 const getPersistTo = ({
   feature,

--- a/client/src/app/hooks/useLegacyFilterState.ts
+++ b/client/src/app/hooks/useLegacyFilterState.ts
@@ -1,4 +1,5 @@
-import { IFilterValues, FilterCategory } from "@app/components/FilterToolbar";
+import { FilterCategory, IFilterValues } from "@app/components/FilterToolbar";
+
 import {
   getLocalFilterDerivedState,
   useFilterState,

--- a/client/src/app/hooks/useLegacyPaginationState.ts
+++ b/client/src/app/hooks/useLegacyPaginationState.ts
@@ -1,9 +1,10 @@
 import { PaginationProps } from "@patternfly/react-core";
+
 import {
   getLocalPaginationDerivedState,
-  usePaginationState,
   usePaginationEffects,
   usePaginationPropHelpers,
+  usePaginationState,
 } from "./table-controls";
 
 /**

--- a/client/src/app/hooks/useLegacySortState.ts
+++ b/client/src/app/hooks/useLegacySortState.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { ISortBy, SortByDirection } from "@patternfly/react-table";
+
 import i18n from "@app/i18n";
 import { universalComparator } from "@app/utils/utils";
 

--- a/client/src/app/hooks/usePersistentState.ts
+++ b/client/src/app/hooks/usePersistentState.ts
@@ -1,11 +1,13 @@
 import React from "react";
-import { IUseUrlParamsArgs, useUrlParams } from "./useUrlParams";
+
 import {
   UseStorageTypeOptions,
   useLocalStorage,
   useSessionStorage,
 } from "@app/hooks/useStorage";
 import { DisallowCharacters } from "@app/utils/type-utils";
+
+import { IUseUrlParamsArgs, useUrlParams } from "./useUrlParams";
 
 type PersistToStateOptions = { persistTo?: "state" };
 

--- a/client/src/app/hooks/useUrlParams.ts
+++ b/client/src/app/hooks/useUrlParams.ts
@@ -1,7 +1,8 @@
+import React from "react";
+import { useHistory, useLocation } from "react-router-dom";
+
 import { DisallowCharacters } from "@app/utils/type-utils";
 import { objectKeys } from "@app/utils/utils";
-import React from "react";
-import { useLocation, useHistory } from "react-router-dom";
 
 // useUrlParams is a generic hook similar to React.useState which stores its state in the URL search params string.
 // The state is retained on a page reload, when using the browser back/forward buttons, or when bookmarking the page.

--- a/client/src/app/i18n.ts
+++ b/client/src/app/i18n.ts
@@ -1,6 +1,6 @@
 import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
 import Backend from "i18next-http-backend";
+import { initReactI18next } from "react-i18next";
 
 i18n
   .use(Backend)

--- a/client/src/app/keycloak.ts
+++ b/client/src/app/keycloak.ts
@@ -1,4 +1,5 @@
 import Keycloak, { KeycloakConfig } from "keycloak-js";
+
 import { ENV } from "./env";
 
 const config: KeycloakConfig = {

--- a/client/src/app/layout/AppAboutModal/AppAboutModal.tsx
+++ b/client/src/app/layout/AppAboutModal/AppAboutModal.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { useTranslation, Trans } from "react-i18next";
-
+import { Trans, useTranslation } from "react-i18next";
 import {
   AboutModal,
-  TextContent,
   Text,
-  TextVariants,
+  TextContent,
   TextList,
   TextListItem,
+  TextVariants,
 } from "@patternfly/react-core";
+
 import { ENV } from "@app/env";
 import useBranding from "@app/hooks/useBranding";
 

--- a/client/src/app/layout/AppAboutModal/tests/AppAboutModal.test.tsx
+++ b/client/src/app/layout/AppAboutModal/tests/AppAboutModal.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { AppAboutModal } from "../AppAboutModal";
 
 it("AppAboutModal", () => {

--- a/client/src/app/layout/AppAboutModalState/AppAboutModalState.tsx
+++ b/client/src/app/layout/AppAboutModalState/AppAboutModalState.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+
 import { AppAboutModal } from "../AppAboutModal";
 
 export interface ChildrenProps {

--- a/client/src/app/layout/DefaultLayout/DefaultLayout.tsx
+++ b/client/src/app/layout/DefaultLayout/DefaultLayout.tsx
@@ -1,12 +1,13 @@
 import React, { useRef } from "react";
 import { Page, SkipToContent } from "@patternfly/react-core";
 
-import { HeaderApp } from "../HeaderApp";
-import { SidebarApp } from "../SidebarApp";
 import { Notifications } from "@app/components/Notifications";
 import { PageContentWithDrawerProvider } from "@app/components/PageDrawerContext";
-import { TaskManagerDrawer } from "@app/components/task-manager/TaskManagerDrawer";
 import { useTaskManagerContext } from "@app/components/task-manager/TaskManagerContext";
+import { TaskManagerDrawer } from "@app/components/task-manager/TaskManagerDrawer";
+
+import { HeaderApp } from "../HeaderApp";
+import { SidebarApp } from "../SidebarApp";
 
 export interface DefaultLayoutProps {
   children?: React.ReactNode;

--- a/client/src/app/layout/DefaultLayout/tests/DefaultLayout.test.tsx
+++ b/client/src/app/layout/DefaultLayout/tests/DefaultLayout.test.tsx
@@ -1,8 +1,10 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
-import { DefaultLayout } from "../DefaultLayout";
+
+import { render } from "@app/test-config/test-utils";
+
 import { NotificationsProvider } from "../../../components/NotificationsContext";
+import { DefaultLayout } from "../DefaultLayout";
 
 it.skip("Test snapshot", () => {
   const wrapper = render(

--- a/client/src/app/layout/HeaderApp/HeaderApp.tsx
+++ b/client/src/app/layout/HeaderApp/HeaderApp.tsx
@@ -18,11 +18,13 @@ import {
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 import BarsIcon from "@patternfly/react-icons/dist/js/icons/bars-icon";
 
-import useBranding from "@app/hooks/useBranding";
 import { TaskNotificationBadge } from "@app/components/task-manager/TaskNotificaitonBadge";
+import useBranding from "@app/hooks/useBranding";
+
 import { AppAboutModalState } from "../AppAboutModalState";
-import { SsoToolbarItem } from "./SsoToolbarItem";
+
 import { MobileDropdown } from "./MobileDropdown";
+import { SsoToolbarItem } from "./SsoToolbarItem";
 
 import "./header.css";
 

--- a/client/src/app/layout/HeaderApp/MobileDropdown.tsx
+++ b/client/src/app/layout/HeaderApp/MobileDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { DropdownItem } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
+
 import { KebabDropdown } from "@app/components/KebabDropdown";
 import { AppAboutModal } from "@app/layout/AppAboutModal";
 

--- a/client/src/app/layout/HeaderApp/SsoToolbarItem.tsx
+++ b/client/src/app/layout/HeaderApp/SsoToolbarItem.tsx
@@ -1,16 +1,17 @@
 import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
 import { useKeycloak } from "@react-keycloak/web";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import {
   Dropdown,
-  MenuToggle,
   DropdownGroup,
   DropdownItem,
   DropdownList,
+  MenuToggle,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { isAuthRequired, LocalStorageKey } from "@app/Constants";
-import { useHistory } from "react-router-dom";
+
+import { LocalStorageKey, isAuthRequired } from "@app/Constants";
 
 export const SsoToolbarItem: React.FC = () => {
   return isAuthRequired ? <AuthEnabledSsoToolbarItem /> : <></>;

--- a/client/src/app/layout/HeaderApp/tests/HeaderApp.test.tsx
+++ b/client/src/app/layout/HeaderApp/tests/HeaderApp.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { HeaderApp } from "../HeaderApp";
 
 it("Test snapshot", () => {

--- a/client/src/app/layout/SidebarApp/tests/SidebarApp.test.tsx
+++ b/client/src/app/layout/SidebarApp/tests/SidebarApp.test.tsx
@@ -1,6 +1,8 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
+
+import { render } from "@app/test-config/test-utils";
+
 import { SidebarApp } from "../SidebarApp";
 
 it.skip("Renders without crashing", () => {

--- a/client/src/app/pages/applications/analysis-details/AnalysisDetails.tsx
+++ b/client/src/app/pages/applications/analysis-details/AnalysisDetails.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
 
 import { AnalysisDetailsAttachmentRoute, Paths } from "@app/Paths";
+import { TaskDetailsBase } from "@app/pages/tasks/TaskDetailsBase";
+import { useFetchApplicationById } from "@app/queries/applications";
 import { formatPath } from "@app/utils/utils";
 
 import "@app/components/simple-document-viewer/SimpleDocumentViewer.css";
-import { TaskDetailsBase } from "@app/pages/tasks/TaskDetailsBase";
-import { useFetchApplicationById } from "@app/queries/applications";
 
 export const AnalysisDetails = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/__tests__/analysis-wizard.test.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 import "@testing-library/jest-dom";
+import { server } from "@mocks/server";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+
 import {
   fireEvent,
   render,
   screen,
   waitFor,
 } from "@app/test-config/test-utils";
+
 import { AnalysisWizard } from "../analysis-wizard";
-import userEvent from "@testing-library/user-event";
-import { server } from "@mocks/server";
-import { rest } from "msw";
 
 const applicationData1 = {
   id: 1,

--- a/client/src/app/pages/applications/analysis-wizard/__tests__/utils.test.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/__tests__/utils.test.tsx
@@ -1,4 +1,5 @@
 import { Target, TargetLabel } from "@app/api/models";
+
 import { updateSelectedTargetLabels } from "../utils";
 
 const TARGET_LABELS: TargetLabel[] = [

--- a/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/analysis-wizard.tsx
@@ -1,49 +1,50 @@
 import * as React from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { useIsMutating } from "@tanstack/react-query";
 import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import {
   Modal,
   ModalVariant,
+  Truncate,
   Wizard,
+  WizardHeader,
   WizardStep,
   WizardStepType,
-  WizardHeader,
-  Truncate,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 
 import {
+  AnalysisTaskData,
   Application,
   New,
   Ref,
-  AnalysisTaskData,
   Taskgroup,
   TaskgroupTask,
 } from "@app/api/models";
-import { Review } from "./review";
-import { SetMode } from "./set-mode";
-import { SetOptions } from "./set-options";
-import { SetScope } from "./set-scope";
-import { SetTargets } from "./set-targets";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { useAsyncYupValidation } from "@app/hooks/useAsyncYupValidation";
+import { useFetchIdentities } from "@app/queries/identities";
 import {
   useCreateTaskgroupMutation,
   useDeleteTaskgroupMutation,
   useSubmitTaskgroupMutation,
 } from "@app/queries/taskgroups";
-import { yupResolver } from "@hookform/resolvers/yup";
+import { getParsedLabel } from "@app/utils/rules-utils";
 
-import "./wizard.css";
-import { useAnalyzableApplications, isModeSupported } from "./utils";
-import { NotificationsContext } from "@app/components/NotificationsContext";
+import { useTaskGroup } from "./components/TaskGroupContext";
+import { CustomRules } from "./custom-rules";
+import { Review } from "./review";
 import {
   AnalysisWizardFormValues,
   useAnalysisWizardFormValidationSchema,
 } from "./schema";
-import { useAsyncYupValidation } from "@app/hooks/useAsyncYupValidation";
-import { CustomRules } from "./custom-rules";
-import { useFetchIdentities } from "@app/queries/identities";
-import { useTaskGroup } from "./components/TaskGroupContext";
-import { getParsedLabel } from "@app/utils/rules-utils";
+import { SetMode } from "./set-mode";
+import { SetOptions } from "./set-options";
+import { SetScope } from "./set-scope";
+import { SetTargets } from "./set-targets";
+import { isModeSupported, useAnalyzableApplications } from "./utils";
+
+import "./wizard.css";
 
 interface IAnalysisWizard {
   applications: Application[];

--- a/client/src/app/pages/applications/analysis-wizard/components/TaskGroupContext.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/TaskGroupContext.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useState } from "react";
 import { Taskgroup } from "@app/api/models";
 import { NotificationsContext } from "@app/components/NotificationsContext";
 import { useCreateTaskgroupMutation } from "@app/queries/taskgroups";
+
 import { defaultTaskgroup } from "../analysis-wizard";
 
 interface TaskGroupContext {

--- a/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/components/upload-binary.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { AxiosError } from "axios";
+import { useFormContext } from "react-hook-form";
 import {
   Alert,
   DropEvent,
@@ -7,18 +9,18 @@ import {
   MultipleFileUploadStatusItem,
 } from "@patternfly/react-core";
 import UploadIcon from "@patternfly/react-icons/dist/esm/icons/upload-icon";
-import { useFormContext } from "react-hook-form";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
+import { uploadLimit } from "@app/Constants";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import {
   useRemoveTaskgroupFileMutation,
   useUploadTaskgroupFileMutation,
 } from "@app/queries/taskgroups";
-import { AxiosError } from "axios";
 import { getAxiosErrorMessage } from "@app/utils/utils";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { uploadLimit } from "@app/Constants";
-import { NotificationsContext } from "@app/components/NotificationsContext";
+
 import { AnalysisWizardFormValues } from "../schema";
+
 import { useTaskGroup } from "./TaskGroupContext";
 
 const readFile = (file: File, onProgress: (percent: number) => void) => {

--- a/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/custom-rules.tsx
@@ -1,12 +1,15 @@
 import * as React from "react";
+import { unique } from "radash";
+import { useFieldArray, useForm, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
   Form,
   Modal,
   Tab,
-  Tabs,
   TabTitleText,
+  Tabs,
   Text,
   TextContent,
   Title,
@@ -16,40 +19,38 @@ import {
   ToolbarItem,
   ToolbarToggleGroup,
 } from "@patternfly/react-core";
-import { cellWidth, ICell, IRow, TableText } from "@patternfly/react-table";
+import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
+import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { ICell, IRow, TableText, cellWidth } from "@patternfly/react-table";
 import {
   Table,
   TableBody,
   TableHeader,
 } from "@patternfly/react-table/deprecated";
-import { useFieldArray, useForm, useFormContext } from "react-hook-form";
-import { useTranslation } from "react-i18next";
-import { unique } from "radash";
-import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
-import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
+import { TargetLabel, UploadFile } from "@app/api/models";
+import { CustomRuleFilesUpload } from "@app/components/CustomRuleFilesUpload";
 import {
   FilterCategory,
   FilterToolbar,
   FilterType,
 } from "@app/components/FilterToolbar";
-import { useLegacyFilterState } from "@app/hooks/useLegacyFilterState";
-import { UploadFile, TargetLabel } from "@app/api/models";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
-
-import "./wizard.css";
-import { AnalysisWizardFormValues } from "./schema";
-import { getParsedLabel, parseRules } from "@app/utils/rules-utils";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-import { toOptionLike } from "@app/utils/model-utils";
+import { useLegacyFilterState } from "@app/hooks/useLegacyFilterState";
 import { useFetchIdentities } from "@app/queries/identities";
+import { toOptionLike } from "@app/utils/model-utils";
+import { getParsedLabel, parseRules } from "@app/utils/rules-utils";
+
 import { useTaskGroup } from "./components/TaskGroupContext";
-import { CustomRuleFilesUpload } from "@app/components/CustomRuleFilesUpload";
+import { AnalysisWizardFormValues } from "./schema";
+
+import "./wizard.css";
 
 const buildSetOfTargetLabelsFromUploadFiles = (
   ruleFiles: UploadFile[],

--- a/client/src/app/pages/applications/analysis-wizard/review.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/review.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import {
   DescriptionList,
   DescriptionListDescription,
@@ -10,12 +12,11 @@ import {
   TextContent,
   Title,
 } from "@patternfly/react-core";
-import { useFormContext } from "react-hook-form";
-import { useTranslation } from "react-i18next";
 
 import { Application } from "@app/api/models";
-import { AnalysisWizardFormValues } from "./schema";
 import { getParsedLabel } from "@app/utils/rules-utils";
+
+import { AnalysisWizardFormValues } from "./schema";
 
 interface IReview {
   applications: Application[];

--- a/client/src/app/pages/applications/analysis-wizard/schema.ts
+++ b/client/src/app/pages/applications/analysis-wizard/schema.ts
@@ -1,13 +1,14 @@
-import * as yup from "yup";
 import { useTranslation } from "react-i18next";
+import * as yup from "yup";
 
 import {
   Application,
-  TargetLabel,
   Target,
+  TargetLabel,
   UploadFile,
   UploadFileStatus,
 } from "@app/api/models";
+
 import { useAnalyzableApplicationsByMode } from "./utils";
 
 export const ANALYSIS_MODES = [

--- a/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-mode.tsx
@@ -1,18 +1,19 @@
 import React from "react";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import {
+  Alert,
+  Form,
   SelectOptionProps,
   TextContent,
   Title,
-  Alert,
-  Form,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
+
+import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
+import { SimpleSelectBasic } from "@app/components/SimpleSelectBasic";
 
 import { UploadBinary } from "./components/upload-binary";
 import { AnalysisWizardFormValues } from "./schema";
-import { useFormContext } from "react-hook-form";
-import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
-import { SimpleSelectBasic } from "@app/components/SimpleSelectBasic";
 
 interface ISetMode {
   isSingleApp: boolean;

--- a/client/src/app/pages/applications/analysis-wizard/set-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-options.tsx
@@ -1,4 +1,8 @@
 import * as React from "react";
+import { toggle } from "radash";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import * as yup from "yup";
 import {
   Checkbox,
   Flex,
@@ -10,27 +14,25 @@ import {
   Tooltip,
 } from "@patternfly/react-core";
 import {
-  SelectVariant,
   Select,
   SelectOption,
+  SelectVariant,
 } from "@patternfly/react-core/deprecated";
-import { useFormContext } from "react-hook-form";
-import { useTranslation } from "react-i18next";
-import * as yup from "yup";
-
-import { getValidatedFromErrors, universalComparator } from "@app/utils/utils";
-import { defaultTargets } from "../../../data/targets";
+import { QuestionCircleIcon } from "@patternfly/react-icons";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { AnalysisWizardFormValues } from "./schema";
+
+import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
 import { StringListField } from "@app/components/StringListField";
-import { getParsedLabel } from "@app/utils/rules-utils";
-import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { useFetchTargets } from "@app/queries/targets";
+import { getParsedLabel } from "@app/utils/rules-utils";
+import { getValidatedFromErrors, universalComparator } from "@app/utils/utils";
+
+import { defaultTargets } from "../../../data/targets";
+
+import { AnalysisWizardFormValues } from "./schema";
 import defaultSources from "./sources";
-import { QuestionCircleIcon } from "@patternfly/react-icons";
 import { updateSelectedTargetsBasedOnLabels } from "./utils";
-import { toggle } from "radash";
 
 export const SetOptions: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/applications/analysis-wizard/set-scope.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-scope.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import { Form, Radio, Switch, Text, Title } from "@patternfly/react-core";
-import { useFormContext } from "react-hook-form";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { useTranslation } from "react-i18next";
 
 import "./wizard.css";
-import { AnalysisWizardFormValues } from "./schema";
 import { StringListField } from "@app/components/StringListField";
+
+import { AnalysisWizardFormValues } from "./schema";
 
 export const SetScope: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/set-targets.tsx
@@ -1,32 +1,33 @@
 import React, { useMemo } from "react";
+import { unique } from "radash";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import {
-  Title,
-  TextContent,
-  Text,
+  Alert,
+  Form,
   Gallery,
   GalleryItem,
-  Form,
-  Alert,
+  Text,
+  TextContent,
+  Title,
   Toolbar,
   ToolbarContent,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { useFormContext } from "react-hook-form";
 
-import { TargetCard } from "@app/components/target-card/target-card";
-import { AnalysisWizardFormValues } from "./schema";
-import { useFetchTargets } from "@app/queries/targets";
 import { Application, Target } from "@app/api/models";
-import { useFetchTagCategories } from "@app/queries/tags";
-import { updateSelectedTargetLabels, toggleSelectedTargets } from "./utils";
-import { unique } from "radash";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { StateError } from "@app/components/StateError";
+import { TargetCard } from "@app/components/target-card/target-card";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useSetting } from "@app/queries/settings";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { StateError } from "@app/components/StateError";
-import { universalComparator } from "@app/utils/utils";
+import { useFetchTagCategories } from "@app/queries/tags";
+import { useFetchTargets } from "@app/queries/targets";
 import { toLabelValue } from "@app/utils/rules-utils";
+import { universalComparator } from "@app/utils/utils";
+
+import { AnalysisWizardFormValues } from "./schema";
+import { toggleSelectedTargets, updateSelectedTargetLabels } from "./utils";
 
 interface SetTargetsProps {
   applications: Application[];

--- a/client/src/app/pages/applications/analysis-wizard/utils.ts
+++ b/client/src/app/pages/applications/analysis-wizard/utils.ts
@@ -1,8 +1,10 @@
 import * as React from "react";
-import { Application, Target, TargetLabel } from "@app/api/models";
-import { AnalysisMode, ANALYSIS_MODES } from "./schema";
 import { toggle, unique } from "radash";
+
+import { Application, Target, TargetLabel } from "@app/api/models";
 import { getParsedLabel } from "@app/utils/rules-utils";
+
+import { ANALYSIS_MODES, AnalysisMode } from "./schema";
 
 export const isApplicationBinaryEnabled = (
   application: Application

--- a/client/src/app/pages/applications/application-detail-drawer/application-detail-drawer.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/application-detail-drawer.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-
 import {
-  TextContent,
-  Text,
-  Title,
-  Tabs,
   Tab,
   TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  Title,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
@@ -23,11 +22,12 @@ import {
 } from "@app/components/detail-drawer";
 
 import { DecoratedApplication } from "../useDecoratedApplications";
+
 import { TabDetailsContent } from "./tab-details-content";
-import { TabTagsContent } from "./tab-tags-content";
-import { TabReportsContent } from "./tab-reports-contents";
-import { TabTasksContent } from "./tab-tasks-content";
 import { TabPlatformContent } from "./tab-platform-content";
+import { TabReportsContent } from "./tab-reports-contents";
+import { TabTagsContent } from "./tab-tags-content";
+import { TabTasksContent } from "./tab-tasks-content";
 
 export interface IApplicationDetailDrawerProps
   extends Pick<IPageDrawerContentProps, "onCloseClick"> {

--- a/client/src/app/pages/applications/application-detail-drawer/application-facts.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/application-facts.tsx
@@ -1,8 +1,5 @@
-import {
-  FilterCategory,
-  FilterToolbar,
-  FilterType,
-} from "@app/components/FilterToolbar";
+import React from "react";
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Toolbar,
@@ -10,12 +7,17 @@ import {
   ToolbarItem,
   ToolbarToggleGroup,
 } from "@patternfly/react-core";
-import React from "react";
 import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { useTranslation } from "react-i18next";
-import { useLegacyFilterState } from "@app/hooks/useLegacyFilterState";
+
 import { Fact } from "@app/api/models";
+import {
+  FilterCategory,
+  FilterToolbar,
+  FilterType,
+} from "@app/components/FilterToolbar";
+import { useLegacyFilterState } from "@app/hooks/useLegacyFilterState";
+
 import { FactDetailModal } from "./fact-detail-modal/fact-detail-modal";
 
 export interface IApplicationRiskProps {
@@ -76,7 +78,7 @@ export const ApplicationFacts: React.FC<IApplicationRiskProps> = ({
       </Toolbar>
       {filteredFacts.map((fact) => {
         return (
-          <div>
+          <div key={fact.name}>
             <Button
               variant="link"
               isInline

--- a/client/src/app/pages/applications/application-detail-drawer/components/application-tags.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/components/application-tags.tsx
@@ -1,34 +1,34 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import {
+  Bullseye,
   Button,
+  ButtonVariant,
   Flex,
   Spinner,
-  TextContent,
   Text,
+  TextContent,
   Toolbar,
   ToolbarContent,
-  ToolbarToggleGroup,
   ToolbarItem,
-  ButtonVariant,
-  Bullseye,
+  ToolbarToggleGroup,
 } from "@patternfly/react-core";
-
+import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
-import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+
 import { Application, Tag, TagCategory } from "@app/api/models";
 import { getTagById, getTagCategoryById } from "@app/api/rest";
+import { ConditionalRender } from "@app/components/ConditionalRender";
 import {
   FilterCategory,
   FilterToolbar,
   FilterType,
 } from "@app/components/FilterToolbar";
-import { useLegacyFilterState } from "@app/hooks/useLegacyFilterState";
-import { useHistory } from "react-router-dom";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 import { ItemTagLabel } from "@app/components/labels/item-tag-label/item-tag-label";
+import { useLegacyFilterState } from "@app/hooks/useLegacyFilterState";
 import { capitalizeFirstLetter, universalComparator } from "@app/utils/utils";
 
 interface TagWithSource extends Tag {
@@ -201,7 +201,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
 
       {Array.from(tagsBySource.keys())
         .sort(compareSources)
-        .map((source, tagSourceIndex) => {
+        .map((source) => {
           const tagsInThisSource = tagsBySource.get(source);
           const tagCategoriesInThisSource = new Set<TagCategory>();
           tagsInThisSource?.forEach((tag) => {

--- a/client/src/app/pages/applications/application-detail-drawer/fact-detail-modal/fact-code-snip-viewer.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/fact-detail-modal/fact-code-snip-viewer.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { CodeEditor, Language } from "@patternfly/react-code-editor";
-import { Fact } from "@app/api/models";
 import yaml from "js-yaml";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+
+import { Fact } from "@app/api/models";
 export interface IFactCodeSnipViewerProps {
   fact: Fact;
 }

--- a/client/src/app/pages/applications/application-detail-drawer/fact-detail-modal/fact-detail-modal.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/fact-detail-modal/fact-detail-modal.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { Button, Modal } from "@patternfly/react-core";
-import { FactCodeSnipViewer } from "./fact-code-snip-viewer";
+
 import { Fact } from "@app/api/models";
+
+import { FactCodeSnipViewer } from "./fact-code-snip-viewer";
 
 export interface IFactDetailModalProps {
   fact: Fact;

--- a/client/src/app/pages/applications/application-detail-drawer/tab-details-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-details-content.tsx
@@ -1,44 +1,44 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-
 import {
-  TextContent,
-  Text,
-  Title,
-  List,
-  ListItem,
+  Button,
   DescriptionList,
+  DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  DescriptionListDescription,
-  GridItem,
   Grid,
-  Button,
-  TextVariants,
+  GridItem,
+  List,
+  ListItem,
   Spinner,
+  Text,
+  TextContent,
+  TextVariants,
+  Title,
   Tooltip,
 } from "@patternfly/react-core";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { EditIcon, UnlinkIcon } from "@patternfly/react-icons";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
-import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
-import { LabelsFromItems } from "@app/components/labels/labels-from-items/labels-from-items";
-import { RiskLabel } from "@app/components/RiskLabel";
-import {
-  getDependenciesUrlFilteredByAppName,
-  getIssuesSingleAppSelectedLocation,
-} from "@app/pages/issues/helpers";
-import { DecoratedApplication } from "../useDecoratedApplications";
 import { Archetype } from "@app/api/models";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+import ExternalLink from "@app/components/ExternalLink";
+import { RiskLabel } from "@app/components/RiskLabel";
 import {
   DrawerTabContent,
   DrawerTabContentSection,
 } from "@app/components/detail-drawer";
-import { useFetchTickets } from "@app/queries/tickets";
-import { useDeleteTicketMutation } from "@app/queries/migration-waves";
-import ExternalLink from "@app/components/ExternalLink";
+import { LabelsFromItems } from "@app/components/labels/labels-from-items/labels-from-items";
 import { getInsightsSingleAppSelectedLocation } from "@app/pages/insights/helpers";
+import {
+  getDependenciesUrlFilteredByAppName,
+  getIssuesSingleAppSelectedLocation,
+} from "@app/pages/issues/helpers";
+import { useDeleteTicketMutation } from "@app/queries/migration-waves";
+import { useFetchTickets } from "@app/queries/tickets";
+
+import { DecoratedApplication } from "../useDecoratedApplications";
 
 const ApplicationArchetypesLabels: React.FC<{
   application: DecoratedApplication;

--- a/client/src/app/pages/applications/application-detail-drawer/tab-reports-contents.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-reports-contents.tsx
@@ -1,37 +1,37 @@
 import React from "react";
-import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-
+import { useHistory } from "react-router-dom";
 import {
-  TextContent,
-  Text,
-  Title,
   Button,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
   Divider,
+  Text,
+  TextContent,
+  Title,
   Tooltip,
 } from "@patternfly/react-core";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
-import { Identity, MimeType } from "@app/api/models";
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
+import { Paths } from "@app/Paths";
+import { Identity, MimeType } from "@app/api/models";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { useFetchFacts } from "@app/queries/facts";
 import { useFetchIdentities } from "@app/queries/identities";
 import { useSetting } from "@app/queries/settings";
-import { getKindIdByRef } from "@app/utils/model-utils";
-import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
-import { formatPath } from "@app/utils/utils";
-import { Paths } from "@app/Paths";
-import { DecoratedApplication } from "../useDecoratedApplications";
 import { TaskStates } from "@app/queries/tasks";
+import { getKindIdByRef } from "@app/utils/model-utils";
+import { formatPath } from "@app/utils/utils";
 
-import DownloadButton from "./components/download-button";
+import { DecoratedApplication } from "../useDecoratedApplications";
+
 import { ApplicationFacts } from "./application-facts";
+import DownloadButton from "./components/download-button";
 
 export const TabReportsContent: React.FC<{
   application: DecoratedApplication;

--- a/client/src/app/pages/applications/application-detail-drawer/tab-tags-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-tags-content.tsx
@@ -2,13 +2,15 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Bullseye,
-  TextContent,
-  Text,
-  TextVariants,
   Spinner,
+  Text,
+  TextContent,
+  TextVariants,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
 import { DecoratedApplication } from "../useDecoratedApplications";
+
 import { ApplicationTags } from "./components/application-tags";
 
 export const TabTagsContent: React.FC<{

--- a/client/src/app/pages/applications/application-detail-drawer/tab-tasks-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-tasks-content.tsx
@@ -1,31 +1,31 @@
 import * as React from "react";
-import { Link, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-
+import { Link, useHistory } from "react-router-dom";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { SimplePagination } from "@app/components/SimplePagination";
-import { useServerTasks } from "@app/queries/tasks";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-  deserializeFilterUrlParams,
-} from "@app/hooks/table-controls";
 import { TablePersistenceKeyPrefix } from "@app/Constants";
-import { TaskActionColumn } from "@app/pages/tasks/TaskActionColumn";
+import { Paths } from "@app/Paths";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
+import {
+  deserializeFilterUrlParams,
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
+import { TaskActionColumn } from "@app/pages/tasks/TaskActionColumn";
 import { taskStateToLabel } from "@app/pages/tasks/tasks-page";
+import { useServerTasks } from "@app/queries/tasks";
 import { formatPath } from "@app/utils/utils";
-import { Paths } from "@app/Paths";
+
 import { DecoratedApplication } from "../useDecoratedApplications";
 
 export const TabTasksContent: React.FC<{

--- a/client/src/app/pages/applications/applications-table/components/column-analysis-status.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-analysis-status.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import { TaskState } from "@app/api/models";
 import {
-  buildPresetLabels,
   IconedStatus,
   IconedStatusPreset,
+  buildPresetLabels,
 } from "@app/components/Icons";
 
 export interface ColumnAnalysisStatusProps {

--- a/client/src/app/pages/applications/applications-table/components/column-application-name.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-application-name.tsx
@@ -1,22 +1,22 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import dayjs from "dayjs";
-
+import { Link } from "react-router-dom";
 import { Icon, Popover, PopoverProps, Tooltip } from "@patternfly/react-core";
 import {
   CheckCircleIcon,
-  TimesCircleIcon,
-  InProgressIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
+  InProgressIcon,
   PendingIcon,
+  TimesCircleIcon,
 } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Thead, Tr } from "@patternfly/react-table";
 
-import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
 import { Paths } from "@app/Paths";
-import { formatPath, universalComparator } from "@app/utils/utils";
 import { TaskDashboard } from "@app/api/models";
+import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
+import { formatPath, universalComparator } from "@app/utils/utils";
+
 import {
   ApplicationTasksStatus,
   DecoratedApplication,

--- a/client/src/app/pages/applications/applications-table/components/column-assessment-status.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-assessment-status.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";
 import { Spinner } from "@patternfly/react-core";
+
+import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";
+
 import { DecoratedApplication } from "../../useDecoratedApplications";
 
 interface ColumnAssessmentStatusProps {

--- a/client/src/app/pages/applications/applications-table/components/column-review-status.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-review-status.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { Application } from "@app/api/models";
-import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";
-import { Spinner } from "@patternfly/react-core";
-import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { useTranslation } from "react-i18next";
+import { Spinner } from "@patternfly/react-core";
+
+import { Application } from "@app/api/models";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";
 import { useFetchArchetypes } from "@app/queries/archetypes";
 
 export interface ColumnReviewStatusProps {

--- a/client/src/app/pages/applications/applications-table/components/manage-columns-modal.tsx
+++ b/client/src/app/pages/applications/applications-table/components/manage-columns-modal.tsx
@@ -15,6 +15,7 @@ import {
   TextContent,
   TextVariants,
 } from "@patternfly/react-core";
+
 import { ColumnState } from "@app/hooks/table-controls/column/useColumnState";
 
 export interface ManagedColumnsProps<TColumnKey extends string> {

--- a/client/src/app/pages/applications/applications-table/components/manage-columns-toolbar.tsx
+++ b/client/src/app/pages/applications/applications-table/components/manage-columns-toolbar.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Button,
   OverflowMenu,
@@ -5,11 +7,11 @@ import {
   OverflowMenuItem,
   ToolbarItem,
 } from "@patternfly/react-core";
-import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { ColumnState } from "@app/hooks/table-controls/column/useColumnState";
-import { ManageColumnsModal } from "./manage-columns-modal";
 import { ColumnsIcon } from "@patternfly/react-icons";
+
+import { ColumnState } from "@app/hooks/table-controls/column/useColumnState";
+
+import { ManageColumnsModal } from "./manage-columns-modal";
 
 interface ManageColumnsToolbarProps<TColumnKey extends string> {
   columns: ColumnState<TColumnKey>[];

--- a/client/src/app/pages/applications/applications.tsx
+++ b/client/src/app/pages/applications/applications.tsx
@@ -1,4 +1,5 @@
 import React, { lazy } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Level,
   LevelItem,
@@ -6,7 +7,6 @@ import {
   PageSectionVariants,
   Title,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 
 const ApplicationsTable = lazy(() => import("./applications-table"));
 

--- a/client/src/app/pages/applications/components/import-applications-form.tsx
+++ b/client/src/app/pages/applications/components/import-applications-form.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import axios, { AxiosResponse } from "axios";
 import { useTranslation } from "react-i18next";
-
 import {
   ActionGroup,
   Button,
@@ -15,8 +14,8 @@ import {
 } from "@patternfly/react-core";
 
 import { APP_IMPORTS_SUMMARY_UPLOAD } from "@app/api/rest";
-import { getAxiosErrorMessage } from "@app/utils/utils";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import { getAxiosErrorMessage } from "@app/utils/utils";
 
 export interface ImportApplicationsFormProps {
   onSaved: (response: AxiosResponse) => void;

--- a/client/src/app/pages/applications/generate-assets-wizard/generate-assets-wizard.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/generate-assets-wizard.tsx
@@ -1,24 +1,26 @@
 import * as React from "react";
+import { group } from "radash";
+import { useTranslation } from "react-i18next";
 import {
+  Button,
   Modal,
   ModalVariant,
   Wizard,
-  WizardStep,
   WizardHeader,
-  Button,
+  WizardStep,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { group } from "radash";
 
-import { universalComparator } from "@app/utils/utils";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import { universalComparator } from "@app/utils/utils";
+
 import { DecoratedApplication } from "../useDecoratedApplications";
+
+import { AdvancedOptions } from "./step-advanced-options";
+import { Results } from "./step-results";
+import { Review } from "./step-review";
+import { SelectTargetProfile } from "./step-select-target-profile";
 import { useStartApplicationAssetGeneration } from "./useStartApplicationAssetGeneration";
 import { useWizardReducer } from "./useWizardReducer";
-import { SelectTargetProfile } from "./step-select-target-profile";
-import { Review } from "./step-review";
-import { Results } from "./step-results";
-import { AdvancedOptions } from "./step-advanced-options";
 
 export const GenerateAssetsWizard: React.FC<IGenerateAssetsWizard> = ({
   isOpen,
@@ -54,7 +56,7 @@ const GenerateAssetsWizardInner: React.FC<IGenerateAssetsWizard> = ({
   const {
     state,
     setProfile,
-    setParameters,
+    // setParameters,
     setAdvancedOptions,
     setResults,
     reset,

--- a/client/src/app/pages/applications/generate-assets-wizard/step-advanced-options.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/step-advanced-options.tsx
@@ -1,19 +1,18 @@
 import * as React from "react";
-import { useTranslation } from "react-i18next";
-import { useForm, useWatch, UseFormReturn } from "react-hook-form";
-import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
-
+import { UseFormReturn, useForm, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import * as yup from "yup";
 import {
   Form,
-  TextContent,
-  Text,
-  PanelMainBody,
-  PanelMain,
-  Panel,
-  Popover,
   Icon,
+  Panel,
+  PanelMain,
+  PanelMainBody,
+  Popover,
   Radio,
+  Text,
+  TextContent,
 } from "@patternfly/react-core";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
 

--- a/client/src/app/pages/applications/generate-assets-wizard/step-results.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/step-results.tsx
@@ -1,25 +1,26 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import {
   Card,
   CardBody,
   CardHeader,
   CardTitle,
-  Text,
-  TextContent,
-  TextVariants,
   Grid,
   GridItem,
   Icon,
+  Text,
+  TextContent,
+  TextVariants,
 } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
 import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
 } from "@patternfly/react-icons";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { ApplicationAssetGenerationTask } from "@app/api/models";
+
 import { DecoratedApplication } from "../useDecoratedApplications";
 
 export interface ResultsData {

--- a/client/src/app/pages/applications/generate-assets-wizard/step-select-target-profile.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/step-select-target-profile.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { TextContent, Text } from "@patternfly/react-core";
+import { Text, TextContent } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { Archetype, TargetProfile } from "@app/api/models";
 import { intersection } from "@app/utils/utils";
+
 import { DecoratedApplication } from "../useDecoratedApplications";
 
 export interface TargetProfileState {

--- a/client/src/app/pages/applications/generate-assets-wizard/useStartApplicationAssetGeneration.tsx
+++ b/client/src/app/pages/applications/generate-assets-wizard/useStartApplicationAssetGeneration.tsx
@@ -6,8 +6,9 @@ import {
   TargetProfile,
 } from "@app/api/models";
 import { useCreateTaskMutation } from "@app/queries/tasks";
-import { DecoratedApplication } from "../useDecoratedApplications";
 import { toRef, toRefs } from "@app/utils/model-utils";
+
+import { DecoratedApplication } from "../useDecoratedApplications";
 
 export const useStartApplicationAssetGeneration = () => {
   const { mutateAsync: createTask } = useCreateTaskMutation<

--- a/client/src/app/pages/applications/generate-assets-wizard/useWizardReducer.ts
+++ b/client/src/app/pages/applications/generate-assets-wizard/useWizardReducer.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { TargetProfile } from "@app/api/models";
+
 import { AdvancedOptionsState } from "./step-advanced-options";
 import { ParameterState } from "./step-capture-parameters";
 import { ResultsData } from "./step-results";

--- a/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
+++ b/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { useParams } from "react-router-dom";
-import { useTranslation } from "react-i18next";
 import { saveAs } from "file-saver";
-
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
@@ -16,31 +15,31 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { CubesIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { ImportSummaryRoute, Paths } from "@app/Paths";
 import { getApplicationSummaryCSV } from "@app/api/rest";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import {
-  useFetchImports,
-  useFetchImportSummaryById,
-} from "@app/queries/imports";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
 import {
   FilterToolbar,
   FilterType,
 } from "@app/components/FilterToolbar/FilterToolbar";
 import { NotificationsContext } from "@app/components/NotificationsContext";
 import { PageHeader } from "@app/components/PageHeader";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { ConditionalRender } from "@app/components/ConditionalRender";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
-  TableHeaderContentWithControls,
   ConditionalTableBody,
+  TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
 import { useLocalTableControls } from "@app/hooks/table-controls";
-import { CubesIcon } from "@patternfly/react-icons";
+import {
+  useFetchImportSummaryById,
+  useFetchImports,
+} from "@app/queries/imports";
+import { getAxiosErrorMessage } from "@app/utils/utils";
 
 export const ManageImportsDetails: React.FC = () => {
   // i18

--- a/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -1,47 +1,48 @@
 import React, { useState } from "react";
-import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
+  DropdownItem,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
   Modal,
   PageSection,
+  Popover,
+  Title,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateBody,
-  Title,
-  DropdownItem,
-  Popover,
 } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import CubesIcon from "@patternfly/react-icons/dist/js/icons/cubes-icon";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { useLocalTableControls } from "@app/hooks/table-controls";
 import { Paths } from "@app/Paths";
 import { ApplicationImportSummary } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { FilterType, FilterToolbar } from "@app/components/FilterToolbar";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { IconedStatus } from "@app/components/Icons";
 import { KebabDropdown } from "@app/components/KebabDropdown";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import { PageHeader } from "@app/components/PageHeader";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
-  TableHeaderContentWithControls,
   ConditionalTableBody,
+  TableHeaderContentWithControls,
 } from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import {
-  useFetchImportSummaries,
   useDeleteImportSummaryMutation,
+  useFetchImportSummaries,
 } from "@app/queries/imports";
 import { formatDate, formatPath } from "@app/utils/utils";
+
 import { ImportApplicationsForm } from "../components/import-applications-form";
-import { PageHeader } from "@app/components/PageHeader";
 
 export const ManageImports: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/applications/retrieve-config-wizard/results.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/results.tsx
@@ -1,25 +1,26 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import {
   Card,
   CardBody,
   CardHeader,
   CardTitle,
-  Text,
-  TextContent,
-  TextVariants,
   Grid,
   GridItem,
   Icon,
+  Text,
+  TextContent,
+  TextVariants,
 } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
 import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
 } from "@patternfly/react-icons";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { ApplicationManifestTask } from "@app/api/models";
+
 import { DecoratedApplication } from "../useDecoratedApplications";
 
 export interface ResultsData {

--- a/client/src/app/pages/applications/retrieve-config-wizard/retrieve-config-wizard.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/retrieve-config-wizard.tsx
@@ -1,25 +1,26 @@
 import * as React from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { group } from "radash";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import * as yup from "yup";
 import {
+  Button,
   Modal,
   ModalVariant,
   Wizard,
-  WizardStep,
   WizardHeader,
-  Button,
+  WizardStep,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-
-import { FormProvider, useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
-import * as yup from "yup";
-import { group } from "radash";
 
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { DecoratedApplication } from "../useDecoratedApplications";
-import { Review } from "./review";
-import { Results, ResultsData } from "./results";
-import { useStartFetchApplicationManifest } from "./useStartFetchApplicationManifest";
 import { universalComparator } from "@app/utils/utils";
+
+import { DecoratedApplication } from "../useDecoratedApplications";
+
+import { Results, ResultsData } from "./results";
+import { Review } from "./review";
+import { useStartFetchApplicationManifest } from "./useStartFetchApplicationManifest";
 
 export const RetrieveConfigWizard: React.FC<IRetrieveConfigWizard> = ({
   isOpen,

--- a/client/src/app/pages/applications/retrieve-config-wizard/review.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/review.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import {
   DataList,
   DataListCell,
@@ -14,8 +16,6 @@ import {
   TextContent,
   TextVariants,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { useFormContext } from "react-hook-form";
 
 import { FormValues } from "./retrieve-config-wizard";
 

--- a/client/src/app/pages/applications/retrieve-config-wizard/useStartFetchApplicationManifest.tsx
+++ b/client/src/app/pages/applications/retrieve-config-wizard/useStartFetchApplicationManifest.tsx
@@ -1,5 +1,6 @@
-import { EmptyObject, ApplicationManifestTask, New } from "@app/api/models";
+import { ApplicationManifestTask, EmptyObject, New } from "@app/api/models";
 import { useCreateTaskMutation } from "@app/queries/tasks";
+
 import { DecoratedApplication } from "../useDecoratedApplications";
 
 export const useStartFetchApplicationManifest = () => {

--- a/client/src/app/pages/applications/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/useDecoratedApplications.ts
@@ -1,4 +1,6 @@
 import { useMemo } from "react";
+import { group, listify, mapEntries, unique } from "radash";
+
 import {
   Application,
   Archetype,
@@ -7,17 +9,16 @@ import {
   Identity,
   TaskDashboard,
 } from "@app/api/models";
-import { group, listify, mapEntries, unique } from "radash";
+import { useFetchArchetypes } from "@app/queries/archetypes";
+import { useFetchAssessments } from "@app/queries/assessments";
+import { useFetchBusinessServices } from "@app/queries/businessservices";
+import { useFetchIdentities } from "@app/queries/identities";
 import { TaskStates } from "@app/queries/tasks";
-import { universalComparator } from "@app/utils/utils";
 import {
   ApplicationAssessmentStatus,
   buildApplicationAssessmentStatus,
 } from "@app/utils/application-assessment-status";
-import { useFetchIdentities } from "@app/queries/identities";
-import { useFetchArchetypes } from "@app/queries/archetypes";
-import { useFetchAssessments } from "@app/queries/assessments";
-import { useFetchBusinessServices } from "@app/queries/businessservices";
+import { universalComparator } from "@app/utils/utils";
 
 export interface TasksGroupedByKind {
   [key: string]: TaskDashboard[];

--- a/client/src/app/pages/archetypes/archetypes-page.tsx
+++ b/client/src/app/pages/archetypes/archetypes-page.tsx
@@ -19,21 +19,27 @@ import {
   ToolbarItem,
   Tooltip,
 } from "@patternfly/react-core";
+import { CubesIcon, PencilAltIcon } from "@patternfly/react-icons";
 import {
+  ActionsColumn,
+  IAction,
   Table,
   Tbody,
+  Td,
   Th,
   Thead,
   Tr,
-  Td,
-  ActionsColumn,
-  IAction,
 } from "@patternfly/react-table";
-import { CubesIcon, PencilAltIcon } from "@patternfly/react-icons";
+
+import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Paths } from "@app/Paths";
+import { Archetype } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-
+import { IconedStatus } from "@app/components/Icons";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
@@ -43,29 +49,22 @@ import {
   deserializeFilterUrlParams,
   useLocalTableControls,
 } from "@app/hooks/table-controls";
+import keycloak from "@app/keycloak";
 import { useFetchArchetypes } from "@app/queries/archetypes";
+import {
+  archetypesWriteScopes,
+  assessmentWriteScopes,
+  reviewsWriteScopes,
+} from "@app/rbac";
+import { filterAndAddSeparator } from "@app/utils/grouping";
+import { checkAccess } from "@app/utils/rbac-utils";
+import { formatPath } from "@app/utils/utils";
 
-import LinkToArchetypeApplications from "./components/link-to-archetype-applications";
 import ArchetypeDetailDrawer from "./components/archetype-detail-drawer";
 import ArchetypeForm from "./components/archetype-form";
 import ArchetypeMaintainersColumn from "./components/archetype-maintainers-column";
 import ArchetypeTagsColumn from "./components/archetype-tags-column";
-import { Archetype } from "@app/api/models";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { formatPath } from "@app/utils/utils";
-import { Paths } from "@app/Paths";
-import { SimplePagination } from "@app/components/SimplePagination";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
-import { filterAndAddSeparator } from "@app/utils/grouping";
-
-import {
-  assessmentWriteScopes,
-  reviewsWriteScopes,
-  archetypesWriteScopes,
-} from "@app/rbac";
-import { checkAccess } from "@app/utils/rbac-utils";
-import keycloak from "@app/keycloak";
-import { IconedStatus } from "@app/components/Icons";
+import LinkToArchetypeApplications from "./components/link-to-archetype-applications";
 import { useArchetypeMutations } from "./hooks/useArchetypeMutations";
 
 const Archetypes: React.FC = () => {

--- a/client/src/app/pages/archetypes/components/archetype-detail-drawer.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-detail-drawer.tsx
@@ -1,27 +1,27 @@
 import "./archetype-detail-drawer.css";
 import React from "react";
 import { useTranslation } from "react-i18next";
-
 import {
-  TextContent,
-  Text,
-  Title,
-  Tabs,
   Tab,
   TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  Title,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { Archetype } from "@app/api/models";
 
+import { Archetype } from "@app/api/models";
 import { PageDrawerContent } from "@app/components/PageDrawerContext";
-import { ReviewFields } from "@app/components/detail-drawer/review-fields";
 import {
   DrawerTabContent,
   DrawerTabsContainer,
   NoEntitySelected,
 } from "@app/components/detail-drawer";
-import { TabTargetProfiles } from "./tab-target-profiles";
+import { ReviewFields } from "@app/components/detail-drawer/review-fields";
+
 import { TabDetailsContent } from "./tab-details-content";
+import { TabTargetProfiles } from "./tab-target-profiles";
 
 export interface IArchetypeDetailDrawerProps {
   onCloseClick: () => void;

--- a/client/src/app/pages/archetypes/components/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form.tsx
@@ -1,9 +1,8 @@
 import React, { useMemo } from "react";
-import { useTranslation } from "react-i18next";
-import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import * as yup from "yup";
-
 import {
   ActionGroup,
   Button,
@@ -12,19 +11,19 @@ import {
 } from "@patternfly/react-core";
 
 import type { Archetype, New, Ref, TagRef } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
 import {
   HookFormPFTextArea,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
+import { HookFormAutocomplete } from "@app/components/HookFormPFFields";
 import { useFetchArchetypes } from "@app/queries/archetypes";
-import { type TagItemType, useFetchTagsWithTagItems } from "@app/queries/tags";
 import { useFetchStakeholderGroups } from "@app/queries/stakeholdergroups";
 import { useFetchStakeholders } from "@app/queries/stakeholders";
-import { HookFormAutocomplete } from "@app/components/HookFormPFFields";
-import { duplicateNameCheck, universalComparator } from "@app/utils/utils";
+import { type TagItemType, useFetchTagsWithTagItems } from "@app/queries/tags";
 import { matchItemsToRefs } from "@app/utils/model-utils";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { duplicateNameCheck, universalComparator } from "@app/utils/utils";
 
 import { useArchetypeMutations } from "../hooks/useArchetypeMutations";
 

--- a/client/src/app/pages/archetypes/components/archetype-maintainers-column.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-maintainers-column.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LabelGroup, Label } from "@patternfly/react-core";
+import { Label, LabelGroup } from "@patternfly/react-core";
 
 import type { Archetype } from "@app/api/models";
 

--- a/client/src/app/pages/archetypes/components/archetype-tags-column.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-tags-column.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { LabelGroup } from "@patternfly/react-core";
 
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";
-import type { Archetype, TagCategory, Tag } from "@app/api/models";
+import type { Archetype, Tag, TagCategory } from "@app/api/models";
 import { LabelCustomColor } from "@app/components/LabelCustomColor";
 
 // copied from application-tag-label.tsx

--- a/client/src/app/pages/archetypes/components/link-to-archetype-applications.tsx
+++ b/client/src/app/pages/archetypes/components/link-to-archetype-applications.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Text } from "@patternfly/react-core";
 
+import { Paths } from "@app/Paths";
 import type { Archetype } from "@app/api/models";
 import { serializeFilterUrlParams } from "@app/hooks/table-controls";
-import { Paths } from "@app/Paths";
 
 const getApplicationsUrl = (archetypeName?: string) => {
   if (!archetypeName) return "";

--- a/client/src/app/pages/archetypes/components/tab-details-content.tsx
+++ b/client/src/app/pages/archetypes/components/tab-details-content.tsx
@@ -13,12 +13,12 @@ import {
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { Archetype, Ref, Tag, TagRef } from "@app/api/models";
-import { DrawerTabContent } from "@app/components/detail-drawer";
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+import { RiskLabel } from "@app/components/RiskLabel";
+import { DrawerTabContent } from "@app/components/detail-drawer";
 import { LabelsFromItems } from "@app/components/labels/labels-from-items/labels-from-items";
 import { LabelsFromTags } from "@app/components/labels/labels-from-tags/labels-from-tags";
 import { dedupeArrayOfObjects } from "@app/utils/utils";
-import { RiskLabel } from "@app/components/RiskLabel";
 
 import LinkToArchetypeApplications from "./link-to-archetype-applications";
 

--- a/client/src/app/pages/archetypes/components/tab-target-profiles.tsx
+++ b/client/src/app/pages/archetypes/components/tab-target-profiles.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Bullseye,
   EmptyState,
+  EmptyStateBody,
   EmptyStateHeader,
   EmptyStateIcon,
-  EmptyStateBody,
-  Bullseye,
 } from "@patternfly/react-core";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { CubesIcon } from "@patternfly/react-icons";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
 import { Archetype } from "@app/api/models";
-import { Table, Tr, Th, Thead, Tbody, Td } from "@patternfly/react-table";
-import { LabelsFromItems } from "@app/components/labels/labels-from-items/labels-from-items";
 import { DrawerTabContent } from "@app/components/detail-drawer";
+import { LabelsFromItems } from "@app/components/labels/labels-from-items/labels-from-items";
 
 export interface TabTargetProfilesProps {
   archetype: Archetype;

--- a/client/src/app/pages/archetypes/components/target-profile-form.tsx
+++ b/client/src/app/pages/archetypes/components/target-profile-form.tsx
@@ -1,26 +1,26 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback, useState } from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { fork } from "radash";
+import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import * as yup from "yup";
 import {
+  ActionGroup,
   Button,
+  DualListSelector,
+  Form,
   Modal,
   ModalVariant,
-  Form,
-  ActionGroup,
-  DualListSelector,
 } from "@patternfly/react-core";
-import { useForm } from "react-hook-form";
-import * as yup from "yup";
-import { yupResolver } from "@hookform/resolvers/yup";
 
+import type { Archetype, Generator, TargetProfile } from "@app/api/models";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
-import type { TargetProfile, Generator, Archetype } from "@app/api/models";
-import { refsToItems, toRefs } from "@app/utils/model-utils";
 import { useFetchGenerators } from "@app/queries/generators";
+import { refsToItems, toRefs } from "@app/utils/model-utils";
 import { duplicateNameCheck } from "@app/utils/utils";
-import { fork } from "radash";
 
 interface TargetProfileFormValues {
   name: string;

--- a/client/src/app/pages/archetypes/hooks/useArchetypeMutations.ts
+++ b/client/src/app/pages/archetypes/hooks/useArchetypeMutations.ts
@@ -1,7 +1,7 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
-import { AxiosError } from "axios";
 import { useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
 
 import type { Archetype, TargetProfile } from "@app/api/models";
 import { NotificationsContext } from "@app/components/NotificationsContext";
@@ -9,8 +9,8 @@ import {
   ARCHETYPES_QUERY_KEY,
   ARCHETYPE_QUERY_KEY,
   useCreateArchetypeMutation,
-  useUpdateArchetypeMutation,
   useDeleteArchetypeMutation,
+  useUpdateArchetypeMutation,
 } from "@app/queries/archetypes";
 import { useDeleteAssessmentMutation } from "@app/queries/assessments";
 import { useDeleteReviewMutation } from "@app/queries/reviews";

--- a/client/src/app/pages/archetypes/target-profiles-page.tsx
+++ b/client/src/app/pages/archetypes/target-profiles-page.tsx
@@ -2,44 +2,44 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import {
+  Alert,
+  AlertVariant,
   Button,
   ButtonVariant,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
   PageSection,
   PageSectionVariants,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  Alert,
-  AlertVariant,
-  EmptyStateHeader,
-  EmptyStateBody,
-  EmptyState,
-  EmptyStateIcon,
 } from "@patternfly/react-core";
+import { CubesIcon } from "@patternfly/react-icons";
 import {
+  ActionsColumn,
   Table,
   Tbody,
+  Td,
   Th,
   Thead,
   Tr,
-  Td,
-  ActionsColumn,
 } from "@patternfly/react-table";
-import { CubesIcon } from "@patternfly/react-icons";
 
+import { ArchetypeTargetProfilesRoute, Paths } from "@app/Paths";
+import type { TargetProfile } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
-
-import type { TargetProfile } from "@app/api/models";
-import { useFetchArchetypeById } from "@app/queries/archetypes";
-import { useArchetypeMutations } from "./hooks/useArchetypeMutations";
-import { ArchetypeTargetProfilesRoute, Paths } from "@app/Paths";
 import { PageHeader } from "@app/components/PageHeader";
-import TargetProfileForm from "./components/target-profile-form";
 import { ConditionalTableBody } from "@app/components/TableControls";
 import { LabelsFromItems } from "@app/components/labels/labels-from-items/labels-from-items";
+import { useFetchArchetypeById } from "@app/queries/archetypes";
+
+import TargetProfileForm from "./components/target-profile-form";
+import { useArchetypeMutations } from "./hooks/useArchetypeMutations";
 
 const TargetProfilesPage: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
+import { AxiosError } from "axios";
+import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
@@ -24,36 +27,34 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { AxiosError } from "axios";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { LockIcon, EllipsisVIcon, CubesIcon } from "@patternfly/react-icons";
+import { CubesIcon, EllipsisVIcon, LockIcon } from "@patternfly/react-icons";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import {
-  useDeleteQuestionnaireMutation,
-  useFetchQuestionnaires,
-  useUpdateQuestionnaireMutation,
-} from "@app/queries/questionnaires";
-import { ConditionalRender } from "@app/components/ConditionalRender";
+import { Paths } from "@app/Paths";
+import { Questionnaire } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
+import ConfirmDeleteDialog from "@app/components/ConfirmDeleteDialog/ConfirmDeleteDialog";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
 import { useLocalTableControls } from "@app/hooks/table-controls";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { formatPath, getAxiosErrorMessage } from "@app/utils/utils";
-import { Questionnaire } from "@app/api/models";
-import { useHistory } from "react-router-dom";
-import { Paths } from "@app/Paths";
 import { ImportQuestionnaireForm } from "@app/pages/assessment-management/import-questionnaire-form/import-questionnaire-form";
-import ConfirmDeleteDialog from "@app/components/ConfirmDeleteDialog/ConfirmDeleteDialog";
+import {
+  useDeleteQuestionnaireMutation,
+  useFetchQuestionnaires,
+  useUpdateQuestionnaireMutation,
+} from "@app/queries/questionnaires";
+import { formatPath, getAxiosErrorMessage } from "@app/utils/utils";
+
 import { ExportQuestionnaireDropdownItem } from "./components/export-questionnaire-dropdown-item";
-import dayjs from "dayjs";
 import { QuestionnaireQuestionsColumn } from "./components/questionnaire-questions-column";
 import { QuestionnaireThresholdsColumn } from "./components/questionnaire-thresholds-column";
 

--- a/client/src/app/pages/assessment-management/assessment-settings/components/export-questionnaire-dropdown-item.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/components/export-questionnaire-dropdown-item.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { DropdownItem } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
+import { DropdownItem } from "@patternfly/react-core";
+
 import { useDownloadQuestionnaire } from "@app/queries/questionnaires";
 
 export interface IExportQuestionnaireDropdownItemProps {

--- a/client/src/app/pages/assessment-management/assessment-settings/components/questionnaire-questions-column.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/components/questionnaire-questions-column.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Text } from "@patternfly/react-core";
+
 import { Questionnaire } from "@app/api/models";
 
 export const QuestionnaireQuestionsColumn: React.FC<{

--- a/client/src/app/pages/assessment-management/assessment-settings/components/questionnaire-thresholds-column.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/components/questionnaire-thresholds-column.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ListItem } from "@patternfly/react-core";
+
 import { Questionnaire, Thresholds } from "@app/api/models";
 
 export const QuestionnaireThresholdsColumn: React.FC<{

--- a/client/src/app/pages/assessment-management/import-questionnaire-form/import-questionnaire-form.tsx
+++ b/client/src/app/pages/assessment-management/import-questionnaire-form/import-questionnaire-form.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo, useState } from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
+import jsYaml from "js-yaml";
+import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
-
 import {
   ActionGroup,
   Button,
@@ -14,16 +16,13 @@ import {
   HelperTextItem,
 } from "@patternfly/react-core";
 
-import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
-import { useForm } from "react-hook-form";
 import { Questionnaire } from "@app/api/models";
-import { yupResolver } from "@hookform/resolvers/yup";
+import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import {
   useCreateQuestionnaireMutation,
   useFetchQuestionnaires,
 } from "@app/queries/questionnaires";
-import jsYaml from "js-yaml";
-import { NotificationsContext } from "@app/components/NotificationsContext";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 
 export interface ImportQuestionnaireFormProps {

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+
 import "./questionnaire-page.css";
 import QuestionnaireSummary, {
   SummaryType,

--- a/client/src/app/pages/assessment/components/assessment-actions/assessment-actions-page.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/assessment-actions-page.tsx
@@ -1,20 +1,22 @@
 import React from "react";
+import { Link, useParams } from "react-router-dom";
 import {
-  Text,
-  TextContent,
-  PageSection,
-  PageSectionVariants,
   Breadcrumb,
   BreadcrumbItem,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
 } from "@patternfly/react-core";
-import { Link, useParams } from "react-router-dom";
+
 import { AssessmentActionsRoute, Paths } from "@app/Paths";
-import { ConditionalRender } from "@app/components/ConditionalRender";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import AssessmentActionsTable from "./components/assessment-actions-table";
-import { useFetchArchetypeById } from "@app/queries/archetypes";
-import { useFetchApplicationById } from "@app/queries/applications";
+import { ConditionalRender } from "@app/components/ConditionalRender";
 import useIsArchetype from "@app/hooks/useIsArchetype";
+import { useFetchApplicationById } from "@app/queries/applications";
+import { useFetchArchetypeById } from "@app/queries/archetypes";
+
+import AssessmentActionsTable from "./components/assessment-actions-table";
 
 const AssessmentActions: React.FC = () => {
   const { applicationId, archetypeId } = useParams<AssessmentActionsRoute>();

--- a/client/src/app/pages/assessment/components/assessment-actions/components/assessment-actions-table.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/assessment-actions-table.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+
 import { Application, Archetype } from "@app/api/models";
-import { useFetchQuestionnaires } from "@app/queries/questionnaires";
-import QuestionnairesTable from "./questionnaires-table";
 import { useFetchAssessmentsByItemId } from "@app/queries/assessments";
+import { useFetchQuestionnaires } from "@app/queries/questionnaires";
+
+import QuestionnairesTable from "./questionnaires-table";
 
 export interface AssessmentActionsTableProps {
   application?: Application;

--- a/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
@@ -1,3 +1,17 @@
+import React, { FunctionComponent } from "react";
+import {
+  useIsFetching,
+  useIsMutating,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import { Button, Spinner } from "@patternfly/react-core";
+import { TrashIcon } from "@patternfly/react-icons";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Td } from "@patternfly/react-table";
+
 import { Paths } from "@app/Paths";
 import {
   Application,
@@ -6,29 +20,17 @@ import {
   InitialAssessment,
   Questionnaire,
 } from "@app/api/models";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import useIsArchetype from "@app/hooks/useIsArchetype";
 import {
   addSectionOrderToQuestions,
   assessmentsByItemIdQueryKey,
   useCreateAssessmentMutation,
   useDeleteAssessmentMutation,
 } from "@app/queries/assessments";
-import { Button, Spinner } from "@patternfly/react-core";
-import React, { FunctionComponent } from "react";
-import { useHistory } from "react-router-dom";
-import "./dynamic-assessment-actions-row.css";
-import { AxiosError } from "axios";
 import { formatPath, getAxiosErrorMessage } from "@app/utils/utils";
-import { Td } from "@patternfly/react-table";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { useTranslation } from "react-i18next";
-import {
-  useIsFetching,
-  useIsMutating,
-  useQueryClient,
-} from "@tanstack/react-query";
-import { TrashIcon } from "@patternfly/react-icons";
-import useIsArchetype from "@app/hooks/useIsArchetype";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+import "./dynamic-assessment-actions-row.css";
 
 enum AssessmentAction {
   Take = "Take",
@@ -98,11 +100,6 @@ const DynamicAssessmentActionsRow: FunctionComponent<
   const isFetching = useIsFetching();
   const isMutating = useIsMutating();
 
-  const { mutateAsync: deleteAssessmentAsync } = useDeleteAssessmentMutation(
-    onDeleteAssessmentSuccess,
-    onDeleteError
-  );
-
   const determineAction = React.useCallback(() => {
     if (!assessment) {
       return AssessmentAction.Take;
@@ -136,8 +133,8 @@ const DynamicAssessmentActionsRow: FunctionComponent<
           ? { archetype: { name: archetype.name, id: archetype.id } }
           : {}
         : application
-        ? { application: { name: application.name, id: application.id } }
-        : {}),
+          ? { application: { name: application.name, id: application.id } }
+          : {}),
     };
 
     try {

--- a/client/src/app/pages/assessment/components/assessment-actions/components/questionnaires-table.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/questionnaires-table.tsx
@@ -2,21 +2,23 @@ import "./questionnaires-table.css";
 import React, { useState } from "react";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { useLocalTableControls } from "@app/hooks/table-controls";
-import {
-  ConditionalTableBody,
-  TableHeaderContentWithControls,
-  TableRowContentWithControls,
-} from "@app/components/TableControls";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
 import {
   Application,
   Archetype,
   AssessmentWithSectionOrder,
   Questionnaire,
 } from "@app/api/models";
-import DynamicAssessmentActionsRow from "./dynamic-assessment-actions-row";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+
 import AssessmentModal from "../../assessment-wizard/assessment-wizard-modal";
+
+import DynamicAssessmentActionsRow from "./dynamic-assessment-actions-row";
 
 interface QuestionnairesTableProps {
   tableName: string;
@@ -50,7 +52,7 @@ const QuestionnairesTable: React.FC<QuestionnairesTableProps> = ({
   const {
     currentPageItems,
     numRenderedColumns,
-    propHelpers: { tableProps, getThProps, getTrProps, getTdProps },
+    propHelpers: { tableProps, getThProps, getTdProps },
   } = tableControls;
 
   const [createdAssessment, setCreatedAssessment] =

--- a/client/src/app/pages/assessment/components/assessment-page-header.tsx
+++ b/client/src/app/pages/assessment/components/assessment-page-header.tsx
@@ -1,16 +1,16 @@
 import React from "react";
-import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import { Button, ButtonVariant, Modal, Text } from "@patternfly/react-core";
 
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { PageHeader } from "@app/components/PageHeader";
 import { Paths } from "@app/Paths";
 import { Application, Assessment } from "@app/api/models";
+import { ApplicationDependenciesForm } from "@app/components/ApplicationDependenciesFormContainer/ApplicationDependenciesForm";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
+import { PageHeader } from "@app/components/PageHeader";
+import useIsArchetype from "@app/hooks/useIsArchetype";
 import { useFetchApplicationById } from "@app/queries/applications";
 import { useFetchArchetypeById } from "@app/queries/archetypes";
-import useIsArchetype from "@app/hooks/useIsArchetype";
-import { ApplicationDependenciesForm } from "@app/components/ApplicationDependenciesFormContainer/ApplicationDependenciesForm";
 
 export interface AssessmentPageHeaderProps {
   assessment?: Assessment;

--- a/client/src/app/pages/assessment/components/assessment-stakeholders-form/assessment-stakeholders-form.tsx
+++ b/client/src/app/pages/assessment/components/assessment-stakeholders-form/assessment-stakeholders-form.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
 import {
   FormSection,
   Grid,
@@ -8,13 +8,13 @@ import {
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import { useFormContext } from "react-hook-form";
 
-import { useFetchStakeholders } from "@app/queries/stakeholders";
-import { useFetchStakeholderGroups } from "@app/queries/stakeholdergroups";
-import { HookFormAutocomplete } from "@app/components/HookFormPFFields";
-import { AssessmentWizardValues } from "../assessment-wizard/assessment-wizard";
 import { GroupedStakeholderRef, Ref, StakeholderType } from "@app/api/models";
+import { HookFormAutocomplete } from "@app/components/HookFormPFFields";
+import { useFetchStakeholderGroups } from "@app/queries/stakeholdergroups";
+import { useFetchStakeholders } from "@app/queries/stakeholders";
+
+import { AssessmentWizardValues } from "../assessment-wizard/assessment-wizard";
 
 export const AssessmentStakeholdersForm: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/assessment/components/assessment-summary/assessment-summary-page.tsx
+++ b/client/src/app/pages/assessment/components/assessment-summary/assessment-summary-page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+
 import QuestionnaireSummary, {
   SummaryType,
 } from "@app/components/questionnaire-summary/questionnaire-summary";

--- a/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard-modal.tsx
+++ b/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard-modal.tsx
@@ -1,7 +1,9 @@
-import { Modal, ModalVariant } from "@patternfly/react-core";
 import React, { FunctionComponent } from "react";
-import { AssessmentWizard } from "./assessment-wizard";
+import { Modal, ModalVariant } from "@patternfly/react-core";
+
 import { AssessmentWithSectionOrder } from "@app/api/models";
+
+import { AssessmentWizard } from "./assessment-wizard";
 
 interface AssessmentModalProps {
   isOpen: boolean;

--- a/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard.tsx
+++ b/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard.tsx
@@ -1,8 +1,11 @@
-import * as yup from "yup";
 import React, { useMemo, useState } from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { FieldErrors, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
-import { FieldErrors, FormProvider, useForm } from "react-hook-form";
+import * as yup from "yup";
 import {
   ButtonVariant,
   Wizard,
@@ -10,6 +13,7 @@ import {
   WizardStep,
 } from "@patternfly/react-core";
 
+import { Paths } from "@app/Paths";
 import {
   Assessment,
   AssessmentStatus,
@@ -19,34 +23,31 @@ import {
   Ref,
   SectionWithQuestionOrder,
 } from "@app/api/models";
-import { CustomWizardFooter } from "../custom-wizard-footer";
 import { getApplicationById, getArchetypeById } from "@app/api/rest";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { QuestionnaireForm } from "../questionnaire-form";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import useIsArchetype from "@app/hooks/useIsArchetype";
+import {
+  assessmentsByItemIdQueryKey,
+  useDeleteAssessmentMutation,
+  useUpdateAssessmentMutation,
+} from "@app/queries/assessments";
+import { formatPath, getAxiosErrorMessage } from "@app/utils/utils";
+
 import {
   COMMENTS_KEY,
   QUESTIONS_KEY,
   getCommentFieldName,
   getQuestionFieldName,
 } from "../../form-utils";
-import { AxiosError } from "axios";
-import {
-  assessmentsByItemIdQueryKey,
-  useDeleteAssessmentMutation,
-  useUpdateAssessmentMutation,
-} from "@app/queries/assessments";
-import { useQueryClient } from "@tanstack/react-query";
-import { formatPath, getAxiosErrorMessage } from "@app/utils/utils";
-import { Paths } from "@app/Paths";
-import { yupResolver } from "@hookform/resolvers/yup";
 import {
   AssessmentStakeholdersForm,
   combineAndGroupStakeholderRefs,
 } from "../assessment-stakeholders-form/assessment-stakeholders-form";
-import useIsArchetype from "@app/hooks/useIsArchetype";
+import { CustomWizardFooter } from "../custom-wizard-footer";
+import { QuestionnaireForm } from "../questionnaire-form";
 import { WizardStepNavDescription } from "../wizard-step-nav-description";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
 
 export const SAVE_ACTION_KEY = "saveAction";
 
@@ -117,8 +118,6 @@ export const AssessmentWizard: React.FC<AssessmentWizardProps> = ({
     return comments;
   }, [assessment]);
 
-  const initialStakeholders = assessment?.stakeholders ?? [];
-  const initialStakeholderGroups = assessment?.stakeholderGroups ?? [];
   const initialQuestions = useMemo(() => {
     const questions: { [key: string]: string | undefined } = {};
     if (assessment) {

--- a/client/src/app/pages/assessment/components/custom-wizard-footer/custom-wizard-footer.tsx
+++ b/client/src/app/pages/assessment/components/custom-wizard-footer/custom-wizard-footer.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-
 import {
   Button,
   WizardFooterWrapper,

--- a/client/src/app/pages/assessment/components/custom-wizard-footer/tests/custom-wizard-footer.test.tsx
+++ b/client/src/app/pages/assessment/components/custom-wizard-footer/tests/custom-wizard-footer.test.tsx
@@ -1,5 +1,7 @@
-import { fireEvent, render, screen } from "@app/test-config/test-utils";
 import React from "react";
+
+import { fireEvent, render, screen } from "@app/test-config/test-utils";
+
 import { CustomWizardFooter } from "../custom-wizard-footer";
 
 describe("AppPlaceholder", () => {

--- a/client/src/app/pages/assessment/components/questionnaire-form/multi-input-selection/multi-input-selection.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/multi-input-selection/multi-input-selection.tsx
@@ -1,14 +1,15 @@
 import React, { useMemo } from "react";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { Icon, Radio, Stack, StackItem, Tooltip } from "@patternfly/react-core";
 import InfoCircleIcon from "@patternfly/react-icons/dist/esm/icons/info-circle-icon";
 
 import { QuestionWithSectionOrder } from "@app/api/models";
 import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
-import { useFormContext } from "react-hook-form";
-import { getQuestionFieldName } from "../../../form-utils";
-import { AssessmentWizardValues } from "@app/pages/assessment/components/assessment-wizard/assessment-wizard";
 import useIsArchetype from "@app/hooks/useIsArchetype";
-import { useTranslation } from "react-i18next";
+import { AssessmentWizardValues } from "@app/pages/assessment/components/assessment-wizard/assessment-wizard";
+
+import { getQuestionFieldName } from "../../../form-utils";
 
 export interface MultiInputSelectionProps {
   question: QuestionWithSectionOrder;

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question-body.test.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question-body.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { QuestionBody } from "../question-body";
 
 describe("QuestionBody", () => {

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question-header.test.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question-header.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { QuestionHeader } from "../question-header";
 
 describe("QuestionHeader", () => {

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question.test.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@app/test-config/test-utils";
 import React from "react";
+
+import { render } from "@app/test-config/test-utils";
+
 import { Question } from "../question";
 
 describe("Question", () => {

--- a/client/src/app/pages/assessment/components/questionnaire-form/questionnaire-form.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/questionnaire-form.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from "react";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {
   Popover,
@@ -10,13 +11,15 @@ import {
   TextContent,
 } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
-import { MultiInputSelection } from "./multi-input-selection";
-import { Question, QuestionHeader, QuestionBody } from "./question";
-import { getCommentFieldName } from "../../form-utils";
-import { useFormContext } from "react-hook-form";
+
 import { SectionWithQuestionOrder } from "@app/api/models";
-import { AssessmentWizardValues } from "@app/pages/assessment/components/assessment-wizard/assessment-wizard";
 import { HookFormPFTextInput } from "@app/components/HookFormPFFields";
+import { AssessmentWizardValues } from "@app/pages/assessment/components/assessment-wizard/assessment-wizard";
+
+import { getCommentFieldName } from "../../form-utils";
+
+import { MultiInputSelection } from "./multi-input-selection";
+import { Question, QuestionBody, QuestionHeader } from "./question";
 
 export interface QuestionnaireFormProps {
   section: SectionWithQuestionOrder;

--- a/client/src/app/pages/assessment/components/view-archetypes/components/view-archetypes-table.tsx
+++ b/client/src/app/pages/assessment/components/view-archetypes/components/view-archetypes-table.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+
 import { Ref } from "@app/api/models";
-import { useFetchQuestionnaires } from "@app/queries/questionnaires";
-import { useFetchAssessmentsByItemId } from "@app/queries/assessments";
 import { useFetchArchetypeById } from "@app/queries/archetypes";
+import { useFetchAssessmentsByItemId } from "@app/queries/assessments";
+import { useFetchQuestionnaires } from "@app/queries/questionnaires";
+
 import QuestionnairesTable from "../../assessment-actions/components/questionnaires-table";
 
 export interface ViewArchetypesTableProps {

--- a/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
+++ b/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
@@ -1,22 +1,24 @@
 import React, { useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
 import {
-  Text,
-  TextContent,
-  PageSection,
-  PageSectionVariants,
   Breadcrumb,
   BreadcrumbItem,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
 } from "@patternfly/react-core";
-import { Link, useParams } from "react-router-dom";
-import { ViewArchetypesRoute, Paths } from "@app/Paths";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import ViewArchetypesTable from "./components/view-archetypes-table";
-import { useFetchArchetypeById } from "@app/queries/archetypes";
-import { useFetchApplicationById } from "@app/queries/applications";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+
+import { Paths, ViewArchetypesRoute } from "@app/Paths";
 import { Ref } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { useFetchApplicationById } from "@app/queries/applications";
+import { useFetchArchetypeById } from "@app/queries/archetypes";
 import { formatPath } from "@app/utils/utils";
+
+import ViewArchetypesTable from "./components/view-archetypes-table";
 
 const ViewArchetypes: React.FC = () => {
   const { applicationId, archetypeId } = useParams<ViewArchetypesRoute>();

--- a/client/src/app/pages/assessment/components/wizard-step-nav-description/tests/wizard-step-nav-description.test.tsx
+++ b/client/src/app/pages/assessment/components/wizard-step-nav-description/tests/wizard-step-nav-description.test.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+
 import { Section } from "@app/api/models";
-import { WizardStepNavDescription } from "../wizard-step-nav-description";
 import { render } from "@app/test-config/test-utils";
+
+import { WizardStepNavDescription } from "../wizard-step-nav-description";
 
 describe("WizardStepNavDescription", () => {
   const section: Section = {

--- a/client/src/app/pages/assessment/components/wizard-step-nav-description/wizard-step-nav-description.tsx
+++ b/client/src/app/pages/assessment/components/wizard-step-nav-description/wizard-step-nav-description.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-
 import { Text, TextContent } from "@patternfly/react-core";
+
 import { Section } from "@app/api/models";
 
 export interface IWizardStepNavDescriptionProps {

--- a/client/src/app/pages/assessment/form-utils.test.ts
+++ b/client/src/app/pages/assessment/form-utils.test.ts
@@ -2,6 +2,7 @@ import {
   QuestionWithSectionOrder,
   SectionWithQuestionOrder,
 } from "@app/api/models";
+
 import { getCommentFieldName, getQuestionFieldName } from "./form-utils";
 
 describe("Application assessment - form utils", () => {

--- a/client/src/app/pages/asset-generators/asset-generators.tsx
+++ b/client/src/app/pages/asset-generators/asset-generators.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback, useState } from "react";
+import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {
@@ -19,12 +20,17 @@ import {
   ToolbarItem,
   Tooltip,
 } from "@patternfly/react-core";
-import { Table, Tbody, Th, Thead, Tr, Td } from "@patternfly/react-table";
 import { CubesIcon, PencilAltIcon, TrashIcon } from "@patternfly/react-icons";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
+import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Generator } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { useNotifications } from "@app/components/NotificationsContext";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
@@ -32,15 +38,11 @@ import {
 } from "@app/components/TableControls";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useDeleteGeneratorMutation } from "@app/queries/generators";
-import { Generator } from "@app/api/models";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
+import { useFetchGenerators } from "@app/queries/generators";
 import { getAxiosErrorMessage } from "@app/utils/utils";
-import { AxiosError } from "axios";
-import { SimplePagination } from "@app/components/SimplePagination";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
+
 import GeneratorDetailDrawer from "./components/generator-detail-drawer";
 import GeneratorForm from "./components/generator-form";
-import { useFetchGenerators } from "@app/queries/generators";
 
 // Static empty state configuration
 const NO_DATA_EMPTY_STATE = (

--- a/client/src/app/pages/asset-generators/components/generator-collection-table.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-collection-table.tsx
@@ -2,20 +2,21 @@ import * as React from "react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import {
-  useTableControlState,
-  useTableControlProps,
-} from "@app/hooks/table-controls";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
 import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { SimplePagination } from "@app/components/SimplePagination";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import {
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
 
 interface GeneratorCollectionItem {
   key: string;

--- a/client/src/app/pages/asset-generators/components/generator-detail-drawer.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-detail-drawer.tsx
@@ -1,24 +1,26 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import {
-  TextContent,
-  Text,
-  Title,
   DescriptionList,
+  DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  DescriptionListDescription,
-  Tabs,
   Tab,
   TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  Title,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { Generator } from "@app/api/models";
 import { PageDrawerContent } from "@app/components/PageDrawerContext";
 import { RepositoryDetails } from "@app/components/detail-drawer/repository-details";
-import GeneratorCollectionTable from "./generator-collection-table";
+
 import { parametersToArray } from "../utils";
+
+import GeneratorCollectionTable from "./generator-collection-table";
 
 export interface IGeneratorDetailDrawerProps {
   onCloseClick: () => void;
@@ -137,12 +139,13 @@ const ValuesTab: React.FC<{ generator: Generator | null }> = ({
   );
 };
 
-const ParametersTab: React.FC<{ generator: Generator | null }> = ({
-  generator,
-}) => {
-  return (
-    <GeneratorCollectionTable
-      collection={parametersToArray(generator?.params || {}) || []}
-    />
-  );
-};
+// TODO: Restore with #2498
+// const ParametersTab: React.FC<{ generator: Generator | null }> = ({
+//   generator,
+// }) => {
+//   return (
+//     <GeneratorCollectionTable
+//       collection={parametersToArray(generator?.params || {}) || []}
+//     />
+//   );
+// };

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-fields-mapper.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-fields-mapper.tsx
@@ -1,15 +1,16 @@
 import React from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
 import {
-  GridItem,
-  Grid,
-  Button,
   Bullseye,
+  Button,
+  Grid,
+  GridItem,
   Tooltip,
 } from "@patternfly/react-core";
-import { useFieldArray, useFormContext } from "react-hook-form";
-import { HookFormPFTextInput as InputField } from "@app/components/HookFormPFFields";
 import { MinusCircleIcon } from "@patternfly/react-icons/dist/js/icons/minus-circle-icon";
+
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+import { HookFormPFTextInput as InputField } from "@app/components/HookFormPFFields";
 
 interface KeyValueFieldsProps {
   noValuesMessage: string;

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form-parameters.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form-parameters.tsx
@@ -1,10 +1,12 @@
 import React, { useRef, useState } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Button, FormFieldGroupHeader, Label } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons/dist/js/icons/plus-circle-icon";
+
 import { ControlledFormFieldGroupExpandable } from "@app/components/ControlledFormFieldGroupExpandable";
+
 import { KeyValueFields } from "./generator-fields-mapper";
-import { useFormContext, useWatch } from "react-hook-form";
 
 interface GeneratorFormParametersProps {}
 

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form-repository.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form-repository.tsx
@@ -1,18 +1,19 @@
 import React from "react";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {
   FormFieldGroupExpandable,
   FormFieldGroupHeader,
 } from "@patternfly/react-core";
-import { useFormContext } from "react-hook-form";
+
+import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
 import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-import { toOptionLike } from "@app/utils/model-utils";
-import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { useFetchIdentities } from "@app/queries/identities";
+import { toOptionLike } from "@app/utils/model-utils";
 
 // Static configuration moved outside component to prevent recreation
 const REPOSITORY_KIND_OPTIONS = [

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form-values.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form-values.tsx
@@ -1,10 +1,12 @@
 import React, { useRef, useState } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Button, FormFieldGroupHeader, Label } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons/dist/js/icons/plus-circle-icon";
-import { KeyValueFields } from "./generator-fields-mapper";
-import { useFormContext, useWatch } from "react-hook-form";
+
 import { ControlledFormFieldGroupExpandable } from "@app/components/ControlledFormFieldGroupExpandable";
+
+import { KeyValueFields } from "./generator-fields-mapper";
 
 interface GeneratorFormValuesProps {}
 

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form.tsx
@@ -1,10 +1,9 @@
 import React, { useMemo } from "react";
-import { useTranslation } from "react-i18next";
-import { AxiosError } from "axios";
-import { useForm, FormProvider } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { AxiosError } from "axios";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import * as yup from "yup";
-
 import {
   ActionGroup,
   Button,
@@ -12,30 +11,30 @@ import {
   Form,
 } from "@patternfly/react-core";
 
-import type { New, Generator, Repository } from "@app/api/models";
+import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
+import type { Generator, New, Repository } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-
-import { duplicateNameCheck, getAxiosErrorMessage } from "@app/utils/utils";
-
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { SimpleSelect } from "@app/components/SimpleSelect";
-import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
-import { useFetchIdentities } from "@app/queries/identities";
 import {
   useCreateGeneratorMutation,
   useFetchGenerators,
   useUpdateGeneratorMutation,
 } from "@app/queries/generators";
-import { useGeneratorProviderList } from "../../useGeneratorProviderList";
-import { parametersToArray, arrayToParameters } from "../../utils";
-import { GeneratorFormValues as GeneratorValuesSection } from "./generator-form-values";
-import { GeneratorFormRepository as GeneratorRepositorySection } from "./generator-form-repository";
+import { useFetchIdentities } from "@app/queries/identities";
 import { matchItemsToRef } from "@app/utils/model-utils";
+import { duplicateNameCheck, getAxiosErrorMessage } from "@app/utils/utils";
+
+import { useGeneratorProviderList } from "../../useGeneratorProviderList";
+import { arrayToParameters, parametersToArray } from "../../utils";
+
+import { GeneratorFormRepository as GeneratorRepositorySection } from "./generator-form-repository";
+import { GeneratorFormValues as GeneratorValuesSection } from "./generator-form-values";
 
 export interface GeneratorFormValues {
   kind: string;

--- a/client/src/app/pages/controls/ControlTableActionsColumn.tsx
+++ b/client/src/app/pages/controls/ControlTableActionsColumn.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
-import { ActionsColumn, Td } from "@patternfly/react-table";
 import { Button, OverflowMenu, Tooltip } from "@patternfly/react-core";
 import { PencilAltIcon } from "@patternfly/react-icons";
+import { ActionsColumn, Td } from "@patternfly/react-table";
+
+import { RBAC, RBAC_TYPE, controlsWriteScopes } from "@app/rbac";
 
 export interface ControlTableActionsColumnProps {
   isDeleteEnabled?: boolean;

--- a/client/src/app/pages/controls/business-services/business-services.tsx
+++ b/client/src/app/pages/controls/business-services/business-services.tsx
@@ -14,31 +14,33 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { CubesIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { BusinessService } from "@app/api/models";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { BusinessServiceForm } from "./components/business-service-form";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { SimplePagination } from "@app/components/SimplePagination";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useFetchApplications } from "@app/queries/applications";
 import {
   useDeleteBusinessServiceMutation,
   useFetchBusinessServices,
 } from "@app/queries/businessservices";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { useLocalTableControls } from "@app/hooks/table-controls";
-import { SimplePagination } from "@app/components/SimplePagination";
-import {
-  TableHeaderContentWithControls,
-  ConditionalTableBody,
-  TableRowContentWithControls,
-} from "@app/components/TableControls";
-import { CubesIcon } from "@patternfly/react-icons";
-import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
+import { RBAC, RBAC_TYPE, controlsWriteScopes } from "@app/rbac";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
 import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
+
+import { BusinessServiceForm } from "./components/business-service-form";
 
 export const BusinessServices: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/controls/business-services/components/business-service-form.tsx
+++ b/client/src/app/pages/controls/business-services/components/business-service-form.tsx
@@ -1,33 +1,33 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { object, string } from "yup";
-
 import {
   ActionGroup,
   Button,
   ButtonVariant,
   Form,
 } from "@patternfly/react-core";
+
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { BusinessService, New } from "@app/api/models";
-import { duplicateNameCheck } from "@app/utils/utils";
-import { useFetchStakeholders } from "@app/queries/stakeholders";
-import {
-  useCreateBusinessServiceMutation,
-  useFetchBusinessServices,
-  useUpdateBusinessServiceMutation,
-} from "@app/queries/businessservices";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
 import {
   HookFormPFGroupController,
   HookFormPFTextArea,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import {
+  useCreateBusinessServiceMutation,
+  useFetchBusinessServices,
+  useUpdateBusinessServiceMutation,
+} from "@app/queries/businessservices";
+import { useFetchStakeholders } from "@app/queries/stakeholders";
 import { matchItemsToRef } from "@app/utils/model-utils";
+import { duplicateNameCheck } from "@app/utils/utils";
 
 export interface FormValues {
   name: string;

--- a/client/src/app/pages/controls/controls.tsx
+++ b/client/src/app/pages/controls/controls.tsx
@@ -1,4 +1,5 @@
-import React, { lazy, Suspense, useEffect } from "react";
+import React, { Suspense, lazy, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Redirect,
   Route,
@@ -12,15 +13,14 @@ import {
   PageSection,
   PageSectionVariants,
   Tab,
-  Tabs,
   TabTitleText,
+  Tabs,
   Title,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { Paths } from "@app/Paths";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { useTranslation } from "react-i18next";
 
 const Stakeholders = lazy(() => import("./stakeholders"));
 const StakeholderGroups = lazy(() => import("./stakeholder-groups"));

--- a/client/src/app/pages/controls/job-functions/components/job-function-form.tsx
+++ b/client/src/app/pages/controls/job-functions/components/job-function-form.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { object, string } from "yup";
-
 import {
   ActionGroup,
   Button,
@@ -11,16 +12,14 @@ import {
 } from "@patternfly/react-core";
 
 import { JobFunction, New } from "@app/api/models";
-import { duplicateNameCheck } from "@app/utils/utils";
+import { HookFormPFTextInput } from "@app/components/HookFormPFFields";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import {
   useCreateJobFunctionMutation,
   useFetchJobFunctions,
   useUpdateJobFunctionMutation,
 } from "@app/queries/jobfunctions";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { useForm } from "react-hook-form";
-import { HookFormPFTextInput } from "@app/components/HookFormPFFields";
-import { NotificationsContext } from "@app/components/NotificationsContext";
+import { duplicateNameCheck } from "@app/utils/utils";
 
 export interface FormValues {
   name: string;

--- a/client/src/app/pages/controls/job-functions/job-functions.tsx
+++ b/client/src/app/pages/controls/job-functions/job-functions.tsx
@@ -13,31 +13,33 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { CubesIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { JobFunction } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { JobFunction } from "@app/api/models";
-import { JobFunctionForm } from "./components/job-function-form";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { SimplePagination } from "@app/components/SimplePagination";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import {
   useDeleteJobFunctionMutation,
   useFetchJobFunctions,
 } from "@app/queries/jobfunctions";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { SimplePagination } from "@app/components/SimplePagination";
-import {
-  TableHeaderContentWithControls,
-  ConditionalTableBody,
-  TableRowContentWithControls,
-} from "@app/components/TableControls";
-import { useLocalTableControls } from "@app/hooks/table-controls";
-import { CubesIcon } from "@patternfly/react-icons";
 import { RBAC, RBAC_TYPE, controlsWriteScopes } from "@app/rbac";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
 import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+
+import { JobFunctionForm } from "./components/job-function-form";
 
 export const JobFunctions: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { object, string } from "yup";
-
 import {
   ActionGroup,
   Button,
@@ -10,26 +11,23 @@ import {
   Form,
 } from "@patternfly/react-core";
 
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { New, Ref, StakeholderGroup } from "@app/api/models";
-import { duplicateNameCheck } from "@app/utils/utils";
-import { toOptionLike } from "@app/utils/model-utils";
-import { useFetchStakeholders } from "@app/queries/stakeholders";
-import {
-  useCreateStakeholderGroupMutation,
-  useFetchStakeholderGroups,
-  useUpdateStakeholderGroupMutation,
-} from "@app/queries/stakeholdergroups";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
 import {
   HookFormPFGroupController,
   HookFormPFTextArea,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import {
+  useCreateStakeholderGroupMutation,
+  useFetchStakeholderGroups,
+  useUpdateStakeholderGroupMutation,
+} from "@app/queries/stakeholdergroups";
+import { useFetchStakeholders } from "@app/queries/stakeholders";
+import { toOptionLike } from "@app/utils/model-utils";
+import { duplicateNameCheck } from "@app/utils/utils";
 
 export interface FormValues {
   name: string;
@@ -49,17 +47,9 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
   const { t } = useTranslation();
   const { pushNotification } = React.useContext(NotificationsContext);
 
-  const {
-    stakeholders,
-    isFetching: isFetchingStakeholders,
-    fetchError: fetchErrorStakeholders,
-  } = useFetchStakeholders();
+  const { stakeholders } = useFetchStakeholders();
 
-  const {
-    stakeholderGroups,
-    isFetching: isFetchingStakeholderGroups,
-    fetchError: fetchErrorStakeholderGroups,
-  } = useFetchStakeholderGroups();
+  const { stakeholderGroups } = useFetchStakeholderGroups();
 
   const stakeholdersOptions = stakeholders.map((stakeholder) => {
     return {
@@ -93,10 +83,7 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
   const {
     handleSubmit,
     formState: { isSubmitting, isValidating, isValid, isDirty },
-    getValues,
-    setValue,
     control,
-    watch,
   } = useForm<FormValues>({
     defaultValues: {
       name: stakeholderGroup?.name || "",
@@ -119,7 +106,7 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
       variant: "success",
     });
 
-  const onCreateStakeholderGroupError = (error: AxiosError) => {
+  const onCreateStakeholderGroupError = (_error: AxiosError) => {
     pushNotification({
       title: t("toastr.fail.create", {
         type: t("terms.stakeholderGroup").toLowerCase(),
@@ -144,7 +131,7 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
       variant: "success",
     });
 
-  const onUpdateStakeholderGroupError = (error: AxiosError) => {
+  const onUpdateStakeholderGroupError = (_error: AxiosError) => {
     pushNotification({
       title: t("toastr.fail.save", {
         type: t("terms.stakeholderGroup").toLowerCase(),
@@ -160,9 +147,8 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
 
   const onSubmit = (formValues: FormValues) => {
     const matchingStakeholderRefs: Ref[] = stakeholders
-      .filter(
-        (stakeholder) =>
-          formValues?.stakeholderNames?.includes(stakeholder.name)
+      .filter((stakeholder) =>
+        formValues?.stakeholderNames?.includes(stakeholder.name)
       )
       .map((stakeholder) => {
         return {

--- a/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
@@ -19,6 +19,8 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/js/icons/cubes-icon";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import {
   ExpandableRowContent,
   Table,
@@ -29,29 +31,29 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
-import { getAxiosErrorMessage, numStr } from "@app/utils/utils";
 import { StakeholderGroup } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { SimplePagination } from "@app/components/SimplePagination";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import {
   useDeleteStakeholderGroupMutation,
   useFetchStakeholderGroups,
 } from "@app/queries/stakeholdergroups";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { StakeholderGroupForm } from "./components/stakeholder-group-form";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { SimplePagination } from "@app/components/SimplePagination";
-import {
-  TableHeaderContentWithControls,
-  ConditionalTableBody,
-  TableRowContentWithControls,
-} from "@app/components/TableControls";
-import { useLocalTableControls } from "@app/hooks/table-controls";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import CubesIcon from "@patternfly/react-icons/dist/js/icons/cubes-icon";
+import { RBAC, RBAC_TYPE, controlsWriteScopes } from "@app/rbac";
+import { getAxiosErrorMessage, numStr } from "@app/utils/utils";
+
 import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
+
+import { StakeholderGroupForm } from "./components/stakeholder-group-form";
 
 export const StakeholderGroups: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
+++ b/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { object, string } from "yup";
-
 import {
   ActionGroup,
   Button,
@@ -11,23 +12,21 @@ import {
 } from "@patternfly/react-core";
 
 import { New, Ref, Stakeholder } from "@app/api/models";
-import { duplicateFieldCheck, duplicateNameCheck } from "@app/utils/utils";
-import { toOptionLike } from "@app/utils/model-utils";
+import {
+  HookFormPFGroupController,
+  HookFormPFTextInput,
+} from "@app/components/HookFormPFFields";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { useFetchJobFunctions } from "@app/queries/jobfunctions";
+import { useFetchStakeholderGroups } from "@app/queries/stakeholdergroups";
 import {
   useCreateStakeholderMutation,
   useFetchStakeholders,
   useUpdateStakeholderMutation,
 } from "@app/queries/stakeholders";
-import { useFetchStakeholderGroups } from "@app/queries/stakeholdergroups";
-import { useFetchJobFunctions } from "@app/queries/jobfunctions";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
-import {
-  HookFormPFGroupController,
-  HookFormPFTextInput,
-} from "@app/components/HookFormPFFields";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-import { NotificationsContext } from "@app/components/NotificationsContext";
+import { toOptionLike } from "@app/utils/model-utils";
+import { duplicateFieldCheck, duplicateNameCheck } from "@app/utils/utils";
 
 export interface FormValues {
   email: string;
@@ -99,7 +98,6 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
   const {
     handleSubmit,
     formState: { isSubmitting, isValidating, isValid, isDirty },
-    getValues,
     control,
   } = useForm<FormValues>({
     defaultValues: {
@@ -122,7 +120,7 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
       variant: "success",
     });
 
-  const onCreateStakeholderError = (error: AxiosError) => {
+  const onCreateStakeholderError = (_error: AxiosError) => {
     pushNotification({
       title: t("toastr.fail.create", {
         type: t("terms.stakeholder").toLowerCase(),
@@ -144,7 +142,7 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
       variant: "success",
     });
 
-  const onUpdateStakeholderError = (error: AxiosError) => {
+  const onUpdateStakeholderError = (_error: AxiosError) => {
     pushNotification({
       title: t("toastr.fail.save", {
         type: t("terms.stakeholder").toLowerCase(),
@@ -159,9 +157,8 @@ export const StakeholderForm: React.FC<StakeholderFormProps> = ({
 
   const onSubmit = (formValues: FormValues) => {
     const matchingStakeholderGroupRefs: Ref[] = stakeholderGroups
-      .filter(
-        (stakeholderGroup) =>
-          formValues?.stakeholderGroupNames?.includes(stakeholderGroup.name)
+      .filter((stakeholderGroup) =>
+        formValues?.stakeholderGroupNames?.includes(stakeholderGroup.name)
       )
       .map((stakeholderGroup) => {
         return {

--- a/client/src/app/pages/controls/stakeholders/stakeholders.tsx
+++ b/client/src/app/pages/controls/stakeholders/stakeholders.tsx
@@ -19,6 +19,8 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import {
   ExpandableRowContent,
   Table,
@@ -28,30 +30,30 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
 
+import { Stakeholder } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { Stakeholder } from "@app/api/models";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import {
-  useDeleteStakeholderMutation,
-  useFetchStakeholders,
-} from "@app/queries/stakeholders";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { useLocalTableControls } from "@app/hooks/table-controls";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { StakeholderForm } from "./components/stakeholder-form";
-import { controlsWriteScopes, RBAC, RBAC_TYPE } from "@app/rbac";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+import {
+  useDeleteStakeholderMutation,
+  useFetchStakeholders,
+} from "@app/queries/stakeholders";
+import { RBAC, RBAC_TYPE, controlsWriteScopes } from "@app/rbac";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
 import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
+
+import { StakeholderForm } from "./components/stakeholder-form";
 
 export const Stakeholders: React.FC = () => {
   const { t } = useTranslation();
@@ -68,7 +70,7 @@ export const Stakeholders: React.FC = () => {
 
   const { pushNotification } = React.useContext(NotificationsContext);
 
-  const onDeleteStakeholderSuccess = (response: any) => {
+  const onDeleteStakeholderSuccess = () => {
     pushNotification({
       title: t("terms.stakeholderDeleted"),
       variant: "success",

--- a/client/src/app/pages/controls/tags/components/tag-category-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-category-form.tsx
@@ -1,4 +1,6 @@
 import React, { useContext } from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { object, string } from "yup";
 import {
@@ -9,27 +11,25 @@ import {
 } from "@patternfly/react-core";
 
 import {
-  DEFAULT_SELECT_MAX_HEIGHT,
   COLOR_HEX_VALUES_BY_NAME,
+  DEFAULT_SELECT_MAX_HEIGHT,
 } from "@app/Constants";
 import { New, TagCategory } from "@app/api/models";
-import { duplicateNameCheck } from "@app/utils/utils";
-import { toOptionLike } from "@app/utils/model-utils";
+import { Color } from "@app/components/Color";
+import {
+  HookFormPFGroupController,
+  HookFormPFTextInput,
+} from "@app/components/HookFormPFFields";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { getTagCategoryFallbackColor } from "@app/components/labels/item-tag-label/item-tag-label";
 import {
   useCreateTagCategoryMutation,
   useFetchTagCategories,
   useUpdateTagCategoryMutation,
 } from "@app/queries/tags";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
-import {
-  HookFormPFGroupController,
-  HookFormPFTextInput,
-} from "@app/components/HookFormPFFields";
-import { Color } from "@app/components/Color";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { getTagCategoryFallbackColor } from "@app/components/labels/item-tag-label/item-tag-label";
+import { toOptionLike } from "@app/utils/model-utils";
+import { duplicateNameCheck } from "@app/utils/utils";
 
 export interface FormValues {
   name: string;

--- a/client/src/app/pages/controls/tags/components/tag-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-form.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo } from "react";
-import { useTranslation } from "react-i18next";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
-import { object, string, mixed } from "yup";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { mixed, object, string } from "yup";
 import {
   ActionGroup,
   Button,
@@ -11,22 +13,20 @@ import {
 
 import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { New, Tag, TagCategory } from "@app/api/models";
-import { duplicateNameCheck, universalComparator } from "@app/utils/utils";
-import { ITagCategoryDropdown } from "@app/utils/model-utils";
-import {
-  useFetchTags,
-  useFetchTagCategories,
-  useCreateTagMutation,
-  useUpdateTagMutation,
-} from "@app/queries/tags";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import {
+  useCreateTagMutation,
+  useFetchTagCategories,
+  useFetchTags,
+  useUpdateTagMutation,
+} from "@app/queries/tags";
+import { ITagCategoryDropdown } from "@app/utils/model-utils";
+import { duplicateNameCheck, universalComparator } from "@app/utils/utils";
 
 export interface FormValues {
   name: string;

--- a/client/src/app/pages/controls/tags/components/tag-table.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-table.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
 import { Tag, TagCategory } from "@app/api/models";
 import "./tag-table.css";
 import { universalComparator } from "@app/utils/utils";
+
 import { ControlTableActionsColumn } from "../../ControlTableActionsColumn";
 
 export interface TabTableProps {

--- a/client/src/app/pages/controls/tags/tag-categories-table.tsx
+++ b/client/src/app/pages/controls/tags/tag-categories-table.tsx
@@ -15,6 +15,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { CubesIcon } from "@patternfly/react-icons";
 import {
   ExpandableRowContent,
   Table,
@@ -24,42 +25,43 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import { CubesIcon } from "@patternfly/react-icons";
 
+import {
+  COLOR_NAMES_BY_HEX_VALUE,
+  DEFAULT_REFETCH_INTERVAL,
+} from "@app/Constants";
+import { Tag, TagCategory } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { Color } from "@app/components/Color";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { SimplePagination } from "@app/components/SimplePagination";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import { getTagCategoryFallbackColor } from "@app/components/labels/item-tag-label/item-tag-label";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+import {
+  useDeleteTagCategoryMutation,
+  useDeleteTagMutation,
+  useFetchTagCategories,
+} from "@app/queries/tags";
+import { RBAC, RBAC_TYPE, controlsWriteScopes } from "@app/rbac";
 import {
   dedupeFunction,
   getAxiosErrorMessage,
   universalComparator,
 } from "@app/utils/utils";
-import { Tag, TagCategory } from "@app/api/models";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import {
-  useDeleteTagMutation,
-  useDeleteTagCategoryMutation,
-  useFetchTagCategories,
-} from "@app/queries/tags";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import {
-  COLOR_NAMES_BY_HEX_VALUE,
-  DEFAULT_REFETCH_INTERVAL,
-} from "@app/Constants";
-import { TagForm } from "./components/tag-form";
-import { TagCategoryForm } from "./components/tag-category-form";
-import { getTagCategoryFallbackColor } from "@app/components/labels/item-tag-label/item-tag-label";
-import { Color } from "@app/components/Color";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { SimplePagination } from "@app/components/SimplePagination";
-import {
-  TableHeaderContentWithControls,
-  ConditionalTableBody,
-  TableRowContentWithControls,
-} from "@app/components/TableControls";
-import { useLocalTableControls } from "@app/hooks/table-controls";
-import { RBAC, controlsWriteScopes, RBAC_TYPE } from "@app/rbac";
-import { TagTable } from "./components/tag-table";
+
 import { ControlTableActionsColumn } from "../ControlTableActionsColumn";
+
+import { TagCategoryForm } from "./components/tag-category-form";
+import { TagForm } from "./components/tag-form";
+import { TagTable } from "./components/tag-table";
 
 export const Tags: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/dependencies/dependencies.tsx
+++ b/client/src/app/pages/dependencies/dependencies.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import {
   Label,
   LabelGroup,
@@ -10,27 +12,28 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-  deserializeFilterUrlParams,
-} from "@app/hooks/table-controls";
+
 import { TablePersistenceKeyPrefix, UI_UNIQUE_ID } from "@app/Constants";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import {
+  deserializeFilterUrlParams,
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
 import { useFetchDependencies } from "@app/queries/dependencies";
-import { DependencyAppsDetailDrawer } from "./dependency-apps-detail-drawer";
-import { useSharedAffectedApplicationFilterCategories } from "../issues/helpers";
 import { getParsedLabel } from "@app/utils/rules-utils";
-import { useHistory } from "react-router-dom";
+
+import { useSharedAffectedApplicationFilterCategories } from "../issues/helpers";
+
+import { DependencyAppsDetailDrawer } from "./dependency-apps-detail-drawer";
 
 export const Dependencies: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/dependencies/dependency-apps-detail-drawer.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-detail-drawer.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-
 import {
-  TextContent,
-  Text,
-  Title,
-  Tabs,
-  TabTitleText,
   Tab,
+  TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  Title,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
@@ -17,6 +16,7 @@ import {
   PageDrawerContent,
 } from "@app/components/PageDrawerContext";
 import { StateNoData } from "@app/components/StateNoData";
+
 import { DependencyAppsTable } from "./dependency-apps-table";
 
 export interface IDependencyAppsDetailDrawerProps

--- a/client/src/app/pages/dependencies/dependency-apps-table.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-table.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import {
   Text,
   TextContent,
@@ -7,30 +8,30 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { AnalysisAppDependency, AnalysisDependency } from "@app/api/models";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-  deserializeFilterUrlParams,
-} from "@app/hooks/table-controls";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
 import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { AnalysisAppDependency, AnalysisDependency } from "@app/api/models";
+import { ExternalLink } from "@app/components/ExternalLink";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { ExternalLink } from "@app/components/ExternalLink";
-import { SimplePagination } from "@app/components/SimplePagination";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import { useFetchAppDependencies } from "@app/queries/dependencies";
+import {
+  deserializeFilterUrlParams,
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
 import { useFetchBusinessServices } from "@app/queries/businessservices";
+import { useFetchAppDependencies } from "@app/queries/dependencies";
 import { useFetchTagsWithTagItems } from "@app/queries/tags";
 import { getParsedLabel } from "@app/utils/rules-utils";
 import { extractFirstSha } from "@app/utils/utils";
-import { useHistory } from "react-router-dom";
 
 export interface IDependencyAppsTableProps {
   dependency: AnalysisDependency;

--- a/client/src/app/pages/external/jira/components/tracker-status.tsx
+++ b/client/src/app/pages/external/jira/components/tracker-status.tsx
@@ -1,6 +1,5 @@
 import "./tracker-status.css";
 import React, { useState } from "react";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -8,11 +7,13 @@ import {
   CodeBlockCode,
   ExpandableSectionToggle,
   Popover,
+  Spinner,
   Text,
   TextContent,
-  Spinner,
 } from "@patternfly/react-core";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
 import { IconedStatus } from "@app/components/Icons";
 
 interface ITrackerStatusProps {

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
   ActionGroup,
@@ -12,32 +14,30 @@ import {
   PopoverPosition,
   Switch,
 } from "@patternfly/react-core";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
+import { QuestionCircleIcon } from "@patternfly/react-icons";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import "./tracker-form.css";
+import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import { IdentityKind, IssueManagerKind, Tracker } from "@app/api/models";
-import { IssueManagerOptions, toOptionLike } from "@app/utils/model-utils";
-import {
-  useCreateTrackerMutation,
-  useFetchTrackers,
-  useUpdateTrackerMutation,
-} from "@app/queries/trackers";
-import { useFetchIdentities } from "@app/queries/identities";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-import {
-  duplicateNameCheck,
-  getAxiosErrorMessage,
-  standardStrictURLRegex,
-} from "@app/utils/utils";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
-import { QuestionCircleIcon } from "@patternfly/react-icons";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { useFetchIdentities } from "@app/queries/identities";
+import {
+  useCreateTrackerMutation,
+  useFetchTrackers,
+  useUpdateTrackerMutation,
+} from "@app/queries/trackers";
+import { IssueManagerOptions, toOptionLike } from "@app/utils/model-utils";
+import {
+  duplicateNameCheck,
+  getAxiosErrorMessage,
+  standardStrictURLRegex,
+} from "@app/utils/utils";
 
 const supportedIdentityKindByIssueManagerKind: Record<
   IssueManagerKind,
@@ -173,9 +173,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     handleSubmit,
     formState: { isSubmitting, isValidating, isValid, isDirty },
     getValues,
-    setValue,
     control,
-    watch,
   } = useForm<FormValues>({
     defaultValues: {
       name: tracker?.name || "",
@@ -190,7 +188,6 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
   });
 
   const values = getValues();
-  const watchAllFields = watch();
 
   const identityOptions = (kind?: IssueManagerKind) => {
     const identityKinds = kind

--- a/client/src/app/pages/external/jira/trackers.tsx
+++ b/client/src/app/pages/external/jira/trackers.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
 import {
   Button,
   ButtonVariant,
@@ -16,34 +18,33 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import {
-  useDeleteTrackerMutation,
-  useFetchTrackers,
-} from "@app/queries/trackers";
-import { Tbody, Tr, Td, Thead, Th, Table } from "@patternfly/react-table";
 import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { useLocalTableControls } from "@app/hooks/table-controls";
+import { Tracker } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { AppTableActionButtons } from "@app/components/AppTableActionButtons";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { TrackerForm } from "./tracker-form";
-import { Tracker } from "@app/api/models";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { AxiosError } from "axios";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useFetchTickets } from "@app/queries/tickets";
-import TrackerStatus from "./components/tracker-status";
+import {
+  useDeleteTrackerMutation,
+  useFetchTrackers,
+} from "@app/queries/trackers";
 import { IssueManagerOptions, toOptionLike } from "@app/utils/model-utils";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { AppTableActionButtons } from "@app/components/AppTableActionButtons";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
+import TrackerStatus from "./components/tracker-status";
+import { TrackerForm } from "./tracker-form";
 import useUpdatingTrackerIds from "./useUpdatingTrackerIds";
 
 export const JiraTrackers: React.FC = () => {

--- a/client/src/app/pages/general/general.tsx
+++ b/client/src/app/pages/general/general.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Card,
@@ -10,8 +11,8 @@ import {
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
 import { useSetting, useSettingMutation } from "@app/queries/settings";
 
 export const General: React.FC = () => {

--- a/client/src/app/pages/insights/affected-applications-page.tsx
+++ b/client/src/app/pages/insights/affected-applications-page.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useLocation, useParams } from "react-router-dom";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -10,31 +12,30 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { ConditionalRender } from "@app/components/ConditionalRender";
+import { TablePersistenceKeyPrefix } from "@app/Constants";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-} from "@app/hooks/table-controls";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { FilterToolbar } from "@app/components/FilterToolbar";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import {
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
 import { useFetchReportInsightApps } from "@app/queries/analysis";
-import { Link, useLocation, useParams } from "react-router-dom";
-import { FilterToolbar } from "@app/components/FilterToolbar";
+
 import {
   getBackToAllInsightsUrl,
   useSharedAffectedApplicationFilterCategories,
 } from "./helpers";
 import { InsightDetailDrawer } from "./insight-detail-drawer";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
 
 interface IAffectedApplicationsRouteParams {
   ruleset: string;

--- a/client/src/app/pages/insights/file-incidents-detail-modal/file-all-incidents-table.tsx
+++ b/client/src/app/pages/insights/file-incidents-detail-modal/file-all-incidents-table.tsx
@@ -1,22 +1,23 @@
 import "./file-all-incidents-table.css";
 import * as React from "react";
-import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
+import ReactMarkdown from "react-markdown";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
 import { TablePersistenceKeyPrefix } from "@app/Constants";
 import { AnalysisReportFile } from "@app/api/models";
-import { useFetchIncidentsForInsight } from "@app/queries/analysis";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
-  TableHeaderContentWithControls,
   ConditionalTableBody,
+  TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-} from "@app/hooks/table-controls";
-import ReactMarkdown from "react-markdown";
 import { markdownPFComponents } from "@app/components/markdownPFComponents";
+import {
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
+import { useFetchIncidentsForInsight } from "@app/queries/analysis";
 
 export interface IFileAllIncidentsTableProps {
   fileReport: AnalysisReportFile;

--- a/client/src/app/pages/insights/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/insights/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -1,28 +1,30 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Alert,
   Button,
   Grid,
   GridItem,
   Modal,
   Tab,
   Tabs,
-  TextContent,
   Text,
-  Alert,
+  TextContent,
   Truncate,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
+import { AnalysisInsight, AnalysisReportFile } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { StateError } from "@app/components/StateError";
 import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
-import { AnalysisReportFile, AnalysisInsight } from "@app/api/models";
-import { useFetchIncidentsForInsight } from "@app/queries/analysis";
-import { IncidentCodeSnipViewer } from "./incident-code-snip-viewer";
-import { FileAllIncidentsTable } from "./file-all-incidents-table";
+import { StateError } from "@app/components/StateError";
 import { InsightDescriptionAndLinks } from "@app/components/insights/components";
+import { useFetchIncidentsForInsight } from "@app/queries/analysis";
+
 import { getInsightTitle } from "../helpers";
+
+import { FileAllIncidentsTable } from "./file-all-incidents-table";
+import { IncidentCodeSnipViewer } from "./incident-code-snip-viewer";
 
 export interface IFileIncidentsDetailModalProps {
   insight: AnalysisInsight;

--- a/client/src/app/pages/insights/file-incidents-detail-modal/incident-code-snip-viewer.tsx
+++ b/client/src/app/pages/insights/file-incidents-detail-modal/incident-code-snip-viewer.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
-import { CodeEditor, Language } from "@patternfly/react-code-editor";
-import { AnalysisIncident } from "@app/api/models";
-
-import "./incident-code-snip-viewer.css";
 import { LANGUAGES_BY_FILE_EXTENSION } from "config/monacoConstants";
+import { useTranslation } from "react-i18next";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
   EmptyState,
   EmptyStateBody,
@@ -12,7 +10,10 @@ import {
   EmptyStateVariant,
 } from "@patternfly/react-core";
 import { CubesIcon } from "@patternfly/react-icons";
-import { useTranslation } from "react-i18next";
+
+import { AnalysisIncident } from "@app/api/models";
+
+import "./incident-code-snip-viewer.css";
 
 const codeLineRegex = /^\s*([0-9]+)( {2})?(.*)$/; // Pattern: leading whitespace (line number) (2 spaces)? (code)
 

--- a/client/src/app/pages/insights/helpers.ts
+++ b/client/src/app/pages/insights/helpers.ts
@@ -1,9 +1,13 @@
 import { Location, LocationDescriptor } from "history";
+import { useTranslation } from "react-i18next";
+
+import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Paths } from "@app/Paths";
 import {
   AnalysisInsight,
-  UiAnalysisReportInsight,
-  UiAnalysisReportApplicationInsight,
   Archetype,
+  UiAnalysisReportApplicationInsight,
+  UiAnalysisReportInsight,
 } from "@app/api/models";
 import {
   FilterCategory,
@@ -15,13 +19,10 @@ import {
   serializeFilterUrlParams,
 } from "@app/hooks/table-controls";
 import { trimAndStringifyUrlParams } from "@app/hooks/useUrlParams";
-import { Paths } from "@app/Paths";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { useFetchApplications } from "@app/queries/applications";
+import { useFetchArchetypes } from "@app/queries/archetypes";
 import { useFetchBusinessServices } from "@app/queries/businessservices";
 import { useFetchTagsWithTagItems } from "@app/queries/tags";
-import { useTranslation } from "react-i18next";
-import { useFetchArchetypes } from "@app/queries/archetypes";
-import { useFetchApplications } from "@app/queries/applications";
 import { universalComparator } from "@app/utils/utils";
 
 // Certain filters are shared between the Insights page and the Affected Applications Page.

--- a/client/src/app/pages/insights/insight-affected-files-table.tsx
+++ b/client/src/app/pages/insights/insight-affected-files-table.tsx
@@ -6,24 +6,26 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { AnalysisReportFile, AnalysisInsight, WithUiId } from "@app/api/models";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-} from "@app/hooks/table-controls";
-import { useFetchReportInsightFiles } from "@app/queries/analysis";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
 import { TablePersistenceKeyPrefix, UI_UNIQUE_ID } from "@app/Constants";
+import { AnalysisInsight, AnalysisReportFile, WithUiId } from "@app/api/models";
+import { BreakingPathDisplay } from "@app/components/BreakingPathDisplay";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { SimplePagination } from "@app/components/SimplePagination";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import { BreakingPathDisplay } from "@app/components/BreakingPathDisplay";
+import {
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
+import { useFetchReportInsightFiles } from "@app/queries/analysis";
+
 import { FileIncidentsDetailModal } from "./file-incidents-detail-modal";
 
 export interface IInsightAffectedFilesTableProps {

--- a/client/src/app/pages/insights/insight-detail-drawer.tsx
+++ b/client/src/app/pages/insights/insight-detail-drawer.tsx
@@ -1,23 +1,25 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Tab,
+  TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  Title,
+} from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import {
   IPageDrawerContentProps,
   PageDrawerContent,
 } from "@app/components/PageDrawerContext";
-import {
-  TextContent,
-  Text,
-  Title,
-  Tabs,
-  TabTitleText,
-  Tab,
-} from "@patternfly/react-core";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { useFetchInsight } from "@app/queries/analysis";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { StateNoData } from "@app/components/StateNoData";
-import { InsightAffectedFilesTable } from "./insight-affected-files-table";
+import { useFetchInsight } from "@app/queries/analysis";
+
 import { getInsightTitle } from "./helpers";
+import { InsightAffectedFilesTable } from "./insight-affected-files-table";
 
 export interface IInsightDetailDrawerProps
   extends Pick<IPageDrawerContentProps, "onCloseClick"> {

--- a/client/src/app/pages/insights/insights-page.tsx
+++ b/client/src/app/pages/insights/insights-page.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import {
   ButtonVariant,
   PageSection,
@@ -14,17 +14,18 @@ import {
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
-import { Paths } from "@app/Paths";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Paths } from "@app/Paths";
+import { UiAnalysisReportApplicationInsight } from "@app/api/models";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { AllInsightsTable } from "@app/components/insights/tables/all-insights-table";
+import { SingleApplicationInsightsTable } from "@app/components/insights/tables/single-application-insights-table";
 import {
   useFetchReportAllInsights,
   useFetchReportApplicationInsights,
 } from "@app/queries/analysis";
-import { SingleApplicationInsightsTable } from "@app/components/insights/tables/single-application-insights-table";
+
 import { InsightDetailDrawer } from "./insight-detail-drawer";
-import { UiAnalysisReportApplicationInsight } from "@app/api/models";
 
 export type InsightsTabPath =
   | typeof Paths.insightsAllTab

--- a/client/src/app/pages/issues/affected-applications-page.tsx
+++ b/client/src/app/pages/issues/affected-applications-page.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useLocation, useParams } from "react-router-dom";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -10,31 +12,30 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { ConditionalRender } from "@app/components/ConditionalRender";
+import { TablePersistenceKeyPrefix } from "@app/Constants";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-} from "@app/hooks/table-controls";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { FilterToolbar } from "@app/components/FilterToolbar";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import {
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
 import { useFetchReportIssueApps } from "@app/queries/analysis";
-import { Link, useLocation, useParams } from "react-router-dom";
-import { FilterToolbar } from "@app/components/FilterToolbar";
+
 import {
   getBackToAllIssuesUrl,
   useSharedAffectedApplicationFilterCategories,
 } from "./helpers";
 import { IssueDetailDrawer } from "./issue-detail-drawer";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
 
 interface IAffectedApplicationsRouteParams {
   ruleset: string;

--- a/client/src/app/pages/issues/file-incidents-detail-modal/file-all-incidents-table.tsx
+++ b/client/src/app/pages/issues/file-incidents-detail-modal/file-all-incidents-table.tsx
@@ -1,22 +1,23 @@
 import "./file-all-incidents-table.css";
 import * as React from "react";
-import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
+import ReactMarkdown from "react-markdown";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
 import { TablePersistenceKeyPrefix } from "@app/Constants";
 import { AnalysisReportFile } from "@app/api/models";
-import { useFetchIncidentsForInsight } from "@app/queries/analysis";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
-  TableHeaderContentWithControls,
   ConditionalTableBody,
+  TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-} from "@app/hooks/table-controls";
-import ReactMarkdown from "react-markdown";
 import { markdownPFComponents } from "@app/components/markdownPFComponents";
+import {
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
+import { useFetchIncidentsForInsight } from "@app/queries/analysis";
 
 export interface IFileRemainingIncidentsTableProps {
   fileReport: AnalysisReportFile;

--- a/client/src/app/pages/issues/file-incidents-detail-modal/file-incidents-detail-modal.tsx
+++ b/client/src/app/pages/issues/file-incidents-detail-modal/file-incidents-detail-modal.tsx
@@ -1,28 +1,30 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Alert,
   Button,
   Grid,
   GridItem,
   Modal,
   Tab,
   Tabs,
-  TextContent,
   Text,
-  Alert,
+  TextContent,
   Truncate,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
+import { AnalysisInsight, AnalysisReportFile } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { StateError } from "@app/components/StateError";
 import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
-import { AnalysisReportFile, AnalysisInsight } from "@app/api/models";
-import { useFetchIncidentsForInsight } from "@app/queries/analysis";
-import { IncidentCodeSnipViewer } from "./incident-code-snip-viewer";
-import { FileAllIncidentsTable } from "./file-all-incidents-table";
+import { StateError } from "@app/components/StateError";
 import { InsightDescriptionAndLinks } from "@app/components/insights/components";
+import { useFetchIncidentsForInsight } from "@app/queries/analysis";
+
 import { getIssueTitle } from "../helpers";
+
+import { FileAllIncidentsTable } from "./file-all-incidents-table";
+import { IncidentCodeSnipViewer } from "./incident-code-snip-viewer";
 
 export interface IFileIncidentsDetailModalProps {
   issue: AnalysisInsight;

--- a/client/src/app/pages/issues/file-incidents-detail-modal/incident-code-snip-viewer.tsx
+++ b/client/src/app/pages/issues/file-incidents-detail-modal/incident-code-snip-viewer.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
-import { CodeEditor, Language } from "@patternfly/react-code-editor";
-import { AnalysisIncident } from "@app/api/models";
-
-import "./incident-code-snip-viewer.css";
 import { LANGUAGES_BY_FILE_EXTENSION } from "config/monacoConstants";
+import { useTranslation } from "react-i18next";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
   EmptyState,
   EmptyStateBody,
@@ -12,7 +10,10 @@ import {
   EmptyStateVariant,
 } from "@patternfly/react-core";
 import { CubesIcon } from "@patternfly/react-icons";
-import { useTranslation } from "react-i18next";
+
+import { AnalysisIncident } from "@app/api/models";
+
+import "./incident-code-snip-viewer.css";
 
 const codeLineRegex = /^\s*([0-9]+)( {2})?(.*)$/; // Pattern: leading whitespace (line number) (2 spaces)? (code)
 

--- a/client/src/app/pages/issues/helpers.ts
+++ b/client/src/app/pages/issues/helpers.ts
@@ -1,9 +1,13 @@
 import { Location, LocationDescriptor } from "history";
+import { useTranslation } from "react-i18next";
+
+import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Paths } from "@app/Paths";
 import {
   AnalysisInsight,
-  UiAnalysisReportInsight,
-  UiAnalysisReportApplicationInsight,
   Archetype,
+  UiAnalysisReportApplicationInsight,
+  UiAnalysisReportInsight,
 } from "@app/api/models";
 import {
   FilterCategory,
@@ -15,15 +19,13 @@ import {
   serializeFilterUrlParams,
 } from "@app/hooks/table-controls";
 import { trimAndStringifyUrlParams } from "@app/hooks/useUrlParams";
-import { Paths } from "@app/Paths";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
-import { IssueFilterGroups } from "./issues-page";
+import { useFetchApplications } from "@app/queries/applications";
+import { useFetchArchetypes } from "@app/queries/archetypes";
 import { useFetchBusinessServices } from "@app/queries/businessservices";
 import { useFetchTagsWithTagItems } from "@app/queries/tags";
-import { useTranslation } from "react-i18next";
-import { useFetchArchetypes } from "@app/queries/archetypes";
-import { useFetchApplications } from "@app/queries/applications";
 import { universalComparator } from "@app/utils/utils";
+
+import { IssueFilterGroups } from "./issues-page";
 
 // Certain filters are shared between the Issues page and the Affected Applications Page.
 // We carry these filter values between the two pages when determining the URLs to navigate between them.

--- a/client/src/app/pages/issues/issue-affected-files-table.tsx
+++ b/client/src/app/pages/issues/issue-affected-files-table.tsx
@@ -6,25 +6,27 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { AnalysisReportFile, AnalysisInsight, WithUiId } from "@app/api/models";
-import {
-  useTableControlState,
-  useTableControlProps,
-  getHubRequestParams,
-} from "@app/hooks/table-controls";
-import { useFetchReportInsightFiles } from "@app/queries/analysis";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
 import { TablePersistenceKeyPrefix, UI_UNIQUE_ID } from "@app/Constants";
+import { AnalysisInsight, AnalysisReportFile, WithUiId } from "@app/api/models";
+import { BreakingPathDisplay } from "@app/components/BreakingPathDisplay";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { SimplePagination } from "@app/components/SimplePagination";
+import {
+  getHubRequestParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
+import { useFetchReportInsightFiles } from "@app/queries/analysis";
+
 import { FileIncidentsDetailModal } from "./file-incidents-detail-modal";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import { BreakingPathDisplay } from "@app/components/BreakingPathDisplay";
 
 export interface IIssueAffectedFilesTableProps {
   issue: AnalysisInsight;

--- a/client/src/app/pages/issues/issue-detail-drawer.tsx
+++ b/client/src/app/pages/issues/issue-detail-drawer.tsx
@@ -1,22 +1,24 @@
 import * as React from "react";
 import {
+  Tab,
+  TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  Title,
+} from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import {
   IPageDrawerContentProps,
   PageDrawerContent,
 } from "@app/components/PageDrawerContext";
-import {
-  TextContent,
-  Text,
-  Title,
-  Tabs,
-  TabTitleText,
-  Tab,
-} from "@patternfly/react-core";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { IssueAffectedFilesTable } from "./issue-affected-files-table";
-import { useFetchInsight } from "@app/queries/analysis";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { StateNoData } from "@app/components/StateNoData";
+import { useFetchInsight } from "@app/queries/analysis";
+
 import { getIssueTitle } from "./helpers";
+import { IssueAffectedFilesTable } from "./issue-affected-files-table";
 
 export interface IIssueDetailDrawerProps
   extends Pick<IPageDrawerContentProps, "onCloseClick"> {

--- a/client/src/app/pages/issues/issues-page.tsx
+++ b/client/src/app/pages/issues/issues-page.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import {
   ButtonVariant,
   PageSection,
@@ -14,17 +14,18 @@ import {
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
-import { Paths } from "@app/Paths";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Paths } from "@app/Paths";
+import { UiAnalysisReportApplicationInsight } from "@app/api/models";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { AllInsightsTable } from "@app/components/insights/tables/all-insights-table";
+import { SingleApplicationInsightsTable } from "@app/components/insights/tables/single-application-insights-table";
 import {
   useFetchReportAllIssues,
   useFetchReportApplicationIssues,
 } from "@app/queries/analysis";
-import { SingleApplicationInsightsTable } from "@app/components/insights/tables/single-application-insights-table";
+
 import { IssueDetailDrawer } from "./issue-detail-drawer";
-import { UiAnalysisReportApplicationInsight } from "@app/api/models";
 
 export enum IssueFilterGroups {
   ApplicationInventory = "Application inventory",

--- a/client/src/app/pages/migration-targets/components/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/components/custom-target-form.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useState, useMemo } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { AxiosError, AxiosResponse } from "axios";
+import { unique } from "radash";
+import { useFieldArray, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import * as yup from "yup";
 import {
   ActionGroup,
   Alert,
@@ -9,39 +15,35 @@ import {
   Form,
   Radio,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { useFieldArray, useForm } from "react-hook-form";
-import * as yup from "yup";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { AxiosError, AxiosResponse } from "axios";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
-import defaultImage from "./default.png";
+import { New, Rule, Target, TargetLabel, UploadFile } from "@app/api/models";
+import { CustomRuleFilesUpload } from "@app/components/CustomRuleFilesUpload";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { useCreateFileMutation } from "@app/queries/targets";
-import { UploadFile, New, Rule, Target, TargetLabel } from "@app/api/models";
-import { getParsedLabel, parseRules } from "@app/utils/rules-utils";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-import { toOptionLike, toRef } from "@app/utils/model-utils";
-import { useFetchIdentities } from "@app/queries/identities";
-import { duplicateNameCheck } from "@app/utils/utils";
 import { UploadFileSchema } from "@app/pages/applications/analysis-wizard/schema";
+import { useFetchIdentities } from "@app/queries/identities";
 import {
   useCreateTargetMutation,
   useFetchTargets,
   useUpdateTargetMutation,
 } from "@app/queries/targets";
-import { NotificationsContext } from "@app/components/NotificationsContext";
+import { useCreateFileMutation } from "@app/queries/targets";
+import { toOptionLike, toRef } from "@app/utils/model-utils";
+import { getParsedLabel, parseRules } from "@app/utils/rules-utils";
+import { duplicateNameCheck } from "@app/utils/utils";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
 import {
   DEFAULT_PROVIDER,
   useMigrationProviderList,
 } from "../useMigrationProviderList";
-import { unique } from "radash";
-import { CustomRuleFilesUpload } from "@app/components/CustomRuleFilesUpload";
+
+import defaultImage from "./default.png";
 
 export interface CustomTargetFormProps {
   target?: Target | null;

--- a/client/src/app/pages/migration-targets/components/dnd/sortable-target-item.tsx
+++ b/client/src/app/pages/migration-targets/components/dnd/sortable-target-item.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+
 import { Target } from "@app/api/models";
+
 import { TargetItem } from "./target-item";
 
 interface SortableTargetItemProps {

--- a/client/src/app/pages/migration-targets/components/dnd/target-item.tsx
+++ b/client/src/app/pages/migration-targets/components/dnd/target-item.tsx
@@ -2,8 +2,8 @@ import React, { forwardRef } from "react";
 import { Button, ButtonVariant } from "@patternfly/react-core";
 import { GripVerticalIcon } from "@patternfly/react-icons";
 
-import { TargetCard } from "@app/components/target-card/target-card";
 import { Target } from "@app/api/models";
+import { TargetCard } from "@app/components/target-card/target-card";
 import "./target-item.css";
 
 interface TargetItemProps {

--- a/client/src/app/pages/migration-targets/migration-targets.tsx
+++ b/client/src/app/pages/migration-targets/migration-targets.tsx
@@ -1,51 +1,50 @@
 import React, { useMemo, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { AxiosError, AxiosResponse } from "axios";
-import { unique } from "radash";
-
 import {
   DndContext,
-  closestCenter,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
+  DragOverEvent,
   DragOverlay,
   DragStartEvent,
-  DragOverEvent,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
 } from "@dnd-kit/core";
 import {
-  arrayMove,
   SortableContext,
+  arrayMove,
   rectSortingStrategy,
 } from "@dnd-kit/sortable";
-import { SortableTargetItem } from "./components/dnd/sortable-target-item";
-import { TargetItem } from "./components/dnd/target-item";
-
+import { AxiosError, AxiosResponse } from "axios";
+import { unique } from "radash";
+import { useTranslation } from "react-i18next";
 import {
+  Button,
+  Gallery,
+  Modal,
   PageSection,
   PageSectionVariants,
-  TextContent,
-  Button,
   Text,
-  Modal,
+  TextContent,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  Gallery,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
+import { Target } from "@app/api/models";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { CustomTargetForm } from "./components/custom-target-form";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useSetting, useSettingMutation } from "@app/queries/settings";
 import { useDeleteTargetMutation, useFetchTargets } from "@app/queries/targets";
-import { Target } from "@app/api/models";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
+import { CustomTargetForm } from "./components/custom-target-form";
+import { SortableTargetItem } from "./components/dnd/sortable-target-item";
+import { TargetItem } from "./components/dnd/target-item";
 import { DEFAULT_PROVIDER } from "./useMigrationProviderList";
-import { useLocalTableControls } from "@app/hooks/table-controls";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 
 export const MigrationTargets: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/migration-waves/components/export-form.tsx
+++ b/client/src/app/pages/migration-waves/components/export-form.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
   ActionGroup,
@@ -8,25 +10,23 @@ import {
   ButtonVariant,
   Form,
 } from "@patternfly/react-core";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
 
-import { Tracker, IssueManagerKind, Ref, Ticket, New } from "@app/api/models";
-import { IssueManagerOptions, toOptionLike } from "@app/utils/model-utils";
-import {
-  useTrackerTypesByProjectName,
-  useTrackerProjectsByTracker,
-  getTrackersByKind,
-} from "@app/queries/trackers";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-import { getAxiosErrorMessage } from "@app/utils/utils";
+import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
+import { IssueManagerKind, New, Ref, Ticket, Tracker } from "@app/api/models";
 import { HookFormPFGroupController } from "@app/components/HookFormPFFields";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import {
   useCreateTicketsMutation,
   useFetchTickets,
 } from "@app/queries/tickets";
+import {
+  getTrackersByKind,
+  useTrackerProjectsByTracker,
+  useTrackerTypesByProjectName,
+} from "@app/queries/trackers";
+import { IssueManagerOptions, toOptionLike } from "@app/utils/model-utils";
+import { getAxiosErrorMessage } from "@app/utils/utils";
 
 interface FormValues {
   issueManager: IssueManagerKind | undefined;

--- a/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
+++ b/client/src/app/pages/migration-waves/components/manage-applications-form.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { AxiosError, AxiosResponse } from "axios";
+import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 import {
   ActionGroup,
@@ -13,24 +14,23 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import dayjs from "dayjs";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { Application, MigrationWave } from "@app/api/models";
-import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { useLocalTableControls } from "@app/hooks/table-controls";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import { SimplePagination } from "@app/components/SimplePagination";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { dedupeFunction } from "@app/utils/utils";
-import { useUpdateMigrationWaveMutation } from "@app/queries/migration-waves";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
 import { useBulkSelection } from "@app/hooks/selection/useBulkSelection";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+import { useUpdateMigrationWaveMutation } from "@app/queries/migration-waves";
+import { dedupeFunction } from "@app/utils/utils";
 
 export interface ManageApplicationsFormProps {
   applications: Application[];

--- a/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
+++ b/client/src/app/pages/migration-waves/components/migration-wave-form.tsx
@@ -1,41 +1,40 @@
 import * as React from "react";
+import { useRef } from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
+import dayjs from "dayjs";
+import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
 import {
   ActionGroup,
   Button,
+  DatePicker,
   Form,
   Grid,
   GridItem,
-  DatePicker,
 } from "@patternfly/react-core";
 
-import { useFetchStakeholders } from "@app/queries/stakeholders";
-import { useFetchStakeholderGroups } from "@app/queries/stakeholdergroups";
+import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
 import {
-  useCreateMigrationWaveMutation,
-  useUpdateMigrationWaveMutation,
-} from "@app/queries/migration-waves";
-import dayjs from "dayjs";
-
-import {
-  Stakeholder,
-  StakeholderGroup,
   MigrationWave,
   New,
+  Stakeholder,
+  StakeholderGroup,
 } from "@app/api/models";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { DEFAULT_SELECT_MAX_HEIGHT } from "@app/Constants";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import {
+  useCreateMigrationWaveMutation,
+  useUpdateMigrationWaveMutation,
+} from "@app/queries/migration-waves";
+import { useFetchStakeholderGroups } from "@app/queries/stakeholdergroups";
+import { useFetchStakeholders } from "@app/queries/stakeholders";
 import { matchItemsToRefs } from "@app/utils/model-utils";
-import { useRef } from "react";
 
 const stakeholderGroupToOption = (
   value: StakeholderGroup
@@ -195,13 +194,7 @@ export const WaveForm: React.FC<WaveFormProps> = ({
 
   const {
     handleSubmit,
-    formState: {
-      isSubmitting,
-      isValidating,
-      isValid,
-      isDirty,
-      errors: formErrors,
-    },
+    formState: { isSubmitting, isValidating, isValid, isDirty },
     control,
     watch,
     trigger,

--- a/client/src/app/pages/migration-waves/components/stakeholders-table.tsx
+++ b/client/src/app/pages/migration-waves/components/stakeholders-table.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { WaveWithStatus } from "@app/api/models";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { useLocalTableControls } from "@app/hooks/table-controls";
+
+import { WaveWithStatus } from "@app/api/models";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 
 export interface IWaveStakeholdersTableProps {
   migrationWave: WaveWithStatus;

--- a/client/src/app/pages/migration-waves/components/ticket-issue.tsx
+++ b/client/src/app/pages/migration-waves/components/ticket-issue.tsx
@@ -1,8 +1,8 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Text, TextVariants } from "@patternfly/react-core";
 
 import { Ticket } from "@app/api/models";
-import { useTranslation } from "react-i18next";
 import ExternalLink from "@app/components/ExternalLink";
 import { useTrackerTypesByProjectId } from "@app/queries/trackers";
 

--- a/client/src/app/pages/migration-waves/components/wave-applications-table.tsx
+++ b/client/src/app/pages/migration-waves/components/wave-applications-table.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import {
   ActionsColumn,
@@ -9,15 +10,15 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import { useLocalTableControls } from "@app/hooks/table-controls";
+
+import { MigrationWave, WaveWithStatus } from "@app/api/models";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { SimplePagination } from "@app/components/SimplePagination";
-import { MigrationWave, WaveWithStatus } from "@app/api/models";
-import { useTranslation } from "react-i18next";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useDeleteTicketMutation } from "@app/queries/migration-waves";
 import { useFetchTickets } from "@app/queries/tickets";
 

--- a/client/src/app/pages/migration-waves/components/wave-status-table.tsx
+++ b/client/src/app/pages/migration-waves/components/wave-status-table.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { MigrationWave, Ticket, WaveWithStatus } from "@app/api/models";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -11,22 +10,23 @@ import {
   ToolbarItem,
   Tooltip,
 } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import alignment from "@patternfly/react-styles/css/utilities/Alignment/alignment";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import UnlinkIcon from "@patternfly/react-icons/dist/esm/icons/unlink-icon";
+import alignment from "@patternfly/react-styles/css/utilities/Alignment/alignment";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { useLocalTableControls } from "@app/hooks/table-controls";
+import { MigrationWave, Ticket, WaveWithStatus } from "@app/api/models";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { SimplePagination } from "@app/components/SimplePagination";
-import { useHistory } from "react-router-dom";
-import { useFetchTickets } from "@app/queries/tickets";
-import { TicketIssue } from "./ticket-issue";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useDeleteTicketMutation } from "@app/queries/migration-waves";
-import UnlinkIcon from "@patternfly/react-icons/dist/esm/icons/unlink-icon";
+import { useFetchTickets } from "@app/queries/tickets";
+
+import { TicketIssue } from "./ticket-issue";
 
 type SetCellExpandedArgs = {
   item: WaveWithStatus;
@@ -55,7 +55,6 @@ export const WaveStatusTable: React.FC<IWaveStatusTableProps> = ({
   const [codeModalState, setCodeModalState] = useState<
     string | null | undefined
   >("");
-  const history = useHistory();
 
   const { tickets } = useFetchTickets();
   const { mutate: deleteTicket } = useDeleteTicketMutation();

--- a/client/src/app/pages/migration-waves/migration-waves.tsx
+++ b/client/src/app/pages/migration-waves/migration-waves.tsx
@@ -1,4 +1,7 @@
 import * as React from "react";
+import { AxiosError, AxiosResponse } from "axios";
+import dayjs from "dayjs";
+import { useTranslation } from "react-i18next";
 import {
   Button,
   ButtonVariant,
@@ -21,6 +24,8 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+import EllipsisVIcon from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
 import {
   ExpandableRowContent,
   Table,
@@ -30,48 +35,44 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import { useTranslation } from "react-i18next";
-import { AxiosError, AxiosResponse } from "axios";
-import dayjs from "dayjs";
-import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
-import EllipsisVIcon from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
 
-import {
-  useDeleteAllMigrationWavesMutation,
-  useDeleteMigrationWaveMutation,
-  useFetchMigrationWaves,
-  useUpdateMigrationWaveMutation,
-} from "@app/queries/migration-waves";
 import { MigrationWave, Ref, Ticket, WaveWithStatus } from "@app/api/models";
+import { deleteMigrationWave } from "@app/api/rest";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import { useLocalTableControls } from "@app/hooks/table-controls";
+import { isInClosedRange } from "@app/components/FilterToolbar/dateUtils";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { ExportForm } from "./components/export-form";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { getAxiosErrorMessage } from "@app/utils/utils";
-import { useFetchTrackers } from "@app/queries/trackers";
+import { ToolbarBulkExpander } from "@app/components/ToolbarBulkExpander";
+import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
+import { useBulkSelection } from "@app/hooks/selection/useBulkSelection";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useFetchApplications } from "@app/queries/applications";
+import {
+  useDeleteAllMigrationWavesMutation,
+  useDeleteMigrationWaveMutation,
+  useFetchMigrationWaves,
+  useUpdateMigrationWaveMutation,
+} from "@app/queries/migration-waves";
+import { useFetchTickets } from "@app/queries/tickets";
+import { useFetchTrackers } from "@app/queries/trackers";
+import { toRefs } from "@app/utils/model-utils";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
+import { ExportForm } from "./components/export-form";
+import { ManageApplicationsForm } from "./components/manage-applications-form";
+import { WaveForm } from "./components/migration-wave-form";
 import { WaveStakeholdersTable } from "./components/stakeholders-table";
 import { WaveApplicationsTable } from "./components/wave-applications-table";
 import { WaveStatusTable } from "./components/wave-status-table";
-import { WaveForm } from "./components/migration-wave-form";
-import { ManageApplicationsForm } from "./components/manage-applications-form";
-import { deleteMigrationWave } from "@app/api/rest";
-import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { AppPlaceholder } from "@app/components/AppPlaceholder";
-import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
-import { toRefs } from "@app/utils/model-utils";
-import { useFetchTickets } from "@app/queries/tickets";
-import { isInClosedRange } from "@app/components/FilterToolbar/dateUtils";
-import { ToolbarBulkExpander } from "@app/components/ToolbarBulkExpander";
-import { useBulkSelection } from "@app/hooks/selection/useBulkSelection";
 
 export const MigrationWaves: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/proxies/__tests__/proxy-form.test.tsx
+++ b/client/src/app/pages/proxies/__tests__/proxy-form.test.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 import "@testing-library/jest-dom";
+import { server } from "@mocks/server";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+
 import {
-  render,
-  waitFor,
-  screen,
   fireEvent,
+  render,
+  screen,
+  waitFor,
 } from "@app/test-config/test-utils";
 
 import { Proxies } from "../proxies";
-import userEvent from "@testing-library/user-event";
-import { server } from "@mocks/server";
-import { rest } from "msw";
 
 describe("Component: proxy-form", () => {
   beforeEach(() => {

--- a/client/src/app/pages/proxies/proxies-validation-schema.ts
+++ b/client/src/app/pages/proxies/proxies-validation-schema.ts
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
+
 import { ProxyFormValues } from "./proxy-form";
 
 export const useProxyFormValidationSchema =

--- a/client/src/app/pages/proxies/proxies.tsx
+++ b/client/src/app/pages/proxies/proxies.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import {
   Card,
   CardBody,
@@ -12,9 +13,10 @@ import {
   Title,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { useTranslation } from "react-i18next";
-import { ProxyForm } from "./proxy-form";
+
 import { useFetchProxies } from "@app/queries/proxies";
+
+import { ProxyForm } from "./proxy-form";
 import "./proxies.css";
 
 export const Proxies: React.FC = () => {

--- a/client/src/app/pages/proxies/proxy-form.tsx
+++ b/client/src/app/pages/proxies/proxy-form.tsx
@@ -1,4 +1,13 @@
 import React, { useMemo } from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { AxiosError } from "axios";
+import {
+  Controller,
+  FieldValues,
+  SubmitHandler,
+  useForm,
+} from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import {
   ActionGroup,
   Button,
@@ -6,29 +15,21 @@ import {
   Form,
   Switch,
 } from "@patternfly/react-core";
-import {
-  Controller,
-  FieldValues,
-  SubmitHandler,
-  useForm,
-} from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { AxiosError } from "axios";
-import { useTranslation } from "react-i18next";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
-import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
-import { getAxiosErrorMessage, getValidatedFromErrors } from "@app/utils/utils";
-import { useProxyFormValidationSchema } from "./proxies-validation-schema";
 import { Proxy } from "@app/api/models";
-import { useUpdateProxyMutation } from "@app/queries/proxies";
-import { useFetchIdentities } from "@app/queries/identities";
 import {
   HookFormPFGroupController,
   HookFormPFTextArea,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { useFetchIdentities } from "@app/queries/identities";
+import { useUpdateProxyMutation } from "@app/queries/proxies";
+import { getAxiosErrorMessage, getValidatedFromErrors } from "@app/utils/utils";
+
+import { useProxyFormValidationSchema } from "./proxies-validation-schema";
 
 export interface ProxyFormValues {
   isHttpProxyEnabled: boolean;

--- a/client/src/app/pages/reports/application-selection-context.tsx
+++ b/client/src/app/pages/reports/application-selection-context.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { useSelectionState, ISelectionState } from "@app/hooks/selection";
+
 import { Application } from "@app/api/models";
+import { ISelectionState, useSelectionState } from "@app/hooks/selection";
 
 interface IApplicationSelectionContext extends ISelectionState<Application> {
   allItems: Application[];

--- a/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
@@ -1,13 +1,7 @@
 import React, { useContext, useEffect, useMemo, useState } from "react";
-import Measure from "react-measure";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import {
-  Bullseye,
-  Checkbox,
-  Skeleton,
-  Stack,
-  StackItem,
-} from "@patternfly/react-core";
+import Measure from "react-measure";
 import {
   Chart,
   ChartAxis,
@@ -18,26 +12,33 @@ import {
   ChartTooltip,
 } from "@patternfly/react-charts";
 import {
-  global_palette_black_800 as black,
+  Bullseye,
+  Checkbox,
+  Skeleton,
+  Stack,
+  StackItem,
+} from "@patternfly/react-core";
+import {
   chart_color_green_100 as green,
+  global_palette_black_800 as black,
   global_palette_white as white,
 } from "@patternfly/react-tokens";
-import { useQuery } from "@tanstack/react-query";
 
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { StateError } from "@app/components/StateError";
 import { EFFORT_ESTIMATE_LIST, PROPOSED_ACTION_LIST } from "@app/Constants";
-// import { getAssessmentConfidence } from "@app/api/rest";
 import {
   Application,
   AssessmentConfidence,
   ProposedAction,
 } from "@app/api/models";
-import { ApplicationSelectionContext } from "../../application-selection-context";
-import { CartesianSquare } from "./cartesian-square";
-import { Arrow } from "./arrow";
-import { useFetchReviewById } from "@app/queries/reviews";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { StateError } from "@app/components/StateError";
 import { useFetchApplicationDependencies } from "@app/queries/applications";
+import { useFetchReviewById } from "@app/queries/reviews";
+
+import { ApplicationSelectionContext } from "../../application-selection-context";
+
+import { Arrow } from "./arrow";
+import { CartesianSquare } from "./cartesian-square";
 
 interface Line {
   from: LinePoint;

--- a/client/src/app/pages/reports/components/adoption-candidate-graph/cartesian-square.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-graph/cartesian-square.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { BlockProps, VictoryTheme } from "victory-core";
 import { ChartAxis } from "@patternfly/react-charts";
-import { VictoryTheme, BlockProps } from "victory-core";
 
 interface ICartesianSquareProps {
   height: number;

--- a/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -1,17 +1,18 @@
 import React, { useContext, useMemo } from "react";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { useLocalTableControls } from "@app/hooks/table-controls";
+import { Application, Review } from "@app/api/models"; // Add the necessary model imports
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+import { RiskLabel } from "@app/components/RiskLabel";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
-import { Application, Review } from "@app/api/models"; // Add the necessary model imports
-import { ApplicationSelectionContext } from "../../application-selection-context";
+import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useFetchReviews } from "@app/queries/reviews";
-import { RiskLabel } from "@app/components/RiskLabel";
+
+import { ApplicationSelectionContext } from "../../application-selection-context";
 
 interface AdoptionCandidateTableProps {
   allApplications?: Application[];

--- a/client/src/app/pages/reports/components/adoption-plan/adoption-plan.tsx
+++ b/client/src/app/pages/reports/components/adoption-plan/adoption-plan.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo } from "react";
-import Measure from "react-measure";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-
-import { Bullseye, Skeleton } from "@patternfly/react-core";
+import Measure from "react-measure";
 import {
   Chart,
   ChartAxis,
@@ -11,15 +10,16 @@ import {
   ChartThemeColor,
   ChartVoronoiContainer,
 } from "@patternfly/react-charts";
+import { Bullseye, Skeleton } from "@patternfly/react-core";
 
-import { ConditionalRender } from "@app/components/ConditionalRender";
-import { StateError } from "@app/components/StateError";
 import { PROPOSED_ACTION_LIST } from "@app/Constants";
 import { ApplicationAdoptionPlan } from "@app/api/models";
 import { getApplicationAdoptionPlan } from "@app/api/rest";
-import { NoApplicationSelectedEmptyState } from "../no-application-selected-empty-state";
-import { useQuery } from "@tanstack/react-query";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { StateError } from "@app/components/StateError";
 import { useFetchApplications } from "@app/queries/applications";
+
+import { NoApplicationSelectedEmptyState } from "../no-application-selected-empty-state";
 
 interface IChartData {
   applicationId: number;

--- a/client/src/app/pages/reports/components/application-cell/application-cell.tsx
+++ b/client/src/app/pages/reports/components/application-cell/application-cell.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 
-import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { Application } from "@app/api/models";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 
 export interface IApplicationCellProps {
   application?: Application;

--- a/client/src/app/pages/reports/components/application-landscape/application-landscape.tsx
+++ b/client/src/app/pages/reports/components/application-landscape/application-landscape.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import { Flex, FlexItem, Skeleton } from "@patternfly/react-core";
 
 import { RISK_LIST } from "@app/Constants";
+import { Paths } from "@app/Paths";
 import {
   Application,
   AssessmentWithArchetypeApplications,
@@ -11,12 +13,11 @@ import {
   Ref,
 } from "@app/api/models";
 import { ConditionalRender } from "@app/components/ConditionalRender";
-import { useFetchAssessmentsWithArchetypeApplications } from "@app/queries/assessments";
-import { useFetchApplications } from "@app/queries/applications";
-import { Donut } from "../donut/donut";
 import { serializeFilterUrlParams } from "@app/hooks/table-controls";
-import { Paths } from "@app/Paths";
-import { Link } from "react-router-dom";
+import { useFetchApplications } from "@app/queries/applications";
+import { useFetchAssessmentsWithArchetypeApplications } from "@app/queries/assessments";
+
+import { Donut } from "../donut/donut";
 
 interface IAggregateRiskData {
   green: number;

--- a/client/src/app/pages/reports/components/donut/donut.tsx
+++ b/client/src/app/pages/reports/components/donut/donut.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-
 import { ChartDonut } from "@patternfly/react-charts";
-import { global_palette_black_300 as black } from "@patternfly/react-tokens";
-
 import {
   Bullseye,
   Stack,
@@ -12,6 +9,7 @@ import {
   TextContent,
   TextVariants,
 } from "@patternfly/react-core";
+import { global_palette_black_300 as black } from "@patternfly/react-tokens";
 
 export interface IDonutProps {
   id: string;

--- a/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
+++ b/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
@@ -1,7 +1,18 @@
 import React, { Fragment } from "react";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { useFetchAssessmentsWithArchetypeApplications } from "@app/queries/assessments";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import {
+  Divider,
+  Text,
+  TextContent,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
+import { Paths } from "@app/Paths";
 import {
   Answer,
   AssessmentWithArchetypeApplications,
@@ -9,30 +20,20 @@ import {
   Question,
   Ref,
 } from "@app/api/models";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
-  TableHeaderContentWithControls,
   ConditionalTableBody,
+  TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import RiskIcon from "@app/components/risk-icon/risk-icon";
 import {
   serializeFilterUrlParams,
   useLocalTableControls,
 } from "@app/hooks/table-controls";
-import { SimplePagination } from "@app/components/SimplePagination";
-import {
-  TextContent,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
-  Text,
-  Divider,
-} from "@patternfly/react-core";
-import { Link } from "react-router-dom";
-import { Paths } from "@app/Paths";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import RiskIcon from "@app/components/risk-icon/risk-icon";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { useFetchAssessmentsWithArchetypeApplications } from "@app/queries/assessments";
 
 export interface IIdentifiedRisksTableProps {
   assessmentRefs?: IdRef[];

--- a/client/src/app/pages/reports/reports.tsx
+++ b/client/src/app/pages/reports/reports.tsx
@@ -18,19 +18,18 @@ import {
 } from "@patternfly/react-core";
 
 import { Questionnaire } from "@app/api/models";
-import { useFetchApplications } from "@app/queries/applications";
-import { useFetchAssessments } from "@app/queries/assessments";
-import { useFetchQuestionnaires } from "@app/queries/questionnaires";
-
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { StateError } from "@app/components/StateError";
+import { useFetchApplications } from "@app/queries/applications";
+import { useFetchAssessments } from "@app/queries/assessments";
+import { useFetchQuestionnaires } from "@app/queries/questionnaires";
+import { toIdRef } from "@app/utils/model-utils";
+import { universalComparator } from "@app/utils/utils";
 
 import { ApplicationSelectionContextProvider } from "./application-selection-context";
-import { IdentifiedRisksTable } from "./components/identified-risks-table";
-import { toIdRef } from "@app/utils/model-utils";
 import { ApplicationLandscape } from "./components/application-landscape";
-import { universalComparator } from "@app/utils/utils";
+import { IdentifiedRisksTable } from "./components/identified-risks-table";
 
 const ALL_QUESTIONNAIRES = -1;
 

--- a/client/src/app/pages/repositories/Git.tsx
+++ b/client/src/app/pages/repositories/Git.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Card,
@@ -9,7 +10,6 @@ import {
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 
 import "./Repositories.css";
 import { useSetting, useSettingMutation } from "@app/queries/settings";

--- a/client/src/app/pages/repositories/Mvn.tsx
+++ b/client/src/app/pages/repositories/Mvn.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -18,15 +19,15 @@ import {
   TextInput,
   Tooltip,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-
-import "./Repositories.css";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { useDeleteCacheMutation, useFetchCache } from "@app/queries/cache";
-import { ConfirmDialog } from "@app/components/ConfirmDialog";
+
 import { isRWXSupported } from "@app/Constants";
 import { ConditionalTooltip } from "@app/components/ConditionalTooltip";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
+import { useDeleteCacheMutation, useFetchCache } from "@app/queries/cache";
 import { useSetting, useSettingMutation } from "@app/queries/settings";
+
+import "./Repositories.css";
 
 export const RepositoriesMvn: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/repositories/Svn.tsx
+++ b/client/src/app/pages/repositories/Svn.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Card,
@@ -9,7 +10,6 @@ import {
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 
 import "./Repositories.css";
 import { useSetting, useSettingMutation } from "@app/queries/settings";

--- a/client/src/app/pages/review/components/application-assessment-donut-chart/application-assessment-donut-chart.tsx
+++ b/client/src/app/pages/review/components/application-assessment-donut-chart/application-assessment-donut-chart.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ChartDonut, ChartLegend } from "@patternfly/react-charts";
-
 import { global_palette_blue_300 as defaultColor } from "@patternfly/react-tokens";
 
 import { RISK_LIST } from "@app/Constants";

--- a/client/src/app/pages/review/components/application-assessment-donut-chart/tests/application-assessment-donut-chart.test.tsx
+++ b/client/src/app/pages/review/components/application-assessment-donut-chart/tests/application-assessment-donut-chart.test.tsx
@@ -1,5 +1,5 @@
 describe("AppTable", () => {
-  const assessments = [];
+  // const assessments = [];
   // const assessment: Assessment = {
   //   id: 209,
   //   applicationId: 1,

--- a/client/src/app/pages/review/components/review-form/review-form.tsx
+++ b/client/src/app/pages/review/components/review-form/review-form.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo } from "react";
-import { useTranslation } from "react-i18next";
-import { object, string, mixed } from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
-
+import { FieldErrors, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import { mixed, object, string } from "yup";
+import { number } from "yup";
 import {
   ActionGroup,
   Button,
@@ -11,8 +13,8 @@ import {
   NumberInput,
 } from "@patternfly/react-core";
 
-import { PROPOSED_ACTION_LIST, EFFORT_ESTIMATE_LIST } from "@app/Constants";
-import { number } from "yup";
+import { EFFORT_ESTIMATE_LIST, PROPOSED_ACTION_LIST } from "@app/Constants";
+import { Paths } from "@app/Paths";
 import {
   Application,
   Archetype,
@@ -21,20 +23,17 @@ import {
   ProposedAction,
   Review,
 } from "@app/api/models";
-import { FieldErrors, useForm } from "react-hook-form";
 import {
   HookFormPFGroupController,
   HookFormPFTextArea,
 } from "@app/components/HookFormPFFields";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import useIsArchetype from "@app/hooks/useIsArchetype";
 import {
   useCreateReviewMutation,
   useUpdateReviewMutation,
 } from "@app/queries/reviews";
-import { useHistory } from "react-router-dom";
-import { Paths } from "@app/Paths";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import useIsArchetype from "@app/hooks/useIsArchetype";
 
 export interface FormValues {
   action: ProposedAction;
@@ -126,10 +125,10 @@ export const ReviewForm: React.FC<IReviewFormProps> = ({
             archetype: { id: archetype.id, name: archetype.name },
           }
         : application
-        ? {
-            application: { id: application.id, name: application.name },
-          }
-        : undefined),
+          ? {
+              application: { id: application.id, name: application.name },
+            }
+          : undefined),
     };
 
     try {

--- a/client/src/app/pages/review/review-page.tsx
+++ b/client/src/app/pages/review/review-page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
 import {
   Bullseye,
   Card,
@@ -16,17 +16,19 @@ import {
 import BanIcon from "@patternfly/react-icons/dist/esm/icons/ban-icon";
 
 import { Paths, ReviewRoute } from "@app/Paths";
-import { ReviewForm } from "./components/review-form";
-import { SimpleEmptyState } from "@app/components/SimpleEmptyState";
-import { ConditionalRender } from "@app/components/ConditionalRender";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
 import { PageHeader } from "@app/components/PageHeader";
-import { useFetchReviewById } from "@app/queries/reviews";
+import { SimpleEmptyState } from "@app/components/SimpleEmptyState";
 import useIsArchetype from "@app/hooks/useIsArchetype";
 import { useFetchApplicationById } from "@app/queries/applications";
 import { useFetchArchetypeById } from "@app/queries/archetypes";
-import { IdentifiedRisksTable } from "../reports/components/identified-risks-table";
+import { useFetchReviewById } from "@app/queries/reviews";
+
 import { ApplicationAssessmentDonutChart } from "../../components/application-assessment-donut-chart/application-assessment-donut-chart";
+import { IdentifiedRisksTable } from "../reports/components/identified-risks-table";
+
+import { ReviewForm } from "./components/review-form";
 
 const ReviewPage: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/source-platforms/components/column-platform-name.tsx
+++ b/client/src/app/pages/source-platforms/components/column-platform-name.tsx
@@ -1,9 +1,8 @@
 import "./column-platform-name.css";
 
 import React from "react";
-import { Link } from "react-router-dom";
 import dayjs from "dayjs";
-
+import { Link } from "react-router-dom";
 import {
   Alert,
   Icon,
@@ -13,19 +12,20 @@ import {
 } from "@patternfly/react-core";
 import {
   CheckCircleIcon,
-  TimesCircleIcon,
-  InProgressIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
+  InProgressIcon,
   PendingIcon,
   ResourcesEmptyIcon,
+  TimesCircleIcon,
 } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
 import { Paths } from "@app/Paths";
-import { formatPath, universalComparator } from "@app/utils/utils";
 import { TaskDashboard } from "@app/api/models";
+import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
+import { formatPath, universalComparator } from "@app/utils/utils";
+
 import {
   SourcePlatformTasksStatus,
   SourcePlatformWithTasks,

--- a/client/src/app/pages/source-platforms/components/link-to-platform-applications.tsx
+++ b/client/src/app/pages/source-platforms/components/link-to-platform-applications.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Text } from "@patternfly/react-core";
 
+import { Paths } from "@app/Paths";
 import type { SourcePlatform } from "@app/api/models";
 import { serializeFilterUrlParams } from "@app/hooks/table-controls";
-import { Paths } from "@app/Paths";
 
 const getApplicationsUrl = (platformName?: string) => {
   if (!platformName) return "";

--- a/client/src/app/pages/source-platforms/components/platform-applications-table.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-applications-table.tsx
@@ -1,22 +1,23 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { Ref } from "@app/api/models";
-import {
-  useTableControlState,
-  useTableControlProps,
-  deserializeFilterUrlParams,
-} from "@app/hooks/table-controls";
+
 import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Ref } from "@app/api/models";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
-import { SimplePagination } from "@app/components/SimplePagination";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import { useHistory } from "react-router-dom";
+import {
+  deserializeFilterUrlParams,
+  useTableControlProps,
+  useTableControlState,
+} from "@app/hooks/table-controls";
 import { useFetchApplications } from "@app/queries/applications";
 
 export interface IPlatformAppsTableProps {

--- a/client/src/app/pages/source-platforms/components/platform-detail-drawer.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-detail-drawer.tsx
@@ -1,30 +1,31 @@
 import "./platform-detail-drawer.css";
 import React from "react";
 import { useTranslation } from "react-i18next";
-
 import {
-  TextContent,
-  Text,
-  Title,
   DescriptionList,
+  DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  DescriptionListDescription,
-  Tabs,
   Tab,
   TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  Title,
 } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import { SourcePlatform } from "@app/api/models";
 
+import { SourcePlatform } from "@app/api/models";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { PageDrawerContent } from "@app/components/PageDrawerContext";
-import PlatformAppsTable from "./platform-applications-table";
 import {
   DrawerTabContent,
   DrawerTabsContainer,
 } from "@app/components/detail-drawer";
-import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
+
 import { usePlatformKindList } from "../usePlatformKindList";
+
+import PlatformAppsTable from "./platform-applications-table";
 
 export interface IPlatformDetailDrawerProps {
   onCloseClick: () => void;

--- a/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/discover-import-wizard.tsx
@@ -1,22 +1,23 @@
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import {
+  Button,
   Modal,
   ModalVariant,
   Wizard,
-  WizardStep,
   WizardHeader,
-  Button,
+  WizardStep,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 
 import { SourcePlatform } from "@app/api/models";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { useWizardReducer } from "./useWizardReducer";
-import { FilterInput } from "./filter-input";
-import { Review } from "./review";
-import { Results } from "./results";
-import { useStartPlatformApplicationImport } from "./useStartPlatformApplicationImport";
 import { universalComparator } from "@app/utils/utils";
+
+import { FilterInput } from "./filter-input";
+import { Results } from "./results";
+import { Review } from "./review";
+import { useStartPlatformApplicationImport } from "./useStartPlatformApplicationImport";
+import { useWizardReducer } from "./useWizardReducer";
 
 export const DiscoverImportWizard: React.FC<IDiscoverImportWizard> = ({
   isOpen,

--- a/client/src/app/pages/source-platforms/discover-import-wizard/filter-input-cloudfoundry.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/filter-input-cloudfoundry.tsx
@@ -147,7 +147,7 @@ export const FilterInputCloudFoundry: React.FC<
     mode: "all",
   });
 
-  const { control, subscribe } = form;
+  const { subscribe } = form;
 
   React.useEffect(() => {
     const subscription = subscribe({

--- a/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/results.tsx
@@ -1,18 +1,17 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-
 import {
-  TextContent,
-  Text,
-  TextVariants,
-  CardBody,
   Card,
-  GridItem,
-  Grid,
-  CardTitle,
+  CardBody,
   CardHeader,
+  CardTitle,
+  Grid,
+  GridItem,
   Icon,
+  Text,
+  TextContent,
+  TextVariants,
 } from "@patternfly/react-core";
 import {
   CheckCircleIcon,

--- a/client/src/app/pages/source-platforms/discover-import-wizard/useWizardReducer.ts
+++ b/client/src/app/pages/source-platforms/discover-import-wizard/useWizardReducer.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { FilterState } from "./filter-input";
 import { ResultsData } from "./results";
 

--- a/client/src/app/pages/tasks/TaskActionColumn.tsx
+++ b/client/src/app/pages/tasks/TaskActionColumn.tsx
@@ -1,7 +1,8 @@
 import React, { FC } from "react";
+import { ActionsColumn } from "@patternfly/react-table";
 
 import { Task } from "@app/api/models";
-import { ActionsColumn } from "@patternfly/react-table";
+
 import { useTaskActions } from "./useTaskActions";
 
 export const TaskActionColumn: FC<{ task: Task<unknown> }> = ({ task }) => {

--- a/client/src/app/pages/tasks/TaskDetails.tsx
+++ b/client/src/app/pages/tasks/TaskDetails.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
 
 import { Paths, TaskDetailsAttachmentRoute } from "@app/Paths";
 import "@app/components/simple-document-viewer/SimpleDocumentViewer.css";
-import { formatPath } from "@app/utils/utils";
-import { TaskDetailsBase } from "./TaskDetailsBase";
 import { useFetchApplicationById } from "@app/queries/applications";
+import { formatPath } from "@app/utils/utils";
+
+import { TaskDetailsBase } from "./TaskDetailsBase";
 
 export const TaskDetails = () => {
   const { t } = useTranslation();

--- a/client/src/app/pages/tasks/TaskDetailsBase.tsx
+++ b/client/src/app/pages/tasks/TaskDetailsBase.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-
+import { useHistory, useLocation } from "react-router-dom";
 import { PageSection } from "@patternfly/react-core";
 
 import { PageHeader, PageHeaderProps } from "@app/components/PageHeader";

--- a/client/src/app/pages/tasks/tasks-page.tsx
+++ b/client/src/app/pages/tasks/tasks-page.tsx
@@ -14,14 +14,21 @@ import {
 import {
   Table,
   Tbody,
+  Td,
   Th,
+  ThProps,
   Thead,
   Tr,
-  Td,
-  ThProps,
 } from "@patternfly/react-table";
 
+import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { Paths } from "@app/Paths";
+import { Task, TaskState } from "@app/api/models";
+import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
+import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
+import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
   TableHeaderContentWithControls,
@@ -33,18 +40,11 @@ import {
   useTableControlProps,
   useTableControlState,
 } from "@app/hooks/table-controls";
-
-import { SimplePagination } from "@app/components/SimplePagination";
-import { IconWithLabel, TaskStateIcon } from "@app/components/Icons";
-import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
-import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
-import { TablePersistenceKeyPrefix } from "@app/Constants";
-
 import { useServerTasks } from "@app/queries/tasks";
-import { Task, TaskState } from "@app/api/models";
 import { formatPath } from "@app/utils/utils";
-import { Paths } from "@app/Paths";
+
 import { ManageColumnsToolbar } from "../applications/applications-table/components/manage-columns-toolbar";
+
 import { TaskActionColumn } from "./TaskActionColumn";
 
 export const taskStateToLabel: Record<TaskState, string> = {

--- a/client/src/app/pages/tasks/useTaskActions.tsx
+++ b/client/src/app/pages/tasks/useTaskActions.tsx
@@ -1,15 +1,15 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 
+import { Paths } from "@app/Paths";
+import { Task, TaskState } from "@app/api/models";
+import { NotificationsContext } from "@app/components/NotificationsContext";
 import {
   useCancelTaskMutation,
   useUpdateTaskMutation,
 } from "@app/queries/tasks";
-import { Task, TaskState } from "@app/api/models";
-import { NotificationsContext } from "@app/components/NotificationsContext";
-import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
 import { formatPath } from "@app/utils/utils";
-import { Paths } from "@app/Paths";
 
 const canCancel = (state: TaskState = "No task") =>
   !["Succeeded", "Failed", "Canceled"].includes(state);

--- a/client/src/app/queries/analysis.ts
+++ b/client/src/app/queries/analysis.ts
@@ -1,15 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
+
 import {
-  AnalysisReportFile,
   AnalysisIncident,
   AnalysisInsight,
   AnalysisReportApplicationInsight,
+  AnalysisReportFile,
   AnalysisReportInsight,
   HubPaginatedResult,
   HubRequestParams,
+  UiAnalysisReportApplicationInsight,
   UiAnalysisReportInsight,
   WithUiId,
-  UiAnalysisReportApplicationInsight,
 } from "@app/api/models";
 import {
   getInsight,

--- a/client/src/app/queries/archetypes.ts
+++ b/client/src/app/queries/archetypes.ts
@@ -1,6 +1,9 @@
+import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-
 import { AxiosError } from "axios";
+import { objectify } from "radash";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { Archetype } from "@app/api/models";
 import {
   createArchetype,
@@ -9,10 +12,8 @@ import {
   getArchetypes,
   updateArchetype,
 } from "@app/api/rest";
+
 import { assessmentsByItemIdQueryKey } from "./assessments";
-import { useMemo } from "react";
-import { objectify } from "radash";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const ARCHETYPES_QUERY_KEY = "archetypes";
 export const ARCHETYPE_QUERY_KEY = "archetype";

--- a/client/src/app/queries/assessments.ts
+++ b/client/src/app/queries/assessments.ts
@@ -5,7 +5,14 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import {
+  Assessment,
+  AssessmentWithSectionOrder,
+  InitialAssessment,
+} from "@app/api/models";
 import {
   createAssessment,
   deleteAssessment,
@@ -15,16 +22,10 @@ import {
   getAssessmentsByItemId,
   updateAssessment,
 } from "@app/api/rest";
-import { AxiosError } from "axios";
-import {
-  Assessment,
-  AssessmentWithSectionOrder,
-  InitialAssessment,
-} from "@app/api/models";
-import { QuestionnairesQueryKey } from "./questionnaires";
-import { ARCHETYPE_QUERY_KEY } from "./archetypes";
+
 import { ApplicationsQueryKey } from "./applications";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { ARCHETYPE_QUERY_KEY } from "./archetypes";
+import { QuestionnairesQueryKey } from "./questionnaires";
 
 export const assessmentsQueryKey = "assessments";
 export const assessmentQueryKey = "assessment";

--- a/client/src/app/queries/cache.ts
+++ b/client/src/app/queries/cache.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 
-import { deleteCache, getCache } from "@app/api/rest";
 import { isRWXSupported } from "@app/Constants";
+import { deleteCache, getCache } from "@app/api/rest";
 
 export const CacheQueryKey = "cache";
 export const CleanProgressQueryKey = "cleanProgress";

--- a/client/src/app/queries/dependencies.ts
+++ b/client/src/app/queries/dependencies.ts
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import {
   AnalysisDependency,
   HubPaginatedResult,
@@ -7,7 +9,6 @@ import {
 } from "@app/api/models";
 import { getAppDependencies, getDependencies } from "@app/api/rest";
 import { useWithUiId } from "@app/utils/query-utils";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const DependenciesQueryKey = "dependencies";
 export const AppDependenciesQueryKey = "appDependencies";

--- a/client/src/app/queries/facts.ts
+++ b/client/src/app/queries/facts.ts
@@ -1,9 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-
-import { getFacts } from "@app/api/rest";
 import { AxiosError } from "axios";
-import { Fact } from "@app/api/models";
+
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { Fact } from "@app/api/models";
+import { getFacts } from "@app/api/rest";
 
 export const FactsQueryKey = "facts";
 

--- a/client/src/app/queries/generators.ts
+++ b/client/src/app/queries/generators.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-
 import { AxiosError } from "axios";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { Generator } from "@app/api/models";
 import {
   createGenerator,
@@ -9,7 +10,6 @@ import {
   getGenerators,
   updateGenerator,
 } from "@app/api/rest";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const GENERATORS_QUERY_KEY = "generators";
 export const GENERATOR_QUERY_KEY = "generator";

--- a/client/src/app/queries/identities.ts
+++ b/client/src/app/queries/identities.ts
@@ -1,15 +1,15 @@
 import { useMemo } from "react";
-import { group } from "radash";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { group } from "radash";
 
+import { Identity, New } from "@app/api/models";
 import {
   createIdentity,
   deleteIdentity,
   getIdentities,
   updateIdentity,
 } from "@app/api/rest";
-import { AxiosError } from "axios";
-import { Identity, New } from "@app/api/models";
 
 export const IdentitiesQueryKey = "identities";
 

--- a/client/src/app/queries/imports.ts
+++ b/client/src/app/queries/imports.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import {
   deleteApplicationImportSummary,
-  getApplicationImports,
   getApplicationImportSummaryById,
+  getApplicationImports,
   getApplicationsImportSummary,
 } from "@app/api/rest";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const ImportSummariesQueryKey = "importsummaries";
 export const ImportsQueryKey = "imports";

--- a/client/src/app/queries/jobfunctions.ts
+++ b/client/src/app/queries/jobfunctions.ts
@@ -1,4 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
 import { JobFunction } from "@app/api/models";
 import {
   createJobFunction,
@@ -6,7 +8,6 @@ import {
   getJobFunctions,
   updateJobFunction,
 } from "@app/api/rest";
-import { AxiosError } from "axios";
 
 export const JobFunctionsQueryKey = "jobfunctions";
 

--- a/client/src/app/queries/migration-waves.ts
+++ b/client/src/app/queries/migration-waves.ts
@@ -1,19 +1,21 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import {
-  getMigrationWaves,
   createMigrationWave,
-  deleteMigrationWave,
-  updateMigrationWave,
   deleteAllMigrationWaves,
+  deleteMigrationWave,
   deleteTicket,
+  getMigrationWaves,
+  updateMigrationWave,
 } from "@app/api/rest";
 import { getWavesWithStatus } from "@app/utils/waves-selector";
-import { TicketsQueryKey, useFetchTickets } from "./tickets";
-import { TrackersQueryKey } from "./trackers";
+
 import { useFetchApplications } from "./applications";
 import { useFetchStakeholders } from "./stakeholders";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { TicketsQueryKey, useFetchTickets } from "./tickets";
+import { TrackersQueryKey } from "./trackers";
 
 export const MigrationWavesQueryKey = "migration-waves";
 

--- a/client/src/app/queries/proxies.ts
+++ b/client/src/app/queries/proxies.ts
@@ -1,7 +1,8 @@
-import { AxiosError } from "axios";
-import { getProxies, updateProxy } from "@app/api/rest";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { getProxies, updateProxy } from "@app/api/rest";
 
 export const ProxiesTasksQueryKey = "proxies";
 

--- a/client/src/app/queries/questionnaires.ts
+++ b/client/src/app/queries/questionnaires.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios, { AxiosError } from "axios";
+import saveAs from "file-saver";
 import yaml from "js-yaml";
 
+import { LooseQuestionnaire, Questionnaire } from "@app/api/models";
 import {
   QUESTIONNAIRES,
   createQuestionnaire,
@@ -10,8 +12,6 @@ import {
   getQuestionnaires,
   updateQuestionnaire,
 } from "@app/api/rest";
-import { LooseQuestionnaire, Questionnaire } from "@app/api/models";
-import saveAs from "file-saver";
 
 export const QuestionnairesQueryKey = "questionnaires";
 export const QuestionnaireByIdQueryKey = "questionnaireById";

--- a/client/src/app/queries/reviews.ts
+++ b/client/src/app/queries/reviews.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { New, Review } from "@app/api/models";
 import {
   createReview,
   deleteReview,
@@ -8,9 +10,8 @@ import {
   getReviews,
   updateReview,
 } from "@app/api/rest";
-import { New, Review } from "@app/api/models";
+
 import { ApplicationsQueryKey } from "./applications";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const reviewQueryKey = "review";
 export const reviewsByItemIdQueryKey = "reviewsByItemId";

--- a/client/src/app/queries/settings.ts
+++ b/client/src/app/queries/settings.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { getSettingById, updateSetting } from "@app/api/rest";
-import { SettingTypes } from "@app/api/models";
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { SettingTypes } from "@app/api/models";
+import { getSettingById, updateSetting } from "@app/api/rest";
 
 export const SettingQueryKey = "setting";
 

--- a/client/src/app/queries/stakeholdergroups.ts
+++ b/client/src/app/queries/stakeholdergroups.ts
@@ -1,12 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import {
   createStakeholderGroup,
   deleteStakeholderGroup,
   getStakeholderGroups,
   updateStakeholderGroup,
 } from "@app/api/rest";
-import { AxiosError } from "axios";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const StakeholderGroupsQueryKey = "stakeholderGroups";
 

--- a/client/src/app/queries/tags.ts
+++ b/client/src/app/queries/tags.ts
@@ -1,17 +1,17 @@
 import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
 import {
+  createTag,
+  createTagCategory,
   deleteTag,
   deleteTagCategory,
-  getTags,
   getTagCategories,
-  createTag,
+  getTags,
   updateTag,
-  createTagCategory,
   updateTagCategory,
 } from "@app/api/rest";
-import { AxiosError } from "axios";
 import { universalComparator } from "@app/utils/utils";
 
 export const TagsQueryKey = "tags";

--- a/client/src/app/queries/targets.ts
+++ b/client/src/app/queries/targets.ts
@@ -1,4 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError, AxiosResponse } from "axios";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { HubFile, Target } from "@app/api/models";
 import {
   createFile,
@@ -7,8 +10,6 @@ import {
   getTargets,
   updateTarget,
 } from "@app/api/rest";
-import { AxiosError, AxiosResponse } from "axios";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const TargetsQueryKey = "targets";
 

--- a/client/src/app/queries/taskgroups.ts
+++ b/client/src/app/queries/taskgroups.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError, AxiosResponse } from "axios";
 
+import { Taskgroup } from "@app/api/models";
 import {
   createTaskgroup,
   deleteTaskgroup,
@@ -7,8 +9,7 @@ import {
   submitTaskgroup,
   uploadFileTaskgroup,
 } from "@app/api/rest";
-import { Taskgroup } from "@app/api/models";
-import { AxiosError, AxiosResponse } from "axios";
+
 import { TasksQueryKey } from "./tasks";
 
 export const useCreateTaskgroupMutation = (

--- a/client/src/app/queries/tasks.ts
+++ b/client/src/app/queries/tasks.ts
@@ -5,6 +5,15 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import {
+  HubPaginatedResult,
+  HubRequestParams,
+  New,
+  Task,
+  TaskDashboard,
+  TaskQueue,
+} from "@app/api/models";
 import {
   cancelTask,
   cancelTasks,
@@ -20,15 +29,6 @@ import {
   updateTask,
 } from "@app/api/rest";
 import { universalComparator } from "@app/utils/utils";
-import {
-  HubPaginatedResult,
-  HubRequestParams,
-  Task,
-  TaskQueue,
-  TaskDashboard,
-  New,
-} from "@app/api/models";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const TaskStates = {
   Canceled: ["Canceled"],

--- a/client/src/app/queries/tickets.ts
+++ b/client/src/app/queries/tickets.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-
-import { createTickets, getTickets } from "@app/api/rest";
 import { AxiosError } from "axios";
-import { New, Ref, Ticket } from "@app/api/models";
+
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { New, Ref, Ticket } from "@app/api/models";
+import { createTickets, getTickets } from "@app/api/rest";
 
 export const TicketsQueryKey = "tickets";
 

--- a/client/src/app/queries/trackers.ts
+++ b/client/src/app/queries/trackers.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { Tracker } from "@app/api/models";
 import {
   createTracker,
   deleteTracker,
@@ -9,9 +11,8 @@ import {
   getTrackers,
   updateTracker,
 } from "@app/api/rest";
-import { Tracker } from "@app/api/models";
+
 import { TicketsQueryKey } from "./tickets";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const TrackersQueryKey = "trackers";
 export const TrackerProjectsQueryKey = "trackerProjects";

--- a/client/src/app/rbac.ts
+++ b/client/src/app/rbac.ts
@@ -1,6 +1,6 @@
-import { checkAccess } from "./utils/rbac-utils";
 import { isAuthRequired } from "./Constants";
 import keycloak from "./keycloak";
+import { checkAccess } from "./utils/rbac-utils";
 interface IRBACProps {
   allowedPermissions: string[];
   children: any;

--- a/client/src/app/test-config/setupTests.ts
+++ b/client/src/app/test-config/setupTests.ts
@@ -1,6 +1,5 @@
-import { server } from "@mocks/server";
-
 // init @testing-library
+import { server } from "@mocks/server";
 import "@testing-library/jest-dom";
 import { configure } from "@testing-library/react";
 

--- a/client/src/app/test-config/test-utils.tsx
+++ b/client/src/app/test-config/test-utils.tsx
@@ -1,15 +1,14 @@
 import React, { FC, ReactElement } from "react";
+import { createContext, useContext } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
-  render,
-  renderHook,
   RenderHookOptions,
   RenderOptions,
+  render,
+  renderHook,
 } from "@testing-library/react";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Application, Archetype, Assessment } from "@app/api/models";
-
-import { createContext, useContext } from "react";
 
 const QueryClientContext = createContext<QueryClient | undefined>(undefined);
 

--- a/client/src/app/utils/application-assessment-status.ts
+++ b/client/src/app/utils/application-assessment-status.ts
@@ -41,9 +41,8 @@ export const buildApplicationAssessmentStatus = (
   const directStatus = chooseAssessmentStatus(application.assessed, direct);
 
   const inherited = archetypes
-    .filter(
-      (archetype) =>
-        archetype.applications?.some(({ id }) => id === application.id)
+    .filter((archetype) =>
+      archetype.applications?.some(({ id }) => id === application.id)
     )
     .map((archetype) => {
       const archetypeAssessments = assessments.filter(
@@ -67,8 +66,8 @@ export const buildApplicationAssessmentStatus = (
     inherited.every(({ status }) => status === "none")
       ? "none"
       : inherited.every(({ status }) => status === "complete")
-      ? "complete"
-      : "partial";
+        ? "complete"
+        : "partial";
 
   return {
     isDirectlyAssessed,

--- a/client/src/app/utils/maven-settings/index.test.ts
+++ b/client/src/app/utils/maven-settings/index.test.ts
@@ -1,5 +1,6 @@
-import path from "node:path";
 import fs from "node:fs";
+import path from "node:path";
+
 import { validateSettingsXml } from "./index";
 
 function readFile(relativePath: string) {

--- a/client/src/app/utils/query-utils.ts
+++ b/client/src/app/utils/query-utils.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+
 import { UI_UNIQUE_ID } from "@app/Constants";
 import { WithUiId } from "@app/api/models";
 

--- a/client/src/app/utils/rules-utils.ts
+++ b/client/src/app/utils/rules-utils.ts
@@ -1,5 +1,6 @@
-import { UploadFile, ParsedRule } from "@app/api/models";
 import yaml from "js-yaml";
+
+import { ParsedRule, UploadFile } from "@app/api/models";
 
 type RuleFileType = "YAML" | null;
 

--- a/client/src/app/utils/utils.test.ts
+++ b/client/src/app/utils/utils.test.ts
@@ -1,18 +1,20 @@
 import { AxiosError } from "axios";
+
+import { Paths } from "@app/Paths";
+
 import {
+  collapseSpacesAndCompare,
+  extractFirstSha,
+  formatPath,
   getAxiosErrorMessage,
+  getToolbarChipKey,
   getValidatedFromError,
   getValidatedFromErrors,
-  getToolbarChipKey,
+  intersection,
   isValidGitUrl,
   isValidStandardUrl,
   isValidSvnUrl,
-  formatPath,
-  extractFirstSha,
-  collapseSpacesAndCompare,
-  intersection,
 } from "./utils";
-import { Paths } from "@app/Paths";
 
 describe("utils", () => {
   // getAxiosErrorMessage

--- a/client/src/app/utils/waves-selector.ts
+++ b/client/src/app/utils/waves-selector.ts
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+
 import {
   AggregateTicketStatus,
   Application,
@@ -8,7 +10,6 @@ import {
   TicketStatus,
   WaveWithStatus,
 } from "@app/api/models";
-import dayjs from "dayjs";
 
 export const getWavesWithStatus = (
   waves: MigrationWave[],

--- a/client/src/app/yup.ts
+++ b/client/src/app/yup.ts
@@ -1,10 +1,11 @@
 import * as yup from "yup";
+
+import { validateSettingsXml } from "@app/utils/maven-settings";
 import {
   isValidGitUrl,
   isValidStandardUrl,
   isValidSvnUrl,
 } from "@app/utils/utils";
-import { validateSettingsXml } from "@app/utils/maven-settings";
 
 export {};
 declare module "yup" {

--- a/client/src/mocks/browser.ts
+++ b/client/src/mocks/browser.ts
@@ -1,4 +1,4 @@
-import { type RestHandler, setupWorker, rest } from "msw";
+import { type RestHandler, rest, setupWorker } from "msw";
 
 import config from "./config";
 import stubNewWork from "./stub-new-work";

--- a/client/src/mocks/stub-new-work/applications.ts
+++ b/client/src/mocks/stub-new-work/applications.ts
@@ -1,7 +1,7 @@
 import { rest } from "msw";
 
-import * as AppRest from "@app/api/rest";
 import { Application } from "@app/api/models";
+import * as AppRest from "@app/api/rest";
 
 function generateRandomId(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;

--- a/client/src/mocks/stub-new-work/archetypes.ts
+++ b/client/src/mocks/stub-new-work/archetypes.ts
@@ -1,7 +1,7 @@
 import { type RestHandler, rest } from "msw";
 
-import * as AppRest from "@app/api/rest";
 import type { Archetype, Tag, TagCategory } from "@app/api/models";
+import * as AppRest from "@app/api/rest";
 
 /**
  * Simple stub handlers as place holders until hub API is ready.

--- a/client/src/mocks/stub-new-work/assessments.ts
+++ b/client/src/mocks/stub-new-work/assessments.ts
@@ -1,7 +1,8 @@
-import { Assessment, InitialAssessment } from "@app/api/models";
 import { rest } from "msw";
 
+import { Assessment, InitialAssessment } from "@app/api/models";
 import * as AppRest from "@app/api/rest";
+
 import { mockApplicationArray } from "./applications";
 import questionnaireData from "./questionnaireData";
 

--- a/client/src/mocks/stub-new-work/index.ts
+++ b/client/src/mocks/stub-new-work/index.ts
@@ -1,4 +1,5 @@
 import { type RestHandler } from "msw";
+
 import { config } from "../config";
 
 import applications from "./applications";

--- a/client/src/mocks/stub-new-work/questionnaires.ts
+++ b/client/src/mocks/stub-new-work/questionnaires.ts
@@ -1,6 +1,7 @@
 import { type RestHandler, rest } from "msw";
 
 import * as AppRest from "@app/api/rest";
+
 import data from "./questionnaireData";
 
 /**


### PR DESCRIPTION
After setting up the "import/order" rule, there were a lot more lint warnings. This update fixes all of the import/order warnings plus other easy to fix warnings.

See #2584
