### PR TITLE
:test_tube: Update e2e workflow to build UI image

### DIFF
--- a/.github/workflows/e2e-repo-main.yaml
+++ b/.github/workflows/e2e-repo-main.yaml
@@ -19,7 +19,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # TODO: If changes are only cypress related, we don't need to build the UI image.
+  build-ui-image-if-needed:
+    runs-on: ubuntu-latest
+    outputs:
+      ui_image: ${{ steps.build-ui-image.outputs.ui_image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build UI image
+        id: build-ui-image
+        env:
+          IMG_NAME: ttl.sh/tackle2-ui-e2e-${{ github.sha }}:2h
+        run: |
+          echo "ui_image=${IMG_NAME}" >> "$GITHUB_OUTPUT"
+          docker build . -t ${IMG_NAME}
+          docker push ${IMG_NAME}
+
   e2e-tests:
+    needs: build-ui-image-if-needed
     uses: ./.github/workflows/e2e-run-ui-tests.yaml
     with:
       test_tags: "@ci,@tier0"
@@ -27,3 +45,4 @@ jobs:
       bundle_image: quay.io/konveyor/tackle2-operator-bundle:latest
       install_konveyor_version: ${{ github.base_ref || github.ref_name }}
       test_ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      ui_image: ${{ needs.build-ui-image-if-needed.outputs.ui_image }}

--- a/.github/workflows/e2e-run-ui-tests.yaml
+++ b/.github/workflows/e2e-run-ui-tests.yaml
@@ -15,6 +15,10 @@ on:
         type: string
         default: quay.io/konveyor/tackle2-operator-bundle:latest
 
+      ui_image:
+        type: string
+        default: quay.io/konveyor/tackle2-ui:latest
+
       install_konveyor_version:
         type: string
         default: main
@@ -39,6 +43,11 @@ on:
         description: Operator bundle image to use
         type: string
         default: quay.io/konveyor/tackle2-operator-bundle:latest
+
+      ui_image:
+        description: UI image to use when installing Konveyor
+        type: string
+        default: quay.io/konveyor/tackle2-ui:latest
 
       install_konveyor_version:
         description: Ref in operator repo to use for the install-konveyor action
@@ -81,6 +90,7 @@ jobs:
             spec:
               image_pull_policy: IfNotPresent
               feature_auth_required: ${{ inputs.feature_auth_required }}
+              ui_image_fqin: ${{ inputs.ui_image }}
 
       - name: Wait for Ingress
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #   - https://github.com/konveyor/tackle2-ui/pull/1781
 
 # Builder image
-FROM registry.access.redhat.com/ubi9/nodejs-20:9.7-1766414952 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-20:9.7-1766414952 AS builder
 
 USER 1001
 COPY --chown=1001 . .


### PR DESCRIPTION
If a PR has both application and cypress changes, we need to build the UI image to test against the PR's changes. Reconfigure `e2e-repo-main.yaml` to always build the UI image (that's the safest thing to do) and pass it to `e2e-run-ui-tests.yaml`. The test runner workflow will install Konveyor to use the custom built image.

Fix a `Dockerfile` warning by changing "as" to "AS".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated Docker image builds for end-to-end testing.
  * Added configuration option to specify custom UI images when running tests.
  * Minor syntax standardization in build configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->