### PR TITLE
:bug: Fix application source and asset repository validation

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -653,7 +653,12 @@
     "invalidQuestionnaireYAML": "Invalid questionnaire YAML",
     "invalidValue": "Invalid value",
     "mustBeNumber": "Must be a number",
-    "notOneOf": "Value is not a valid option."
+    "notOneOf": "Value is not a valid option.",
+    "repositoryTypeRequired": "Repository type is required.",
+    "repositoryTypeRequiredWhen": "Repository type is required when URL, branch, or path is specified.",
+    "repositoryUrlRequired": "Repository URL is required.",
+    "repositoryUrlRequiredWhen": "Repository URL is required when branch or path is specified.",
+    "repositoryUrlInvalid": "Must be a valid repository URL."
   },
   "wizard": {
     "alert": {

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -126,8 +126,8 @@ export type EffortEstimate = "small" | "medium" | "large" | "extra_large";
 
 export type ImportSummaryStatus = "Completed" | "In Progress" | "Failed";
 
-export interface Repository {
-  kind?: string;
+export interface Repository<Kind = string> {
+  kind?: Kind;
   url?: string;
   branch?: string;
   path?: string;

--- a/client/src/app/components/repository-fields/RepositoryFields.tsx
+++ b/client/src/app/components/repository-fields/RepositoryFields.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import {
+  FieldPath,
+  FieldPathValue,
+  FieldValues,
+  Path,
+  useForm,
+  useWatch,
+} from "react-hook-form";
+
+import { Repository } from "@app/api/models";
+import {
+  HookFormPFGroupController,
+  HookFormPFTextInput,
+} from "@app/components/HookFormPFFields";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { RepositoryKind } from "@app/hooks/useRepositoryKind";
+import { toOptionLike } from "@app/utils/model-utils";
+
+import { isNotEmptyString } from "./model-utils";
+
+/**
+ * Type constraint to ensure the prefix points to a Repository field in TFormValues
+ */
+type RepositoryFieldPath<TFormValues extends FieldValues> = {
+  [K in FieldPath<TFormValues>]: FieldPathValue<TFormValues, K> extends
+    | Repository<RepositoryKind>
+    | undefined
+    ? K
+    : never;
+}[FieldPath<TFormValues>];
+
+export interface RepositoryFieldsProps<TFormValues extends FieldValues> {
+  form: ReturnType<typeof useForm<TFormValues>>;
+  /**
+   * The field path in TFormValues that points to a Repository object.
+   * TypeScript will ensure this path points to a Repository or Repository | undefined field.
+   */
+  prefix: RepositoryFieldPath<TFormValues>;
+  kindOptions: OptionWithValue<RepositoryKind>[];
+  labels: {
+    type: string;
+    url: string;
+    branch: string;
+    path: string;
+  };
+  fieldIds?: {
+    type?: string;
+    url?: string;
+    branch?: string;
+    path?: string;
+  };
+  toggleIds?: {
+    type?: string;
+  };
+  showRepositoryTypeTooltip?: boolean;
+}
+
+export const RepositoryFields = <TFormValues extends FieldValues>({
+  form,
+  prefix,
+  kindOptions,
+  labels,
+  fieldIds = {},
+  toggleIds = {},
+}: RepositoryFieldsProps<TFormValues>) => {
+  const { control, trigger } = form;
+
+  const nameKind = `${prefix}.kind` as Path<TFormValues>;
+  const nameUrl = `${prefix}.url` as Path<TFormValues>;
+  const nameBranch = `${prefix}.branch` as Path<TFormValues>;
+  const namePath = `${prefix}.path` as Path<TFormValues>;
+
+  const watchRepo = useWatch({
+    control,
+    name: prefix as Path<TFormValues>,
+  }) as Repository<RepositoryKind> | undefined;
+
+  const isTypeRequired =
+    isNotEmptyString(watchRepo?.url) ||
+    isNotEmptyString(watchRepo?.branch) ||
+    isNotEmptyString(watchRepo?.path);
+  const isUrlRequired =
+    isNotEmptyString(watchRepo?.branch) || isNotEmptyString(watchRepo?.path);
+
+  return (
+    <>
+      <HookFormPFGroupController
+        control={control}
+        name={nameKind}
+        label={labels.type}
+        fieldId={fieldIds.type || `${prefix}-type-select`}
+        aria-label={`${prefix} repository type`}
+        isRequired={isTypeRequired}
+        renderInput={({ field: { value, name, onChange } }) => (
+          <SimpleSelect
+            toggleId={toggleIds.type || `${prefix}-repo-type-toggle`}
+            toggleAriaLabel="Type select dropdown toggle"
+            aria-label={name}
+            value={value ? toOptionLike(value, kindOptions) : undefined}
+            options={kindOptions}
+            onChange={(selection) => {
+              const selectionValue = selection as OptionWithValue<string>;
+              onChange(selectionValue.value);
+              trigger(nameUrl);
+            }}
+          />
+        )}
+      />
+      <HookFormPFTextInput
+        control={control}
+        type="text"
+        aria-label={`${prefix} repository url`}
+        name={nameUrl}
+        label={labels.url}
+        fieldId={fieldIds.url || `${prefix}-repository-url`}
+        isRequired={isUrlRequired}
+      />
+      <HookFormPFTextInput
+        control={control}
+        type="text"
+        aria-label="Repository branch"
+        name={nameBranch}
+        label={labels.branch}
+        fieldId={fieldIds.branch || `${prefix}-branch`}
+      />
+      <HookFormPFTextInput
+        control={control}
+        type="text"
+        aria-label={`${prefix} repository root path`}
+        name={namePath}
+        label={labels.path}
+        fieldId={fieldIds.path || `${prefix}-path`}
+      />
+    </>
+  );
+};

--- a/client/src/app/components/repository-fields/index.ts
+++ b/client/src/app/components/repository-fields/index.ts
@@ -1,0 +1,3 @@
+export * from "./model-utils";
+export * from "./schema";
+export * from "./RepositoryFields";

--- a/client/src/app/components/repository-fields/model-utils.ts
+++ b/client/src/app/components/repository-fields/model-utils.ts
@@ -1,0 +1,18 @@
+import { Repository } from "@app/api/models";
+import { RepositoryKind } from "@app/hooks/useRepositoryKind";
+
+export const normalizeRepository = (repository: Repository<RepositoryKind>) => {
+  return {
+    kind: repository.kind?.trim() ?? "",
+    url: repository.url?.trim() ?? "",
+    branch: repository.branch?.trim() ?? "",
+    path: repository.path?.trim() ?? "",
+  };
+};
+
+export const isNotEmptyString = (value: unknown) => {
+  if (typeof value !== "string") {
+    return false;
+  }
+  return value.length > 0;
+};

--- a/client/src/app/components/repository-fields/schema.test.ts
+++ b/client/src/app/components/repository-fields/schema.test.ts
@@ -1,0 +1,732 @@
+import * as yup from "yup";
+
+import { yupRepositoryFields } from "./schema";
+import "@app/yup"; // Import custom yup methods
+
+const tt = (key: string) => key;
+
+describe("yupRepositoryFields", () => {
+  describe("custom translation function", () => {
+    it("should use custom translation function for error messages", async () => {
+      const customT = jest.fn((key: string) => `Custom: ${key}`);
+      const schema = yupRepositoryFields({ t: customT, isRequired: true });
+
+      await expect(
+        schema.validate({
+          kind: "",
+        })
+      ).rejects.toThrow("Custom: validation.repositoryTypeRequired");
+      expect(customT).toHaveBeenCalled();
+    });
+
+    it("should use custom translation function with interpolation", async () => {
+      const customT = jest.fn(
+        (key: string, options?: Record<string, unknown>) => {
+          if (key === "validation.maxLength") {
+            return `Maximum ${options?.length} chars`;
+          }
+          return key;
+        }
+      );
+      const schema = yupRepositoryFields({ t: customT });
+      const longBranch = "a".repeat(251);
+
+      await expect(
+        schema.validate({
+          kind: "git",
+          url: "https://github.com/test/repo.git",
+          branch: longBranch,
+          path: "",
+        })
+      ).rejects.toThrow("Maximum 250 chars");
+      expect(customT).toHaveBeenCalled();
+    });
+  });
+
+  describe("basic validation", () => {
+    it("should accept empty object when not required", async () => {
+      const schema = yupRepositoryFields({ isRequired: false });
+      await expect(schema.validate({})).resolves.toBeDefined();
+    });
+
+    it("should accept kind but empty url when not required", async () => {
+      const schema = yupRepositoryFields({ isRequired: false });
+      await expect(
+        schema.validate({
+          kind: "git",
+          url: "",
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it("should reject empty object when required", async () => {
+      const schema = yupRepositoryFields({ isRequired: true });
+      await expect(schema.validate({})).rejects.toThrow();
+    });
+  });
+
+  describe("standalone schema", () => {
+    describe("kind field", () => {
+      it("should accept empty string when allowEmptyKind is true (default) without url", async () => {
+        const schema = yupRepositoryFields();
+        await expect(schema.validate({ kind: "" })).resolves.toBeDefined();
+      });
+
+      it("should accept 'git' as a valid kind with valid url", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should accept 'subversion' as a valid kind with valid url", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "subversion",
+            url: "https://svn.example.com/repo",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should reject invalid kind values", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "invalid",
+          })
+        ).rejects.toThrow();
+      });
+
+      it("should reject empty string when allowEmptyKind is false", async () => {
+        const schema = yupRepositoryFields({ allowEmptyKind: false });
+        await expect(
+          schema.validate({
+            kind: "",
+          })
+        ).rejects.toThrow();
+      });
+
+      it("should require kind when url is provided", async () => {
+        const schema = yupRepositoryFields({ t: tt });
+        await expect(
+          schema.validate({
+            kind: "",
+            url: "https://github.com/test/repo",
+          })
+        ).rejects.toThrow("validation.repositoryTypeRequiredWhen");
+      });
+
+      it("should require kind when branch is provided", async () => {
+        const schema = yupRepositoryFields({ t: tt });
+        await expect(
+          schema.validate({
+            kind: "",
+            branch: "main",
+          })
+        ).rejects.toThrow("validation.repositoryTypeRequiredWhen");
+      });
+
+      it("should require kind when path is provided", async () => {
+        const schema = yupRepositoryFields({ t: tt });
+        await expect(
+          schema.validate({
+            kind: "",
+            path: "/src",
+          })
+        ).rejects.toThrow("validation.repositoryTypeRequiredWhen");
+      });
+
+      it("should require kind when isRequired is true", async () => {
+        const schema = yupRepositoryFields({ isRequired: true, t: tt });
+        await expect(
+          schema.validate({
+            kind: "",
+          })
+        ).rejects.toThrow("validation.repositoryTypeRequired");
+      });
+
+      it("should require kind when isRequired function returns true", async () => {
+        const schema = yupRepositoryFields({ isRequired: () => true, t: tt });
+        await expect(
+          schema.validate({
+            kind: "",
+          })
+        ).rejects.toThrow("validation.repositoryTypeRequired");
+      });
+
+      it("should not require kind when isRequired function returns false", async () => {
+        const schema = yupRepositoryFields({ isRequired: () => false });
+        await expect(
+          schema.validate({
+            kind: "",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should restrict to custom allowed kinds", async () => {
+        const schema = yupRepositoryFields({
+          allowedKinds: ["git"],
+          allowEmptyKind: false,
+        });
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+          })
+        ).resolves.toBeDefined();
+        await expect(
+          schema.validate({
+            kind: "subversion",
+          })
+        ).rejects.toThrow();
+      });
+    });
+
+    describe("url field", () => {
+      it("should require url when branch is provided", async () => {
+        const schema = yupRepositoryFields({ t: tt });
+        await expect(
+          schema.validate({
+            kind: "git",
+            branch: "main",
+          })
+        ).rejects.toThrow("validation.repositoryUrlRequiredWhen");
+      });
+
+      it("should require url when path is provided", async () => {
+        const schema = yupRepositoryFields({ t: tt });
+        await expect(
+          schema.validate({
+            kind: "git",
+            path: "/src",
+          })
+        ).rejects.toThrow("validation.repositoryUrlRequiredWhen");
+      });
+
+      it("should require url when isRequired is true", async () => {
+        const schema = yupRepositoryFields({ isRequired: true, t: tt });
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "",
+          })
+        ).rejects.toThrow("validation.repositoryUrlRequired");
+      });
+
+      it("should require url when isRequired function returns true", async () => {
+        const schema = yupRepositoryFields({ isRequired: () => true, t: tt });
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "",
+          })
+        ).rejects.toThrow("validation.repositoryUrlRequired");
+      });
+
+      it("should NOT require url when isRequired function returns false, kind is valid, and url omitted", async () => {
+        const schema = yupRepositoryFields({ isRequired: () => false, t: tt });
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should validate git URL format when kind is git", async () => {
+        const schema = yupRepositoryFields({ t: tt });
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should reject invalid git URL format when kind is git", async () => {
+        const schema = yupRepositoryFields({ t: tt });
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "not-a-valid-url",
+          })
+        ).rejects.toThrow("validation.repositoryUrlInvalid");
+      });
+    });
+
+    describe("branch field", () => {
+      it("should accept empty branch", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "",
+            branch: "",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should accept valid branch name", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            branch: "main",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should trim whitespace from branch", async () => {
+        const schema = yupRepositoryFields();
+        const result = await schema.validate({
+          kind: "git",
+          url: "https://github.com/test/repo.git",
+          branch: "  main  ",
+        });
+        expect(result.branch).toBe("main");
+      });
+
+      it("should reject branch exceeding 250 characters", async () => {
+        const schema = yupRepositoryFields({ t: tt });
+        const longBranch = "a".repeat(251);
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            branch: longBranch,
+          })
+        ).rejects.toThrow("validation.maxLength");
+      });
+
+      it("should accept branch with exactly 250 characters", async () => {
+        const schema = yupRepositoryFields();
+        const maxBranch = "a".repeat(250);
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            branch: maxBranch,
+          })
+        ).resolves.toBeDefined();
+      });
+    });
+
+    describe("path field", () => {
+      it("should accept empty path", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "",
+            path: "",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should accept valid path", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            path: "/src/main",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should trim whitespace from path", async () => {
+        const schema = yupRepositoryFields();
+        const result = await schema.validate({
+          kind: "git",
+          url: "https://github.com/test/repo.git",
+          path: "  /src/main  ",
+        });
+        expect(result.path).toBe("/src/main");
+      });
+
+      it("should reject path exceeding 250 characters", async () => {
+        const schema = yupRepositoryFields();
+        const longPath = "/" + "a".repeat(250);
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            path: longPath,
+          })
+        ).rejects.toThrow("Maximum length is 250 characters");
+      });
+
+      it("should accept path with exactly 250 characters", async () => {
+        const schema = yupRepositoryFields();
+        const maxPath = "/" + "a".repeat(249);
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            path: maxPath,
+          })
+        ).resolves.toBeDefined();
+      });
+    });
+
+    describe("field interdependencies", () => {
+      it("should validate complete repository data", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            branch: "main",
+            path: "/src",
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it("should require both kind and url when branch is set", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "",
+            branch: "main",
+          })
+        ).rejects.toThrow();
+      });
+
+      it("should require both kind and url when path is set", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "",
+            path: "/src",
+          })
+        ).rejects.toThrow();
+      });
+
+      it("should allow branch and path together with valid kind and url", async () => {
+        const schema = yupRepositoryFields();
+        await expect(
+          schema.validate({
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            branch: "develop",
+            path: "/backend",
+          })
+        ).resolves.toBeDefined();
+      });
+    });
+  });
+
+  describe("schema as part of a bigger object", () => {
+    it("should validate repository fields within a larger schema", async () => {
+      const applicationSchema = yup.object().shape({
+        name: yup.string().required("Name is required"),
+        description: yup.string(),
+        repository: yupRepositoryFields(),
+      });
+
+      await expect(
+        applicationSchema.validate({
+          name: "My App",
+          description: "Test application",
+          repository: {
+            kind: "git",
+            url: "https://github.com/test/repo.git",
+            branch: "main",
+            path: "",
+          },
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it("should fail validation when repository fields are invalid in larger object", async () => {
+      const applicationSchema = yup.object().shape({
+        name: yup.string().required("Name is required"),
+        repository: yupRepositoryFields(),
+      });
+
+      await expect(
+        applicationSchema.validate({
+          name: "My App",
+          repository: {
+            kind: "",
+            branch: "main", // branch requires url and kind
+            path: "",
+          },
+        })
+      ).rejects.toThrow();
+    });
+
+    it("should handle nested repository fields with isRequired option", async () => {
+      const migrationTargetSchema = yup.object().shape({
+        name: yup.string().required(),
+        rules: yup.object().shape({
+          repository: yupRepositoryFields({ isRequired: true, t: tt }),
+        }),
+      });
+
+      await expect(
+        migrationTargetSchema.validate({
+          name: "Target 1",
+          rules: {
+            repository: {
+              kind: "",
+              branch: "",
+              path: "",
+            },
+          },
+        })
+      ).rejects.toThrow("validation.repositoryTypeRequired");
+    });
+
+    it("should validate multiple repository objects in array", async () => {
+      const schema = yup.object().shape({
+        repositories: yup.array().of(yupRepositoryFields()),
+      });
+
+      await expect(
+        schema.validate({
+          repositories: [
+            {
+              kind: "git",
+              url: "https://github.com/repo1.git",
+              branch: "main",
+              path: "",
+            },
+            {
+              kind: "subversion",
+              url: "https://svn.example.com/repo2",
+              branch: "",
+              path: "/trunk",
+            },
+          ],
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it("should fail when one repository in array is invalid", async () => {
+      const schema = yup.object().shape({
+        repositories: yup.array().of(yupRepositoryFields()),
+      });
+
+      await expect(
+        schema.validate({
+          repositories: [
+            {
+              kind: "git",
+              url: "https://github.com/repo1.git",
+              branch: "main",
+              path: "",
+            },
+            {
+              kind: "", // Invalid: missing kind when url is provided
+              url: "https://github.com/repo2.git",
+              branch: "",
+              path: "",
+            },
+          ],
+        })
+      ).rejects.toThrow();
+    });
+
+    it("should work with conditional repository fields based on parent context", async () => {
+      const formSchema = yup.object().shape({
+        rulesKind: yup.string().oneOf(["manual", "repository"]),
+        repository: yup.object().when("rulesKind", {
+          is: "repository",
+          then: (schema) =>
+            schema.concat(yupRepositoryFields({ isRequired: true })),
+          otherwise: (schema) =>
+            schema.concat(yupRepositoryFields({ isRequired: false })),
+        }),
+      });
+
+      // Should require repository fields when rulesKind is "repository"
+      await expect(
+        formSchema.validate({
+          rulesKind: "repository",
+          repository: {
+            kind: "",
+            url: "",
+            branch: "",
+            path: "",
+          },
+        })
+      ).rejects.toThrow();
+
+      // Should not require repository fields when rulesKind is "manual"
+      await expect(
+        formSchema.validate({
+          rulesKind: "manual",
+          repository: {
+            kind: "",
+            url: "",
+            branch: "",
+            path: "",
+          },
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it.skip("should work with dynamic isRequired based on sibling field", async () => {
+      const schema = yup.object().shape({
+        hasRepository: yup.boolean(),
+        repository: yupRepositoryFields({
+          isRequired: (context?: any) => {
+            // In yup 0.32, context.from[1] contains the parent of the repository object
+            // context.parent is the repository object itself
+            // context.from[1].value is the top-level object containing hasRepository
+            const topLevelObject = context.from?.[1]?.value;
+            return topLevelObject?.hasRepository === true;
+          },
+        }),
+      });
+
+      await expect(
+        schema.validate({
+          hasRepository: true,
+          repository: {
+            kind: "",
+            url: "",
+            branch: "",
+            path: "",
+          },
+        })
+      ).rejects.toThrow();
+
+      await expect(
+        schema.validate({
+          hasRepository: false,
+          repository: {
+            kind: "",
+            url: "",
+            branch: "",
+            path: "",
+          },
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it("should preserve other fields when validating repository", async () => {
+      const schema = yup.object().shape({
+        id: yup.number(),
+        name: yup.string().required(),
+        repository: yupRepositoryFields(),
+      });
+
+      const result = await schema.validate({
+        id: 123,
+        name: "Test App",
+        repository: {
+          kind: "git",
+          url: "https://github.com/test/repo.git",
+          branch: "  main  ",
+          path: "  /src  ",
+        },
+      });
+
+      expect(result.id).toBe(123);
+      expect(result.name).toBe("Test App");
+      expect(result.repository.branch).toBe("main");
+      expect(result.repository.path).toBe("/src");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle omitted fields as empty", async () => {
+      const schema = yupRepositoryFields();
+      await expect(
+        schema.validate({
+          kind: "",
+          url: "",
+          branch: "",
+          path: "",
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it("should handle empty strings for all fields", async () => {
+      const schema = yupRepositoryFields();
+      await expect(
+        schema.validate({
+          kind: "",
+          url: "",
+          branch: "",
+          path: "",
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it("should handle partial objects with valid data", async () => {
+      const schema = yupRepositoryFields();
+      await expect(
+        schema.validate({
+          kind: "git",
+          url: "https://github.com/test/repo.git",
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it("should handle whitespace-only strings for branch and path", async () => {
+      const schema = yupRepositoryFields();
+      const result = await schema.validate({
+        kind: "",
+        branch: "   ",
+        path: "   ",
+      });
+      expect(result.branch).toBe("");
+      expect(result.path).toBe("");
+    });
+
+    it("should validate with all options combined", async () => {
+      const schema = yupRepositoryFields({
+        isRequired: true,
+        allowEmptyKind: false,
+        allowedKinds: ["git"],
+      });
+
+      await expect(
+        schema.validate({
+          kind: "git",
+          url: "https://github.com/test/repo.git",
+          branch: "main",
+          path: "/src",
+        })
+      ).resolves.toBeDefined();
+
+      await expect(
+        schema.validate({
+          kind: "",
+          url: "",
+          branch: "",
+          path: "",
+        })
+      ).rejects.toThrow();
+    });
+
+    it("should handle kind with url but no branch or path", async () => {
+      const schema = yupRepositoryFields();
+      await expect(
+        schema.validate({
+          kind: "git",
+          url: "https://github.com/test/repo.git",
+          branch: "",
+          path: "",
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it("should reject when branch and path provided without url", async () => {
+      const schema = yupRepositoryFields();
+      await expect(
+        schema.validate({
+          kind: "git",
+          branch: "main",
+          path: "/src",
+        })
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/client/src/app/components/repository-fields/schema.ts
+++ b/client/src/app/components/repository-fields/schema.ts
@@ -1,0 +1,138 @@
+import { TFunction } from "i18next";
+import { get, template } from "radash";
+import { FieldPath } from "react-hook-form";
+import * as yup from "yup";
+
+import { RepositoryKind } from "@app/hooks/useRepositoryKind";
+
+import { isNotEmptyString } from "./model-utils";
+
+export interface RepositorySchemaOptions {
+  /** Translation function for error messages */
+  t?: TFunction | ((k: string, v?: Record<string, unknown>) => string);
+
+  /** Whether the repository fields are required (e.g., when rulesKind is "repository") */
+  isRequired?: boolean | (() => boolean);
+
+  /** Allow empty string for kind when no repoUrl is provided */
+  allowEmptyKind?: boolean;
+
+  /** Allowed repository kinds (defaults to ["", "git", "subversion"]) */
+  allowedKinds?: RepositoryKind[];
+
+  /** Default repository kind (defaults to "git") */
+  defaultKind?: RepositoryKind;
+}
+
+const DEFAULT_MESSAGES = {
+  validation: {
+    repositoryTypeRequiredWhen:
+      "Repository type is required when URL, branch, or path is specified.",
+    repositoryUrlRequiredWhen:
+      "Repository URL is required when branch or path is specified.",
+    repositoryTypeRequired: "Repository type is required.",
+    repositoryUrlRequired: "Repository URL is required.",
+    maxLength: "Maximum length is {{length}} characters.",
+    repositoryUrlInvalid: "Must be a valid repository URL.",
+  },
+};
+
+const DEFAULT_T = (
+  key: FieldPath<typeof DEFAULT_MESSAGES>,
+  options?: Record<string, unknown>
+) => {
+  const message = get(DEFAULT_MESSAGES, key) as string;
+  return options ? template(message, options) : message;
+};
+
+/**
+ * Creates a schema for repository fields (kind, url, branch, path).
+ * This method can be chained on yup.object() to add repository field validation.
+ *
+ * This handles the interdependencies between these fields:
+ * - kind can be empty only when url is not provided
+ * - url is required when branch or path is specified
+ * - All fields can be conditionally required based on context
+ */
+export const yupRepositoryFields = ({
+  t: tFromOptions,
+  isRequired = false,
+  allowEmptyKind = true,
+  allowedKinds = ["", "git", "subversion"],
+}: RepositorySchemaOptions = {}) => {
+  const t = tFromOptions ?? DEFAULT_T;
+  const checkIsRequired = () =>
+    typeof isRequired === "function" ? isRequired() : isRequired;
+
+  const kindSchema = yup
+    .string()
+    .oneOf(
+      allowEmptyKind ? allowedKinds : allowedKinds.filter(isNotEmptyString)
+    )
+    .when(["url", "branch", "path"], {
+      is: (url: string, branch: string, path: string) =>
+        isNotEmptyString(url) ||
+        isNotEmptyString(branch) ||
+        isNotEmptyString(path),
+      then: (schema) =>
+        schema.required(t("validation.repositoryTypeRequiredWhen")),
+    })
+    .test({
+      name: "required",
+      message: t("validation.repositoryTypeRequired"),
+      exclusive: true,
+      test: function (value) {
+        if (checkIsRequired()) {
+          return isNotEmptyString(value);
+        }
+        return true;
+      },
+    });
+
+  const urlSchema = yup
+    .string()
+    .when(["branch", "path"], {
+      is: (branch: string, path: string) =>
+        isNotEmptyString(branch) || isNotEmptyString(path),
+      then: (schema) =>
+        schema.required(t("validation.repositoryUrlRequiredWhen")),
+    })
+    .when("kind", (kind: string, schema) => {
+      const isKindPresent = isNotEmptyString(kind);
+      const isExplicitlyRequired = checkIsRequired();
+
+      if (isKindPresent && isExplicitlyRequired) {
+        schema = schema.required(t("validation.repositoryUrlRequiredWhen"));
+      }
+      if (isKindPresent) {
+        schema = schema.repositoryUrl(
+          "kind",
+          !isExplicitlyRequired,
+          t("validation.repositoryUrlInvalid")
+        );
+      }
+
+      return schema;
+    });
+
+  const maxLengthMessage = t("validation.maxLength", { length: 250 });
+
+  const branchSchema = yup.string().trim().max(250, maxLengthMessage);
+
+  const pathSchema = yup.string().trim().max(250, maxLengthMessage);
+
+  return yup.object().shape(
+    {
+      kind: kindSchema,
+      url: urlSchema,
+      branch: branchSchema,
+      path: pathSchema,
+    },
+    // Handle circular dependencies between fields
+    [
+      ["kind", "url"],
+      ["url", "branch"],
+      ["url", "path"],
+    ]
+  );
+};

--- a/client/src/app/hooks/useLogFormValues.ts
+++ b/client/src/app/hooks/useLogFormValues.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { FieldValues, UseFormReturn } from "react-hook-form";
+
+/**
+ * Log the form's values and state every time it changes
+ */
+export const useLogFormValues = <TFormValues extends FieldValues>(
+  form: UseFormReturn<TFormValues>
+) => {
+  useEffect(() => {
+    const { subscribe } = form;
+    const subscription = subscribe({
+      formState: { values: true, isValid: true, errors: true },
+      callback: ({ values, isValid, errors }) => {
+        console.log(
+          "Form isValid?",
+          isValid,
+          "values:",
+          values,
+          "errors:",
+          errors
+        );
+      },
+    });
+    return () => subscription();
+  }, [form]);
+};

--- a/client/src/app/pages/applications/application-form/__tests__/application-form.test.tsx
+++ b/client/src/app/pages/applications/application-form/__tests__/application-form.test.tsx
@@ -85,8 +85,8 @@ describe("Component: application-form", () => {
         })
       );
     });
-    await userEvent.selectOptions(screen.getByRole("listbox"), [data.repoType]);
-    expect(createButton).not.toBeEnabled();
+    await userEvent.click(screen.getByRole("option", { name: data.repoType }));
+    expect(createButton).toBeEnabled();
 
     // type in a valid git repo URL, and the create button should be enabled again
     const sourceRepositoryInput = await screen.findByLabelText(

--- a/client/src/app/pages/applications/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/application-form/application-form.tsx
@@ -20,6 +20,7 @@ import {
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
 import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
+import { RepositoryFields } from "@app/components/repository-fields";
 import { SchemaDefinedField } from "@app/components/schema-defined-fields";
 import { toOptionLike } from "@app/utils/model-utils";
 import { wrapAsEvent } from "@app/utils/utils";
@@ -45,7 +46,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = (props) => {
 };
 
 export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
-  form: { control, trigger, getValues, setValue },
+  form,
   data: {
     tagItems,
     stakeholdersOptions,
@@ -57,16 +58,15 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
   },
   application,
 }) => {
+  const { control, getValues, setValue } = form;
   const { t } = useTranslation();
-  const watchKind = useWatch({ control, name: "kind" });
-  const watchAssetKind = useWatch({ control, name: "assetKind" });
   const watchSourcePlatform = useWatch({ control, name: "sourcePlatform" });
   const values = getValues();
 
   const [isBasicExpanded, setBasicExpanded] = React.useState(true);
 
   const [isSourceCodeExpanded, setSourceCodeExpanded] = React.useState(
-    application === null || (!!values.kind && !!values.sourceRepository)
+    application === null || (!!values.source.kind && !!values.source.url)
   );
 
   const [isBinaryExpanded, setBinaryExpanded] = React.useState(
@@ -82,7 +82,7 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
 
   const [isAssetRepositoryExpanded, setAssetRepositoryExpanded] =
     React.useState(
-      application !== null && !!values.assetKind && !!values.assetRepository
+      application !== null && !!values.assets.kind && !!values.assets.url
     );
 
   return (
@@ -250,51 +250,25 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
         isExpanded={isSourceCodeExpanded}
       >
         <div className="pf-v5-c-form">
-          <HookFormPFGroupController
-            control={control}
-            name="kind"
-            label="Repository type"
-            fieldId="repository-type-select"
-            renderInput={({ field: { value, name, onChange } }) => (
-              <SimpleSelect
-                toggleId="repo-type-toggle"
-                toggleAriaLabel="Type select dropdown toggle"
-                aria-label={name}
-                value={
-                  value ? toOptionLike(value, repositoryKindOptions) : undefined
-                }
-                options={repositoryKindOptions}
-                onChange={(selection) => {
-                  const selectionValue = selection as OptionWithValue<string>;
-                  onChange(selectionValue.value);
-                  trigger("sourceRepository");
-                }}
-              />
-            )}
-          />
-          <HookFormPFTextInput
-            control={control}
-            name="sourceRepository"
-            label={t("terms.sourceRepo")}
-            fieldId="sourceRepository"
-            aria-label="source repository url"
-            isRequired={repositoryKindOptions.some(
-              ({ value }) => value === watchKind
-            )}
-          />
-          <HookFormPFTextInput
-            control={control}
-            type="text"
-            aria-label="Repository branch"
-            name="branch"
-            label={t("terms.sourceBranch")}
-            fieldId="branch"
-          />
-          <HookFormPFTextInput
-            control={control}
-            name="rootPath"
-            label={t("terms.sourceRootPath")}
-            fieldId="rootPath"
+          <RepositoryFields
+            form={form}
+            prefix="source"
+            kindOptions={repositoryKindOptions}
+            labels={{
+              type: t("terms.repositoryType"),
+              url: t("terms.sourceRepo"),
+              branch: t("terms.sourceBranch"),
+              path: t("terms.sourceRootPath"),
+            }}
+            fieldIds={{
+              type: "repository-type-select",
+              url: "sourceRepository",
+              branch: "branch",
+              path: "rootPath",
+            }}
+            toggleIds={{
+              type: "repo-type-toggle",
+            }}
           />
         </div>
       </ExpandableSection>
@@ -426,51 +400,25 @@ export const ApplicationFormReady: React.FC<ApplicationFormProps> = ({
         isExpanded={isAssetRepositoryExpanded}
       >
         <div className="pf-v5-c-form">
-          <HookFormPFGroupController
-            control={control}
-            name="assetKind"
-            label="Asset repository type"
-            fieldId="asset-repository-type-select"
-            renderInput={({ field: { value, name, onChange } }) => (
-              <SimpleSelect
-                toggleId="asset-repo-type-toggle"
-                toggleAriaLabel="Type select dropdown toggle"
-                aria-label={name}
-                value={
-                  value ? toOptionLike(value, repositoryKindOptions) : undefined
-                }
-                options={repositoryKindOptions}
-                onChange={(selection) => {
-                  const selectionValue = selection as OptionWithValue<string>;
-                  onChange(selectionValue.value);
-                  trigger("assetRepository");
-                }}
-              />
-            )}
-          />
-          <HookFormPFTextInput
-            control={control}
-            name="assetRepository"
-            label={t("terms.assetRepository")}
-            fieldId="assetRepository"
-            aria-label="asset repository url"
-            isRequired={repositoryKindOptions.some(
-              ({ value }) => value === watchAssetKind
-            )}
-          />
-          <HookFormPFTextInput
-            control={control}
-            type="text"
-            aria-label="Repository branch"
-            name="assetBranch"
-            label={t("terms.sourceBranch")}
-            fieldId="assetBranch"
-          />
-          <HookFormPFTextInput
-            control={control}
-            name="assetRootPath"
-            label={t("terms.sourceRootPath")}
-            fieldId="assetRootPath"
+          <RepositoryFields
+            form={form}
+            prefix="assets"
+            kindOptions={repositoryKindOptions}
+            labels={{
+              type: t("terms.repositoryType"),
+              url: t("terms.assetRepository"),
+              branch: t("terms.sourceBranch"),
+              path: t("terms.sourceRootPath"),
+            }}
+            fieldIds={{
+              type: "asset-repository-type-select",
+              url: "assetRepository",
+              branch: "assetBranch",
+              path: "assetRootPath",
+            }}
+            toggleIds={{
+              type: "asset-repo-type-toggle",
+            }}
           />
         </div>
       </ExpandableSection>

--- a/client/src/app/yup.ts
+++ b/client/src/app/yup.ts
@@ -16,7 +16,11 @@ declare module "yup" {
      * If the linked field's value is "svn" or "subversion", use svn URL validation.  Any
      * other type will use standard URL validation.
      */
-    repositoryUrl(repositoryTypeField: string, message?: string): StringSchema;
+    repositoryUrl(
+      repositoryTypeField: string,
+      allowEmpty?: boolean,
+      message?: string
+    ): StringSchema;
 
     validMavenSettingsXml(
       skipValidation?: (value?: string) => boolean
@@ -29,6 +33,7 @@ yup.addMethod(
   "repositoryUrl",
   function (
     repositoryTypeField: string,
+    allowEmpty = false,
     message = "Must be a valid repository URL."
   ) {
     return this.test("repositoryUrl", message, function (value) {
@@ -40,7 +45,7 @@ yup.addMethod(
             ? isValidSvnUrl(value)
             : isValidStandardUrl(value);
       }
-      return false;
+      return allowEmpty;
     });
   }
 );


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-6114
Resolves: https://issues.redhat.com/browse/MTA-6105
Resolves: https://issues.redhat.com/browse/MTA-5769
Resolves: #2615
Partially addresses: #2541

UI Tests PR: 1697

To properly support the input and validation of the 4 fields needed for a source repository, the "repository-fields" components, schemas, and tests were created.  Now, the source repository fields and the asset repository fields are handled with exactly the same schemas and components.

Now:
  - The type is defaulted to 'git' url validation
  - The type is required once the url, branch or path is entered
  - The url is required one the branch or path is entered
  - If the branch or path are empty, the url is allowed to be empty
  - If only the type is selected, the repository is considered empty

With the new Repository based schema, it can be shared anywhere the 4 repo fields are needed.  A collection of unit tests cover the main functionality of the schema.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified repository fields for source and assets with a single, consistent form section.
  - Added detailed, localized error messages for repository validation.
  - Configurable validation for kind, URL, branch, and path with conditional requiredness and length checks.

- Bug Fixes
  - URL validation now correctly allows empty values when not required, preventing false errors.

- Refactor
  - Simplified application form by replacing multiple fields with reusable repository fields.

- Tests
  - Added comprehensive tests covering translations, conditional rules, URL formats, and nested scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->