### PR TITLE
:test_tube: Add test maintainers to CODEOWNERS and OWNERS.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,6 @@
 # The list (or group membership) should match up with the `OWNERS.md` file.
 #
 * @ibolton336 @sjd78 @rszwajko
+
+# Cypress tests
+/cypress/ @sshveta @abrugaro

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -7,3 +7,8 @@ This file specifies the code owners of the project.
 - Ian Bolton ([ibolton336](https://github.com/ibolton336))
 - Scott Dickerson ([sjd78](https://github.com/sjd78))
 - Radoslaw Szwajkowski ([rszwajko](https://github.com/rszwajko))
+
+## Our Test Maintainers
+
+- Shveta Sachdeva ([sshveta](https://github.com/sshveta))
+- Alejandro Brugarolas ([abrugaro](https://github.com/abrugaro))


### PR DESCRIPTION
Resolves: #2669

Add test maintainers to CODEOWNERS and OWNERS.md.  This may be a temporary solution until we have a dedicated group of people to review cypress tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test maintenance and code ownership information to reflect current team structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->