### PR TITLE
[release-0.8] :test_tube: Update downloads folder (#2791)

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -496,7 +496,7 @@ export class Analysis extends Application {
 
   extractHTMLReport() {
     cy.task("unzip", {
-      path: "downloads/",
+      path: `${Cypress.config("downloadsFolder")}/`,
       file: `analysis-report-app-${this.name}.tar`,
     });
     cy.verifyDownload(`analysis-report-app-${this.name}/index.html`);

--- a/cypress/e2e/tests/administration/questionnaires/crud.test.ts
+++ b/cypress/e2e/tests/administration/questionnaires/crud.test.ts
@@ -52,12 +52,11 @@ describe(["@tier2"], "Questionnaire CRUD operations", () => {
 
   it("Export questionnaire and Import it back", function () {
     AssessmentQuestionnaire.export(legacyQuestionnaire);
-    cy.readFile("downloads/questionnaire-1.yaml").should(
-      "contain",
-      legacyQuestionnaire
-    );
+    cy.readFile(
+      `${Cypress.config("downloadsFolder")}/questionnaire-1.yaml`
+    ).should("contain", legacyQuestionnaire);
     cy.exec(
-      "cp downloads/questionnaire-1.yaml fixtures/questionnaire_import/questionnaire-1.yaml"
+      `cp "${Cypress.config("downloadsFolder")}/questionnaire-1.yaml" "fixtures/questionnaire_import/questionnaire-1.yaml"`
     ).then((result) => {
       cy.log(result.stdout);
     });

--- a/cypress/e2e/tests/administration/questionnaires/miscellaneous.test.ts
+++ b/cypress/e2e/tests/administration/questionnaires/miscellaneous.test.ts
@@ -17,13 +17,13 @@ import { closeModal } from "../../../views/assessment.view";
 import { downloadYamlTemplate } from "../../../views/assessmentquestionnaire.view";
 import { alertTitle } from "../../../views/common.view";
 
-const filePath = "downloads/questionnaire-template.yaml";
+const filePath = `${Cypress.config("downloadsFolder")}/questionnaire-template.yaml`;
 const yamlFile = "questionnaire_import/questionnaire-template-sample.yaml";
 const invalidYamlFile =
   "questionnaire_import/invalid-questionnaire-template.yaml";
 const cloudNativePath = "questionnaire_import/cloud-native.yaml";
 
-const cloudNativeDownloadPath = "downloads/";
+const cloudNativeDownloadPath = `${Cypress.config("downloadsFolder")}/`;
 
 describe(["@tier3"], "Miscellaneous Questionnaire tests", () => {
   it("Download YAML template", function () {

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/static_report.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/static_report.test.ts
@@ -93,8 +93,10 @@ describe(["@tier2"], "Test Static Report UI", { baseUrl: null }, function () {
     technology: "EJB XML",
   };
 
-  beforeEach("Load data", function () {
-    cy.visit(`/downloads/analysis-report-app-${appName}/index.html`);
+  beforeEach("Open static report", function () {
+    // Visit file by using the relative path from rootDir
+    // https://github.com/cypress-io/cypress/issues/4450#issuecomment-778110994
+    cy.visit(`./run/downloads/analysis-report-app-${appName}/index.html`);
   });
 
   it("Validate Application Menu", function () {

--- a/cypress/e2e/tests/migration/applicationinventory/manageimports/csv.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/manageimports/csv.test.ts
@@ -33,10 +33,9 @@ describe(["@tier3"], "Manage imports tests", function () {
     openManageImportsPage();
     cy.get(manageImportsActionsButton).click();
     cy.get(kebabMenuItem).contains("Download CSV template").click();
-    cy.readFile("downloads/template_application_import.csv").should(
-      "contain",
-      "Customers"
-    );
+    cy.readFile(
+      `${Cypress.config("downloadsFolder")}/template_application_import.csv`
+    ).should("contain", "Customers");
   });
 
   after("Cleaning up", function () {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1940,9 +1940,13 @@ export function clickTab(name: string): void {
 
 export function cleanupDownloads(): void {
   // This will eliminate content of `downloads` folder
-  cy.exec("cd downloads; rm -rf ./*").then((result) => {
-    cy.log(result.stdout);
-  });
+  const downloadsFolder = Cypress.config("downloadsFolder");
+  cy.exec(
+    `bash -lc 'set -euo pipefail; cd "$DOWNLOADS_FOLDER"; rm -rf -- ./*'`,
+    {
+      env: { DOWNLOADS_FOLDER: String(downloadsFolder) },
+    }
+  ).then((result) => cy.log(result.stdout));
 }
 
 export function selectAssessmentApplications(apps: string): void {
@@ -2293,7 +2297,7 @@ export function downloadTaskDetails(format = downloadFormatDetails.yaml) {
   cy.url().should("include", "tasks");
   cy.url().then((url) => {
     const taskId = url.split("/").pop();
-    const filePath = `downloads/log-${taskId}.${format.key}`;
+    const filePath = `${Cypress.config("downloadsFolder")}/log-${taskId}.${format.key}`;
     cy.get(format.button).click();
     cy.get(downloadTaskButton).click();
     if (format === downloadFormatDetails.json) {


### PR DESCRIPTION
The downloads folder is now under `run/downloads`, this PR updates the tests accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
* Replaced hard-coded download paths across end-to-end tests, test utilities, and migration helpers with dynamic resolution using the configured downloads folder. This improves compatibility with custom environments and download locations while preserving existing test behavior and outcomes.
* Adjusted one test setup to load a static report via a relative path and updated its description for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

<details>
<summary>PR Title emoji</summary>

Types recognized:

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- Integration/E2E tests: :test_tube: (`:test_tube:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

</details>

For more information, please see the Konveyor [Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
