### PR TITLE
:test_tube: Migrate e2e tests workflows

### DIFF
--- a/.github/workflows/e2e-run-ui-tests.yaml
+++ b/.github/workflows/e2e-run-ui-tests.yaml
@@ -1,4 +1,4 @@
-name: run UI tests on minikube
+name: e2e - run UI tests on minikube
 
 on:
   workflow_call: # call from another workflow
@@ -127,6 +127,4 @@ jobs:
         with:
           name: test-reports-${{ env.AUTH_KIND }}-${{ env.TEST_KIND }}
           path: |
-            tackle2-ui/cypress/reports
-            tackle2-ui/cypress/screenshots
-            tackle2-ui/cypress/videos
+            tackle2-ui/cypress/run

--- a/.github/workflows/e2e-tier0-nightly.yaml
+++ b/.github/workflows/e2e-tier0-nightly.yaml
@@ -1,4 +1,4 @@
-name: Test nightly tier0
+name: e2e - run tier0 tests nightly
 
 on:
   workflow_dispatch:

--- a/.github/workflows/e2e-tier0-push-main.yaml
+++ b/.github/workflows/e2e-tier0-push-main.yaml
@@ -1,4 +1,4 @@
-name: Test push to main tier0
+name: e2e - run tier0 tests for cypress test changes on push to main
 
 on:
   push:


### PR DESCRIPTION
Moving e2e workflows from tackle-ui-test repo.

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated end-to-end UI test workflows: reusable run configuration, scheduled nightly runs, on-push (main) and manual triggers.
  * Supports configurable test tags, authentication toggle, selectable bundle/version and test reference.
  * Executes UI tests on a local cluster environment and uploads detailed failure reports (logs, screenshots, videos).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->