### PR TITLE
:seedling: Default repository type to Git with optional validation

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -534,7 +534,7 @@
     "sourcePlatforms": "Source platforms",
     "sourcePlatform": "Source platform",
     "sourcePlatformCoordinates": "Source platform coordinates",
-    "sourceRepo": "Source Repository",
+    "sourceRepo": "Source repository",
     "sourceRootPath": "Root path",
     "southboundDependencies": "Southbound dependencies",
     "stakeholder": "Stakeholder",
@@ -633,7 +633,8 @@
   "tooltip": {
     "priority": "Tasks priority, a non-negative number, impacts tasks scheduling policy. Lowest priority is 0. Higher priority tasks run before lower priority tasks.",
     "preemption": "If enabled, allows the scheduler to reschedule other running tasks to free cluster resources needed to run higher priority tasks.",
-    "defaultIdentity": "Credential {{name}} is the default credential for {{type}} types."
+    "defaultIdentity": "Credential {{name}} is the default credential for {{type}} types.",
+    "repositoryType": "Repository type will default to Git if left empty"
   },
   "validation": {
     "email": "This field requires a valid email.",

--- a/client/src/app/pages/applications/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/application-form/application-form.tsx
@@ -253,7 +253,7 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
           <HookFormPFGroupController
             control={control}
             name="kind"
-            label="Repository type"
+            label={t("terms.repositoryType")}
             fieldId="repository-type-select"
             renderInput={({ field: { value, name, onChange } }) => (
               <SimpleSelect
@@ -271,6 +271,18 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
                 }}
               />
             )}
+            labelIcon={
+              <Popover
+                position={PopoverPosition.top}
+                aria-label="More information for source repository type"
+                bodyContent={t("tooltip.repositoryType")}
+                className="popover"
+              >
+                <span className="pf-v5-c-icon pf-m-info">
+                  <QuestionCircleIcon />
+                </span>
+              </Popover>
+            }
           />
           <HookFormPFTextInput
             control={control}
@@ -278,9 +290,6 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
             label={t("terms.sourceRepo")}
             fieldId="sourceRepository"
             aria-label="source repository url"
-            isRequired={repositoryKindOptions.some(
-              ({ value }) => value === watchKind
-            )}
           />
           <HookFormPFTextInput
             control={control}
@@ -429,7 +438,7 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
           <HookFormPFGroupController
             control={control}
             name="assetKind"
-            label="Asset repository type"
+            label={t("terms.repositoryType")}
             fieldId="asset-repository-type-select"
             renderInput={({ field: { value, name, onChange } }) => (
               <SimpleSelect
@@ -447,6 +456,18 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
                 }}
               />
             )}
+            labelIcon={
+              <Popover
+                position={PopoverPosition.top}
+                aria-label="More information for asset repository type"
+                bodyContent={t("tooltip.repositoryType")}
+                className="popover"
+              >
+                <span className="pf-v5-c-icon pf-m-info">
+                  <QuestionCircleIcon />
+                </span>
+              </Popover>
+            }
           />
           <HookFormPFTextInput
             control={control}
@@ -454,9 +475,6 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
             label={t("terms.assetRepository")}
             fieldId="assetRepository"
             aria-label="asset repository url"
-            isRequired={repositoryKindOptions.some(
-              ({ value }) => value === watchAssetKind
-            )}
           />
           <HookFormPFTextInput
             control={control}

--- a/client/src/app/pages/applications/application-form/useApplicationForm.ts
+++ b/client/src/app/pages/applications/application-form/useApplicationForm.ts
@@ -119,10 +119,7 @@ export const useApplicationForm = ({
 
       // source code fields
       kind: string().oneOf(["", "git", "subversion"]),
-      sourceRepository: string().when("kind", {
-        is: (kind: string) => kind !== "",
-        then: (schema) => schema.repositoryUrl("kind").required(),
-      }),
+      sourceRepository: string().repositoryUrl("kind"),
       branch: string()
         .trim()
         .max(250, t("validation.maxLength", { length: 250 })),
@@ -167,10 +164,7 @@ export const useApplicationForm = ({
 
       // asset repository fields
       assetKind: string().oneOf(["", "git", "subversion"]),
-      assetRepository: string().when("assetKind", {
-        is: (kind: string) => kind !== "",
-        then: (schema) => schema.repositoryUrl("assetKind").required(),
-      }),
+      assetRepository: string().repositoryUrl("assetKind"),
       assetBranch: string()
         .trim()
         .max(250, t("validation.maxLength", { length: 250 })),

--- a/client/src/app/yup.ts
+++ b/client/src/app/yup.ts
@@ -34,13 +34,13 @@ yup.addMethod(
     return this.test("repositoryUrl", message, function (value) {
       const type = this.parent[repositoryTypeField];
       if (value) {
-        return type === "git"
+        return type === "git" || type === ""
           ? isValidGitUrl(value)
           : type === "svn" || type === "subversion"
             ? isValidSvnUrl(value)
             : isValidStandardUrl(value);
       }
-      return false;
+      return true;
     });
   }
 );


### PR DESCRIPTION
This is a suggested solution for: #2615 (and #2541)
  
- Modified repositoryUrl validation to default to Git when repository type is empty
- Made source and asset repository fields optional but validated when provided
- Removed required asterisk from repository URL fields in UI
- Added tooltip explaining repository type defaults to Git if empty

Before:

[before.webm](https://github.com/user-attachments/assets/fcac3ee1-0cec-42c1-b708-1ffc2471f927)

After:

[after.webm](https://github.com/user-attachments/assets/c9dbd09e-a638-49ce-a375-7afbf6711bdc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual help popovers for repository type fields in source and asset sections.
  * Repository type defaults to Git when left empty, with updated tooltip guidance.
  * Repository URLs are now optional; when provided, validation adapts to the selected (or defaulted) repository type.

* **Style**
  * Updated label capitalization: “Source Repository” → “Source repository”.

* **Chores**
  * Updated translations and keys for repository type and tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->