### PR TITLE
:bug: Fix assessment status calculation for inherited assessments

### DIFF
--- a/client/src/app/utils/application-assessment-status.ts
+++ b/client/src/app/utils/application-assessment-status.ts
@@ -40,10 +40,9 @@ export const buildApplicationAssessmentStatus = (
 
   const directStatus = chooseAssessmentStatus(application.assessed, direct);
 
-  const inherited = archetypes
-    .filter((archetype) =>
-      archetype.applications?.some(({ id }) => id === application.id)
-    )
+  const inherited = (application.archetypes ?? [])
+    .map((ref) => archetypes.find((a) => a.id === ref.id))
+    .filter(Boolean)
     .map((archetype) => {
       const archetypeAssessments = assessments.filter(
         (assessment) =>


### PR DESCRIPTION
## Summary 
Resolves: #2996

Calculates the assessment status for archetype inherited assessments by first cross-referencing the application's archetype ref with the archetypes, and then checking archetype assessment status. The previous approach checked from archetype's application ref list instead.

## Screenshots
Using archetype "Boston Data Center" with a partial assessment (one of 2 questionnaires answered):
<img width="1581" height="834" alt="image" src="https://github.com/user-attachments/assets/1f378c23-c6f4-46ff-a20d-4ee583b68e81" />

Previously that archetype's appications would not show any inherited assessments:
<img width="1581" height="834" alt="image" src="https://github.com/user-attachments/assets/33b5fbd4-ad6b-496d-8396-b3e1647c5319" />

Now, the inherited assessments are shown:
<img width="1581" height="834" alt="image" src="https://github.com/user-attachments/assets/78ed09b4-f678-41dd-99cc-6c8386dce029" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of application assessment status calculations by refining how inherited archetypes are resolved and evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->