### PR TITLE
:sparkles: Remove task preemption

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -32,7 +32,6 @@
     "createTargetProfile": "Create new target profile",
     "cancelAnalysis": "Cancel analysis",
     "delete": "Delete",
-    "disablePreemption": "Disable preemption",
     "discardAssessment": "Discard assessment(s)",
     "discardReview": "Discard review",
     "discoverApplications": "Discover applications",
@@ -40,7 +39,6 @@
     "download": "Download {{what}}",
     "duplicate": "Duplicate",
     "edit": "Edit",
-    "enablePreemption": "Enable preemption",
     "export": "Export",
     "filterBy": "Filter by {{what}}",
     "import": "Import",
@@ -284,7 +282,6 @@
     "selectOwnerFromStakeholdersList": "Select owner from list of stakeholders",
     "suggestedAdoptionPlanHelpText": "The suggested approach to migration based on effort, priority, and dependencies.",
     "taskInProgressForTags": "A new analysis is in-progress.  Tags may be updated upon completion.",
-    "togglePreemptionNotAvailable": "It is not possible to toggle preemption for a task that is in status {{statusName}}",
     "toTagApplication": "Either no tags exist yet or you may not have permission to view any. If you have permission, try creating a new custom tag.",
     "unlinkTicket": "Unlink from Jira",
     "unsavedChanges": "Are you sure you want to close the assessment? Any unsaved changes will be lost.",
@@ -497,7 +494,6 @@
     "pod": "Pod",
     "parameters": "Parameters",
     "path": "Path",
-    "preemption": "Preemption",
     "priority": "Priority",
     "profiles": "Profiles",
     "proposedAction": "Proposed action",
