### PR TITLE
:bug: Adjust max length validation for identity fields

### DIFF
--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -279,14 +279,14 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           then: (schema) =>
             schema
               .required(t("validation.required"))
-              .min(3, t("validation.minLength", { length: 3 }))
+              .min(3, t("validation.minLength", { length: 3 })),
         })
         .when("kind", {
           is: (kind: IdentityKind) => kind === "basic-auth",
           then: (schema) =>
             schema
               .required(t("validation.required"))
-              .min(3, t("validation.minLength", { length: 3 }))
+              .min(3, t("validation.minLength", { length: 3 })),
         })
         .when(["kind", "userCredentials"], {
           is: (kind: IdentityKind, userCredentials: UserCredentials) =>
@@ -294,7 +294,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           then: (schema) =>
             schema
               .required(t("validation.required"))
-              .min(3, t("validation.minLength", { length: 3 }))
+              .min(3, t("validation.minLength", { length: 3 })),
         }),
 
       key: yup


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-6598

Remove max length identity validation for tokens/passwords

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed character length limits on identity form inputs—users can now enter longer values for name and various password fields across authentication types, while existing required and minimum-length checks remain in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->