### PR TITLE
:test_tube: fix e2e-run-ui-tests.yaml

### DIFF
--- a/.github/workflows/e2e-run-ui-tests.yaml
+++ b/.github/workflows/e2e-run-ui-tests.yaml
@@ -100,13 +100,26 @@ jobs:
           ref: ${{ inputs.test_ref }}
           path: tackle2-ui
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: "tackle2-ui/package.json"
+          cache: "npm"
+          cache-dependency-path: "tackle2-ui/package-lock.json"
+
+      - name: Install dependencies
+        run: |
+          cd tackle2-ui
+          npm clean-install --ignore-scripts --no-audit
+
       - name: Run login tests using default credentials from `cypress.config.ts`
         uses: cypress-io/github-action@v6
         env:
           CYPRESS_baseUrl: "${{ env.UI_URL }}"
         with:
-          working-directory: tackle2-ui/cypress
-          spec: "e2e/tests/login.test.ts"
+          working-directory: ./tackle2-ui
+          project: ./cypress
+          spec: "**/e2e/tests/login.test.ts"
 
       - name: Run UI tests (${{ inputs.test_tags }}) using default credentials from `cypress.config.ts`
         uses: cypress-io/github-action@v6
@@ -117,7 +130,8 @@ jobs:
           CYPRESS_git_password: "${{ secrets.GITHUB_TOKEN }}"
           CYPRESS_git_key: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          working-directory: tackle2-ui/cypress
+          working-directory: ./tackle2-ui
+          project: ./cypress
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "engines": {
     "node": ">=20.12.2",
-    "npm": "^9.5.0 || ^10.5.2"
+    "npm": "^9.5.0 || ^10.5.2 || >=11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^29.0.0",


### PR DESCRIPTION
Fixes the e2e-run-ui-tests.yaml workflow to install dependencies correctly so the cypress action will run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow to set up Node.js and install dependencies before running UI tests.
  * Broadened supported npm versions to include npm >= 11.

* **Tests**
  * Updated UI test run configuration to use the correct working directory and target the login and UI test suites for end-to-end checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->