### PR TITLE
:sparkles: Add analysis profiles to target profiles

### DIFF
--- a/client/src/app/pages/archetypes/components/tab-target-profiles.tsx
+++ b/client/src/app/pages/archetypes/components/tab-target-profiles.tsx
@@ -53,15 +53,17 @@ export const TabTargetProfiles: React.FC<TabTargetProfilesProps> = ({
           <Tr>
             <Th>{t("terms.name")}</Th>
             <Th>{t("terms.generators")}</Th>
+            <Th>{t("terms.analysisProfile")}</Th>
           </Tr>
         </Thead>
         <Tbody>
           {profiles.map((profile) => (
             <Tr key={profile.id}>
-              <Td width={40}>{profile.name}</Td>
-              <Td width={60}>
+              <Td width={25}>{profile.name}</Td>
+              <Td width={40}>
                 <LabelsFromItems items={profile.generators} />
               </Td>
+              <Td width={35}>{profile.analysisProfile?.name ?? "-"}</Td>
             </Tr>
           ))}
         </Tbody>

--- a/client/src/app/pages/archetypes/components/target-profile-form.tsx
+++ b/client/src/app/pages/archetypes/components/target-profile-form.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState } from "react";
 import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { fork } from "radash";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
@@ -12,20 +11,30 @@ import {
   Form,
   Modal,
   ModalVariant,
+  Spinner,
 } from "@patternfly/react-core";
 
-import type { Archetype, Generator, TargetProfile } from "@app/api/models";
+import type {
+  AnalysisProfile,
+  Archetype,
+  Generator,
+  TargetProfile,
+} from "@app/api/models";
 import {
   HookFormPFGroupController,
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
+import { OptionWithValue, SimpleSelect } from "@app/components/SimpleSelect";
 import { useFetchGenerators } from "@app/queries/generators";
-import { refsToItems, toRefs } from "@app/utils/model-utils";
+import { refsToItems, toRef, toRefs } from "@app/utils/model-utils";
 import { duplicateNameCheck } from "@app/utils/utils";
+
+import { useAnalysisProfileOptions } from "../hooks/useAnalysisProfileOptions";
 
 interface TargetProfileFormValues {
   name: string;
   generators: Generator[];
+  analysisProfile: AnalysisProfile | null;
 }
 
 interface TargetProfileFormProps {
@@ -36,19 +45,61 @@ interface TargetProfileFormProps {
   profile?: TargetProfile | null;
 }
 
-const TargetProfileForm: React.FC<TargetProfileFormProps> = ({
+interface TargetProfileFormPropsInner extends TargetProfileFormProps {
+  generators: Generator[];
+  analysisProfileOptions: OptionWithValue<AnalysisProfile>[];
+  findProfileById: (id: number | undefined) => AnalysisProfile | undefined;
+}
+
+const TargetProfileForm: React.FC<TargetProfileFormProps> = (props) => {
+  const { generators, isLoading: isGeneratorsLoading } = useFetchGenerators();
+  const {
+    analysisProfileOptions,
+    findProfileById,
+    isFetching: isAnalysisProfilesLoading,
+  } = useAnalysisProfileOptions();
+
+  if (isGeneratorsLoading || isAnalysisProfilesLoading) {
+    return <Spinner aria-label="Loading generators and analysis profiles" />;
+  }
+
+  return (
+    <TargetProfileFormInner
+      {...props}
+      generators={generators}
+      analysisProfileOptions={analysisProfileOptions}
+      findProfileById={findProfileById}
+    />
+  );
+};
+
+const TargetProfileFormInner: React.FC<TargetProfileFormPropsInner> = ({
   isOpen,
   onCancel,
   onSave,
   archetype,
   profile = null,
+  generators,
+  analysisProfileOptions,
+  findProfileById,
 }) => {
   const { t } = useTranslation();
-  const { generators } = useFetchGenerators();
 
   // Dual list selector state
-  const [availableOptions, setAvailableOptions] = useState<Generator[]>([]);
-  const [chosenOptions, setChosenOptions] = useState<Generator[]>([]);
+  const [availableOptions, setAvailableOptions] = useState<Generator[]>(() => {
+    if (profile) {
+      return generators.filter(
+        (g) => !profile.generators.some((r) => r.id === g.id)
+      );
+    }
+    return generators;
+  });
+  const [chosenOptions, setChosenOptions] = useState<Generator[]>(() => {
+    if (profile) {
+      return refsToItems(generators, profile.generators);
+    }
+    return [];
+  });
 
   const validationSchema = yup.object().shape({
     name: yup
@@ -65,14 +116,11 @@ const TargetProfileForm: React.FC<TargetProfileFormProps> = ({
       ),
     generators: yup
       .array()
-      .of(yup.object({ id: yup.number(), name: yup.string() }))
-      .min(1, ({ min }) =>
-        t("validation.minCount", {
-          count: min,
-          type: t("terms.generator"),
-          types: t("terms.generators"),
-        })
-      ),
+      .of(yup.object({ id: yup.number(), name: yup.string() })),
+    analysisProfile: yup
+      .object()
+      .shape({ id: yup.number(), name: yup.string() })
+      .nullable(),
   });
 
   const {
@@ -84,28 +132,11 @@ const TargetProfileForm: React.FC<TargetProfileFormProps> = ({
     defaultValues: {
       name: profile?.name ?? "",
       generators: refsToItems(generators, profile?.generators),
+      analysisProfile: findProfileById(profile?.analysisProfile?.id) ?? null,
     },
     resolver: yupResolver(validationSchema),
     mode: "all",
   });
-
-  // Initialize dual list selector options when modal opens
-  React.useEffect(() => {
-    if (isOpen && generators) {
-      if (!profile) {
-        setAvailableOptions(generators);
-        setChosenOptions([]);
-        setValue("generators", [], { shouldValidate: true });
-      } else {
-        const [chosen, available] = fork(generators, (g) =>
-          profile.generators?.some((ref) => ref.id === g.id)
-        );
-        setAvailableOptions(available);
-        setChosenOptions(chosen);
-        setValue("generators", chosen, { shouldValidate: true });
-      }
-    }
-  }, [isOpen, profile, generators, setValue]);
 
   const onListChange = useCallback(
     (
@@ -139,6 +170,7 @@ const TargetProfileForm: React.FC<TargetProfileFormProps> = ({
       id: profile?.id ?? 0,
       name: values.name,
       generators: toRefs(chosenOptions),
+      analysisProfile: toRef(values.analysisProfile ?? undefined),
     };
 
     onSave(newProfile);
@@ -170,7 +202,6 @@ const TargetProfileForm: React.FC<TargetProfileFormProps> = ({
           name="generators"
           label={t("terms.generators")}
           fieldId="target-profile-generators"
-          isRequired
           renderInput={() => (
             <DualListSelector
               availableOptions={availableOptions.map(({ name }) => name)}
@@ -179,6 +210,36 @@ const TargetProfileForm: React.FC<TargetProfileFormProps> = ({
               id="target-profile-generators-selector"
               availableOptionsTitle={t("message.generatorsAvailable")}
               chosenOptionsTitle={t("message.generatorsChosen")}
+            />
+          )}
+        />
+
+        <HookFormPFGroupController
+          control={control}
+          name="analysisProfile"
+          label={t("terms.analysisProfile")}
+          fieldId="target-profile-analysis-profile"
+          renderInput={({ field: { value, onChange } }) => (
+            <SimpleSelect
+              id="analysis-profile-select"
+              toggleId="analysis-profile-select-toggle"
+              variant="typeahead"
+              placeholderText={t("composed.selectOne", {
+                what: t("terms.analysisProfile").toLowerCase(),
+              })}
+              toggleAriaLabel="Analysis profile select"
+              aria-label="Select analysis profile"
+              value={
+                value
+                  ? analysisProfileOptions.find((o) => o.value.id === value.id)
+                  : undefined
+              }
+              options={analysisProfileOptions}
+              onChange={(selection) => {
+                const selected = selection as OptionWithValue<AnalysisProfile>;
+                onChange(selected?.value ?? null);
+              }}
+              onClear={() => onChange(null)}
             />
           )}
         />

--- a/client/src/app/pages/archetypes/hooks/useAnalysisProfileOptions.ts
+++ b/client/src/app/pages/archetypes/hooks/useAnalysisProfileOptions.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo } from "react";
+
+import { AnalysisProfile } from "@app/api/models";
+import { OptionWithValue } from "@app/components/SimpleSelect";
+import { useFetchAnalysisProfiles } from "@app/queries/analysis-profiles";
+
+export interface UseAnalysisProfileOptionsResult {
+  analysisProfiles: AnalysisProfile[];
+  analysisProfileOptions: OptionWithValue<AnalysisProfile>[];
+  isFetching: boolean;
+  findProfileById: (id: number | undefined) => AnalysisProfile | undefined;
+}
+
+/**
+ * Custom hook to fetch analysis profiles and provide them as select options.
+ * Used in the target profile form for attaching an analysis profile.
+ */
+export const useAnalysisProfileOptions =
+  (): UseAnalysisProfileOptionsResult => {
+    const { analysisProfiles, isFetching } = useFetchAnalysisProfiles();
+
+    const analysisProfileOptions = useMemo(
+      () =>
+        analysisProfiles.map((profile) => ({
+          value: profile,
+          toString: () => profile.name,
+        })),
+      [analysisProfiles]
+    );
+
+    const findProfileById = useCallback(
+      (id: number | undefined) =>
+        id === undefined
+          ? undefined
+          : analysisProfiles.find((p) => p.id === id),
+      [analysisProfiles]
+    );
+
+    return {
+      analysisProfiles,
+      analysisProfileOptions,
+      isFetching,
+      findProfileById,
+    };
+  };

--- a/client/src/app/pages/archetypes/target-profiles-page.tsx
+++ b/client/src/app/pages/archetypes/target-profiles-page.tsx
@@ -144,6 +144,7 @@ const TargetProfilesPage: React.FC = () => {
                 <Tr>
                   <Th>{t("terms.name")}</Th>
                   <Th>{t("terms.generators")}</Th>
+                  <Th>{t("terms.analysisProfile")}</Th>
                   <Th screenReaderText="Actions" />
                 </Tr>
               </Thead>
@@ -163,15 +164,16 @@ const TargetProfilesPage: React.FC = () => {
                     </EmptyStateBody>
                   </EmptyState>
                 }
-                numRenderedColumns={3}
+                numRenderedColumns={4}
               >
                 <Tbody>
                   {profiles.map((profile) => (
                     <Tr key={profile.id}>
-                      <Td width={40}>{profile.name}</Td>
-                      <Td width={60}>
+                      <Td width={25}>{profile.name}</Td>
+                      <Td width={35}>
                         <LabelsFromItems items={profile.generators} />
                       </Td>
+                      <Td width={25}>{profile.analysisProfile?.name ?? "-"}</Td>
                       <Td isActionCell>
                         <ActionsColumn
                           items={[
@@ -198,7 +200,7 @@ const TargetProfilesPage: React.FC = () => {
 
       {/* Create Modal */}
       <TargetProfileForm
-        key={openCreateModal ? 1 : 0}
+        key={openCreateModal ? "opened" : "closed"}
         isOpen={openCreateModal}
         archetype={archetype}
         onCancel={() => setOpenCreateModal(false)}


### PR DESCRIPTION
Resolves: #2712

Add analysis profiles to target profiles.  This allows for the selection of an analysis profile when creating a new target profile.

## Demo

https://github.com/user-attachments/assets/e3087e9a-b6fd-44a9-99ff-03db69f84b11



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Analysis Profile column to Target Profiles table (name shown) and adjusted column widths for better layout
  * Added Analysis Profile selection field in Target Profile form with dropdown options
  * Async loading of generators and analysis profiles with spinner while fetching

* **Refactor**
  * Reworked Target Profile form structure to separate data fetching and inner form logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->