### PR TITLE
:seedling: Update react imports using react-codemod

### DIFF
--- a/client/__mocks__/react-i18next.js
+++ b/client/__mocks__/react-i18next.js
@@ -1,7 +1,7 @@
 /* global module */
 
 // Adapted from https://github.com/i18next/react-i18next/blob/master/example/test-jest/src/__mocks__/react-i18next.js
-import React from "react";
+import { cloneElement, isValidElement } from "react";
 import * as reactI18next from "react-i18next";
 
 const hasChildren = (node) =>
@@ -17,14 +17,14 @@ const renderNodes = (reactNodes) => {
 
   return Object.keys(reactNodes).map((key, i) => {
     const child = reactNodes[key];
-    const isElement = React.isValidElement(child);
+    const isElement = isValidElement(child);
 
     if (typeof child === "string") {
       return child;
     }
     if (hasChildren(child)) {
       const inner = renderNodes(getChildren(child));
-      return React.cloneElement(child, { ...child.props, key: i }, inner);
+      return cloneElement(child, { ...child.props, key: i }, inner);
     }
     if (typeof child === "object" && !isElement) {
       return Object.keys(child).reduce(

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { BrowserRouter } from "react-router-dom";
 
 import { AppRoutes } from "./Routes";

--- a/client/src/app/components/AppPlaceholder.tsx
+++ b/client/src/app/components/AppPlaceholder.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Bullseye, Spinner } from "@patternfly/react-core";
 
 export const AppPlaceholder: React.FC = () => {

--- a/client/src/app/components/AppTable.tsx
+++ b/client/src/app/components/AppTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Bullseye, Skeleton, Spinner } from "@patternfly/react-core";
 import { IRow } from "@patternfly/react-table";
 import {

--- a/client/src/app/components/AppTableActionButtons.tsx
+++ b/client/src/app/components/AppTableActionButtons.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Flex, FlexItem } from "@patternfly/react-core";
 import { Td } from "@patternfly/react-table";

--- a/client/src/app/components/ApplicationDependenciesFormContainer/ApplicationDependenciesForm.tsx
+++ b/client/src/app/components/ApplicationDependenciesFormContainer/ApplicationDependenciesForm.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   ActionGroup,

--- a/client/src/app/components/ApplicationDependenciesFormContainer/SelectDependency.tsx
+++ b/client/src/app/components/ApplicationDependenciesFormContainer/SelectDependency.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 

--- a/client/src/app/components/Autocomplete/Autocomplete.tsx
+++ b/client/src/app/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from "react";
+import { useRef } from "react";
+import * as React from "react";
 import {
   Divider,
   Flex,

--- a/client/src/app/components/Autocomplete/GroupedAutocomplete.tsx
+++ b/client/src/app/components/Autocomplete/GroupedAutocomplete.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from "react";
+import { useRef } from "react";
+import * as React from "react";
 import {
   Divider,
   Flex,

--- a/client/src/app/components/Autocomplete/SearchInput.tsx
+++ b/client/src/app/components/Autocomplete/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { SearchInput } from "@patternfly/react-core";
 
 import { getString } from "@app/utils/utils";

--- a/client/src/app/components/BreadCrumbPath.tsx
+++ b/client/src/app/components/BreadCrumbPath.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Link } from "react-router-dom";
 import { Breadcrumb, BreadcrumbItem, Button } from "@patternfly/react-core";
 

--- a/client/src/app/components/BreakingPathDisplay.tsx
+++ b/client/src/app/components/BreakingPathDisplay.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 export interface BreakingPathDisplayProps {
   path: string;

--- a/client/src/app/components/Color.tsx
+++ b/client/src/app/components/Color.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Split, SplitItem } from "@patternfly/react-core";
 

--- a/client/src/app/components/ConditionalRender.tsx
+++ b/client/src/app/components/ConditionalRender.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 export interface ConditionalRenderProps {
   when: boolean;

--- a/client/src/app/components/ConditionalTooltip.tsx
+++ b/client/src/app/components/ConditionalTooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Tooltip, TooltipProps } from "@patternfly/react-core";
 
 export interface IConditionalTooltipProps extends TooltipProps {

--- a/client/src/app/components/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/client/src/app/components/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import { FC, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import {
   Button,

--- a/client/src/app/components/ConfirmDialog.tsx
+++ b/client/src/app/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   Alert,
   Button,

--- a/client/src/app/components/ControlledFormFieldGroupExpandable.tsx
+++ b/client/src/app/components/ControlledFormFieldGroupExpandable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { FormFieldGroupExpandableProps } from "@patternfly/react-core";
 import { InternalFormFieldGroup } from "@patternfly/react-core/dist/esm/components/Form/InternalFormFieldGroup";
 

--- a/client/src/app/components/EmptyTextMessage.tsx
+++ b/client/src/app/components/EmptyTextMessage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Text } from "@patternfly/react-core";
 

--- a/client/src/app/components/ErrorFallback.tsx
+++ b/client/src/app/components/ErrorFallback.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { useContext, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {
@@ -33,7 +33,7 @@ export const ErrorFallback = ({
   const { t } = useTranslation();
 
   const history = useHistory();
-  const { pushNotification } = React.useContext(NotificationsContext);
+  const { pushNotification } = useContext(NotificationsContext);
   const prevError = usePrevious(error);
 
   if (error.message !== prevError?.message) {

--- a/client/src/app/components/FilterToolbar/DateRangeFilter.tsx
+++ b/client/src/app/components/FilterToolbar/DateRangeFilter.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState } from "react";
+import { FormEvent, useState } from "react";
 import {
   DatePicker,
   InputGroup,

--- a/client/src/app/components/FilterToolbar/FilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/FilterControl.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { DateRangeFilter } from "./DateRangeFilter";
 import {
   FilterCategory,

--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useState } from "react";
 import {
   Dropdown,
   DropdownGroup,
@@ -123,10 +123,10 @@ export const FilterToolbar = <TItem, TFilterCategoryKey extends string>({
   isDisabled = false,
   breakpoint = "2xl",
 }: IFilterToolbarProps<TItem, TFilterCategoryKey>): JSX.Element | null => {
-  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] =
-    React.useState(false);
-  const [currentFilterCategoryKey, setCurrentFilterCategoryKey] =
-    React.useState(filterCategories[0].categoryKey);
+  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
+  const [currentFilterCategoryKey, setCurrentFilterCategoryKey] = useState(
+    filterCategories[0].categoryKey
+  );
 
   const onCategorySelect = (
     category: FilterCategory<TItem, TFilterCategoryKey>

--- a/client/src/app/components/HookFormPFFields/HookFormAutocomplete.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormAutocomplete.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Control, FieldValues, Path } from "react-hook-form";
 
 import {

--- a/client/src/app/components/HookFormPFFields/HookFormPFTextArea.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormPFTextArea.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { FieldValues, Path } from "react-hook-form";
 import { TextArea, TextAreaProps } from "@patternfly/react-core";
 

--- a/client/src/app/components/HookFormPFFields/HookFormPFTextInput.tsx
+++ b/client/src/app/components/HookFormPFFields/HookFormPFTextInput.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { FieldValues, Path, PathValue } from "react-hook-form";
 import { TextInput, TextInputProps } from "@patternfly/react-core";
 

--- a/client/src/app/components/HorizontalNav.tsx
+++ b/client/src/app/components/HorizontalNav.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { NavLink } from "react-router-dom";
 
 export interface HorizontalNavProps {

--- a/client/src/app/components/Icons/IconWithLabel.tsx
+++ b/client/src/app/components/Icons/IconWithLabel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, ReactNode } from "react";
+import { FC, ReactElement, ReactNode } from "react";
 import { Flex, FlexItem } from "@patternfly/react-core";
 
 import { OptionalTooltip } from "./OptionalTooltip";

--- a/client/src/app/components/Icons/IconedStatus.tsx
+++ b/client/src/app/components/Icons/IconedStatus.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { ReactElement } from "react-markdown/lib/react-markdown";
 import { Icon } from "@patternfly/react-core";

--- a/client/src/app/components/Icons/OptionalTooltip.tsx
+++ b/client/src/app/components/Icons/OptionalTooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Tooltip } from "@patternfly/react-core";
 
 export const OptionalTooltip: React.FC<{

--- a/client/src/app/components/Icons/TaskStateIcon.tsx
+++ b/client/src/app/components/Icons/TaskStateIcon.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Icon } from "@patternfly/react-core";
 import {
   CheckCircleIcon,

--- a/client/src/app/components/InfiniteScroller/InfiniteScroller.tsx
+++ b/client/src/app/components/InfiniteScroller/InfiniteScroller.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useVisibilityTracker } from "./useVisibilityTracker";

--- a/client/src/app/components/KebabDropdown.tsx
+++ b/client/src/app/components/KebabDropdown.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import {
   Dropdown,
   DropdownList,

--- a/client/src/app/components/KeycloakProvider.tsx
+++ b/client/src/app/components/KeycloakProvider.tsx
@@ -1,4 +1,5 @@
-import React, { Suspense } from "react";
+import { Suspense } from "react";
+import * as React from "react";
 import { ReactKeycloakProvider } from "@react-keycloak/web";
 
 import { initInterceptors } from "@app/axios-config";

--- a/client/src/app/components/LabelTooltip.tsx
+++ b/client/src/app/components/LabelTooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Tooltip } from "@patternfly/react-core";
 
 import { getString } from "@app/utils/utils";

--- a/client/src/app/components/NoDataEmptyState.tsx
+++ b/client/src/app/components/NoDataEmptyState.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   EmptyState,
   EmptyStateBody,

--- a/client/src/app/components/Notifications.tsx
+++ b/client/src/app/components/Notifications.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   Alert,
   AlertActionCloseButton,

--- a/client/src/app/components/PageHeader.tsx
+++ b/client/src/app/components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   Split,
   SplitItem,

--- a/client/src/app/components/ProposedActionLabel.tsx
+++ b/client/src/app/components/ProposedActionLabel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Label } from "@patternfly/react-core";
 

--- a/client/src/app/components/RiskLabel.tsx
+++ b/client/src/app/components/RiskLabel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Label } from "@patternfly/react-core";
 

--- a/client/src/app/components/RouteWrapper.tsx
+++ b/client/src/app/components/RouteWrapper.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Redirect, Route } from "react-router-dom";
 
 import { isAuthRequired } from "@app/Constants";

--- a/client/src/app/components/SimpleEmptyState.tsx
+++ b/client/src/app/components/SimpleEmptyState.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   EmptyState,
   EmptyStateBody,

--- a/client/src/app/components/SimplePagination.tsx
+++ b/client/src/app/components/SimplePagination.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Pagination, PaginationVariant } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 

--- a/client/src/app/components/SimpleSelect.tsx
+++ b/client/src/app/components/SimpleSelect.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import {
   Select,
   SelectOption,

--- a/client/src/app/components/SimpleSelectBasic.tsx
+++ b/client/src/app/components/SimpleSelectBasic.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import {
   MenuToggle,
   MenuToggleElement,

--- a/client/src/app/components/SimpleSelectCheckbox.tsx
+++ b/client/src/app/components/SimpleSelectCheckbox.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   Badge,
   MenuToggle,

--- a/client/src/app/components/SimpleSelectTypeahead.tsx
+++ b/client/src/app/components/SimpleSelectTypeahead.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   Button,
   Chip,

--- a/client/src/app/components/StateError.tsx
+++ b/client/src/app/components/StateError.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   EmptyState,
   EmptyStateBody,

--- a/client/src/app/components/StateNoData.tsx
+++ b/client/src/app/components/StateNoData.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 
 import { NoDataEmptyState } from "./NoDataEmptyState";

--- a/client/src/app/components/StateNoResults.tsx
+++ b/client/src/app/components/StateNoResults.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   EmptyState,

--- a/client/src/app/components/StatusIcon.tsx
+++ b/client/src/app/components/StatusIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { SpinnerProps, TextContent } from "@patternfly/react-core";
 import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";

--- a/client/src/app/components/TableControls/ConditionalTableBody.tsx
+++ b/client/src/app/components/TableControls/ConditionalTableBody.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Bullseye, Spinner } from "@patternfly/react-core";
 import { Tbody, Td, Tr } from "@patternfly/react-table";
 

--- a/client/src/app/components/TableControls/TableHeaderContentWithControls.tsx
+++ b/client/src/app/components/TableControls/TableHeaderContentWithControls.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Th } from "@patternfly/react-table";
 
 export interface ITableHeaderContentWithControlsProps {

--- a/client/src/app/components/TableControls/TableRowContentWithControls.tsx
+++ b/client/src/app/components/TableControls/TableRowContentWithControls.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Td } from "@patternfly/react-table";
 
 import { BulkSelectionValues } from "@app/hooks/selection/useBulkSelection";

--- a/client/src/app/components/ToolbarBulkExpander.tsx
+++ b/client/src/app/components/ToolbarBulkExpander.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button, ToolbarItem } from "@patternfly/react-core";
 import AngleDownIcon from "@patternfly/react-icons/dist/esm/icons/angle-down-icon";
 import AngleRightIcon from "@patternfly/react-icons/dist/esm/icons/angle-right-icon";

--- a/client/src/app/components/ToolbarBulkSelector.tsx
+++ b/client/src/app/components/ToolbarBulkSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dropdown,

--- a/client/src/app/components/TooltipTitle.tsx
+++ b/client/src/app/components/TooltipTitle.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Flex, FlexItem, Tooltip } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 

--- a/client/src/app/components/application-assessment-donut-chart/application-assessment-donut-chart.tsx
+++ b/client/src/app/components/application-assessment-donut-chart/application-assessment-donut-chart.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { ChartDonut, ChartLegend } from "@patternfly/react-charts";
 import { global_palette_blue_300 as defaultColor } from "@patternfly/react-tokens";

--- a/client/src/app/components/detail-drawer/no-entity.tsx
+++ b/client/src/app/components/detail-drawer/no-entity.tsx
@@ -1,6 +1,6 @@
 import "./drawer-tabs-container.css";
 
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   EmptyState,

--- a/client/src/app/components/detail-drawer/review-label.tsx
+++ b/client/src/app/components/detail-drawer/review-label.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Label } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 

--- a/client/src/app/components/discover-import-wizard/select-platform.tsx
+++ b/client/src/app/components/discover-import-wizard/select-platform.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Form, Text, TextContent } from "@patternfly/react-core";
 

--- a/client/src/app/components/discover-import-wizard/validate-cloudfoundry-schema.tsx
+++ b/client/src/app/components/discover-import-wizard/validate-cloudfoundry-schema.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useMemo } from "react";
 
 import {
   JsonSchemaObject,
@@ -52,7 +52,7 @@ export const useCloudFoundryCheck = (
   platform: SourcePlatform,
   schema?: TargetedSchema
 ) => {
-  return React.useMemo(() => {
+  return useMemo(() => {
     return (
       platform.kind === "cloudfoundry" &&
       schema &&

--- a/client/src/app/components/insights/tables/column-insight-title.tsx
+++ b/client/src/app/components/insights/tables/column-insight-title.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { AnalysisInsight } from "@app/api/models";
 

--- a/client/src/app/components/labels/labels-from-items/labels-from-items.tsx
+++ b/client/src/app/components/labels/labels-from-items/labels-from-items.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Label, LabelGroup, LabelProps } from "@patternfly/react-core";
 

--- a/client/src/app/components/labels/labels-from-tags/labels-from-tags.tsx
+++ b/client/src/app/components/labels/labels-from-tags/labels-from-tags.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { LabelGroup } from "@patternfly/react-core";
 

--- a/client/src/app/components/markdownPFComponents.tsx
+++ b/client/src/app/components/markdownPFComponents.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Components } from "react-markdown";
 import { CodeBlock, CodeBlockCode, Text } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";

--- a/client/src/app/components/questionnaire-summary/components/questionnaire-section-tab-title.tsx
+++ b/client/src/app/components/questionnaire-summary/components/questionnaire-section-tab-title.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Badge, TabTitleText } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 

--- a/client/src/app/components/questionnaire-summary/questionnaire-summary.tsx
+++ b/client/src/app/components/questionnaire-summary/questionnaire-summary.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { Link } from "react-router-dom";
 import {

--- a/client/src/app/components/questions-table/questions-table.tsx
+++ b/client/src/app/components/questions-table/questions-table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import { Label, List, ListItem, Tooltip } from "@patternfly/react-core";

--- a/client/src/app/components/repository-fields/RepositoryFields.tsx
+++ b/client/src/app/components/repository-fields/RepositoryFields.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   FieldPath,
   FieldPathValue,

--- a/client/src/app/components/risk-icon/risk-icon.tsx
+++ b/client/src/app/components/risk-icon/risk-icon.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { TimesCircleIcon, WarningTriangleIcon } from "@patternfly/react-icons";
 
 import { IconedStatus } from "@app/components/Icons";

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
   EmptyState,
@@ -43,15 +42,15 @@ export const SchemaAsCodeEditor = ({
   isReadOnly = false,
   height = "600px",
 }: ISchemaAsCodeEditorProps) => {
-  const editorRef = React.useRef<ControlledEditor>();
+  const editorRef = useRef<ControlledEditor>();
 
-  const [currentCode, setCurrentCode] = React.useState(
+  const [currentCode, setCurrentCode] = useState(
     JSON.stringify(jsonDocument, null, 2)
   );
   // const [documentIsValid, setDocumentIsValid] = React.useState(true);
 
-  const focusMovedOnSelectedDocumentChange = React.useRef<boolean>(false);
-  React.useEffect(() => {
+  const focusMovedOnSelectedDocumentChange = useRef<boolean>(false);
+  useEffect(() => {
     if (currentCode && !focusMovedOnSelectedDocumentChange.current) {
       focusAndHomePosition();
       focusMovedOnSelectedDocumentChange.current = true;

--- a/client/src/app/components/schema-defined-fields/SchemaAsFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsFields.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useMemo, useState } from "react";
 import { Panel, PanelHeader, PanelMain, Switch } from "@patternfly/react-core";
 
 import { JsonSchemaObject } from "@app/api/models";
@@ -25,7 +25,7 @@ export const SchemaDefinedField = ({
   onDocumentChanged,
   isReadOnly = false,
 }: ISchemaDefinedFieldProps) => {
-  const [isJsonView, setIsJsonView] = React.useState<boolean>(
+  const [isJsonView, setIsJsonView] = useState<boolean>(
     !jsonSchema || isComplexSchema(jsonSchema)
   );
 
@@ -33,7 +33,7 @@ export const SchemaDefinedField = ({
     onDocumentChanged?.(newJsonDocument);
   };
 
-  const isComplex = React.useMemo(() => {
+  const isComplex = useMemo(() => {
     const isComplex = jsonSchema && isComplexSchema(jsonSchema);
     // console.log("jsonSchema", jsonSchema, "isComplex?", isComplex);
     return isComplex;

--- a/client/src/app/components/simple-document-viewer/AttachmentToggle.tsx
+++ b/client/src/app/components/simple-document-viewer/AttachmentToggle.tsx
@@ -1,4 +1,5 @@
-import React, { FC, useState } from "react";
+import { FC, useState } from "react";
+import * as React from "react";
 import {
   MenuToggle,
   MenuToggleElement,

--- a/client/src/app/components/simple-document-viewer/SimpleDocumentViewer.tsx
+++ b/client/src/app/components/simple-document-viewer/SimpleDocumentViewer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
   EmptyState,
@@ -101,7 +101,7 @@ export const SimpleDocumentViewer = ({
   height = "450px",
   onDocumentChange,
 }: ISimpleDocumentViewerProps) => {
-  const configuredDocuments: Document[] = React.useMemo(
+  const configuredDocuments: Document[] = useMemo(
     () => [
       {
         id: "LOG_VIEW",
@@ -132,7 +132,7 @@ export const SimpleDocumentViewer = ({
     [attachments, taskId]
   );
 
-  const [selectedDocument, setSelectedDocument] = React.useState<Document>(
+  const [selectedDocument, setSelectedDocument] = useState<Document>(
     configuredDocuments.find(({ id }) => id === documentId) ??
       configuredDocuments[0]
   );
@@ -140,11 +140,11 @@ export const SimpleDocumentViewer = ({
     ({ id }) => id === selectedDocument.id
   )?.languages ?? [Language.yaml, Language.json];
 
-  const [currentLanguage, setCurrentLanguage] = React.useState(
+  const [currentLanguage, setCurrentLanguage] = useState(
     supportedLanguages[0] ?? Language.plaintext
   );
 
-  const editorRef = React.useRef<ControlledEditor>();
+  const editorRef = useRef<ControlledEditor>();
 
   const { code, refetch } = useDocuments({
     taskId,
@@ -153,8 +153,8 @@ export const SimpleDocumentViewer = ({
   });
 
   // move focus on first code change AFTER a new document was selected
-  const focusMovedOnSelectedDocumentChange = React.useRef<boolean>(false);
-  React.useEffect(() => {
+  const focusMovedOnSelectedDocumentChange = useRef<boolean>(false);
+  useEffect(() => {
     if (code && !focusMovedOnSelectedDocumentChange.current) {
       focusAndHomePosition();
       focusMovedOnSelectedDocumentChange.current = true;

--- a/client/src/app/components/simple-document-viewer/SimpleDocumentViewerModal.tsx
+++ b/client/src/app/components/simple-document-viewer/SimpleDocumentViewerModal.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Button, Modal, ModalProps } from "@patternfly/react-core";
 import { css } from "@patternfly/react-styles";
 

--- a/client/src/app/components/tests/AppPlaceholder.test.tsx
+++ b/client/src/app/components/tests/AppPlaceholder.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { AppPlaceholder } from "../AppPlaceholder";

--- a/client/src/app/components/tests/AppTable.test.tsx
+++ b/client/src/app/components/tests/AppTable.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Label } from "@patternfly/react-core";
 import { ICell, IRow, sortable } from "@patternfly/react-table";
 

--- a/client/src/app/components/tests/BreadCrumbPath.test.tsx
+++ b/client/src/app/components/tests/BreadCrumbPath.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import { fireEvent, render, screen } from "@app/test-config/test-utils";

--- a/client/src/app/components/tests/ConditionalRender.test.tsx
+++ b/client/src/app/components/tests/ConditionalRender.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render, screen } from "@app/test-config/test-utils";
 
 import { ConditionalRender } from "../ConditionalRender";

--- a/client/src/app/components/tests/ConfirmDialog.test.tsx
+++ b/client/src/app/components/tests/ConfirmDialog.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ButtonVariant } from "@patternfly/react-core";
 
 import { fireEvent, render, screen } from "@app/test-config/test-utils";

--- a/client/src/app/components/tests/EmptyTextMessage.test.tsx
+++ b/client/src/app/components/tests/EmptyTextMessage.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { EmptyTextMessage } from "../EmptyTextMessage";

--- a/client/src/app/components/tests/HorizontalNav.test.tsx
+++ b/client/src/app/components/tests/HorizontalNav.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import { render } from "@app/test-config/test-utils";

--- a/client/src/app/components/tests/NoDataEmptyState.test.tsx
+++ b/client/src/app/components/tests/NoDataEmptyState.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { NoDataEmptyState } from "../NoDataEmptyState";

--- a/client/src/app/components/tests/PageHeader.test.tsx
+++ b/client/src/app/components/tests/PageHeader.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { Button } from "@patternfly/react-core";
 

--- a/client/src/app/components/tests/RiskLabel.test.tsx
+++ b/client/src/app/components/tests/RiskLabel.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render, screen } from "@app/test-config/test-utils";
 
 import { RiskLabel } from "../RiskLabel";

--- a/client/src/app/components/tests/SimpleEmptyState.test.tsx
+++ b/client/src/app/components/tests/SimpleEmptyState.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import AdIcon from "@patternfly/react-icons/dist/esm/icons/ad-icon";
 
 import { render } from "@app/test-config/test-utils";

--- a/client/src/app/components/tests/SimpleSelect.test.tsx
+++ b/client/src/app/components/tests/SimpleSelect.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { SimpleSelect } from "../SimpleSelect";

--- a/client/src/app/components/tests/StateError.test.tsx
+++ b/client/src/app/components/tests/StateError.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { StateError } from "../StateError";

--- a/client/src/app/components/tests/StateNoData.test.tsx
+++ b/client/src/app/components/tests/StateNoData.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { StateNoData } from "../StateNoData";

--- a/client/src/app/components/tests/StateNoResults.test.tsx
+++ b/client/src/app/components/tests/StateNoResults.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { StateNoResults } from "../StateNoResults";

--- a/client/src/app/components/tests/StatusIcon.test.tsx
+++ b/client/src/app/components/tests/StatusIcon.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { IconedStatus } from "../Icons";

--- a/client/src/app/devtools/schema-defined/StatusAlert.tsx
+++ b/client/src/app/devtools/schema-defined/StatusAlert.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Alert, AlertProps, Icon } from "@patternfly/react-core";
 import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";

--- a/client/src/app/devtools/schema-defined/schema-defined-page.tsx
+++ b/client/src/app/devtools/schema-defined/schema-defined-page.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import * as React from "react";
 import ReactJsonView from "@microlink/react-json-view";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {

--- a/client/src/app/hooks/table-controls/active-item/useActiveItemEffects.ts
+++ b/client/src/app/hooks/table-controls/active-item/useActiveItemEffects.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect } from "react";
 
 import { IActiveItemDerivedState } from "./getActiveItemDerivedState";
 import { IActiveItemState } from "./useActiveItemState";
@@ -34,7 +34,7 @@ export const useActiveItemEffects = <TItem>({
   activeItemState: { activeItemId },
   activeItemDerivedState: { activeItem, clearActiveItem },
 }: IUseActiveItemEffectsArgs<TItem>) => {
-  React.useEffect(() => {
+  useEffect(() => {
     if (!isLoading && activeItemId && !activeItem) {
       clearActiveItem();
     }

--- a/client/src/app/hooks/table-controls/pagination/usePaginationEffects.ts
+++ b/client/src/app/hooks/table-controls/pagination/usePaginationEffects.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect } from "react";
 
 import { IPaginationState } from "./usePaginationState";
 
@@ -28,7 +28,7 @@ export const usePaginationEffects = ({
 }: IUsePaginationEffectsArgs) => {
   // When items are removed, make sure the current page still exists
   const lastPageNumber = Math.max(Math.ceil(totalItemCount / itemsPerPage), 1);
-  React.useEffect(() => {
+  useEffect(() => {
     if (isPaginationEnabled && pageNumber > lastPageNumber && !isLoading) {
       setPageNumber(lastPageNumber);
     }

--- a/client/src/app/hooks/table-controls/utils.ts
+++ b/client/src/app/hooks/table-controls/utils.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 /**
  * Works around problems caused by event propagation when handling a clickable element that contains other clickable elements.

--- a/client/src/app/hooks/useAsyncYupValidation.ts
+++ b/client/src/app/hooks/useAsyncYupValidation.ts
@@ -1,12 +1,12 @@
-import * as React from "react";
+import { useEffect, useState } from "react";
 import * as yup from "yup";
 
 export const useAsyncYupValidation = <TFieldValues>(
   values: TFieldValues,
   schema: yup.SchemaOf<TFieldValues>
 ) => {
-  const [isValid, setIsValid] = React.useState(false);
-  React.useEffect(() => {
+  const [isValid, setIsValid] = useState(false);
+  useEffect(() => {
     const validate = async () => {
       try {
         await schema.validate(values);

--- a/client/src/app/hooks/useCreateEditModalState.ts
+++ b/client/src/app/hooks/useCreateEditModalState.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 
 type ModalState<T> =
   | { mode: "create"; resource: null }
@@ -7,7 +7,7 @@ type ModalState<T> =
   | null;
 
 export default function useCreateEditModalState<T>() {
-  const [modalState, setModalState] = React.useState<ModalState<T>>(null);
+  const [modalState, setModalState] = useState<ModalState<T>>(null);
   const isModalOpen = modalState !== null;
 
   return {

--- a/client/src/app/hooks/usePersistentState.ts
+++ b/client/src/app/hooks/usePersistentState.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 
 import {
   UseStorageTypeOptions,
@@ -81,7 +81,7 @@ export const usePersistentState = <
     persistenceKeyPrefix ? `${persistenceKeyPrefix}:${key}` : key;
 
   const persistence = {
-    state: React.useState(defaultValue),
+    state: useState(defaultValue),
     urlParams: useUrlParams(
       isUrlParamsOptions(options)
         ? options

--- a/client/src/app/hooks/useSelectionState/useSelectionState.ts
+++ b/client/src/app/hooks/useSelectionState/useSelectionState.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useCallback, useMemo, useState } from "react";
 
 export interface ISelectionStateArgs<T> {
   items: T[];
@@ -30,16 +30,16 @@ export const useSelectionState = <T>({
   initialSelected = [],
   isEqual = (a, b) => a === b,
 }: ISelectionStateArgs<T>): ISelectionState<T> => {
-  const [selectedSet, setSelectedSet] = React.useState<T[]>(
+  const [selectedSet, setSelectedSet] = useState<T[]>(
     doSelect(isEqual, items, initialSelected)
   );
 
-  const isItemSelected = React.useCallback(
+  const isItemSelected = useCallback(
     (item: T) => selectedSet.some((i) => isEqual(item, i)),
     [isEqual, selectedSet]
   );
 
-  const selectItems = React.useCallback(
+  const selectItems = useCallback(
     (itemsSubset: T[], isSelecting: boolean) => {
       const verifiedItemsSubset = doSelect(isEqual, items, itemsSubset);
       const selectedNotInItemsSubset = selectedSet.filter(
@@ -55,7 +55,7 @@ export const useSelectionState = <T>({
     [isEqual, items, selectedSet]
   );
 
-  const selectOnly = React.useCallback(
+  const selectOnly = useCallback(
     (toSelect: T[]) => {
       const filtered = doSelect(isEqual, items, toSelect);
       setSelectedSet(filtered);
@@ -63,19 +63,19 @@ export const useSelectionState = <T>({
     [isEqual, items]
   );
 
-  const selectAll = React.useCallback(
+  const selectAll = useCallback(
     (isSelecting: boolean) => setSelectedSet(isSelecting ? items : []),
     [items]
   );
 
-  const areAllSelected = React.useMemo(() => {
+  const areAllSelected = useMemo(() => {
     return (
       selectedSet.length === items.length &&
       selectedSet.every((si) => items.some((i) => isEqual(si, i)))
     );
   }, [selectedSet, items, isEqual]);
 
-  const selectedItems = React.useMemo(() => {
+  const selectedItems = useMemo(() => {
     if (selectedSet.length === 0) {
       return [];
     }

--- a/client/src/app/hooks/useUrlParams.ts
+++ b/client/src/app/hooks/useUrlParams.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useEffect } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 
 import { DisallowCharacters } from "@app/utils/type-utils";
@@ -114,7 +114,7 @@ export const useUrlParams = <
     params = allParamsEmpty ? defaultValue : deserialize(serializedParams);
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (allParamsEmpty) setParams(defaultValue);
     // Leaving this rule enabled results in a cascade of unnecessary useCallbacks:
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/app/layout/AppAboutModal/AppAboutModal.tsx
+++ b/client/src/app/layout/AppAboutModal/AppAboutModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import {
   AboutModal,

--- a/client/src/app/layout/AppAboutModal/tests/AppAboutModal.test.tsx
+++ b/client/src/app/layout/AppAboutModal/tests/AppAboutModal.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { AppAboutModal } from "../AppAboutModal";

--- a/client/src/app/layout/AppAboutModalState/AppAboutModalState.tsx
+++ b/client/src/app/layout/AppAboutModalState/AppAboutModalState.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 
 import { AppAboutModal } from "../AppAboutModal";
 

--- a/client/src/app/layout/DefaultLayout/DefaultLayout.tsx
+++ b/client/src/app/layout/DefaultLayout/DefaultLayout.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from "react";
+import { useRef } from "react";
+import * as React from "react";
 import { Page, SkipToContent } from "@patternfly/react-core";
 
 import { Notifications } from "@app/components/Notifications";

--- a/client/src/app/layout/DefaultLayout/tests/DefaultLayout.test.tsx
+++ b/client/src/app/layout/DefaultLayout/tests/DefaultLayout.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import { render } from "@app/test-config/test-utils";

--- a/client/src/app/layout/HeaderApp/HeaderApp.tsx
+++ b/client/src/app/layout/HeaderApp/HeaderApp.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   Brand,
   Button,

--- a/client/src/app/layout/HeaderApp/MobileDropdown.tsx
+++ b/client/src/app/layout/HeaderApp/MobileDropdown.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { DropdownItem } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 

--- a/client/src/app/layout/HeaderApp/SsoToolbarItem.tsx
+++ b/client/src/app/layout/HeaderApp/SsoToolbarItem.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useKeycloak } from "@react-keycloak/web";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";

--- a/client/src/app/layout/HeaderApp/tests/HeaderApp.test.tsx
+++ b/client/src/app/layout/HeaderApp/tests/HeaderApp.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { HeaderApp } from "../HeaderApp";

--- a/client/src/app/layout/SidebarApp/tests/SidebarApp.test.tsx
+++ b/client/src/app/layout/SidebarApp/tests/SidebarApp.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import { render } from "@app/test-config/test-utils";

--- a/client/src/app/pages/applications/analysis-details/AnalysisDetails.tsx
+++ b/client/src/app/pages/applications/analysis-details/AnalysisDetails.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 

--- a/client/src/app/pages/applications/analysis-wizard/utils.ts
+++ b/client/src/app/pages/applications/analysis-wizard/utils.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useMemo } from "react";
 import { toggle, unique } from "radash";
 
 import { Application, Target, TargetLabel } from "@app/api/models";
@@ -34,7 +34,7 @@ export const useAnalyzableApplications = (
   applications: Application[],
   mode: AnalysisMode
 ) =>
-  React.useMemo(
+  useMemo(
     () => filterAnalyzableApplications(applications, mode),
     [applications, mode]
   );
@@ -42,7 +42,7 @@ export const useAnalyzableApplications = (
 export const useAnalyzableApplicationsByMode = (
   applications: Application[]
 ): Record<AnalysisMode, Application[]> =>
-  React.useMemo(
+  useMemo(
     () =>
       ANALYSIS_MODES.reduce(
         (record, mode) => ({

--- a/client/src/app/pages/applications/application-detail-drawer/application-facts.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/application-facts.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/client/src/app/pages/applications/application-detail-drawer/components/application-tags.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/components/application-tags.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {

--- a/client/src/app/pages/applications/application-detail-drawer/tab-details-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-details-content.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import {

--- a/client/src/app/pages/applications/application-detail-drawer/tab-reports-contents.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-reports-contents.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {

--- a/client/src/app/pages/applications/application-detail-drawer/tab-tags-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-tags-content.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Bullseye,

--- a/client/src/app/pages/applications/application-form/application-form.tsx
+++ b/client/src/app/pages/applications/application-form/application-form.tsx
@@ -1,5 +1,5 @@
 import "./application-form.css";
-import React from "react";
+import * as React from "react";
 import { useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/applications/application-form/useApplicationFormData.ts
+++ b/client/src/app/pages/applications/application-form/useApplicationFormData.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 
@@ -33,7 +33,7 @@ export const useApplicationFormData = ({
   onActionFail?: () => void;
 } = {}) => {
   const { t } = useTranslation();
-  const { pushNotification } = React.useContext(NotificationsContext);
+  const { pushNotification } = useContext(NotificationsContext);
 
   // Fetch data
   const { tags, tagItems, isSuccess: is1 } = useFetchTagsWithTagItems();

--- a/client/src/app/pages/applications/application-identity-form/application-identity-form.tsx
+++ b/client/src/app/pages/applications/application-identity-form/application-identity-form.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/applications/application-identity-form/application-identity-modal.tsx
+++ b/client/src/app/pages/applications/application-identity-form/application-identity-modal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Modal } from "@patternfly/react-core";
 
 import { DecoratedApplication } from "../useDecoratedApplications";

--- a/client/src/app/pages/applications/applications-table/components/column-analysis-status.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-analysis-status.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { TaskState } from "@app/api/models";
 import {

--- a/client/src/app/pages/applications/applications-table/components/column-application-name.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-application-name.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import dayjs from "dayjs";
 import { Link } from "react-router-dom";
 import { Icon, Popover, PopoverProps, Tooltip } from "@patternfly/react-core";

--- a/client/src/app/pages/applications/applications-table/components/column-assessment-status.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-assessment-status.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Spinner } from "@patternfly/react-core";
 
 import { IconedStatus, IconedStatusPreset } from "@app/components/Icons";

--- a/client/src/app/pages/applications/applications-table/components/column-review-status.tsx
+++ b/client/src/app/pages/applications/applications-table/components/column-review-status.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "@patternfly/react-core";
 

--- a/client/src/app/pages/applications/applications-table/components/manage-columns-modal.tsx
+++ b/client/src/app/pages/applications/applications-table/components/manage-columns-modal.tsx
@@ -1,6 +1,6 @@
 import "./manage-columns-modal.css";
 
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   Button,
   DataList,

--- a/client/src/app/pages/applications/applications-table/components/manage-columns-toolbar.tsx
+++ b/client/src/app/pages/applications/applications-table/components/manage-columns-toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/client/src/app/pages/applications/applications.tsx
+++ b/client/src/app/pages/applications/applications.tsx
@@ -1,4 +1,5 @@
-import React, { lazy } from "react";
+import { lazy } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Level,

--- a/client/src/app/pages/applications/components/import-applications-form.tsx
+++ b/client/src/app/pages/applications/components/import-applications-form.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import axios, { AxiosResponse } from "axios";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
+++ b/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { saveAs } from "file-saver";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";

--- a/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {

--- a/client/src/app/pages/archetypes/archetypes-page.tsx
+++ b/client/src/app/pages/archetypes/archetypes-page.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {

--- a/client/src/app/pages/archetypes/components/archetype-detail-drawer.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-detail-drawer.tsx
@@ -1,5 +1,5 @@
 import "./archetype-detail-drawer.css";
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Tab,

--- a/client/src/app/pages/archetypes/components/archetype-maintainers-column.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-maintainers-column.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Label, LabelGroup } from "@patternfly/react-core";
 
 import type { Archetype } from "@app/api/models";

--- a/client/src/app/pages/archetypes/components/archetype-tags-column.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-tags-column.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { LabelGroup } from "@patternfly/react-core";
 
 import { COLOR_HEX_VALUES_BY_NAME } from "@app/Constants";

--- a/client/src/app/pages/archetypes/components/link-to-archetype-applications.tsx
+++ b/client/src/app/pages/archetypes/components/link-to-archetype-applications.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Text } from "@patternfly/react-core";

--- a/client/src/app/pages/archetypes/components/tab-details-content.tsx
+++ b/client/src/app/pages/archetypes/components/tab-details-content.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   DescriptionList,

--- a/client/src/app/pages/archetypes/components/tab-target-profiles.tsx
+++ b/client/src/app/pages/archetypes/components/tab-target-profiles.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Bullseye,

--- a/client/src/app/pages/archetypes/components/target-profile-form.tsx
+++ b/client/src/app/pages/archetypes/components/target-profile-form.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { fork } from "radash";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/archetypes/hooks/useArchetypeMutations.ts
+++ b/client/src/app/pages/archetypes/hooks/useArchetypeMutations.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useContext } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
@@ -26,7 +26,7 @@ export const useArchetypeMutations = ({
   onActionFail = () => {},
 }: UseArchetypeMutationsOptions = {}) => {
   const { t } = useTranslation();
-  const { pushNotification } = React.useContext(NotificationsContext);
+  const { pushNotification } = useContext(NotificationsContext);
   const queryClient = useQueryClient();
 
   // Common error handler

--- a/client/src/app/pages/archetypes/target-profiles-page.tsx
+++ b/client/src/app/pages/archetypes/target-profiles-page.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import {

--- a/client/src/app/pages/assessment-management/assessment-settings/components/questionnaire-questions-column.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/components/questionnaire-questions-column.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Text } from "@patternfly/react-core";
 
 import { Questionnaire } from "@app/api/models";

--- a/client/src/app/pages/assessment-management/assessment-settings/components/questionnaire-thresholds-column.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/components/questionnaire-thresholds-column.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { ListItem } from "@patternfly/react-core";
 
 import { Questionnaire, Thresholds } from "@app/api/models";

--- a/client/src/app/pages/assessment-management/import-questionnaire-form/import-questionnaire-form.tsx
+++ b/client/src/app/pages/assessment-management/import-questionnaire-form/import-questionnaire-form.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
 import jsYaml from "js-yaml";

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useParams } from "react-router-dom";
 
 import "./questionnaire-page.css";

--- a/client/src/app/pages/assessment/components/assessment-actions/assessment-actions-page.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/assessment-actions-page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   Breadcrumb,

--- a/client/src/app/pages/assessment/components/assessment-actions/components/assessment-actions-table.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/assessment-actions-table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { Application, Archetype } from "@app/api/models";
 import { useFetchAssessmentsByItemId } from "@app/queries/assessments";

--- a/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
@@ -1,4 +1,10 @@
-import React, { FunctionComponent } from "react";
+import {
+  FunctionComponent,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import {
   useIsFetching,
   useIsMutating,
@@ -62,7 +68,7 @@ const DynamicAssessmentActionsRow: FunctionComponent<
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
-  const { pushNotification } = React.useContext(NotificationsContext);
+  const { pushNotification } = useContext(NotificationsContext);
 
   const onSuccessHandler = () => {};
   const onErrorHandler = () => {};
@@ -100,7 +106,7 @@ const DynamicAssessmentActionsRow: FunctionComponent<
   const isFetching = useIsFetching();
   const isMutating = useIsMutating();
 
-  const determineAction = React.useCallback(() => {
+  const determineAction = useCallback(() => {
     if (!assessment) {
       return AssessmentAction.Take;
     } else if (assessment.status === "started") {
@@ -110,9 +116,9 @@ const DynamicAssessmentActionsRow: FunctionComponent<
     }
   }, [assessment]);
 
-  const [action, setAction] = React.useState(determineAction());
+  const [action, setAction] = useState(determineAction());
 
-  React.useEffect(() => {
+  useEffect(() => {
     setAction(determineAction());
   }, [determineAction, assessment]);
 

--- a/client/src/app/pages/assessment/components/assessment-actions/components/questionnaires-table.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/questionnaires-table.tsx
@@ -1,5 +1,6 @@
 import "./questionnaires-table.css";
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import {

--- a/client/src/app/pages/assessment/components/assessment-page-header.tsx
+++ b/client/src/app/pages/assessment/components/assessment-page-header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import { Button, ButtonVariant, Modal, Text } from "@patternfly/react-core";

--- a/client/src/app/pages/assessment/components/assessment-stakeholders-form/assessment-stakeholders-form.tsx
+++ b/client/src/app/pages/assessment/components/assessment-stakeholders-form/assessment-stakeholders-form.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/assessment/components/assessment-summary/assessment-summary-page.tsx
+++ b/client/src/app/pages/assessment/components/assessment-summary/assessment-summary-page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useParams } from "react-router-dom";
 
 import QuestionnaireSummary, {

--- a/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard-modal.tsx
+++ b/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard-modal.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react";
+import { FunctionComponent } from "react";
 import { Modal, ModalVariant } from "@patternfly/react-core";
 
 import { AssessmentWithSectionOrder } from "@app/api/models";

--- a/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard.tsx
+++ b/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";

--- a/client/src/app/pages/assessment/components/custom-wizard-footer/custom-wizard-footer.tsx
+++ b/client/src/app/pages/assessment/components/custom-wizard-footer/custom-wizard-footer.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/client/src/app/pages/assessment/components/custom-wizard-footer/tests/custom-wizard-footer.test.tsx
+++ b/client/src/app/pages/assessment/components/custom-wizard-footer/tests/custom-wizard-footer.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { fireEvent, render, screen } from "@app/test-config/test-utils";
 
 import { CustomWizardFooter } from "../custom-wizard-footer";

--- a/client/src/app/pages/assessment/components/questionnaire-form/multi-input-selection/multi-input-selection.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/multi-input-selection/multi-input-selection.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Icon, Radio, Stack, StackItem, Tooltip } from "@patternfly/react-core";

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/question-body.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/question-body.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { StackItem } from "@patternfly/react-core";
 
 export interface QuestionBodyProps {

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/question-header.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/question-header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { StackItem } from "@patternfly/react-core";
 
 export interface QuestionHeaderProps {

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/question.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/question.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Stack } from "@patternfly/react-core";
 
 export interface RadioButtonQuestionProps {

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question-body.test.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question-body.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { QuestionBody } from "../question-body";

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question-header.test.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question-header.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { QuestionHeader } from "../question-header";

--- a/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question.test.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/question/tests/question.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { render } from "@app/test-config/test-utils";
 
 import { Question } from "../question";

--- a/client/src/app/pages/assessment/components/questionnaire-form/questionnaire-form.tsx
+++ b/client/src/app/pages/assessment/components/questionnaire-form/questionnaire-form.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
+import * as React from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/assessment/components/view-archetypes/components/view-archetypes-table.tsx
+++ b/client/src/app/pages/assessment/components/view-archetypes/components/view-archetypes-table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import { Ref } from "@app/api/models";
 import { useFetchArchetypeById } from "@app/queries/archetypes";

--- a/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
+++ b/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
+import * as React from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   Breadcrumb,

--- a/client/src/app/pages/assessment/components/wizard-step-nav-description/tests/wizard-step-nav-description.test.tsx
+++ b/client/src/app/pages/assessment/components/wizard-step-nav-description/tests/wizard-step-nav-description.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Section } from "@app/api/models";
 import { render } from "@app/test-config/test-utils";
 

--- a/client/src/app/pages/assessment/components/wizard-step-nav-description/wizard-step-nav-description.tsx
+++ b/client/src/app/pages/assessment/components/wizard-step-nav-description/wizard-step-nav-description.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Text, TextContent } from "@patternfly/react-core";
 

--- a/client/src/app/pages/asset-generators/components/generator-detail-drawer.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-detail-drawer.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   DescriptionList,

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-fields-mapper.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-fields-mapper.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Fragment, forwardRef, useImperativeHandle } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import {
   Bullseye,
@@ -18,7 +18,7 @@ interface KeyValueFieldsProps {
   name: string;
 }
 
-export const KeyValueFields = React.forwardRef<
+export const KeyValueFields = forwardRef<
   { addField: () => void },
   KeyValueFieldsProps
 >(({ noValuesMessage, removeLabel, name }, ref) => {
@@ -36,7 +36,7 @@ export const KeyValueFields = React.forwardRef<
     append({ key: "", value: "" });
   };
 
-  React.useImperativeHandle(ref, () => ({
+  useImperativeHandle(ref, () => ({
     addField: handleAddField,
   }));
 
@@ -49,7 +49,7 @@ export const KeyValueFields = React.forwardRef<
           </GridItem>
         )}
         {fields.map((field, index) => (
-          <React.Fragment key={`${name}-${field.id}`}>
+          <Fragment key={`${name}-${field.id}`}>
             <GridItem span={5}>
               <InputField
                 control={control}
@@ -74,7 +74,7 @@ export const KeyValueFields = React.forwardRef<
                 onRemove={() => handleRemoveField(index)}
               />
             </GridItem>
-          </React.Fragment>
+          </Fragment>
         ))}
       </Grid>
     </Grid>

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form-parameters.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form-parameters.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
+import * as React from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Button, FormFieldGroupHeader, Label } from "@patternfly/react-core";

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form-repository.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form-repository.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form-values.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form-values.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
+import * as React from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Button, FormFieldGroupHeader, Label } from "@patternfly/react-core";

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
 import { FormProvider, useForm } from "react-hook-form";

--- a/client/src/app/pages/controls/ControlTableActionsColumn.tsx
+++ b/client/src/app/pages/controls/ControlTableActionsColumn.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Button, OverflowMenu, Tooltip } from "@patternfly/react-core";
 import { PencilAltIcon } from "@patternfly/react-icons";

--- a/client/src/app/pages/controls/business-services/business-services.tsx
+++ b/client/src/app/pages/controls/business-services/business-services.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/controls/business-services/components/business-service-form.tsx
+++ b/client/src/app/pages/controls/business-services/components/business-service-form.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/controls/controls.tsx
+++ b/client/src/app/pages/controls/controls.tsx
@@ -1,4 +1,5 @@
-import React, { Suspense, lazy, useEffect } from "react";
+import { Suspense, lazy, useEffect } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Redirect,

--- a/client/src/app/pages/controls/job-functions/components/job-function-form.tsx
+++ b/client/src/app/pages/controls/job-functions/components/job-function-form.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/controls/job-functions/job-functions.tsx
+++ b/client/src/app/pages/controls/job-functions/job-functions.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/stakeholder-groups.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
+++ b/client/src/app/pages/controls/stakeholders/components/stakeholder-form.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/controls/tags/components/tag-category-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-category-form.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";

--- a/client/src/app/pages/controls/tags/components/tag-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-form.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/controls/tags/components/tag-table.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 

--- a/client/src/app/pages/controls/tags/tag-categories-table.tsx
+++ b/client/src/app/pages/controls/tags/tag-categories-table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import {

--- a/client/src/app/pages/external/jira/components/tracker-status.tsx
+++ b/client/src/app/pages/external/jira/components/tracker-status.tsx
@@ -1,5 +1,5 @@
 import "./tracker-status.css";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/general/general.tsx
+++ b/client/src/app/pages/general/general.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Alert,

--- a/client/src/app/pages/identities/components/DefaultLabel.tsx
+++ b/client/src/app/pages/identities/components/DefaultLabel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Icon, Tooltip } from "@patternfly/react-core";
 import StarIcon from "@patternfly/react-icons/dist/esm/icons/star-icon";

--- a/client/src/app/pages/identities/components/identity-form/identity-form-modal.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form-modal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Modal } from "@patternfly/react-core";
 

--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
 import { FormProvider, useForm } from "react-hook-form";

--- a/client/src/app/pages/identities/components/identity-form/kind-bearer-token-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/kind-bearer-token-form.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useFormContext } from "react-hook-form";
 
 import { Identity } from "@app/api/models";

--- a/client/src/app/pages/identities/components/identity-form/kind-maven-settings-file-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/kind-maven-settings-file-form.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useFormContext } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import { Alert, FileUpload, Switch } from "@patternfly/react-core";

--- a/client/src/app/pages/identities/components/identity-form/kind-simple-username-password-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/kind-simple-username-password-form.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useFormContext } from "react-hook-form";
 
 import { Identity } from "@app/api/models";

--- a/client/src/app/pages/identities/components/identity-form/kind-source-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/kind-source-form.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import { Alert, FileUpload, Switch } from "@patternfly/react-core";

--- a/client/src/app/pages/identities/identities.tsx
+++ b/client/src/app/pages/identities/identities.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { objectify } from "radash";
 import { Trans, useTranslation } from "react-i18next";

--- a/client/src/app/pages/migration-waves/components/export-form.tsx
+++ b/client/src/app/pages/migration-waves/components/export-form.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/migration-waves/components/stakeholders-table.tsx
+++ b/client/src/app/pages/migration-waves/components/stakeholders-table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 

--- a/client/src/app/pages/migration-waves/components/ticket-issue.tsx
+++ b/client/src/app/pages/migration-waves/components/ticket-issue.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Text, TextVariants } from "@patternfly/react-core";
 

--- a/client/src/app/pages/migration-waves/components/wave-applications-table.tsx
+++ b/client/src/app/pages/migration-waves/components/wave-applications-table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import {

--- a/client/src/app/pages/migration-waves/components/wave-status-table.tsx
+++ b/client/src/app/pages/migration-waves/components/wave-status-table.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/client/src/app/pages/proxies/proxy-form.tsx
+++ b/client/src/app/pages/proxies/proxy-form.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
 import {

--- a/client/src/app/pages/reports/application-selection-context.tsx
+++ b/client/src/app/pages/reports/application-selection-context.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import * as React from "react";
 
 import { Application } from "@app/api/models";
 import { ISelectionState, useSelectionState } from "@app/hooks/selection";

--- a/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-graph/adoption-candidate-graph.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
+import * as React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import Measure from "react-measure";

--- a/client/src/app/pages/reports/components/adoption-candidate-graph/arrow.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-graph/arrow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Curve } from "victory-line";
 import { global_palette_black_800 as black } from "@patternfly/react-tokens";
 

--- a/client/src/app/pages/reports/components/adoption-candidate-graph/cartesian-square.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-graph/cartesian-square.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { BlockProps, VictoryTheme } from "victory-core";
 import { ChartAxis } from "@patternfly/react-charts";

--- a/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/client/src/app/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useMemo } from "react";
+import { useContext, useMemo } from "react";
+import * as React from "react";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { Application, Review } from "@app/api/models"; // Add the necessary model imports

--- a/client/src/app/pages/reports/components/adoption-plan/adoption-plan.tsx
+++ b/client/src/app/pages/reports/components/adoption-plan/adoption-plan.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
+import * as React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import Measure from "react-measure";

--- a/client/src/app/pages/reports/components/application-cell/application-cell.tsx
+++ b/client/src/app/pages/reports/components/application-cell/application-cell.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 

--- a/client/src/app/pages/reports/components/application-landscape/application-landscape.tsx
+++ b/client/src/app/pages/reports/components/application-landscape/application-landscape.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Flex, FlexItem, Skeleton } from "@patternfly/react-core";

--- a/client/src/app/pages/reports/components/donut/donut.tsx
+++ b/client/src/app/pages/reports/components/donut/donut.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { ChartDonut } from "@patternfly/react-charts";
 import {

--- a/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
+++ b/client/src/app/pages/reports/components/identified-risks-table/identified-risks-table.tsx
@@ -1,4 +1,5 @@
-import React, { Fragment } from "react";
+import { Fragment } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import {

--- a/client/src/app/pages/reports/components/no-application-selected-empty-state/no-application-selected-empty-state.tsx
+++ b/client/src/app/pages/reports/components/no-application-selected-empty-state/no-application-selected-empty-state.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 
 import { NoDataEmptyState } from "@app/components/NoDataEmptyState";

--- a/client/src/app/pages/reports/reports.tsx
+++ b/client/src/app/pages/reports/reports.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Card,

--- a/client/src/app/pages/review/components/application-assessment-donut-chart/application-assessment-donut-chart.tsx
+++ b/client/src/app/pages/review/components/application-assessment-donut-chart/application-assessment-donut-chart.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { ChartDonut, ChartLegend } from "@patternfly/react-charts";
 import { global_palette_blue_300 as defaultColor } from "@patternfly/react-tokens";

--- a/client/src/app/pages/review/review-page.tsx
+++ b/client/src/app/pages/review/review-page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import {

--- a/client/src/app/pages/source-platforms/components/column-platform-name.tsx
+++ b/client/src/app/pages/source-platforms/components/column-platform-name.tsx
@@ -1,6 +1,6 @@
 import "./column-platform-name.css";
 
-import React from "react";
+import * as React from "react";
 import dayjs from "dayjs";
 import { Link } from "react-router-dom";
 import {

--- a/client/src/app/pages/source-platforms/components/link-to-platform-applications.tsx
+++ b/client/src/app/pages/source-platforms/components/link-to-platform-applications.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Text } from "@patternfly/react-core";

--- a/client/src/app/pages/source-platforms/components/platform-detail-drawer.tsx
+++ b/client/src/app/pages/source-platforms/components/platform-detail-drawer.tsx
@@ -1,5 +1,5 @@
 import "./platform-detail-drawer.css";
-import React from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
   DescriptionList,

--- a/client/src/app/pages/source-platforms/source-platforms.tsx
+++ b/client/src/app/pages/source-platforms/source-platforms.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {

--- a/client/src/app/pages/tasks/useTaskActions.tsx
+++ b/client/src/app/pages/tasks/useTaskActions.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
@@ -13,7 +13,7 @@ const canCancel = (state: TaskState = "No task") =>
 
 const useAsyncTaskActions = () => {
   const { t } = useTranslation();
-  const { pushNotification } = React.useContext(NotificationsContext);
+  const { pushNotification } = useContext(NotificationsContext);
 
   const { mutate: cancelTask } = useCancelTaskMutation(
     () =>

--- a/client/src/app/utils/model-utils.tsx
+++ b/client/src/app/utils/model-utils.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import {
   Application,
   BusinessService,

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,6 +1,5 @@
 import "@patternfly/react-core/dist/styles/base.css";
 
-import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createRoot } from "react-dom/client";


### PR DESCRIPTION
After the react 18 upgrade, run the codemod `npx react-codemod update-imports` to update the imports. The default import is no longer used. React is only imported when needed.

This import is no longer used:
```ts
import React from "react";
```

It is replaced with these imports as appropriate:
```ts
import * as React from "react"; // if needed for types
import { useState } from "react"; // for destructured imports
```