### PR TITLE
:seedling: Fix builder image lookup in ci-repo workflow

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Lookup builder image from the project's Dockerfile
         id: grepBuilder
         run: |
-          builder=$(grep 'as builder' Dockerfile | sed -e 's/^FROM \(.*\) as builder$/\1/')
+          builder=$(grep -i 'as builder' Dockerfile | sed -e 's/^from \(.*\) as builder$/\1/i')
           echo "builder=$builder" >> "$GITHUB_OUTPUT"
 
       - name: Did only docs and hacks change?


### PR DESCRIPTION
Since the `Dockerfile` isn't case-sensitive, we need to use a case-insensitive grep/sed to find the builder image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness of the CI pipeline to handle varying Dockerfile formatting conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->