### PR TITLE
:bug: Parse targets from Analysis Profile rule labels

### DIFF
--- a/client/src/app/utils/rules-utils.ts
+++ b/client/src/app/utils/rules-utils.ts
@@ -134,7 +134,7 @@ export type ParsedTargetLabel = {
   /** Full label string, e.g. "konveyor.io/target=my-target" */
   label: string;
   /** Type of label, e.g. "source" or "target" */
-  type: "source" | "target" | "other";
+  type: "source" | "target" | "other" | "invalid";
   /** Value of label, e.g. "my-target" */
   value: string;
 };
@@ -156,7 +156,7 @@ export const parseLabel = (label: TargetLabel): ParsedTargetLabel => {
     targetLabel: label,
     name: label.name,
     label: label.label,
-    type: "other",
+    type: "invalid",
     value: label.label,
   };
 };
@@ -173,6 +173,7 @@ export const parseAndGroupLabels = (
     source: [],
     target: [],
     other: [],
+    invalid: [],
     ...group(parsedLabels, ({ type }) => type),
   };
 };


### PR DESCRIPTION
Problems:
1. Targets contributed from custom rules are not present in the rules.targets list (which is the source of values displayed in the UI)
2. Both target and source labels from custom rules are stored in the rules.labels.included list together with source labels retrieved from selected targets.
3. Labels from custom rules are in konveyor.io/type=value format and labels from selected targets are regular strings (value only).

Changes:
1. extract targets from target labels and display them with targets from rules.targets list. Use the same grouped label as in the wizard review step.
2. display all labels from rules.labels.included as values only.
3. filter out custom target labels since they are already displayed with the selected targets.

Fixes: https://github.com/konveyor/tackle2-ui/issues/2870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Analysis profile UI now shows resolved targets and manual custom targets together for clearer visibility.
  * Label parsing and grouping for analysis profile rules enhanced, with explicit handling and grouping of invalid/malformed labels for more accurate display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->