### PR TITLE
:sparkles: refactor form state management to use FormStateSubscribe and scoped useWatch

### DIFF
--- a/client/src/app/components/analysis/steps/analysis-labels.tsx
+++ b/client/src/app/components/analysis/steps/analysis-labels.tsx
@@ -87,7 +87,7 @@ export const AnalysisLabels: React.FC<AnalysisLabelsProps> = ({
   );
 
   const { control } = form;
-  const { excludedLabels } = useWatch({ control });
+  const excludedLabels = useWatch({ control, name: "excludedLabels" });
   useFormChangeHandler({ form, onStateChanged });
 
   const [isSelectTargetsOpen, setSelectTargetsOpen] = React.useState(false);

--- a/client/src/app/components/analysis/steps/options-advanced.tsx
+++ b/client/src/app/components/analysis/steps/options-advanced.tsx
@@ -140,12 +140,20 @@ export const OptionsAdvanced: React.FC<OptionsAdvancedProps> = ({
   );
   const { control } = form;
 
-  const {
+  const [
     excludedLabels,
     autoTaggingEnabled,
     advancedAnalysisEnabled,
     saveAsProfile,
-  } = useWatch({ control });
+  ] = useWatch({
+    control,
+    name: [
+      "excludedLabels",
+      "autoTaggingEnabled",
+      "advancedAnalysisEnabled",
+      "saveAsProfile",
+    ],
+  });
 
   useFormChangeHandler({ form, onStateChanged });
 

--- a/client/src/app/hooks/useFormChangeHandler.ts
+++ b/client/src/app/hooks/useFormChangeHandler.ts
@@ -20,6 +20,12 @@ export type DefaultFormState<TFormValues extends FieldValues> =
  * Generic form change handler that watches form fields and calls a state change callback.
  * @template TFormValues - The type of the form values
  * @template TState - The type of the state object (defaults to form values + isValid)
+ *
+ * NOTE: useWatch's `compute` prop (v7.61+) cannot be used here because `isValid`
+ * comes from formState, not from watched values. The `compute` callback only
+ * re-evaluates when watched values change, so it would produce stale results when
+ * `isValid` transitions independently (e.g. async validation). The explicit
+ * `useMemo` over both `watchedValues` and `isValid` keeps the derived state correct.
  */
 export const useFormChangeHandler = <
   TFormValues extends FieldValues,

--- a/client/src/app/pages/archetypes/components/archetype-form.tsx
+++ b/client/src/app/pages/archetypes/components/archetype-form.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useForm } from "react-hook-form";
+import { FormStateSubscribe, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
@@ -150,7 +150,6 @@ const ArchetypeFormReady: React.FC<ArchetypeFormProps> = ({
 
   const {
     handleSubmit,
-    formState: { isSubmitting, isValidating, isValid, isDirty },
     control,
     // for debugging
     // getValues,
@@ -293,34 +292,39 @@ const ArchetypeFormReady: React.FC<ArchetypeFormProps> = ({
         resizeOrientation="vertical"
       />
 
-      <ActionGroup>
-        <Button
-          type="submit"
-          id="submit"
-          aria-label="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={
-            !isValid ||
-            isSubmitting ||
-            isValidating ||
-            (!isDirty && !isDuplicating)
-          }
-        >
-          {!archetype || isDuplicating
-            ? t("actions.create")
-            : t("actions.save")}
-        </Button>
-        <Button
-          type="button"
-          id="cancel"
-          aria-label="cancel"
-          variant={ButtonVariant.link}
-          isDisabled={isSubmitting || isValidating}
-          onClick={onClose}
-        >
-          {t("actions.cancel")}
-        </Button>
-      </ActionGroup>
+      <FormStateSubscribe
+        control={control}
+        render={({ isSubmitting, isValidating, isValid, isDirty }) => (
+          <ActionGroup>
+            <Button
+              type="submit"
+              id="submit"
+              aria-label="submit"
+              variant={ButtonVariant.primary}
+              isDisabled={
+                !isValid ||
+                isSubmitting ||
+                isValidating ||
+                (!isDirty && !isDuplicating)
+              }
+            >
+              {!archetype || isDuplicating
+                ? t("actions.create")
+                : t("actions.save")}
+            </Button>
+            <Button
+              type="button"
+              id="cancel"
+              aria-label="cancel"
+              variant={ButtonVariant.link}
+              isDisabled={isSubmitting || isValidating}
+              onClick={onClose}
+            >
+              {t("actions.cancel")}
+            </Button>
+          </ActionGroup>
+        )}
+      />
     </Form>
   );
 };

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
-import { FormStateSubscribe, useForm } from "react-hook-form";
+import { FormStateSubscribe, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
@@ -167,7 +167,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     insecure: yup.boolean().required(),
   });
 
-  const { handleSubmit, getValues, control } = useForm<FormValues>({
+  const { handleSubmit, control } = useForm<FormValues>({
     defaultValues: {
       name: tracker?.name || "",
       url: tracker?.url || "",
@@ -180,7 +180,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     mode: "all",
   });
 
-  const values = getValues();
+  const kind = useWatch({ control, name: "kind" });
 
   const identityOptions = (kind?: IssueManagerKind) => {
     const identityKinds = kind
@@ -265,11 +265,9 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
             toggleAriaLabel="Credentials select dropdown toggle"
             aria-label={name}
             value={
-              value
-                ? toOptionLike(value, identityOptions(values.kind))
-                : undefined
+              value ? toOptionLike(value, identityOptions(kind)) : undefined
             }
-            options={identityOptions(values.kind)}
+            options={identityOptions(kind)}
             onChange={(selection) => {
               const selectionValue = selection as OptionWithValue<string>;
               onChange(selectionValue.value);

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
-import { useForm } from "react-hook-form";
+import { FormStateSubscribe, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
@@ -167,12 +167,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     insecure: yup.boolean().required(),
   });
 
-  const {
-    handleSubmit,
-    formState: { isSubmitting, isValidating, isValid, isDirty },
-    getValues,
-    control,
-  } = useForm<FormValues>({
+  const { handleSubmit, getValues, control } = useForm<FormValues>({
     defaultValues: {
       name: tracker?.name || "",
       url: tracker?.url || "",
@@ -310,27 +305,32 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
         )}
       />
 
-      <ActionGroup>
-        <Button
-          type="submit"
-          aria-label="submit"
-          id="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={!isValid || isSubmitting || isValidating || !isDirty}
-        >
-          {!tracker ? "Create" : "Save"}
-        </Button>
-        <Button
-          type="button"
-          id="cancel"
-          aria-label="cancel"
-          variant={ButtonVariant.link}
-          isDisabled={isSubmitting || isValidating}
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-      </ActionGroup>
+      <FormStateSubscribe
+        control={control}
+        render={({ isSubmitting, isValidating, isValid, isDirty }) => (
+          <ActionGroup>
+            <Button
+              type="submit"
+              aria-label="submit"
+              id="submit"
+              variant={ButtonVariant.primary}
+              isDisabled={!isValid || isSubmitting || isValidating || !isDirty}
+            >
+              {!tracker ? "Create" : "Save"}
+            </Button>
+            <Button
+              type="button"
+              id="cancel"
+              aria-label="cancel"
+              variant={ButtonVariant.link}
+              isDisabled={isSubmitting || isValidating}
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+          </ActionGroup>
+        )}
+      />
     </Form>
   );
 };

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -86,6 +86,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     });
 
     addUpdatingTrackerId(tracker.id);
+    onClose();
   };
 
   const onUpdateTrackerSuccess = (_response: unknown, tracker: Tracker) => {
@@ -97,6 +98,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     });
 
     addUpdatingTrackerId(tracker.id);
+    onClose();
   };
 
   const onCreateUpdatetrackerError = (error: AxiosError) => {
@@ -137,7 +139,6 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     } else {
       createTracker(payload);
     }
-    onClose();
   };
 
   const standardStrictURL = new RegExp(standardStrictURLRegex);

--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, FormStateSubscribe, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
@@ -331,13 +331,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
     resolver: yupResolver(validationSchema),
     mode: "all",
   });
-  const {
-    handleSubmit,
-    formState: { isSubmitting, isValidating, isValid, isDirty },
-    getValues,
-    control,
-    resetField,
-  } = methods;
+  const { handleSubmit, getValues, control, resetField } = methods;
 
   const values = getValues();
 
@@ -427,27 +421,34 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           <KindBearerTokenForm identity={identity} />
         )}
 
