### PR TITLE
:test_tube: Update e2e PR workflow to run based on PR description text

### DIFF
--- a/.github/workflows/e2e-repo-main.yaml
+++ b/.github/workflows/e2e-repo-main.yaml
@@ -13,6 +13,7 @@ on:
     paths:
       - "cypress/**"
       - ".github/workflows/e2e*.yaml"
+      - ".github/actions/**"
 
 concurrency:
   group: e2e-repo-main-${{ github.ref }}
@@ -36,14 +37,42 @@ jobs:
           docker build . -t ${IMG_NAME}
           docker push ${IMG_NAME}
 
+  extract-test-tags:
+    runs-on: ubuntu-latest
+    outputs:
+      test_tags: ${{ steps.extract.outputs.test_tags }}
+    steps:
+      - name: Extract test tags from PR body
+        id: extract
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          DEFAULT_TAGS: "@ci,@tier0"
+        run: |
+          if [[ -n "$PR_BODY" ]]; then
+            # Look for pattern "ci test tags: @tag1,@tag2,..." in PR body
+            EXTRACTED=$(echo "$PR_BODY" | grep -oP '^ci test tags: \K@.+(,@.+)*$' || true)
+            if [[ -n "$EXTRACTED" ]]; then
+              echo "Found test tags in PR body: $EXTRACTED"
+              echo "test_tags=$EXTRACTED" >> "$GITHUB_OUTPUT"
+            else
+              echo "No test tags pattern found in PR body, using default: $DEFAULT_TAGS"
+              echo "test_tags=$DEFAULT_TAGS" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "No PR body available (not a pull request or body is empty), using default: $DEFAULT_TAGS"
+            echo "test_tags=$DEFAULT_TAGS" >> "$GITHUB_OUTPUT"
+          fi
+
   e2e-tests:
-    needs: build-ui-image-if-needed
+    needs:
+      - extract-test-tags
+      - build-ui-image-if-needed
     uses: ./.github/workflows/e2e-run-ui-tests.yaml
     with:
-      test_tags: "@ci,@tier0"
-      feature_auth_required: false
+      test_tags: ${{ needs.extract-test-tags.outputs.test_tags }}
+      feature_auth_required: true
       bundle_image: quay.io/konveyor/tackle2-operator-bundle:latest
-      install_konveyor_version: ${{ github.base_ref || github.ref_name }}
+      install_konveyor_version: main
       test_ref: ${{ github.event.pull_request.head.sha || github.sha }}
       ui_image: ${{ needs.build-ui-image-if-needed.outputs.ui_image }}
     secrets: inherit

--- a/.github/workflows/e2e-run-ui-tests.yaml
+++ b/.github/workflows/e2e-run-ui-tests.yaml
@@ -122,11 +122,11 @@ jobs:
             -n konveyor-tackle \
             ingress/tackle \
             --timeout=600s \
-            --for=jsonpath='{.status.loadBalancer.ingress[0]}'
+            --for=jsonpath='{.status.loadBalancer.ingress[0].ip}'
 
-          minikube_ip=$(minikube ip)
-          echo "ingress is ready at: ${minikube_ip}"
-          echo "UI_URL=https://${minikube_ip}" >>$GITHUB_ENV
+          ingress_ip=$(kubectl get ingress/tackle -n konveyor-tackle -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo "ingress is ready at: ${ingress_ip}"
+          echo "UI_URL=https://${ingress_ip}" >>$GITHUB_ENV
 
       - name: Get Keycloak admin password
         if: ${{ inputs.feature_auth_required }}


### PR DESCRIPTION
This workflow allows PRs to specify test tags to use for the E2E tests in the PR body.  By adding a line like this to the PR body:

```
ci test tags: @ci,@tier0,@tier1
```

the workflow will run the cypress tests for the ci, tier0 and tier1 tagged tests for this PR.

When the workflow is run outside of a PR, or the PR body does not have the string, the workflow will use the default tags of `@ci,@tier0`.

Part of: #2670


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved E2E testing workflows with automated test tag extraction from pull request metadata and enhanced job dependency management.
  * Updated UI testing infrastructure integration to better handle ingress configuration and IP address extraction.
  * Adjusted authentication requirements in testing environments for improved validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->