### PR TITLE
:bug: Analysis wizard, Targets: set default target label for choice targets

### DIFF
--- a/client/src/app/pages/applications/analysis-wizard/steps/set-targets.tsx
+++ b/client/src/app/pages/applications/analysis-wizard/steps/set-targets.tsx
@@ -265,7 +265,8 @@ export const SetTargets: FC<SetTargetsProps> = ({
                 item={target}
                 isCardSelected={targetStatus[target.id]?.isSelected ?? false}
                 selectedLabel={
-                  targetStatus[target.id]?.choiceTargetLabel ?? null
+                  targetStatus[target.id]?.choiceTargetLabel ??
+                  (target.choice && target.labels ? target.labels[0] : null)
                 }
                 onChange={handleOnCardChange}
               />


### PR DESCRIPTION
Fixes: #2847

When rendering the target cards on the Analysis wizard, set targets step, if the target has a choice and labels, set the default target label to the target's first label.  This prevents a choice target from having all of its labels selected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default label selection logic in the analysis wizard's target configuration step, ensuring a fallback label is displayed when the primary selection is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->