### PR TITLE
:test_tube: Fix analysis wizard test flake with next button

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/steps/advanced-options.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/steps/advanced-options.tsx
@@ -301,6 +301,7 @@ export const AdvancedOptions: React.FC<AdvancedOptionsProps> = ({
         isChecked={autoTaggingEnabled}
         onChange={() => setValue("autoTaggingEnabled", !autoTaggingEnabled)}
         id="enable-auto-tagging-checkbox"
+        name="autoTaggingEnabled"
       />
 
       <Flex>
@@ -315,6 +316,7 @@ export const AdvancedOptions: React.FC<AdvancedOptionsProps> = ({
               setValue("advancedAnalysisEnabled", !advancedAnalysisEnabled)
             }
             id="enable-advanced-analysis-details-checkbox"
+            name="advancedAnalysisEnabled"
           />
         </FlexItem>
         <FlexItem>

--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -334,7 +334,6 @@ export class Analysis extends Application {
     if (this.openSourceLibraries) {
       click("#oss");
     }
-    next();
   }
 
   protected tagsToExclude() {
@@ -343,6 +342,7 @@ export class Analysis extends Application {
   }
 
   analyze(cancel = false): void {
+    cy.log("Starting Analysis on application", this.name);
     Application.open();
     this.selectApplication();
     if (cancel) {
@@ -364,6 +364,7 @@ export class Analysis extends Application {
     this.selectTarget(this.target);
     next();
     this.scopeSelect();
+    next();
     if (this.customRule) {
       this.uploadCustomRule();
     }

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1964,8 +1964,14 @@ export function closeModalWindow(): void {
   click(closeModal, false, true);
 }
 
-export function next(): void {
-  clickByText(button, "Next");
+export function next(waitForEnabled = true): void {
+  if (waitForEnabled) {
+    cy.contains(button, "Next", { timeout: 10 * SEC })
+      .should("not.be.disabled")
+      .click();
+  } else {
+    clickByText(button, "Next");
+  }
 }
 
 export function performWithin(


### PR DESCRIPTION
When running the an analysis wizard test, the next button on the custom rules step was not immediately enabled.  The form requires a few renders to properly validate and enable the Next button.  The tests would click right away, and sometimes it would be enabled and sometimes not.  This would cause the next "Next" click to hit the custom rules step instead of the advanced options step.  In that case, the test would fail.

This fix adds a wait for the next button to be enabled before clicking it.  This wait allows the form to validate, update state, and the next buttons to be enabled.

First noticed in CI working on #2747


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test automation to enhance step progression and logging in the analysis workflow.
  * Improved test utility for better button state verification.

* **Chores**
  * Enhanced form field wiring for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->