### PR TITLE
:bug: Memoize validateSettingsXml

### DIFF
--- a/client/src/app/utils/maven-settings/index.ts
+++ b/client/src/app/utils/maven-settings/index.ts
@@ -1,4 +1,5 @@
 import { XMLValidator } from "fast-xml-parser";
+import { memoize } from "lodash-es";
 
 // Import schemas
 import schema0 from "./schema-1.0.0.xsd";
@@ -20,7 +21,7 @@ type XSD_NAMES = keyof typeof XSD_BY_NAME;
  * @returns {boolean} `true` if valid, `false` if content is empty
  * @throws {Error} Contents fails validation. Details is the message.
  */
-export async function validateSettingsXml(contents?: string) {
+export const validateSettingsXml = memoize(async (contents?: string) => {
   if (contents === undefined || contents.length === 0) {
     return false;
   }
@@ -70,4 +71,4 @@ export async function validateSettingsXml(contents?: string) {
       validationResult.errors.map((e) => e.rawMessage).join(", ")
     );
   }
-}
+});

--- a/client/src/app/yup.ts
+++ b/client/src/app/yup.ts
@@ -58,6 +58,9 @@ yup.addMethod(
 
       let resp: boolean | yup.ValidationError = false;
       try {
+        if (!validateSettingsXml.cache.has(value)) {
+          validateSettingsXml.cache.clear?.();
+        }
         resp = await validateSettingsXml(value);
       } catch (e) {
         resp = this.createError({


### PR DESCRIPTION
Partial fix for:  https://issues.redhat.com/browse/MTA-6007

Due to memoization the extra requests are fired only when xml is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Validation now caches results so repeated validation of the same settings returns cached outcomes, reducing repeated work and improving responsiveness.
  * Cache handling is improved to avoid stale results by clearing cache when the input value changes, while preserving existing validation behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->