-        <ActionGroup>
-          <Button
-            type="submit"
-            aria-label="submit"
-            id="submit"
-            variant={ButtonVariant.primary}
-            isDisabled={!isValid || isSubmitting || isValidating || !isDirty}
-          >
-            {!identity ? "Create" : "Save"}
-          </Button>
-          <Button
-            type="button"
-            id="cancel"
-            aria-label="cancel"
-            variant={ButtonVariant.link}
-            isDisabled={isSubmitting || isValidating}
-            onClick={onClose}
-          >
-            Cancel
-          </Button>
-        </ActionGroup>
+        <FormStateSubscribe
+          control={control}
+          render={({ isSubmitting, isValidating, isValid, isDirty }) => (
+            <ActionGroup>
+              <Button
+                type="submit"
+                aria-label="submit"
+                id="submit"
+                variant={ButtonVariant.primary}
+                isDisabled={
+                  !isValid || isSubmitting || isValidating || !isDirty
+                }
+              >
+                {!identity ? "Create" : "Save"}
+              </Button>
+              <Button
+                type="button"
+                id="cancel"
+                aria-label="cancel"
+                variant={ButtonVariant.link}
+                isDisabled={isSubmitting || isValidating}
+                onClick={onClose}
+              >
+                Cancel
+              </Button>
+            </ActionGroup>
+          )}
+        />
       </Form>
     </FormProvider>
   );

--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
-import { FormProvider, FormStateSubscribe, useForm } from "react-hook-form";
+import {
+  FormProvider,
+  FormStateSubscribe,
+  useForm,
+  useWatch,
+} from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
@@ -331,9 +336,9 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
     resolver: yupResolver(validationSchema),
     mode: "all",
   });
-  const { handleSubmit, getValues, control, resetField } = methods;
+  const { handleSubmit, control, resetField } = methods;
 
-  const values = getValues();
+  const kind = useWatch({ control, name: "kind" });
 
   const clearIdentityDataFields = React.useCallback(() => {
     resetField("settings", { defaultValue: "" });
@@ -386,21 +391,21 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           )}
         />
 
