### PR TITLE
[release-0.9] :test_tube: Add release-0.9 ui_image to nightly-release09 workflow

### DIFF
--- a/.github/workflows/nightly-release09.yaml
+++ b/.github/workflows/nightly-release09.yaml
@@ -32,6 +32,7 @@ jobs:
       test_tags: "@ci,@tier0,@tier2,@tier3"
       feature_auth_required: true
       bundle_image: quay.io/konveyor/tackle2-operator-bundle:release-0.9
+      ui_image: quay.io/konveyor/tackle2-ui:release-0.9
       install_konveyor_version: release-0.9
       test_ref: release-0.9
     secrets: inherit
@@ -43,6 +44,7 @@ jobs:
       test_tags: "@ci,@tier0,@tier2,@tier3"
       feature_auth_required: false
       bundle_image: quay.io/konveyor/tackle2-operator-bundle:release-0.9
+      ui_image: quay.io/konveyor/tackle2-ui:release-0.9
       install_konveyor_version: release-0.9
       test_ref: release-0.9
     secrets: inherit


### PR DESCRIPTION
The workflow was running with the `:latest` ui_image. It should be using the `:release-0.9` image.
