### PR TITLE
:test_tube: [RFR] Fixed analysis wizard for RBAC test

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -531,6 +531,7 @@ export class Application {
     cy.contains("button", analyzeButton, { timeout: 20 * SEC })
       .should("be.enabled")
       .click();
+    clickByText(button, "Next");
     cy.get(sourceDropdown).click();
     doesExistText("Upload a local binary", rbacRules["Upload binary"]);
     clickByText(button, "Cancel");


### PR DESCRIPTION
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

<details>
<summary>PR Title emoji</summary>

Types recognized:

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- Integration/E2E tests: :test_tube: (`:test_tube:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

</details>

For more information, please see the Konveyor [Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test automation for the application upload validation flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->