-        {values?.kind === "source" && (
+        {kind === "source" && (
           <KindSourceForm
             identity={identity}
             defaultIdentities={defaultIdentities}
           />
         )}
 
-        {values?.kind === "maven" && (
+        {kind === "maven" && (
           <KindMavenSettingsFileForm
             identity={identity}
             defaultIdentities={defaultIdentities}
           />
         )}
 
-        {values?.kind === "proxy" && (
+        {kind === "proxy" && (
           <KindSimpleUsernamePasswordForm
             identity={identity}
             usernameLabel="Username"
@@ -409,7 +414,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           />
         )}
 
-        {values?.kind === "basic-auth" && (
+        {kind === "basic-auth" && (
           <KindSimpleUsernamePasswordForm
             identity={identity}
             usernameLabel="Jira username or email"
@@ -417,9 +422,7 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           />
         )}
 
-        {values?.kind === "bearer" && (
-          <KindBearerTokenForm identity={identity} />
-        )}
+        {kind === "bearer" && <KindBearerTokenForm identity={identity} />}
 
         <FormStateSubscribe
           control={control}

--- a/client/src/app/pages/identities/components/identity-form/kind-source-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/kind-source-form.tsx
@@ -25,7 +25,18 @@ export const KindSourceForm: React.FC<{
 }> = ({ identity, defaultIdentities }) => {
   const { t } = useTranslation();
   const { control, setValue, resetField } = useFormContext();
-  const values = useWatch({ control });
+  const [userCredentials, password, key, kind, isDefault, keyFilename] =
+    useWatch({
+      control,
+      name: [
+        "userCredentials",
+        "password",
+        "key",
+        "kind",
+        "default",
+        "keyFilename",
+      ],
+    });
 
   const [isKeyFileRejected, setIsKeyFileRejected] = useState(false);
 
@@ -36,13 +47,11 @@ export const KindSourceForm: React.FC<{
     setIsPasswordHidden(!isPasswordHidden);
   };
 
-  const isPasswordEncrypted = identity?.password === values.password;
-  const isKeyEncrypted = identity?.key === values.key;
-  const kindDefault = defaultIdentities?.[values.kind as IdentityKind];
+  const isPasswordEncrypted = identity?.password === password;
+  const isKeyEncrypted = identity?.key === key;
+  const kindDefault = defaultIdentities?.[kind as IdentityKind];
   const isReplacingDefault =
-    values.default &&
-    kindDefault &&
-    (!identity || kindDefault.id !== identity.id);
+    isDefault && kindDefault && (!identity || kindDefault.id !== identity.id);
 
   return (
     <>
@@ -107,7 +116,7 @@ export const KindSourceForm: React.FC<{
         )}
       />
 
-      {values?.userCredentials === "userpass" && (
+      {userCredentials === "userpass" && (
         <KindSimpleUsernamePasswordForm
           identity={identity}
           usernameLabel="Username"
@@ -115,7 +124,7 @@ export const KindSourceForm: React.FC<{
         />
       )}
 
-      {values?.userCredentials === "source" && (
+      {userCredentials === "source" && (
         <>
           <HookFormPFGroupController
             control={control}
@@ -130,7 +139,7 @@ export const KindSourceForm: React.FC<{
                 name={name}
                 type="text"
                 value={isKeyEncrypted ? "[Encrypted]" : (value ?? "")}
-                filename={values.keyFilename}
+                filename={keyFilename}
                 filenamePlaceholder="Drag and drop a file or upload one"
                 dropzoneProps={{
                   onDropRejected: () => setIsKeyFileRejected(true),

--- a/client/src/app/pages/migration-targets/components/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/components/custom-target-form.tsx
@@ -3,7 +3,12 @@ import { useContext, useEffect, useMemo, useState } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
 import { unique } from "radash";
-import { FormStateSubscribe, useFieldArray, useForm } from "react-hook-form";
+import {
+  FormStateSubscribe,
+  useFieldArray,
+  useForm,
+  useWatch,
+} from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
@@ -265,7 +270,6 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
 
   const {
     handleSubmit,
-    getValues,
     setValue,
     control,
     setFocus,
@@ -304,7 +308,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
     };
   }, [initialTarget]);
 
-  const values = getValues();
+  const rulesKind = useWatch({ control, name: "rulesKind" });
 
   const {
     createTargetAsync,
@@ -560,7 +564,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
         )}
       />
 
-      {values?.rulesKind === "manual" && (
+      {rulesKind === "manual" && (
         <CustomRuleFilesUpload
           ruleFiles={fields}
           onAddRuleFiles={(ruleFiles) => {
@@ -582,7 +586,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
         />
       )}
 
-      {values?.rulesKind === "repository" && (
+      {rulesKind === "repository" && (
         <>
           <HookFormPFGroupController
             control={control}

--- a/client/src/app/pages/migration-targets/components/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/components/custom-target-form.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useMemo, useState } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError, AxiosResponse } from "axios";
 import { unique } from "radash";
-import { useFieldArray, useForm } from "react-hook-form";
+import { FormStateSubscribe, useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
@@ -265,7 +265,6 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
 
   const {
     handleSubmit,
-    formState: { isSubmitting, isValidating, isValid, isDirty },
     getValues,
     setValue,
     control,
@@ -654,33 +653,38 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
         </>
       )}
 
-      <ActionGroup>
-        <Button
-          type="submit"
-          aria-label="submit"
-          id="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={
-            !isValid ||
-            isSubmitting ||
-            isValidating ||
-            !isDirty ||
-            !!imageRejectedError
-          }
-        >
-          {!target ? t("actions.create") : t("actions.save")}
-        </Button>
-        <Button
-          type="button"
-          id="cancel"
-          aria-label="cancel"
-          variant={ButtonVariant.link}
-          isDisabled={isSubmitting || isValidating}
-          onClick={onCancelHandler}
-        >
-          {t("actions.cancel")}
-        </Button>
-      </ActionGroup>
+      <FormStateSubscribe
+        control={control}
+        render={({ isSubmitting, isValidating, isValid, isDirty }) => (
+          <ActionGroup>
+            <Button
+              type="submit"
+              aria-label="submit"
+              id="submit"
+              variant={ButtonVariant.primary}
+              isDisabled={
+                !isValid ||
+                isSubmitting ||
+                isValidating ||
+                !isDirty ||
+                !!imageRejectedError
+              }
+            >
+              {!target ? t("actions.create") : t("actions.save")}
+            </Button>
+            <Button
+              type="button"
+              id="cancel"
+              aria-label="cancel"
+              variant={ButtonVariant.link}
+              isDisabled={isSubmitting || isValidating}
+              onClick={onCancelHandler}
+            >
+              {t("actions.cancel")}
+            </Button>
+          </ActionGroup>
+        )}
+      />
     </Form>
   );
 };

--- a/client/src/app/pages/migration-waves/components/export-form.tsx
+++ b/client/src/app/pages/migration-waves/components/export-form.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { AxiosError } from "axios";
-import { useForm } from "react-hook-form";
+import { FormStateSubscribe, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
 import {
@@ -78,13 +78,7 @@ export const ExportForm: React.FC<ExportFormProps> = ({
     kind: yup.string().required("Issue type is a required field"),
   });
 
-  const {
-    handleSubmit,
-    formState: { isSubmitting, isValidating, isValid, isDirty },
-    watch,
-    setValue,
-    control,
-  } = useForm<FormValues>({
+  const { handleSubmit, setValue, control } = useForm<FormValues>({
     defaultValues: {
       issueManager: undefined,
       tracker: "",
@@ -95,16 +89,18 @@ export const ExportForm: React.FC<ExportFormProps> = ({
     mode: "all",
   });
 
-  const values = watch();
+  const [issueManager, tracker, project, kind] = useWatch({
+    control,
+    name: ["issueManager", "tracker", "project", "kind"],
+  });
 
-  const matchingProject = useTrackerProjectsByTracker(values.tracker).find(
-    (project) => values.project === project.name
+  const matchingProject = useTrackerProjectsByTracker(tracker).find(
+    (p) => project === p.name
   );
 
-  const matchingKind = useTrackerTypesByProjectName(
-    values.tracker,
-    values.project
-  ).find((type) => values.kind === type.name);
+  const matchingKind = useTrackerTypesByProjectName(tracker, project).find(
+    (type) => kind === type.name
+  );
 
   const onSubmit = (formValues: FormValues) => {
     const matchingtracker = trackers.find(
@@ -179,21 +175,18 @@ export const ExportForm: React.FC<ExportFormProps> = ({
             placeholderText={t("composed.selectAn", {
               what: t("terms.instance").toLowerCase(),
             })}
-            isDisabled={!values.issueManager}
+            isDisabled={!issueManager}
             toggleAriaLabel="tracker select dropdown toggle"
             aria-label={name}
             value={value}
             options={
-              values.issueManager
-                ? getTrackersByKind(
-                    trackers,
-                    values.issueManager?.toString()
-                  ).map((tracker) => {
-                    return {
-                      value: tracker.name,
-                      toString: () => tracker.name,
-                    };
-                  })
+              issueManager
+                ? getTrackersByKind(trackers, issueManager.toString()).map(
+                    (t) => ({
+                      value: t.name,
+                      toString: () => t.name,
+                    })
+                  )
                 : []
             }
             onChange={(selection) => {
@@ -221,18 +214,16 @@ export const ExportForm: React.FC<ExportFormProps> = ({
             placeholderText={t("composed.selectOne", {
               what: t("terms.project").toLowerCase(),
             })}
-            isDisabled={!values.tracker}
+            isDisabled={!tracker}
             toggleAriaLabel="project select dropdown toggle"
             aria-label={name}
             value={value}
-            options={useTrackerProjectsByTracker(values.tracker).map(
-              (project) => {
-                return {
-                  value: project.name,
-                  toString: () => project.name,
-                };
-              }
-            )}
+            options={useTrackerProjectsByTracker(tracker).map((project) => {
+              return {
+                value: project.name,
+                toString: () => project.name,
+              };
+            })}
             onChange={(selection) => {
               const selectionValue = selection as OptionWithValue<string>;
               setValue("kind", "");
@@ -257,19 +248,18 @@ export const ExportForm: React.FC<ExportFormProps> = ({
             placeholderText={t("composed.selectAn", {
               what: t("terms.issueType").toLowerCase(),
             })}
-            isDisabled={!values.project}
+            isDisabled={!project}
             toggleAriaLabel="issue-type select dropdown toggle"
             aria-label={name}
             value={value}
-            options={useTrackerTypesByProjectName(
-              values.tracker,
-              values.project
-            ).map((issueType) => {
-              return {
-                value: issueType.name,
-                toString: () => issueType.name,
-              };
-            })}
+            options={useTrackerTypesByProjectName(tracker, project).map(
+              (issueType) => {
+                return {
+                  value: issueType.name,
+                  toString: () => issueType.name,
+                };
+              }
+            )}
             onChange={(selection) => {
               const selectionValue = selection as OptionWithValue<string>;
               onChange(selectionValue.value);
@@ -278,27 +268,32 @@ export const ExportForm: React.FC<ExportFormProps> = ({
           />
         )}
       />
-      <ActionGroup>
-        <Button
-          type="submit"
-          aria-label="submit"
-          id="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={!isValid || isSubmitting || isValidating || !isDirty}
-        >
-          {t("actions.export")}
-        </Button>
-        <Button
-          type="button"
-          id="cancel"
-          aria-label="cancel"
-          variant={ButtonVariant.link}
-          isDisabled={isSubmitting || isValidating}
-          onClick={onClose}
-        >
-          {t("actions.cancel")}
-        </Button>
-      </ActionGroup>
+      <FormStateSubscribe
+        control={control}
+        render={({ isSubmitting, isValidating, isValid, isDirty }) => (
+          <ActionGroup>
+            <Button
+              type="submit"
+              aria-label="submit"
+              id="submit"
+              variant={ButtonVariant.primary}
+              isDisabled={!isValid || isSubmitting || isValidating || !isDirty}
+            >
+              {t("actions.export")}
+            </Button>
+            <Button
+              type="button"
+              id="cancel"
+              aria-label="cancel"
+              variant={ButtonVariant.link}
+              isDisabled={isSubmitting || isValidating}
+              onClick={onClose}
+            >
+              {t("actions.cancel")}
+            </Button>
+          </ActionGroup>
+        )}
+      />
     </Form>
   );
 };

--- a/client/src/app/pages/migration-waves/components/export-form.tsx
+++ b/client/src/app/pages/migration-waves/components/export-form.tsx
@@ -50,13 +50,15 @@ export const ExportForm: React.FC<ExportFormProps> = ({
   const { pushNotification } = React.useContext(NotificationsContext);
   const { tickets } = useFetchTickets();
 
-  const onExportSuccess = () =>
+  const onExportSuccess = () => {
     pushNotification({
       title: t("toastr.success.create", {
         type: t("terms.exportToIssue"),
       }),
       variant: "success",
     });
+    onClose();
+  };
 
   const onExportError = (error: AxiosError) =>
     pushNotification({
@@ -126,7 +128,6 @@ export const ExportForm: React.FC<ExportFormProps> = ({
         applications: applicationsWithNoAssociatedTickets,
       });
     }
-    onClose();
   };
 
   return (

--- a/client/src/app/pages/proxies/proxy-form.tsx
+++ b/client/src/app/pages/proxies/proxy-form.tsx
@@ -5,6 +5,7 @@ import { AxiosError } from "axios";
 import {
   Controller,
   FieldValues,
+  FormStateSubscribe,
   SubmitHandler,
   useForm,
 } from "react-hook-form";
@@ -70,35 +71,29 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
       label: identity?.name || "",
     }));
 
-  const {
-    handleSubmit,
-    formState: { isSubmitting, isValidating, isValid, isDirty },
-    getValues,
-    setValue,
-    control,
-    reset,
-  } = useForm<ProxyFormValues>({
-    defaultValues: useMemo<ProxyFormValues>(
-      () => ({
-        // http
-        isHttpProxyEnabled: httpProxy?.enabled === true,
-        httpHost: httpProxy?.host || "",
-        httpPort: httpProxy?.port || 8080,
-        isHttpIdentityRequired: !!httpProxy?.identity?.name,
-        httpIdentity: httpProxy?.identity?.name || null,
-        // https
-        isHttpsProxyEnabled: httpsProxy?.enabled === true,
-        httpsHost: httpsProxy?.host || "",
-        httpsPort: httpsProxy?.port || 8080,
-        isHttpsIdentityRequired: !!httpsProxy?.identity?.name,
-        httpsIdentity: httpsProxy?.identity?.name || null,
-        excluded: httpProxy?.excluded.join(",") || "",
-      }),
-      [httpProxy, httpsProxy]
-    ),
-    resolver: yupResolver(useProxyFormValidationSchema()),
-    mode: "all",
-  });
+  const { handleSubmit, getValues, setValue, control, reset } =
+    useForm<ProxyFormValues>({
+      defaultValues: useMemo<ProxyFormValues>(
+        () => ({
+          // http
+          isHttpProxyEnabled: httpProxy?.enabled === true,
+          httpHost: httpProxy?.host || "",
+          httpPort: httpProxy?.port || 8080,
+          isHttpIdentityRequired: !!httpProxy?.identity?.name,
+          httpIdentity: httpProxy?.identity?.name || null,
+          // https
+          isHttpsProxyEnabled: httpsProxy?.enabled === true,
+          httpsHost: httpsProxy?.host || "",
+          httpsPort: httpsProxy?.port || 8080,
+          isHttpsIdentityRequired: !!httpsProxy?.identity?.name,
+          httpsIdentity: httpsProxy?.identity?.name || null,
+          excluded: httpProxy?.excluded.join(",") || "",
+        }),
+        [httpProxy, httpsProxy]
+      ),
+      resolver: yupResolver(useProxyFormValidationSchema()),
+      mode: "all",
+    });
 
   const values = getValues();
 
@@ -393,19 +388,28 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
           placeholder="*.example.com, *.example2.com"
         />
       )}
-      <ActionGroup>
-        <Button
-          type="submit"
-          id="submit"
-          aria-label="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={
-            !isValid || isSubmitting || isValidating || isLoading || !isDirty
-          }
-        >
-          {httpProxy || httpsProxy ? "Save" : "Update"}
-        </Button>
-      </ActionGroup>
+      <FormStateSubscribe
+        control={control}
+        render={({ isSubmitting, isValidating, isValid, isDirty }) => (
+          <ActionGroup>
+            <Button
+              type="submit"
+              id="submit"
+              aria-label="submit"
+              variant={ButtonVariant.primary}
+              isDisabled={
+                !isValid ||
+                isSubmitting ||
+                isValidating ||
+                isLoading ||
+                !isDirty
+              }
+            >
+              {httpProxy || httpsProxy ? "Save" : "Update"}
+            </Button>
+          </ActionGroup>
+        )}
+      />
     </Form>
   );
 };

--- a/client/src/app/pages/proxies/proxy-form.tsx
+++ b/client/src/app/pages/proxies/proxy-form.tsx
@@ -8,6 +8,7 @@ import {
   FormStateSubscribe,
   SubmitHandler,
   useForm,
+  useWatch,
 } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {
@@ -71,7 +72,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
       label: identity?.name || "",
     }));
 
-  const { handleSubmit, getValues, setValue, control, reset } =
+  const { handleSubmit, setValue, control, reset, getValues } =
     useForm<ProxyFormValues>({
       defaultValues: useMemo<ProxyFormValues>(
         () => ({
@@ -95,7 +96,20 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
       mode: "all",
     });
 
-  const values = getValues();
+  const [
+    isHttpProxyEnabled,
+    isHttpsProxyEnabled,
+    isHttpIdentityRequired,
+    isHttpsIdentityRequired,
+  ] = useWatch({
+    control,
+    name: [
+      "isHttpProxyEnabled",
+      "isHttpsProxyEnabled",
+      "isHttpIdentityRequired",
+      "isHttpsIdentityRequired",
+    ],
+  });
 
   const onProxySubmitComplete = () => {
     pushNotification({
@@ -104,7 +118,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
       }),
       variant: "success",
     });
-    reset(values);
+    reset(getValues());
   };
 
   const onProxySubmitError = (error: AxiosError) => {
@@ -217,7 +231,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
           />
         )}
       />
-      {values.isHttpProxyEnabled && (
+      {isHttpProxyEnabled && (
         <div className={spacing.mlLg}>
           <HookFormPFTextInput
             control={control}
@@ -258,7 +272,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
               />
             )}
           />
-          {values.isHttpIdentityRequired && (
+          {isHttpIdentityRequired && (
             <HookFormPFGroupController
               control={control}
               name="httpIdentity"
@@ -306,7 +320,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
           />
         )}
       />
-      {values.isHttpsProxyEnabled && (
+      {isHttpsProxyEnabled && (
         <div className={spacing.mlLg}>
           <HookFormPFTextInput
             control={control}
@@ -347,7 +361,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
               />
             )}
           />
-          {values.isHttpsIdentityRequired && (
+          {isHttpsIdentityRequired && (
             <HookFormPFGroupController
               control={control}
               name="httpsIdentity"
@@ -379,7 +393,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
           )}
         </div>
       )}
-      {(values.isHttpProxyEnabled || values.isHttpsProxyEnabled) && (
+      {(isHttpProxyEnabled || isHttpsProxyEnabled) && (
         <HookFormPFTextArea
           control={control}
           name="excluded"

--- a/client/src/app/pages/proxies/proxy-form.tsx
+++ b/client/src/app/pages/proxies/proxy-form.tsx
@@ -88,7 +88,9 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
           httpsPort: httpsProxy?.port || 8080,
           isHttpsIdentityRequired: !!httpsProxy?.identity?.name,
           httpsIdentity: httpsProxy?.identity?.name || null,
-          excluded: httpProxy?.excluded.join(",") || "",
+          excluded: Array.isArray(httpProxy?.excluded)
+            ? httpProxy.excluded.join(",")
+            : "",
         }),
         [httpProxy, httpsProxy]
       ),
@@ -419,7 +421,7 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                 !isDirty
               }
             >
-              {httpProxy || httpsProxy ? "Save" : "Update"}
+              {httpProxy || httpsProxy ? "Update" : "Save"}
             </Button>
           </ActionGroup>
         )}

--- a/docs/plans/react-hook-form-improvements.md
+++ b/docs/plans/react-hook-form-improvements.md
@@ -1,0 +1,115 @@
+# React Hook Form Improvements
+
+**Library version:** Upgraded from `^7.58.1` to latest stable v7.71.x
+
+## Background
+
+An evaluation of react-hook-form usage across the codebase identified several
+opportunities to leverage new features from the v7.59–v7.71 release line and to
+fix existing over-broad subscription patterns that cause unnecessary re-renders.
+
+The upgrade itself provides two automatic wins with zero code changes:
+
+- **Security patches** (v7.69.0) -- CVE-2025-55182 (Critical RCE),
+  CVE-2025-55183, CVE-2025-55184, CVE-2025-67779
+- **FormProvider memoization** (v7.71.0) -- context value is now memoized and
+  the control context is separated, reducing re-renders in all five
+  `FormProvider` trees (`assessment-wizard`, `identity-form`, `generator-form`,
+  `SchemaAsFields`, `retrieve-config-wizard`)
+
+The items below require code changes.
+
+---
+
+## 1. Scope over-broad `useWatch` calls -- DONE
+
+Several components watched the entire form but only used a handful of fields,
+causing re-renders on every keystroke in any field.
+
+**Changes applied:**
+
+- **`analysis-labels.tsx`** -- Scoped to `name: "excludedLabels"`
+- **`options-advanced.tsx`** -- Scoped to
+  `name: ["excludedLabels", "autoTaggingEnabled", "advancedAnalysisEnabled", "saveAsProfile"]`
+- **`kind-source-form.tsx`** -- Scoped to
+  `name: ["userCredentials", "password", "key", "kind", "default", "keyFilename"]`,
+  updated all `values.X` references to individual variables
+- **`export-form.tsx`** -- Replaced `watch()` with
+  `useWatch({ control, name: ["issueManager", "tracker", "project", "kind"] })`,
+  updated all references
+
+---
+
+## 2. Evaluate `compute` prop for `useFormChangeHandler` -- NOT ADOPTED
+
+**File:** `client/src/app/hooks/useFormChangeHandler.ts`
+
+The `compute` prop (v7.61.0) was evaluated for the `useFormChangeHandler` hook.
+However, the hook derives state from both watched values AND `formState.isValid`.
+The `compute` callback only re-evaluates when watched values change -- it does
+not re-evaluate when `isValid` transitions independently (e.g., after async
+validation completes). This would cause stale `isValid` in the derived state.
+
+The existing `useMemo` approach correctly handles both dependencies and remains
+the right pattern. A JSDoc note was added to the hook explaining this decision.
+
+---
+
+## 3. Evaluate `<Watch>` component for conditional rendering -- NOT ADOPTED
+
+**Feature:** v7.65.0
+
+Both candidates were evaluated and determined to not benefit from `<Watch>`:
+
+**`kind-source-form.tsx`:** The 6 watched values (`userCredentials`, `password`,
+`key`, `kind`, `default`, `keyFilename`) are consumed across multiple computed
+values (`isPasswordEncrypted`, `isKeyEncrypted`, `isReplacingDefault`) and JSX
+regions throughout the component. Isolating any value into a `<Watch>` would
+require duplicating watches or splitting the component, adding complexity without
+meaningful benefit. The scoped `useWatch` from step 1 already limits
+subscriptions to only the needed fields.
+
+**`export-form.tsx`:** The watched values (`issueManager`, `tracker`, `project`)
+drive hook calls at the component level (`useTrackerProjectsByTracker`,
+`useTrackerTypesByProjectName`). Since hooks cannot be called inside `<Watch>`
+render callbacks, the watched values must remain at the component scope. The
+`isDisabled` and `options` props on each select depend on these component-level
+variables.
+
+---
+
+## 4. Isolate formState with `<FormStateSubscribe>` -- DONE
+
+**Feature:** v7.68.0
+
+Moved formState subscriptions (`isSubmitting`, `isValidating`, `isValid`,
+`isDirty`) out of the `useForm` destructure and into `<FormStateSubscribe>`
+wrapping the ActionGroup. This prevents the entire form from re-rendering when
+formState flags toggle -- only the action buttons re-render.
+
+**Changes applied to the 6 largest/most complex forms:**
+
+- **`export-form.tsx`** -- 4 cascading selects with hook calls
+- **`identity-form.tsx`** -- FormProvider + conditional sections + many fields
+- **`tracker-form.tsx`** -- Multiple dependent selects
+- **`custom-target-form.tsx`** -- useFieldArray + image upload + many fields
+- **`proxy-form.tsx`** -- Many Controller fields + conditional sections
+- **`archetype-form.tsx`** -- Many fields + duplicate mode logic
+
+**Not applied to smaller forms** (stakeholder-group, stakeholder, tag,
+tag-category, business-service, job-function, migration-wave, review,
+target-profile, application-identity, import-questionnaire, platform) because
+the re-render cost of 2–4 field forms is negligible and the structural change
+adds complexity without measurable benefit. The pattern is available if any of
+these forms grow in complexity.
+
+---
+
+## Implementation order
+
+| Step | Item                                | Files affected | Status      |
+| ---- | ----------------------------------- | -------------- | ----------- |
+| 1    | Scope `useWatch` calls (1a–1d)      | 4 files        | Done        |
+| 2    | `compute` in `useFormChangeHandler` | 1 file         | Not adopted |
+| 3    | `<Watch>` component evaluation      | 2 candidates   | Not adopted |
+| 4    | `<FormStateSubscribe>` isolation    | 6 files        | Done        |

--- a/docs/plans/react-hook-form-improvements.md
+++ b/docs/plans/react-hook-form-improvements.md
@@ -10,8 +10,10 @@ fix existing over-broad subscription patterns that cause unnecessary re-renders.
 
 The upgrade itself provides two automatic wins with zero code changes:
 
-- **Security patches** (v7.69.0) -- CVE-2025-55182 (Critical RCE),
-  CVE-2025-55183, CVE-2025-55184, CVE-2025-67779
+- **Library updates** (v7.69.0–v7.71.x) -- Bug fixes and feature improvements.
+  Note: CVE-2025-55182, CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779
+  affect React Server Components (react-server-dom-\*), not react-hook-form;
+  applications using RSC/Flight should address those separately.
 - **FormProvider memoization** (v7.71.0) -- context value is now memoized and
   the control context is separated, reducing re-renders in all five
   `FormProvider` trees (`assessment-wizard`, `identity-form`, `generator-form`,
@@ -59,7 +61,7 @@ the right pattern. A JSDoc note was added to the hook explaining this decision.
 
 **Feature:** v7.65.0
 
-Both candidates were evaluated and determined to not benefit from `<Watch>`:
+Both candidates were evaluated and determined not to benefit from `<Watch>`:
 
 **`kind-source-form.tsx`:** The 6 watched values (`userCredentials`, `password`,
 `key`, `kind`, `default`, `keyFilename`) are consumed across multiple computed

--- a/docs/plans/react-hook-form-improvements.md
+++ b/docs/plans/react-hook-form-improvements.md
@@ -105,11 +105,41 @@ these forms grow in complexity.
 
 ---
 
+## 5. Replace `getValues()` with reactive `useWatch` -- DONE
+
+Moving formState out of the `useForm` destructure (step 4) removed an implicit
+re-render trigger that several forms relied on. Previously, formState changes
+(e.g. `isDirty` toggling) caused re-renders that kept `getValues()` snapshots
+current. With formState isolated in `<FormStateSubscribe>`, the parent component
+no longer re-renders on formState changes, so `getValues()` returned stale data
+and conditional rendering based on form field values stopped working.
+
+The fix replaced non-reactive `getValues()` calls with scoped `useWatch()`
+subscriptions -- which is also an improvement, since these forms were relying on
+an accidental side-effect for reactivity.
+
+**Changes applied:**
+
+- **`identity-form.tsx`** -- `useWatch({ control, name: "kind" })` replaces
+  `getValues().kind` for conditional rendering of kind-specific form sections
+- **`proxy-form.tsx`** -- `useWatch` for `isHttpProxyEnabled`,
+  `isHttpsProxyEnabled`, `isHttpIdentityRequired`, `isHttpsIdentityRequired`;
+  also changed `reset(values)` to `reset(getValues())` so the callback reads
+  current values at invocation time rather than a stale snapshot
+- **`tracker-form.tsx`** -- `useWatch({ control, name: "kind" })` replaces
+  `getValues().kind` for identity option filtering
+- **`custom-target-form.tsx`** -- `useWatch({ control, name: "rulesKind" })`
+  replaces `getValues().rulesKind` for conditional rendering of manual vs
+  repository rule sections
+
+---
+
 ## Implementation order
 
-| Step | Item                                | Files affected | Status      |
-| ---- | ----------------------------------- | -------------- | ----------- |
-| 1    | Scope `useWatch` calls (1a–1d)      | 4 files        | Done        |
-| 2    | `compute` in `useFormChangeHandler` | 1 file         | Not adopted |
-| 3    | `<Watch>` component evaluation      | 2 candidates   | Not adopted |
-| 4    | `<FormStateSubscribe>` isolation    | 6 files        | Done        |
+| Step | Item                                           | Files affected | Status      |
+| ---- | ---------------------------------------------- | -------------- | ----------- |
+| 1    | Scope `useWatch` calls (1a–1d)                 | 4 files        | Done        |
+| 2    | `compute` in `useFormChangeHandler`            | 1 file         | Not adopted |
+| 3    | `<Watch>` component evaluation                 | 2 candidates   | Not adopted |
+| 4    | `<FormStateSubscribe>` isolation               | 6 files        | Done        |
+| 5    | Replace `getValues()` with reactive `useWatch` | 4 files        | Done        |


### PR DESCRIPTION
Changes:
  - Enhance form handling by updating useWatch usage across multiple components
  - Use FormStateSubscribe to isolate formState subscriptions
  - Refactor to ensure correct state management with async validation and improve readability
  - Update comments for clarity on the use of derived state

Plan includes to retain additional rational about the changes.

Follow up to #3091
Closes #3273

AIA Human-AI blend, Human-initiated, Reviewed, claude-4.6-opus-high v1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Isolated form state access and replaced broad watches with targeted field watches; submit/cancel controls now reflect live form state and success handling.
  * Replaced stale value reads with reactive watches so conditional sections and dependent dropdowns update reliably.

* **Chores**
  * Upgraded form library to a newer stable v7 release for fixes and improvements.

* **Documentation**
  * Added migration guidance and an implementation roadmap for form optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->