### PR TITLE
:test_tube: Run e2e-tier0 on PRs/pushes targeting main

### DIFF
--- a/.github/workflows/e2e-tier0-repo-main.yaml
+++ b/.github/workflows/e2e-tier0-repo-main.yaml
@@ -1,4 +1,4 @@
-name: e2e - run tier0 tests for cypress test changes on push to main
+name: e2e - run tier0 tests for cypress test PRs/pushes targeting main
 
 on:
   push:
@@ -7,8 +7,14 @@ on:
     paths:
       - "cypress/**"
 
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "cypress/**"
+
 concurrency:
-  group: tier0-push-main-${{ github.ref }}
+  group: e2e-tier0-repo-main-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Update the e2e-tier0 workflow to run on PRs/pushes targeting main instead of just pushes to main.

This will be useful for #2699.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to support pull requests targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->