@@ -632,7 +628,6 @@
   },
   "tooltip": {
     "priority": "Tasks priority, a non-negative number, impacts tasks scheduling policy. Lowest priority is 0. Higher priority tasks run before lower priority tasks.",
-    "preemption": "If enabled, allows the scheduler to reschedule other running tasks to free cluster resources needed to run higher priority tasks.",
     "defaultIdentity": "Credential {{name}} is the default credential for {{type}} types."
   },
   "validation": {

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -417,8 +417,6 @@ export interface TaskDashboard {
 
 export interface TaskPolicy {
   isolated?: boolean;
-  preemptEnabled?: boolean;
-  preemptExempt?: boolean;
 }
 
 export interface TTL {

--- a/client/src/app/components/task-manager/TaskManagerContext.tsx
+++ b/client/src/app/components/task-manager/TaskManagerContext.tsx
@@ -1,4 +1,11 @@
-import React, { useContext, useMemo, useState } from "react";
+import {
+  type FC,
+  type ReactNode,
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 
 import { useFetchTaskQueue } from "@app/queries/tasks";
 
@@ -13,7 +20,7 @@ interface TaskManagerContextProps {
   setIsExpanded: (value: boolean) => void;
 }
 
-const TaskManagerContext = React.createContext<TaskManagerContextProps>({
+const TaskManagerContext = createContext<TaskManagerContextProps>({
   queuedCount: 0,
 
   isExpanded: false,
@@ -26,7 +33,7 @@ export const useTaskManagerContext = () => {
   return values;
 };
 
-export const TaskManagerProvider: React.FC<{ children: React.ReactNode }> = ({
+export const TaskManagerProvider: FC<{ children: ReactNode }> = ({
   children,
 }) => {
   const { taskQueue } = useFetchTaskQueue();

--- a/client/src/app/components/task-manager/TaskManagerDrawer.tsx
+++ b/client/src/app/components/task-manager/TaskManagerDrawer.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useCallback, useMemo, useState } from "react";
+import * as React from "react";
+import { forwardRef, useCallback, useMemo, useState } from "react";
 import dayjs from "dayjs";
 import { Link } from "react-router-dom";
 import {
@@ -52,7 +53,6 @@ interface TaskManagerTask {
   priority: number;
   applicationName?: string;
   platformName?: string;
-  preemptEnabled: boolean;
 
   // full object to be used with library functions
   _: Task<unknown>;
@@ -271,13 +271,11 @@ const useTaskManagerData = () => {
               priority: task.priority ?? 0,
               applicationName: task.application?.name,
               platformName: task.platform?.name,
-              preemptEnabled: task?.policy?.preemptEnabled ?? false,
 
               _: task,
 
               // TODO: Add any checks that could be needed later...
               //  - isCancelable (does the current user own the task? other things to check?)
-              //  - isPreemptionToggleAllowed
             }) as TaskManagerTask
         ) ?? [],
     [data]

--- a/client/src/app/components/task-manager/TaskNotificaitonBadge.tsx
+++ b/client/src/app/components/task-manager/TaskNotificaitonBadge.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import { type FC } from "react";
 import { NotificationBadge } from "@patternfly/react-core";
 
 import { useTaskManagerContext } from "./TaskManagerContext";
 
-export const TaskNotificationBadge: React.FC = () => {
+export const TaskNotificationBadge: FC = () => {
   const { isExpanded, setIsExpanded, queuedCount } = useTaskManagerContext();
 
   const badgeClick = () => {

--- a/client/src/app/pages/tasks/TaskActionColumn.tsx
+++ b/client/src/app/pages/tasks/TaskActionColumn.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { type FC } from "react";
 import { ActionsColumn } from "@patternfly/react-table";
 
 import { Task } from "@app/api/models";

--- a/client/src/app/pages/tasks/TaskDetails.tsx
+++ b/client/src/app/pages/tasks/TaskDetails.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 

--- a/client/src/app/pages/tasks/TaskDetailsBase.tsx
+++ b/client/src/app/pages/tasks/TaskDetailsBase.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory, useLocation } from "react-router-dom";
 import { PageSection } from "@patternfly/react-core";
@@ -11,7 +11,7 @@ import {
 import { useFetchTaskByID } from "@app/queries/tasks";
 import "@app/components/simple-document-viewer/SimpleDocumentViewer.css";
 
-export const TaskDetailsBase: React.FC<{
+export const TaskDetailsBase: FC<{
   breadcrumbs: PageHeaderProps["breadcrumbs"];
   formatTitle: (taskName: string) => string;
   detailsPath: string;

--- a/client/src/app/pages/tasks/tasks-page.tsx
+++ b/client/src/app/pages/tasks/tasks-page.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import { type FC, type ReactNode } from "react";
 import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 import { Link, useHistory } from "react-router-dom";
@@ -62,7 +62,7 @@ export const taskStateToLabel: Record<TaskState, string> = {
   SucceededWithErrors: "taskState.SucceededWithErrors",
 };
 
-export const TasksPage: React.FC = () => {
+export const TasksPage: FC = () => {
   const { t } = useTranslation();
   const history = useHistory();
 
@@ -84,7 +84,6 @@ export const TasksPage: React.FC = () => {
       state: t("terms.status"),
       kind: t("terms.kind"),
       priority: t("terms.priority"),
-      preemption: t("terms.preemption"),
       createUser: t("terms.createdBy"),
       pod: t("terms.pod"),
       started: t("terms.started"),
@@ -206,7 +205,6 @@ export const TasksPage: React.FC = () => {
 
   const tooltips: Record<string, ThProps["info"]> = {
     priority: { tooltip: t("tooltip.priority") },
-    preemption: { tooltip: t("tooltip.preemption") },
   };
 
   const clearFilters = () => {
@@ -224,7 +222,6 @@ export const TasksPage: React.FC = () => {
     addon,
     state,
     priority = 0,
-    policy,
     createUser,
     pod,
     started,
@@ -248,7 +245,6 @@ export const TasksPage: React.FC = () => {
       />
     ),
     priority,
-    preemption: String(!!policy?.preemptEnabled),
     createUser,
     pod,
     started: started ? dayjs(started).format("YYYY-MM-DD HH:mm:ss") : "",

--- a/client/src/app/pages/tasks/useTaskActions.tsx
+++ b/client/src/app/pages/tasks/useTaskActions.tsx
@@ -1,21 +1,15 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
 import { Paths } from "@app/Paths";
 import { Task, TaskState } from "@app/api/models";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import {
-  useCancelTaskMutation,
-  useUpdateTaskMutation,
-} from "@app/queries/tasks";
+import { useCancelTaskMutation } from "@app/queries/tasks";
 import { formatPath } from "@app/utils/utils";
 
 const canCancel = (state: TaskState = "No task") =>
   !["Succeeded", "Failed", "Canceled"].includes(state);
-
-const canTogglePreemption = (state: TaskState = "No task") =>
-  !["Succeeded", "Failed", "Canceled", "Running"].includes(state);
 
 const useAsyncTaskActions = () => {
   const { t } = useTranslation();
@@ -36,34 +30,11 @@ const useAsyncTaskActions = () => {
       })
   );
 
-  const { mutate: updateTask } = useUpdateTaskMutation(
-    () =>
-      pushNotification({
-        title: t("titles.task"),
-        message: t("message.updateRequestSubmitted"),
-        variant: "info",
-      }),
-    () =>
-      pushNotification({
-        title: t("titles.task"),
-        message: t("message.updateFailed"),
-        variant: "danger",
-      })
-  );
-
-  const togglePreemption = (task: Task<unknown>) =>
-    updateTask({
-      id: task.id,
-      policy: {
-        preemptEnabled: !task.policy?.preemptEnabled,
-      },
-    });
-
-  return { cancelTask, togglePreemption };
+  return { cancelTask };
 };
 
 export const useTaskActions = (task: Task<unknown>) => {
-  const { cancelTask, togglePreemption } = useAsyncTaskActions();
+  const { cancelTask } = useAsyncTaskActions();
   const { t } = useTranslation();
   const history = useHistory();
 
@@ -77,20 +48,6 @@ export const useTaskActions = (task: Task<unknown>) => {
           : "",
       },
       onClick: () => cancelTask(task.id),
-    },
-    {
-      title: task.policy?.preemptEnabled
-        ? t("actions.disablePreemption")
-        : t("actions.enablePreemption"),
-      isAriaDisabled: !canTogglePreemption(task.state),
-      onClick: () => togglePreemption(task),
-      tooltipProps: {
-        content: !canTogglePreemption(task.state)
-          ? t("message.togglePreemptionNotAvailable", {
-              statusName: task.state,
-            })
-          : "",
-      },
     },
     {
       title: t("actions.taskDetails"),


### PR DESCRIPTION
Remove task preemption from the task manager and tasks page.

Resolves: #2737



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the preemption toggle and related UI elements from task lists and actions.
  * Removed the preemption column and tooltips from the tasks table.

* **Chores**
  * Cleaned up preemption-related translations and configuration surfaces.
  * Simplified task action behavior to only expose cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->