### PR TITLE
:sparkles: upgrade to react-router v6

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,7 @@
     "react-i18next": "^16.5.4",
     "react-markdown": "^8.0.7",
     "react-measure": "^2.5.2",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^6.30.3",
     "tinycolor2": "^1.6.0",
     "use-immer": "^0.11.0",
     "xmllint-wasm": "^5.0.0",

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -1,6 +1,6 @@
 import { type ComponentType, Suspense, lazy } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { Redirect, Switch, useLocation } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import {
   AdminPathValues,
@@ -90,241 +90,69 @@ const AssetGenerators = lazy(
   () => import("./pages/asset-generators/asset-generators")
 );
 
-export interface IRoute<T> {
-  path: T;
+export interface IRoute<T extends string = string> {
+  path: T | `${T}/*`;
   comp: ComponentType;
-  exact?: boolean;
 }
 
 export const migrationRoutes: IRoute<DevPathValues>[] = [
-  {
-    path: Paths.applicationsImportsDetails,
-    comp: ImportDetails,
-    exact: false,
-  },
-  {
-    path: Paths.applicationsAnalysisDetails,
-    comp: AnalysisDetails,
-    exact: true,
-  },
-  {
-    path: Paths.applicationsTaskDetails,
-    comp: TaskDetails,
-    exact: true,
-  },
-  {
-    path: Paths.applicationsAnalysisDetailsAttachment,
-    comp: AnalysisDetails,
-    exact: false,
-  },
-  {
-    path: Paths.applicationsImports,
-    comp: ManageImports,
-    exact: false,
-  },
-  {
-    path: Paths.archetypeReview,
-    comp: Review,
-    exact: false,
-  },
-  {
-    path: Paths.applicationsReview,
-    comp: Review,
-    exact: false,
-  },
-  {
-    path: Paths.applicationAssessmentActions,
-    comp: AssessmentActions,
-    exact: false,
-  },
-  {
-    path: Paths.archetypeAssessmentActions,
-    comp: AssessmentActions,
-    exact: false,
-  },
-  {
-    path: Paths.viewArchetypes,
-    comp: ViewArchetypes,
-    exact: false,
-  },
-  {
-    path: Paths.applicationAssessmentSummary,
-    comp: AssessmentSummary,
-    exact: false,
-  },
-  {
-    path: Paths.archetypeAssessmentSummary,
-    comp: AssessmentSummary,
-    exact: false,
-  },
-  {
-    path: Paths.applications,
-    comp: Applications,
-    exact: false,
-  },
-  {
-    path: Paths.controls,
-    comp: Controls,
-    exact: false,
-  },
-  {
-    path: Paths.reports,
-    comp: Reports,
-    exact: false,
-  },
-  {
-    path: Paths.migrationWaves,
-    comp: MigrationWaves,
-    exact: false,
-  },
+  { path: Paths.applicationsImportsDetails, comp: ImportDetails },
+  { path: Paths.applicationsAnalysisDetails, comp: AnalysisDetails },
+  { path: Paths.applicationsTaskDetails, comp: TaskDetails },
+  { path: Paths.applicationsAnalysisDetailsAttachment, comp: AnalysisDetails },
+  { path: Paths.applicationsImports, comp: ManageImports },
+  { path: Paths.archetypeReview, comp: Review },
+  { path: Paths.applicationsReview, comp: Review },
+  { path: Paths.applicationAssessmentActions, comp: AssessmentActions },
+  { path: Paths.archetypeAssessmentActions, comp: AssessmentActions },
+  { path: Paths.viewArchetypes, comp: ViewArchetypes },
+  { path: Paths.applicationAssessmentSummary, comp: AssessmentSummary },
+  { path: Paths.archetypeAssessmentSummary, comp: AssessmentSummary },
+  { path: Paths.applications, comp: Applications },
+  { path: `${Paths.controls}/*`, comp: Controls },
+  { path: Paths.reports, comp: Reports },
+  { path: Paths.migrationWaves, comp: MigrationWaves },
   {
     path: Paths.issuesAllAffectedApplications,
     comp: IssuesAffectedApplications,
-    exact: false,
   },
-  {
-    path: Paths.issuesAllTab,
-    comp: Issues,
-    exact: false,
-  },
-  {
-    path: Paths.issuesSingleAppTab,
-    comp: Issues,
-    exact: false,
-  },
-  {
-    path: Paths.issuesSingleAppSelected,
-    comp: Issues,
-    exact: false,
-  },
-  {
-    path: Paths.issues,
-    comp: Issues,
-    exact: false,
-  },
+  { path: Paths.issuesAllTab, comp: Issues },
+  { path: Paths.issuesSingleAppTab, comp: Issues },
+  { path: Paths.issuesSingleAppSelected, comp: Issues },
+  { path: Paths.issues, comp: Issues },
   {
     path: Paths.insightsAllAffectedApplications,
     comp: InsightsAffectedApplications,
-    exact: false,
   },
-  {
-    path: Paths.insightsAllTab,
-    comp: Insights,
-    exact: false,
-  },
-  {
-    path: Paths.insightsSingleAppTab,
-    comp: Insights,
-    exact: false,
-  },
-  {
-    path: Paths.insightsSingleAppSelected,
-    comp: Insights,
-    exact: false,
-  },
-  {
-    path: Paths.insights,
-    comp: Insights,
-    exact: false,
-  },
-  {
-    path: Paths.dependencies,
-    comp: Dependencies,
-    exact: false,
-  },
-  // Target profiles route must come before archetypes route due to route matching order
-  {
-    path: Paths.archetypeTargetProfiles,
-    comp: TargetProfilesPage,
-    exact: false,
-  },
-  {
-    path: Paths.archetypes,
-    comp: Archetypes,
-    exact: false,
-  },
-  {
-    path: Paths.migrationTargets,
-    comp: MigrationTargets,
-    exact: false,
-  },
-  {
-    path: Paths.analysisProfiles,
-    comp: AnalysisProfiles,
-    exact: false,
-  },
+  { path: Paths.insightsAllTab, comp: Insights },
+  { path: Paths.insightsSingleAppTab, comp: Insights },
+  { path: Paths.insightsSingleAppSelected, comp: Insights },
+  { path: Paths.insights, comp: Insights },
+  { path: Paths.dependencies, comp: Dependencies },
+  { path: Paths.archetypeTargetProfiles, comp: TargetProfilesPage },
+  { path: Paths.archetypes, comp: Archetypes },
+  { path: Paths.migrationTargets, comp: MigrationTargets },
+  { path: Paths.analysisProfiles, comp: AnalysisProfiles },
 ];
 
 export const universalRoutes: IRoute<UniversalPathValues>[] = [
-  {
-    path: Paths.tasks,
-    comp: TaskManager,
-    exact: true,
-  },
-  {
-    path: Paths.taskDetails,
-    comp: TaskDetails,
-    exact: true,
-  },
-  {
-    path: Paths.taskDetailsAttachment,
-    comp: TaskDetails,
-    exact: false,
-  },
+  { path: Paths.tasks, comp: TaskManager },
+  { path: Paths.taskDetails, comp: TaskDetails },
+  { path: Paths.taskDetailsAttachment, comp: TaskDetails },
 ];
 
 export const administrationRoutes: IRoute<AdminPathValues>[] = [
-  {
-    comp: General,
-    path: Paths.general,
-    exact: false,
-  },
-  {
-    comp: Identities,
-    path: Paths.identities,
-    exact: false,
-  },
-  {
-    comp: RepositoriesGit,
-    path: Paths.repositoriesGit,
-    exact: false,
-  },
-  {
-    comp: RepositoriesSvn,
-    path: Paths.repositoriesSvn,
-    exact: false,
-  },
-  {
-    comp: RepositoriesMvn,
-    path: Paths.repositoriesMvn,
-    exact: false,
-  },
-  {
-    path: Paths.assessment,
-    comp: AssessmentSettings,
-    exact: false,
-  },
-  {
-    path: Paths.questionnaire,
-    comp: Questionnaire,
-    exact: false,
-  },
-  { comp: Proxies, path: Paths.proxies, exact: false },
-  {
-    comp: Jira,
-    path: Paths.jira,
-    exact: false,
-  },
-  {
-    comp: SourcePlatforms,
-    path: Paths.sourcePlatforms,
-    exact: false,
-  },
-  {
-    comp: AssetGenerators,
-    path: Paths.assetGenerators,
-    exact: false,
-  },
+  { comp: General, path: Paths.general },
+  { comp: Identities, path: Paths.identities },
+  { comp: RepositoriesGit, path: Paths.repositoriesGit },
+  { comp: RepositoriesSvn, path: Paths.repositoriesSvn },
+  { comp: RepositoriesMvn, path: Paths.repositoriesMvn },
+  { path: Paths.assessment, comp: AssessmentSettings },
+  { path: Paths.questionnaire, comp: Questionnaire },
+  { comp: Proxies, path: Paths.proxies },
+  { comp: Jira, path: Paths.jira },
+  { comp: SourcePlatforms, path: Paths.sourcePlatforms },
+  { comp: AssetGenerators, path: Paths.assetGenerators },
 ];
 
 export const devtoolRoutes: IRoute<DevtoolPathValues>[] = isDevtoolsEnabled
@@ -334,7 +162,6 @@ export const devtoolRoutes: IRoute<DevtoolPathValues>[] = isDevtoolsEnabled
           () => import("./devtools/schema-defined/schema-defined-page")
         ),
         path: DevtoolPaths.schemaDefined,
-        exact: false,
       },
     ]
   : [];
@@ -345,38 +172,32 @@ export const AppRoutes = () => {
   return (
     <Suspense fallback={<AppPlaceholder />}>
       <ErrorBoundary FallbackComponent={ErrorFallback} key={location.pathname}>
-        <Switch>
+        <Routes>
           {[...migrationRoutes, ...universalRoutes].map(
-            ({ comp, path, exact }, index) => (
-              <RouteWrapper
-                comp={comp}
+            ({ comp, path }, index) => (
+              <Route
                 key={index}
-                roles={devRoles}
                 path={path}
-                exact={exact}
+                element={<RouteWrapper comp={comp} roles={devRoles} />}
               />
             )
           )}
-          {administrationRoutes.map(({ comp, path, exact }, index) => (
-            <RouteWrapper
-              comp={comp}
+          {administrationRoutes.map(({ comp, path }, index) => (
+            <Route
               key={index}
-              roles={adminRoles}
               path={path}
-              exact={exact}
+              element={<RouteWrapper comp={comp} roles={adminRoles} />}
             />
           ))}
-          {devtoolRoutes.map(({ comp, path, exact }, index) => (
-            <RouteWrapper
-              comp={comp}
+          {devtoolRoutes.map(({ comp, path }, index) => (
+            <Route
               key={index}
-              roles={devRoles}
               path={path}
-              exact={exact}
+              element={<RouteWrapper comp={comp} roles={devRoles} />}
             />
           ))}
-          <Redirect from="*" to="/applications" />
-        </Switch>
+          <Route path="*" element={<Navigate to="/applications" replace />} />
+        </Routes>
       </ErrorBoundary>
     </Suspense>
   );

--- a/client/src/app/components/ErrorFallback.tsx
+++ b/client/src/app/components/ErrorFallback.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   Bullseye,
   Button,
@@ -32,7 +32,7 @@ export const ErrorFallback = ({
 }) => {
   const { t } = useTranslation();
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const { pushNotification } = useContext(NotificationsContext);
   const prevError = usePrevious(error);
 
@@ -59,7 +59,7 @@ export const ErrorFallback = ({
             variant="primary"
             className={spacing.mtSm}
             onClick={() => {
-              history.push("/");
+              navigate("/");
               resetErrorBoundary(false);
             }}
           >

--- a/client/src/app/components/HorizontalNav.tsx
+++ b/client/src/app/components/HorizontalNav.tsx
@@ -13,8 +13,9 @@ export const HorizontalNav: React.FC<HorizontalNavProps> = ({ navItems }) => {
           <NavLink
             key={index}
             to={f.path}
-            className="pf-v5-c-tabs__item"
-            activeClassName="pf-m-current"
+            className={({ isActive }) =>
+              `pf-v5-c-tabs__item${isActive ? " pf-m-current" : ""}`
+            }
           >
             <li key={index} className="pf-v5-c-tabs__item">
               <button className="pf-v5-c-tabs__link">

--- a/client/src/app/components/RouteWrapper.tsx
+++ b/client/src/app/components/RouteWrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Redirect, Route } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 
 import { isAuthRequired } from "@app/Constants";
 import keycloak from "@app/keycloak";
@@ -7,17 +7,13 @@ import keycloak from "@app/keycloak";
 import { checkAccess } from "../utils/rbac-utils";
 
 interface IRouteWrapperProps {
-  comp: React.ComponentType<Record<string, unknown>>;
+  comp: React.ComponentType;
   roles: string[];
-  path: string;
-  exact?: boolean;
 }
 
 export const RouteWrapper = ({
   comp: Component,
   roles,
-  path,
-  exact,
 }: IRouteWrapperProps) => {
   const token = keycloak.tokenParsed || undefined;
   const userRoles = token?.realm_access?.roles || [],
@@ -25,16 +21,10 @@ export const RouteWrapper = ({
 
   if (!token && isAuthRequired) {
     //TODO: Handle token expiry & auto logout
-    return <Redirect to="/login" />;
+    return <Navigate to="/login" replace />;
   } else if (token && !access) {
-    return <Redirect to="/applications" />;
+    return <Navigate to="/applications" replace />;
   }
 
-  return (
-    <Route
-      path={path}
-      exact={exact}
-      render={(props) => <Component {...props} />}
-    />
-  );
+  return <Component />;
 };

--- a/client/src/app/components/insights/tables/single-application-insights-table.tsx
+++ b/client/src/app/components/insights/tables/single-application-insights-table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
+import { useLocation, useMatch, useNavigate } from "react-router-dom";
 import {
   Button,
   EmptyState,
@@ -56,11 +56,9 @@ const useSelectedApplicationId = (
   keyPrefix: TablePersistenceKeyPrefix
 ) => {
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
-  const routeMatch = useRouteMatch<{
-    applicationId: string;
-  }>(pathPattern);
+  const routeMatch = useMatch(pathPattern);
 
   const selectedAppId = routeMatch
     ? Number(routeMatch.params.applicationId)
@@ -71,14 +69,17 @@ const useSelectedApplicationId = (
       location &&
       new URLSearchParams(location.search).get(`${keyPrefix}:filters`);
 
-    history.replace({
-      pathname: pathPattern.replace(":applicationId", String(applicationId)),
-      ...(existingFiltersParam && {
-        search: new URLSearchParams({
-          filters: existingFiltersParam,
-        }).toString(),
-      }),
-    });
+    navigate(
+      {
+        pathname: pathPattern.replace(":applicationId", String(applicationId)),
+        ...(existingFiltersParam && {
+          search: new URLSearchParams({
+            filters: existingFiltersParam,
+          }).toString(),
+        }),
+      },
+      { replace: true }
+    );
   };
 
   return { selectedAppId, setSelectedAppId };

--- a/client/src/app/hooks/useUrlParams.ts
+++ b/client/src/app/hooks/useUrlParams.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { DisallowCharacters } from "@app/utils/type-utils";
 import { objectKeys } from "@app/utils/utils";
@@ -61,7 +61,7 @@ export const useUrlParams = <
 >): TURLParamStateTuple<TDeserializedParams> => {
   type TPrefixedURLParamKey = TURLParamKey | `${TKeyPrefix}:${TURLParamKey}`;
 
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const withPrefix = (key: TURLParamKey): TPrefixedURLParamKey =>
     persistenceKeyPrefix ? `${persistenceKeyPrefix}:${key}` : key;
@@ -87,13 +87,16 @@ export const useUrlParams = <
     const existingSearchParams = new URLSearchParams(search);
     // We prefix the params object here so the serialize function doesn't have to care about the keyPrefix.
     const newPrefixedSerializedParams = withPrefixes(serialize(newParams));
-    history.replace({
-      pathname,
-      search: trimAndStringifyUrlParams({
-        existingSearchParams,
-        newPrefixedSerializedParams,
-      }),
-    });
+    navigate(
+      {
+        pathname,
+        search: trimAndStringifyUrlParams({
+          existingSearchParams,
+          newPrefixedSerializedParams,
+        }),
+      },
+      { replace: true }
+    );
   };
 
   // We use useLocation here so we are re-rendering when the params change.

--- a/client/src/app/layout/HeaderApp/SsoToolbarItem.tsx
+++ b/client/src/app/layout/HeaderApp/SsoToolbarItem.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import * as React from "react";
 import { useKeycloak } from "@react-keycloak/web";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   Dropdown,
   DropdownGroup,
@@ -22,7 +22,7 @@ export const AuthEnabledSsoToolbarItem: React.FC = () => {
   const { t } = useTranslation();
 
   const { keycloak } = useKeycloak();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const onDropdownSelect = () => {
@@ -70,11 +70,11 @@ export const AuthEnabledSsoToolbarItem: React.FC = () => {
                   keycloak
                     .logout()
                     .then(() => {
-                      history.push("/");
+                      navigate("/");
                     })
                     .catch((err) => {
                       console.error("Logout failed:", err);
-                      history.push("/");
+                      navigate("/");
                     });
                 }
               }}

--- a/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -131,6 +131,19 @@ const PersonaSidebar: FC<{
   );
 };
 
+const isNavItemActive = (toPathname: string) => {
+  const locationPathname = location.pathname;
+  const endSlashPosition =
+    toPathname !== "/" && toPathname.endsWith("/")
+      ? toPathname.length - 1
+      : toPathname.length;
+  return (
+    locationPathname === toPathname ||
+    (locationPathname.startsWith(toPathname) &&
+      locationPathname.charAt(endSlashPosition) === "/")
+  );
+};
+
 export const MigrationSidebar = ({
   setLastPersona,
 }: {
@@ -147,27 +160,18 @@ export const MigrationSidebar = ({
           groupId="migration-applications"
           isExpanded
         >
-          <NavItem>
-            <NavLink
-              to={DevPaths.applications}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
+          <NavItem isActive={isNavItemActive(DevPaths.applications)}>
+            <NavLink to={DevPaths.applications}>
               {t("sidebar.applicationInventory")}
             </NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={DevPaths.archetypes}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
+          <NavItem isActive={isNavItemActive(DevPaths.archetypes)}>
+            <NavLink to={DevPaths.archetypes}>
               {t("sidebar.archetypes")}
             </NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={DevPaths.migrationWaves}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
+          <NavItem isActive={isNavItemActive(DevPaths.migrationWaves)}>
+            <NavLink to={DevPaths.migrationWaves}>
               {t("sidebar.migrationWaves")}
             </NavLink>
           </NavItem>
@@ -178,35 +182,29 @@ export const MigrationSidebar = ({
           groupId="migration-analysis-results"
           isExpanded
         >
-          <NavItem>
-            <NavLink
-              to={DevPaths.reports}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              {t("sidebar.reports")}
-            </NavLink>
+          <NavItem isActive={isNavItemActive(DevPaths.reports)}>
+            <NavLink to={DevPaths.reports}>{t("sidebar.reports")}</NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={DevPaths.issuesAllTab}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              {t("sidebar.issues")}
-            </NavLink>
+          <NavItem
+            isActive={
+              isNavItemActive(DevPaths.issuesAllTab) ||
+              isNavItemActive(DevPaths.issuesSingleAppTab)
+            }
+          >
+            <NavLink to={DevPaths.issuesAllTab}>{t("sidebar.issues")}</NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={DevPaths.insightsAllTab}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
+          <NavItem
+            isActive={
+              isNavItemActive(DevPaths.insightsAllTab) ||
+              isNavItemActive(DevPaths.insightsSingleAppTab)
+            }
+          >
+            <NavLink to={DevPaths.insightsAllTab}>
               {t("sidebar.insights")}
             </NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={DevPaths.dependencies}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
+          <NavItem isActive={isNavItemActive(DevPaths.dependencies)}>
+            <NavLink to={DevPaths.dependencies}>
               {t("sidebar.dependencies")}
             </NavLink>
           </NavItem>
@@ -217,37 +215,21 @@ export const MigrationSidebar = ({
           groupId="migration-configuration"
           isExpanded
         >
-          <NavItem>
-            <NavLink
-              to={DevPaths.analysisProfiles}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
+          <NavItem isActive={isNavItemActive(DevPaths.analysisProfiles)}>
+            <NavLink to={DevPaths.analysisProfiles}>
               {t("sidebar.analysisProfiles")}
             </NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={DevPaths.controls}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              {t("sidebar.controls")}
-            </NavLink>
+          <NavItem isActive={isNavItemActive(DevPaths.controls)}>
+            <NavLink to={DevPaths.controls}>{t("sidebar.controls")}</NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={DevPaths.migrationTargets}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
+          <NavItem isActive={isNavItemActive(DevPaths.migrationTargets)}>
+            <NavLink to={DevPaths.migrationTargets}>
               {t("sidebar.customMigrationTargets")}
             </NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={UniversalPaths.tasks}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              {t("sidebar.tasks")}
-            </NavLink>
+          <NavItem isActive={isNavItemActive(UniversalPaths.tasks)}>
+            <NavLink to={UniversalPaths.tasks}>{t("sidebar.tasks")}</NavLink>
           </NavItem>
         </NavExpandable>
       </NavList>
@@ -267,21 +249,11 @@ export const AdminSidebar = ({
       setLastPersona={setLastPersona}
     >
       <NavList title="Admin">
-        <NavItem>
-          <NavLink
-            to={AdminPaths.general}
-            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-          >
-            {t("terms.general")}
-          </NavLink>
+        <NavItem isActive={isNavItemActive(AdminPaths.general)}>
+          <NavLink to={AdminPaths.general}>{t("terms.general")}</NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink
-            to={AdminPaths.identities}
-            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-          >
-            {t("terms.credentials")}
-          </NavLink>
+        <NavItem isActive={isNavItemActive(AdminPaths.identities)}>
+          <NavLink to={AdminPaths.identities}>{t("terms.credentials")}</NavLink>
         </NavItem>
         <NavExpandable
           title="Repositories"
@@ -289,38 +261,18 @@ export const AdminSidebar = ({
           groupId="admin-repos"
           isExpanded
         >
-          <NavItem>
-            <NavLink
-              to={AdminPaths.repositoriesGit}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              Git
-            </NavLink>
+          <NavItem isActive={isNavItemActive(AdminPaths.repositoriesGit)}>
+            <NavLink to={AdminPaths.repositoriesGit}>Git</NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={AdminPaths.repositoriesSvn}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              Subversion
-            </NavLink>
+          <NavItem isActive={isNavItemActive(AdminPaths.repositoriesSvn)}>
+            <NavLink to={AdminPaths.repositoriesSvn}>Subversion</NavLink>
           </NavItem>
-          <NavItem>
-            <NavLink
-              to={AdminPaths.repositoriesMvn}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              Maven
-            </NavLink>
+          <NavItem isActive={isNavItemActive(AdminPaths.repositoriesMvn)}>
+            <NavLink to={AdminPaths.repositoriesMvn}>Maven</NavLink>
           </NavItem>
         </NavExpandable>
-        <NavItem>
-          <NavLink
-            to={AdminPaths.proxies}
-            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-          >
-            Proxy
-          </NavLink>
+        <NavItem isActive={isNavItemActive(AdminPaths.proxies)}>
+          <NavLink to={AdminPaths.proxies}>Proxy</NavLink>
         </NavItem>
         <NavExpandable
           title="Issue management"
@@ -328,46 +280,27 @@ export const AdminSidebar = ({
           groupId="admin-issue-management"
           isExpanded
         >
-          <NavItem>
-            <NavLink
-              to={AdminPaths.jira}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              Jira
-            </NavLink>
+          <NavItem isActive={isNavItemActive(AdminPaths.jira)}>
+            <NavLink to={AdminPaths.jira}>Jira</NavLink>
           </NavItem>
         </NavExpandable>
-        <NavItem>
-          <NavLink
-            to={AdminPaths.assessment}
-            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-          >
+        <NavItem isActive={isNavItemActive(AdminPaths.assessment)}>
+          <NavLink to={AdminPaths.assessment}>
             {t("terms.assessmentQuestionnaires")}
           </NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink
-            to={AdminPaths.sourcePlatforms}
-            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-          >
+        <NavItem isActive={isNavItemActive(AdminPaths.sourcePlatforms)}>
+          <NavLink to={AdminPaths.sourcePlatforms}>
             {t("terms.sourcePlatforms")}
           </NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink
-            to={AdminPaths.assetGenerators}
-            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-          >
+        <NavItem isActive={isNavItemActive(AdminPaths.assetGenerators)}>
+          <NavLink to={AdminPaths.assetGenerators}>
             {t("terms.generators")}
           </NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink
-            to={UniversalPaths.tasks}
-            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-          >
-            {t("sidebar.tasks")}
-          </NavLink>
+        <NavItem isActive={isNavItemActive(UniversalPaths.tasks)}>
+          <NavLink to={UniversalPaths.tasks}>{t("sidebar.tasks")}</NavLink>
         </NavItem>
       </NavList>
     </PersonaSidebar>
@@ -383,13 +316,8 @@ const DevtoolSidebar = !isDevtoolsEnabled
     }) => (
       <PersonaSidebar selectedPersona="DEVTOOL" setLastPersona={setLastPersona}>
         <NavList title="Devtool">
-          <NavItem>
-            <NavLink
-              to={DevtoolPaths.schemaDefined}
-              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
-            >
-              SDF Playground
-            </NavLink>
+          <NavItem isActive={isNavItemActive(DevtoolPaths.schemaDefined)}>
+            <NavLink to={DevtoolPaths.schemaDefined}>SDF Playground</NavLink>
           </NavItem>
         </NavList>
       </PersonaSidebar>

--- a/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { NavLink, Route, Switch, useHistory } from "react-router-dom";
+import { NavLink, Route, Routes, useNavigate } from "react-router-dom";
 import {
   Nav,
   NavExpandable,
@@ -45,37 +45,33 @@ type PersonaType = keyof typeof PersonaDefinition;
 export const SidebarApp: React.FC = () => {
   const [lastPersona, setLastPersona] = useState<PersonaType>();
   return (
-    <Switch>
-      {migrationRoutes.map(({ path, exact }, index) => (
+    <Routes>
+      {migrationRoutes.map(({ path }, index) => (
         <Route
           path={path}
-          exact={exact}
           key={index}
-          render={() => <MigrationSidebar setLastPersona={setLastPersona} />}
+          element={<MigrationSidebar setLastPersona={setLastPersona} />}
         />
       ))}
-      {administrationRoutes.map(({ path, exact }, index) => (
+      {administrationRoutes.map(({ path }, index) => (
         <Route
           path={path}
-          exact={exact}
           key={index}
-          render={() => <AdminSidebar setLastPersona={setLastPersona} />}
+          element={<AdminSidebar setLastPersona={setLastPersona} />}
         />
       ))}
-      {devtoolRoutes.map(({ path, exact }, index) => (
+      {devtoolRoutes.map(({ path }, index) => (
         <Route
           path={path}
-          exact={exact}
           key={index}
-          render={() => <DevtoolSidebar setLastPersona={setLastPersona} />}
+          element={<DevtoolSidebar setLastPersona={setLastPersona} />}
         />
       ))}
-      {universalRoutes.map(({ path, exact }, index) => (
+      {universalRoutes.map(({ path }, index) => (
         <Route
           path={path}
-          exact={exact}
           key={index}
-          render={() =>
+          element={
             lastPersona === "ADMINISTRATION" ? (
               <AdminSidebar setLastPersona={setLastPersona} />
             ) : (
@@ -84,7 +80,7 @@ export const SidebarApp: React.FC = () => {
           }
         />
       ))}
-    </Switch>
+    </Routes>
   );
 };
 
@@ -107,7 +103,7 @@ const PersonaSidebar: FC<{
     isDevtoolsEnabled && "DEVTOOL",
   ].filter<PersonaType>(Boolean);
 
-  const history = useHistory();
+  const navigate = useNavigate();
   return (
     <PageSidebar theme={LayoutTheme}>
       <div className="perspective">
@@ -121,7 +117,7 @@ const PersonaSidebar: FC<{
             const startPath =
               PersonaDefinition[value as PersonaType]?.startPath;
             if (value !== selectedPersona && startPath) {
-              history.push(startPath);
+              navigate(startPath);
             }
           }}
         />
@@ -152,19 +148,25 @@ export const MigrationSidebar = ({
           isExpanded
         >
           <NavItem>
-            <NavLink to={DevPaths.applications} activeClassName="pf-m-current">
+            <NavLink
+              to={DevPaths.applications}
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+            >
               {t("sidebar.applicationInventory")}
             </NavLink>
           </NavItem>
           <NavItem>
-            <NavLink to={DevPaths.archetypes} activeClassName="pf-m-current">
+            <NavLink
+              to={DevPaths.archetypes}
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+            >
               {t("sidebar.archetypes")}
             </NavLink>
           </NavItem>
           <NavItem>
             <NavLink
               to={DevPaths.migrationWaves}
-              activeClassName="pf-m-current"
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
             >
               {t("sidebar.migrationWaves")}
             </NavLink>
@@ -177,25 +179,34 @@ export const MigrationSidebar = ({
           isExpanded
         >
           <NavItem>
-            <NavLink to={DevPaths.reports} activeClassName="pf-m-current">
+            <NavLink
+              to={DevPaths.reports}
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+            >
               {t("sidebar.reports")}
             </NavLink>
           </NavItem>
           <NavItem>
-            <NavLink to={DevPaths.issuesAllTab} activeClassName="pf-m-current">
+            <NavLink
+              to={DevPaths.issuesAllTab}
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+            >
               {t("sidebar.issues")}
             </NavLink>
           </NavItem>
           <NavItem>
             <NavLink
               to={DevPaths.insightsAllTab}
-              activeClassName="pf-m-current"
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
             >
               {t("sidebar.insights")}
             </NavLink>
           </NavItem>
           <NavItem>
-            <NavLink to={DevPaths.dependencies} activeClassName="pf-m-current">
+            <NavLink
+              to={DevPaths.dependencies}
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+            >
               {t("sidebar.dependencies")}
             </NavLink>
           </NavItem>
@@ -209,26 +220,32 @@ export const MigrationSidebar = ({
           <NavItem>
             <NavLink
               to={DevPaths.analysisProfiles}
-              activeClassName="pf-m-current"
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
             >
               {t("sidebar.analysisProfiles")}
             </NavLink>
           </NavItem>
           <NavItem>
-            <NavLink to={DevPaths.controls} activeClassName="pf-m-current">
+            <NavLink
+              to={DevPaths.controls}
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+            >
               {t("sidebar.controls")}
             </NavLink>
           </NavItem>
           <NavItem>
             <NavLink
               to={DevPaths.migrationTargets}
-              activeClassName="pf-m-current"
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
             >
               {t("sidebar.customMigrationTargets")}
             </NavLink>
           </NavItem>
           <NavItem>
-            <NavLink to={UniversalPaths.tasks} activeClassName="pf-m-current">
+            <NavLink
+              to={UniversalPaths.tasks}
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+            >
               {t("sidebar.tasks")}
             </NavLink>
           </NavItem>
@@ -251,12 +268,18 @@ export const AdminSidebar = ({
     >
       <NavList title="Admin">
         <NavItem>
-          <NavLink to={AdminPaths.general} activeClassName="pf-m-current">
+          <NavLink
+            to={AdminPaths.general}
+            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+          >
             {t("terms.general")}
           </NavLink>
         </NavItem>
         <NavItem>
-          <NavLink to={AdminPaths.identities} activeClassName="pf-m-current">
+          <NavLink
+            to={AdminPaths.identities}
+            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+          >
             {t("terms.credentials")}
           </NavLink>
         </NavItem>
@@ -269,7 +292,7 @@ export const AdminSidebar = ({
           <NavItem>
             <NavLink
               to={AdminPaths.repositoriesGit}
-              activeClassName="pf-m-current"
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
             >
               Git
             </NavLink>
@@ -277,7 +300,7 @@ export const AdminSidebar = ({
           <NavItem>
             <NavLink
               to={AdminPaths.repositoriesSvn}
-              activeClassName="pf-m-current"
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
             >
               Subversion
             </NavLink>
@@ -285,14 +308,17 @@ export const AdminSidebar = ({
           <NavItem>
             <NavLink
               to={AdminPaths.repositoriesMvn}
-              activeClassName="pf-m-current"
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
             >
               Maven
             </NavLink>
           </NavItem>
         </NavExpandable>
         <NavItem>
-          <NavLink to={AdminPaths.proxies} activeClassName="pf-m-current">
+          <NavLink
+            to={AdminPaths.proxies}
+            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+          >
             Proxy
           </NavLink>
         </NavItem>
@@ -303,20 +329,26 @@ export const AdminSidebar = ({
           isExpanded
         >
           <NavItem>
-            <NavLink to={AdminPaths.jira} activeClassName="pf-m-current">
+            <NavLink
+              to={AdminPaths.jira}
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+            >
               Jira
             </NavLink>
           </NavItem>
         </NavExpandable>
         <NavItem>
-          <NavLink to={AdminPaths.assessment} activeClassName="pf-m-current">
+          <NavLink
+            to={AdminPaths.assessment}
+            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+          >
             {t("terms.assessmentQuestionnaires")}
           </NavLink>
         </NavItem>
         <NavItem>
           <NavLink
             to={AdminPaths.sourcePlatforms}
-            activeClassName="pf-m-current"
+            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
           >
             {t("terms.sourcePlatforms")}
           </NavLink>
@@ -324,13 +356,16 @@ export const AdminSidebar = ({
         <NavItem>
           <NavLink
             to={AdminPaths.assetGenerators}
-            activeClassName="pf-m-current"
+            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
           >
             {t("terms.generators")}
           </NavLink>
         </NavItem>
         <NavItem>
-          <NavLink to={UniversalPaths.tasks} activeClassName="pf-m-current">
+          <NavLink
+            to={UniversalPaths.tasks}
+            className={({ isActive }) => (isActive ? "pf-m-current" : "")}
+          >
             {t("sidebar.tasks")}
           </NavLink>
         </NavItem>
@@ -351,7 +386,7 @@ const DevtoolSidebar = !isDevtoolsEnabled
           <NavItem>
             <NavLink
               to={DevtoolPaths.schemaDefined}
-              activeClassName="pf-m-current"
+              className={({ isActive }) => (isActive ? "pf-m-current" : "")}
             >
               SDF Playground
             </NavLink>

--- a/client/src/app/pages/applications/analysis-details/AnalysisDetails.tsx
+++ b/client/src/app/pages/applications/analysis-details/AnalysisDetails.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
-import { AnalysisDetailsAttachmentRoute, Paths } from "@app/Paths";
+import { Paths } from "@app/Paths";
 import { TaskDetailsBase } from "@app/pages/tasks/TaskDetailsBase";
 import { useFetchApplicationById } from "@app/queries/applications";
 import { formatPath } from "@app/utils/utils";
@@ -10,14 +10,15 @@ import "@app/components/simple-document-viewer/SimpleDocumentViewer.css";
 
 export const AnalysisDetails = () => {
   const { t } = useTranslation();
-  const { applicationId, taskId, attachmentId } =
-    useParams<AnalysisDetailsAttachmentRoute>();
+  const { applicationId, taskId, attachmentId } = useParams<
+    "applicationId" | "taskId" | "attachmentId"
+  >();
   const detailsPath = formatPath(Paths.applicationsAnalysisDetails, {
-    applicationId: applicationId,
-    taskId: taskId,
+    applicationId: applicationId!,
+    taskId: taskId!,
   });
 
-  const { application } = useFetchApplicationById(applicationId);
+  const { application } = useFetchApplicationById(applicationId!);
   const appName: string = application?.name ?? t("terms.unknown");
 
   return (
@@ -29,13 +30,13 @@ export const AnalysisDetails = () => {
         },
         {
           title: appName,
-          path: `${Paths.applications}/?activeItem=${applicationId}`,
+          path: `${Paths.applications}/?activeItem=${applicationId!}`,
         },
         {
           title: t("actions.analysisDetails"),
           path: formatPath(Paths.applicationsAnalysisDetails, {
-            applicationId,
-            taskId,
+            applicationId: applicationId!,
+            taskId: taskId!,
           }),
         },
       ]}
@@ -43,12 +44,12 @@ export const AnalysisDetails = () => {
       formatTitle={(taskName) => `Analysis details for ${taskName}`}
       formatAttachmentPath={(attachmentId) =>
         formatPath(Paths.applicationsAnalysisDetailsAttachment, {
-          applicationId,
-          taskId,
+          applicationId: applicationId!,
+          taskId: taskId!,
           attachmentId,
         })
       }
-      taskId={Number(taskId)}
+      taskId={Number(taskId!)}
       attachmentId={attachmentId}
     />
   );

--- a/client/src/app/pages/applications/application-detail-drawer/components/application-tags.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/components/application-tags.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   Bullseye,
   Button,
@@ -47,7 +47,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
   application,
 }) => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const [tags, setTags] = useState<TagWithSource[]>([]);
   const [tagCategoriesById, setTagCategoriesById] = useState<
@@ -270,7 +270,7 @@ export const ApplicationTags: React.FC<ApplicationTagsProps> = ({
           aria-label="Create Tags"
           variant={ButtonVariant.primary}
           onClick={() => {
-            history.push("/controls/tags");
+            navigate("/controls/tags");
           }}
         >
           {t("actions.createTag")}

--- a/client/src/app/pages/applications/application-detail-drawer/tab-reports-contents.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-reports-contents.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   Button,
   DescriptionList,
@@ -58,11 +58,11 @@ export const TabReportsContent: React.FC<{
 
   const enableDownloadSetting = useSetting("download.html.enabled");
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const navigateToAnalysisDetails = () =>
     application?.id &&
     task?.id &&
-    history.push(
+    navigate(
       formatPath(Paths.applicationsAnalysisDetails, {
         applicationId: application?.id,
         taskId: task?.id,

--- a/client/src/app/pages/applications/application-detail-drawer/tab-tasks-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-tasks-content.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
@@ -32,7 +32,8 @@ export const TabTasksContent: React.FC<{
   application: DecoratedApplication;
 }> = ({ application }) => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
+  const location = useLocation();
   const urlParams = new URLSearchParams(window.location.search);
   const filters = urlParams.get("filters");
   const deserializedFilterValues = deserializeFilterUrlParams({ filters });
@@ -131,10 +132,10 @@ export const TabTasksContent: React.FC<{
   } = tableControls;
 
   const clearFilters = () => {
-    const currentPath = history.location.pathname;
-    const newSearch = new URLSearchParams(history.location.search);
+    const currentPath = location.pathname;
+    const newSearch = new URLSearchParams(location.search);
     newSearch.delete("filters");
-    history.push(`${currentPath}`);
+    navigate(`${currentPath}`);
   };
   return (
     <>

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -1,7 +1,7 @@
 import { type FC, useContext, useState } from "react";
 import { AxiosError } from "axios";
 import { Trans, useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
@@ -120,7 +120,8 @@ export const ApplicationsTable: FC = () => {
   const { t } = useTranslation();
   const { pushNotification } = useContext(NotificationsContext);
 
-  const history = useHistory();
+  const navigate = useNavigate();
+  const location = useLocation();
   const token = keycloak.tokenParsed;
 
   // ----- State for the modals
@@ -671,10 +672,10 @@ export const ApplicationsTable: FC = () => {
   });
 
   const clearFilters = () => {
-    const currentPath = history.location.pathname;
-    const newSearch = new URLSearchParams(history.location.search);
+    const currentPath = location.pathname;
+    const newSearch = new URLSearchParams(location.search);
     newSearch.delete("filters");
-    history.push(`${currentPath}`);
+    navigate(`${currentPath}`);
     filterToolbarProps.setFilterValues({});
   };
 
@@ -721,7 +722,7 @@ export const ApplicationsTable: FC = () => {
           <DropdownItem
             key="manage-import-applications"
             onClick={() => {
-              history.push(Paths.applicationsImports);
+              navigate(Paths.applicationsImports);
             }}
           >
             {t("actions.manageApplicationImports")}
@@ -860,7 +861,7 @@ export const ApplicationsTable: FC = () => {
 
   const handleNavToAssessment = (application: DecoratedApplication) => {
     if (application?.id) {
-      history.push(
+      navigate(
         formatPath(Paths.applicationAssessmentActions, {
           applicationId: application?.id,
         })
@@ -870,7 +871,7 @@ export const ApplicationsTable: FC = () => {
 
   const handleNavToViewArchetypes = (application: DecoratedApplication) => {
     if (application?.id && archetypeRefsToOverride?.length) {
-      history.push(
+      navigate(
         formatPath(Paths.viewArchetypes, {
           applicationId: application?.id,
           archetypeId: archetypeRefsToOverride[0].id,
@@ -909,7 +910,7 @@ export const ApplicationsTable: FC = () => {
           } else if (application.review) {
             setReviewToEdit(application.id);
           } else {
-            history.push(
+            navigate(
               formatPath(Paths.applicationsReview, {
                 applicationId: application.id,
               })
@@ -929,7 +930,7 @@ export const ApplicationsTable: FC = () => {
     } else if (application.review) {
       setReviewToEdit(application.id);
     } else {
-      history.push(
+      navigate(
         formatPath(Paths.applicationsReview, {
           applicationId: application.id,
         })
@@ -1254,7 +1255,7 @@ export const ApplicationsTable: FC = () => {
                                     const taskId =
                                       application.tasks.currentAnalyzer?.id;
                                     if (taskId && application.id) {
-                                      history.push(
+                                      navigate(
                                         formatPath(
                                           Paths.applicationsAnalysisDetails,
                                           {
@@ -1530,7 +1531,7 @@ export const ApplicationsTable: FC = () => {
         onCancel={() => setAssessmentToEdit(null)}
         onClose={() => setAssessmentToEdit(null)}
         onConfirm={() => {
-          history.push(
+          navigate(
             formatPath(Paths.applicationsAssessment, {
               assessmentId: assessmentToEdit?.id,
             })
@@ -1551,7 +1552,7 @@ export const ApplicationsTable: FC = () => {
         onCancel={() => setReviewToEdit(null)}
         onClose={() => setReviewToEdit(null)}
         onConfirm={() => {
-          history.push(
+          navigate(
             formatPath(Paths.applicationsReview, {
               applicationId: reviewToEdit,
             })
@@ -1580,7 +1581,7 @@ export const ApplicationsTable: FC = () => {
         onClose={() => setArchetypeRefsToOverrideReview(null)}
         onConfirm={() => {
           if (applicationToReview) {
-            history.push(
+            navigate(
               formatPath(Paths.applicationsReview, {
                 applicationId: applicationToReview.id,
               })

--- a/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
+++ b/client/src/app/pages/applications/manage-imports-details/manage-imports-details.tsx
@@ -18,7 +18,7 @@ import {
 import { CubesIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { ImportSummaryRoute, Paths } from "@app/Paths";
+import { Paths } from "@app/Paths";
 import { getApplicationSummaryCSV } from "@app/api/rest";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
@@ -46,19 +46,19 @@ export const ManageImportsDetails: React.FC = () => {
   const { t } = useTranslation();
 
   // Router
-  const { importId } = useParams<ImportSummaryRoute>();
+  const { importId } = useParams<"importId">();
 
   const { pushNotification } = React.useContext(NotificationsContext);
 
   const { imports, isFetching, fetchError } = useFetchImports(
-    parseInt(importId),
+    parseInt(importId!),
     false
   );
 
-  const { importSummary } = useFetchImportSummaryById(importId);
+  const { importSummary } = useFetchImportSummaryById(importId!);
 
   const exportCSV = () => {
-    getApplicationSummaryCSV(importId)
+    getApplicationSummaryCSV(importId!)
       .then((response) => {
         const fileName = importSummary?.filename || "file.csv";
         saveAs(new Blob([response.data]), fileName);

--- a/client/src/app/pages/applications/manage-imports/manage-imports.tsx
+++ b/client/src/app/pages/applications/manage-imports/manage-imports.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
@@ -47,7 +47,7 @@ import { ImportApplicationsForm } from "../components/import-applications-form";
 
 export const ManageImports: React.FC = () => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { pushNotification } = React.useContext(NotificationsContext);
 
   const { importSummaries, isFetching, fetchError, refetch } =
@@ -142,7 +142,7 @@ export const ManageImports: React.FC = () => {
   };
 
   const viewRowDetails = (row: ApplicationImportSummary) => {
-    history.push(
+    navigate(
       formatPath(Paths.applicationsImportsDetails, {
         importId: row.id,
       })

--- a/client/src/app/pages/archetypes/archetypes-page.tsx
+++ b/client/src/app/pages/archetypes/archetypes-page.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import * as React from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
@@ -70,7 +70,8 @@ import { useArchetypeMutations } from "./hooks/useArchetypeMutations";
 
 const Archetypes: React.FC = () => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const [openCreateArchetype, setOpenCreateArchetype] =
     useState<boolean>(false);
@@ -208,7 +209,7 @@ const Archetypes: React.FC = () => {
       setArchetypeToAssess(archetype);
     } else {
       if (archetype?.id) {
-        history.push(
+        navigate(
           formatPath(Paths.archetypeAssessmentActions, {
             archetypeId: archetype.id,
           })
@@ -222,7 +223,7 @@ const Archetypes: React.FC = () => {
     if (archetype.review) {
       setReviewToEdit(archetype.id);
     } else {
-      history.push(
+      navigate(
         formatPath(Paths.archetypeReview, {
           archetypeId: archetype.id,
         })
@@ -237,10 +238,10 @@ const Archetypes: React.FC = () => {
     reviewsWriteAccess = checkAccess(userScopes, reviewsWriteScopes);
 
   const clearFilters = () => {
-    const currentPath = history.location.pathname;
-    const newSearch = new URLSearchParams(history.location.search);
+    const currentPath = location.pathname;
+    const newSearch = new URLSearchParams(location.search);
     newSearch.delete("filters");
-    history.push(`${currentPath}`);
+    navigate(`${currentPath}`);
     filterToolbarProps.setFilterValues({});
   };
 
@@ -412,7 +413,7 @@ const Archetypes: React.FC = () => {
                                     archetypeWriteAccess && {
                                       title: t("actions.manageTargetProfiles"),
                                       onClick: () =>
-                                        history.push(
+                                        navigate(
                                           formatPath(
                                             Paths.archetypeTargetProfiles,
                                             {
@@ -615,7 +616,7 @@ const Archetypes: React.FC = () => {
         onClose={() => setArchetypeToAssess(null)}
         onConfirm={() => {
           if (archetypeToAssess) {
-            history.push(
+            navigate(
               formatPath(Paths.archetypeAssessmentActions, {
                 archetypeId: archetypeToAssess.id,
               })
@@ -639,7 +640,7 @@ const Archetypes: React.FC = () => {
         onCancel={() => setReviewToEdit(null)}
         onClose={() => setReviewToEdit(null)}
         onConfirm={() => {
-          history.push(
+          navigate(
             formatPath(Paths.archetypeReview, {
               archetypeId: reviewToEdit,
             })

--- a/client/src/app/pages/archetypes/target-profiles-page.tsx
+++ b/client/src/app/pages/archetypes/target-profiles-page.tsx
@@ -29,7 +29,7 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
-import { ArchetypeTargetProfilesRoute, Paths } from "@app/Paths";
+import { Paths } from "@app/Paths";
 import type { TargetProfile } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
@@ -44,7 +44,7 @@ import { useArchetypeMutations } from "./hooks/useArchetypeMutations";
 
 const TargetProfilesPage: React.FC = () => {
   const { t } = useTranslation();
-  const { archetypeId } = useParams<ArchetypeTargetProfilesRoute>();
+  const { archetypeId } = useParams<"archetypeId">();
 
   const [openCreateModal, setOpenCreateModal] = useState<boolean>(false);
   const [profileToEdit, setProfileToEdit] = useState<TargetProfile | null>(
@@ -58,7 +58,7 @@ const TargetProfilesPage: React.FC = () => {
     archetype,
     isFetching: isArchetypesFetching,
     fetchError,
-  } = useFetchArchetypeById(archetypeId);
+  } = useFetchArchetypeById(archetypeId!);
 
   const { addTargetProfile, updateTargetProfile, deleteTargetProfile } =
     useArchetypeMutations();

--- a/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
+++ b/client/src/app/pages/assessment-management/assessment-settings/assessment-settings-page.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { AxiosError } from "axios";
 import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
@@ -61,7 +61,7 @@ import { QuestionnaireThresholdsColumn } from "./components/questionnaire-thresh
 const AssessmentSettings: React.FC = () => {
   const { t } = useTranslation();
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const { pushNotification } = React.useContext(NotificationsContext);
 
   const { questionnaires, isFetching, fetchError } = useFetchQuestionnaires();
@@ -359,7 +359,7 @@ const AssessmentSettings: React.FC = () => {
                                 key="view"
                                 component="button"
                                 onClick={() => {
-                                  history.push(
+                                  navigate(
                                     formatPath(Paths.questionnaire, {
                                       questionnaireId: questionnaire.id,
                                     })

--- a/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
+++ b/client/src/app/pages/assessment-management/questionnaire/questionnaire-page.tsx
@@ -7,18 +7,14 @@ import QuestionnaireSummary, {
 } from "@app/components/questionnaire-summary/questionnaire-summary";
 import { useFetchQuestionnaireById } from "@app/queries/questionnaires";
 
-interface QuestionnairePageParams {
-  questionnaireId: string;
-}
-
 const QuestionnairePage: React.FC = () => {
-  const { questionnaireId } = useParams<QuestionnairePageParams>();
+  const { questionnaireId } = useParams<"questionnaireId">();
 
   const {
     questionnaire,
     isFetching: isFetchingQuestionnaireById,
     fetchError: fetchQuestionnaireByIdError,
-  } = useFetchQuestionnaireById(questionnaireId);
+  } = useFetchQuestionnaireById(questionnaireId!);
 
   return (
     <QuestionnaireSummary

--- a/client/src/app/pages/assessment/components/assessment-actions/assessment-actions-page.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/assessment-actions-page.tsx
@@ -9,7 +9,7 @@ import {
   TextContent,
 } from "@patternfly/react-core";
 
-import { AssessmentActionsRoute, Paths } from "@app/Paths";
+import { Paths } from "@app/Paths";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import useIsArchetype from "@app/hooks/useIsArchetype";
@@ -19,7 +19,9 @@ import { useFetchArchetypeById } from "@app/queries/archetypes";
 import AssessmentActionsTable from "./components/assessment-actions-table";
 
 const AssessmentActions: React.FC = () => {
-  const { applicationId, archetypeId } = useParams<AssessmentActionsRoute>();
+  const { applicationId, archetypeId } = useParams<
+    "applicationId" | "archetypeId"
+  >();
   const isArchetype = useIsArchetype();
 
   const { archetype } = useFetchArchetypeById(archetypeId);

--- a/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
@@ -12,7 +12,7 @@ import {
 } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button, Spinner } from "@patternfly/react-core";
 import { TrashIcon } from "@patternfly/react-icons";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
@@ -64,7 +64,7 @@ const DynamicAssessmentActionsRow: FunctionComponent<
   onOpenModal,
 }) => {
   const isArchetype = useIsArchetype();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
@@ -222,7 +222,7 @@ const DynamicAssessmentActionsRow: FunctionComponent<
               type="button"
               variant="secondary"
               onClick={() => {
-                history.push(
+                navigate(
                   formatPath(
                     isArchetype
                       ? Paths.archetypeAssessmentSummary

--- a/client/src/app/pages/assessment/components/assessment-page-header.tsx
+++ b/client/src/app/pages/assessment/components/assessment-page-header.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button, ButtonVariant, Modal, Text } from "@patternfly/react-core";
 
 import { Paths } from "@app/Paths";
@@ -20,7 +20,7 @@ export const AssessmentPageHeader: React.FC<AssessmentPageHeaderProps> = ({
   assessment,
 }) => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const isArchetype = useIsArchetype();
 
   const { archetype } = useFetchArchetypeById(assessment?.archetype?.id);
@@ -94,7 +94,7 @@ export const AssessmentPageHeader: React.FC<AssessmentPageHeaderProps> = ({
           onCancel={() => setIsConfirmDialogOpen(false)}
           onClose={() => setIsConfirmDialogOpen(false)}
           onConfirm={() =>
-            history.push(isArchetype ? Paths.archetypes : Paths.applications)
+            navigate(isArchetype ? Paths.archetypes : Paths.applications)
           }
         />
       )}

--- a/client/src/app/pages/assessment/components/assessment-summary/assessment-summary-page.tsx
+++ b/client/src/app/pages/assessment/components/assessment-summary/assessment-summary-page.tsx
@@ -6,18 +6,13 @@ import QuestionnaireSummary, {
 } from "@app/components/questionnaire-summary/questionnaire-summary";
 import { useFetchAssessmentById } from "@app/queries/assessments";
 
-interface AssessmentSummaryRouteParams {
-  assessmentId: string;
-  applicationId: string;
-}
-
 const AssessmentSummaryPage: React.FC = () => {
-  const { assessmentId } = useParams<AssessmentSummaryRouteParams>();
+  const { assessmentId } = useParams<"assessmentId">();
   const {
     assessment,
     isFetching: isFetchingAssessment,
     fetchError: fetchAssessmentError,
-  } = useFetchAssessmentById(assessmentId);
+  } = useFetchAssessmentById(assessmentId!);
 
   return (
     <QuestionnaireSummary

--- a/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard.tsx
+++ b/client/src/app/pages/assessment/components/assessment-wizard/assessment-wizard.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { FieldErrors, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import * as yup from "yup";
 import {
   ButtonVariant,
@@ -102,7 +102,7 @@ export const AssessmentWizard: React.FC<AssessmentWizardProps> = ({
   const [assessmentToCancel, setAssessmentToCancel] =
     React.useState<Assessment | null>(null);
 
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const { pushNotification } = React.useContext(NotificationsContext);
 
@@ -398,7 +398,7 @@ export const AssessmentWizard: React.FC<AssessmentWizardProps> = ({
         if (assessment?.archetype?.id) {
           getArchetypeById(assessment.archetype.id)
             .then((data) => {
-              history.push(
+              navigate(
                 formatPath(Paths.archetypeReview, {
                   archetypeId: data.id,
                 })
@@ -415,7 +415,7 @@ export const AssessmentWizard: React.FC<AssessmentWizardProps> = ({
         if (assessment?.application?.id) {
           getApplicationById(assessment.application.id)
             .then((data) => {
-              history.push(
+              navigate(
                 formatPath(Paths.applicationsReview, {
                   applicationId: data.id,
                 })

--- a/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
+++ b/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
@@ -10,7 +10,7 @@ import {
   TextContent,
 } from "@patternfly/react-core";
 
-import { Paths, ViewArchetypesRoute } from "@app/Paths";
+import { Paths } from "@app/Paths";
 import { Ref } from "@app/api/models";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
@@ -22,7 +22,9 @@ import { formatPath } from "@app/utils/utils";
 import ViewArchetypesTable from "./components/view-archetypes-table";
 
 const ViewArchetypes: React.FC = () => {
-  const { applicationId, archetypeId } = useParams<ViewArchetypesRoute>();
+  const { applicationId, archetypeId } = useParams<
+    "applicationId" | "archetypeId"
+  >();
   const { archetype } = useFetchArchetypeById(archetypeId);
   const { application } = useFetchApplicationById(applicationId);
 
@@ -56,7 +58,7 @@ const ViewArchetypes: React.FC = () => {
           </BreadcrumbItem>
           <BreadcrumbItem
             to={formatPath(Paths.applicationAssessmentActions, {
-              applicationId,
+              applicationId: applicationId!,
             })}
           >
             {application?.name}

--- a/client/src/app/pages/asset-generators/asset-generators.tsx
+++ b/client/src/app/pages/asset-generators/asset-generators.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useState } from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
@@ -48,7 +48,8 @@ import GeneratorForm from "./components/generator-form";
 
 const AssetGenerators: FC = () => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { pushNotification } = useNotifications();
 
   const [openCreateGenerator, setOpenCreateGenerator] =
@@ -200,12 +201,12 @@ const AssetGenerators: FC = () => {
   };
 
   const clearFilters = useCallback(() => {
-    const currentPath = history.location.pathname;
-    const newSearch = new URLSearchParams(history.location.search);
+    const currentPath = location.pathname;
+    const newSearch = new URLSearchParams(location.search);
     newSearch.delete("filters");
-    history.push(`${currentPath}?${newSearch.toString()}`);
+    navigate(`${currentPath}?${newSearch.toString()}`);
     filterToolbarProps.setFilterValues({});
-  }, [history, filterToolbarProps]);
+  }, [navigate, location, filterToolbarProps]);
 
   return (
     <>

--- a/client/src/app/pages/controls/controls.tsx
+++ b/client/src/app/pages/controls/controls.tsx
@@ -2,11 +2,11 @@ import { Suspense, lazy, useEffect } from "react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import {
-  Redirect,
+  Navigate,
   Route,
-  Switch,
-  useHistory,
+  Routes,
   useLocation,
+  useNavigate,
 } from "react-router-dom";
 import {
   Level,
@@ -26,7 +26,7 @@ import { AppPlaceholder } from "@app/components/AppPlaceholder";
 const Stakeholders = lazy(() => import("./stakeholders"));
 const StakeholderGroups = lazy(() => import("./stakeholder-groups"));
 const JobFunctions = lazy(() => import("./job-functions"));
-const businessServices = lazy(() => import("./business-services"));
+const BusinessServices = lazy(() => import("./business-services"));
 const Tags = lazy(() => import("./tags"));
 
 const tabs: string[] = [
@@ -39,7 +39,7 @@ const tabs: string[] = [
 
 export const Controls: React.FC = () => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const [activeTabKey, setActiveTabKey] = React.useState(0);
   const location = useLocation();
@@ -73,7 +73,7 @@ export const Controls: React.FC = () => {
           onSelect={(_event, tabIndex) => {
             setActiveTabKey(tabIndex as number);
 
-            history.push(Paths[tabs[tabIndex as number] as keyof typeof Paths]);
+            navigate(Paths[tabs[tabIndex as number] as keyof typeof Paths]);
           }}
         >
           <Tab
@@ -100,24 +100,17 @@ export const Controls: React.FC = () => {
       </PageSection>
       <PageSection>
         <Suspense fallback={<AppPlaceholder />}>
-          <Switch>
-            <Route path={Paths.controlsStakeholders} component={Stakeholders} />
+          <Routes>
+            <Route path="stakeholders" element={<Stakeholders />} />
+            <Route path="stakeholder-groups" element={<StakeholderGroups />} />
+            <Route path="job-functions" element={<JobFunctions />} />
+            <Route path="business-services" element={<BusinessServices />} />
+            <Route path="tags" element={<Tags />} />
             <Route
-              path={Paths.controlsStakeholderGroups}
-              component={StakeholderGroups}
+              path=""
+              element={<Navigate to={Paths.controlsStakeholders} replace />}
             />
-            <Route path={Paths.controlsJobFunctions} component={JobFunctions} />
-            <Route
-              path={Paths.controlsBusinessServices}
-              component={businessServices}
-            />
-            <Route path={Paths.controlsTags} component={Tags} />
-            <Redirect
-              from={Paths.controls}
-              to={Paths.controlsStakeholders}
-              exact
-            />
-          </Switch>
+          </Routes>
         </Suspense>
       </PageSection>
     </>

--- a/client/src/app/pages/dependencies/dependencies.tsx
+++ b/client/src/app/pages/dependencies/dependencies.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   Label,
   LabelGroup,
@@ -139,13 +139,14 @@ export const Dependencies: React.FC = () => {
     activeItemDerivedState: { activeItem, clearActiveItem },
   } = tableControls;
 
-  const history = useHistory();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const clearFilters = () => {
-    const currentPath = history.location.pathname;
-    const newSearch = new URLSearchParams(history.location.search);
+    const currentPath = location.pathname;
+    const newSearch = new URLSearchParams(location.search);
     newSearch.delete("filters");
-    history.push(`${currentPath}`);
+    navigate(`${currentPath}`);
   };
 
   return (

--- a/client/src/app/pages/dependencies/dependency-apps-table.tsx
+++ b/client/src/app/pages/dependencies/dependency-apps-table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   Text,
   TextContent,
@@ -41,7 +41,8 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
   dependency,
 }) => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const { businessServices } = useFetchBusinessServices();
   const { tagItems } = useFetchTagsWithTagItems();
@@ -158,10 +159,10 @@ export const DependencyAppsTable: React.FC<IDependencyAppsTableProps> = ({
   } = tableControls;
 
   const clearFilters = () => {
-    const currentPath = history.location.pathname;
-    const newSearch = new URLSearchParams(history.location.search);
+    const currentPath = location.pathname;
+    const newSearch = new URLSearchParams(location.search);
     newSearch.delete("filters");
-    history.push(`${currentPath}`);
+    navigate(`${currentPath}`);
   };
   return (
     <>

--- a/client/src/app/pages/insights/affected-applications-page.tsx
+++ b/client/src/app/pages/insights/affected-applications-page.tsx
@@ -37,17 +37,12 @@ import {
 } from "./helpers";
 import { InsightDetailDrawer } from "./insight-detail-drawer";
 
-interface IAffectedApplicationsRouteParams {
-  ruleset: string;
-  rule: string;
-}
-
 export const AffectedApplicationsPage: React.FC = () => {
   const { t } = useTranslation();
 
-  const routeParams = useParams<IAffectedApplicationsRouteParams>();
-  const ruleset = decodeURIComponent(routeParams.ruleset);
-  const rule = decodeURIComponent(routeParams.rule);
+  const routeParams = useParams<"ruleset" | "rule">();
+  const ruleset = decodeURIComponent(routeParams.ruleset ?? "");
+  const rule = decodeURIComponent(routeParams.rule ?? "");
   const insightTitle =
     new URLSearchParams(useLocation().search).get("insightTitle") ||
     "Active rule";

--- a/client/src/app/pages/insights/insights-page.tsx
+++ b/client/src/app/pages/insights/insights-page.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
+import { useLocation, useMatch, useNavigate } from "react-router-dom";
 import {
   ButtonVariant,
   PageSection,
@@ -34,9 +34,9 @@ export type InsightsTabPath =
 export const InsightsPage: React.FC = () => {
   const { t } = useTranslation();
   const location = useLocation();
-  const history = useHistory();
-  const singleAppTabMatch = useRouteMatch(Paths.insightsSingleAppTab);
-  const singleAppSelectedMatch = useRouteMatch(Paths.insightsSingleAppSelected);
+  const navigate = useNavigate();
+  const singleAppTabMatch = useMatch(Paths.insightsSingleAppTab);
+  const singleAppSelectedMatch = useMatch(Paths.insightsSingleAppSelected);
 
   const activeTabPath =
     singleAppTabMatch || singleAppSelectedMatch
@@ -68,7 +68,7 @@ export const InsightsPage: React.FC = () => {
             if (pageHasFilters) {
               setNavConfirmPath(tabPath as InsightsTabPath);
             } else {
-              history.push(tabPath as InsightsTabPath);
+              navigate(tabPath as InsightsTabPath);
             }
           }}
         >
@@ -133,7 +133,7 @@ export const InsightsPage: React.FC = () => {
         cancelBtnLabel="Cancel"
         confirmBtnVariant={ButtonVariant.primary}
         onConfirm={() => {
-          history.push(navConfirmPath!);
+          navigate(navConfirmPath!);
           setNavConfirmPath(null);
         }}
         onCancel={() => setNavConfirmPath(null)}

--- a/client/src/app/pages/issues/affected-applications-page.tsx
+++ b/client/src/app/pages/issues/affected-applications-page.tsx
@@ -37,17 +37,12 @@ import {
 } from "./helpers";
 import { IssueDetailDrawer } from "./issue-detail-drawer";
 
-interface IAffectedApplicationsRouteParams {
-  ruleset: string;
-  rule: string;
-}
-
 export const AffectedApplicationsPage: React.FC = () => {
   const { t } = useTranslation();
 
-  const routeParams = useParams<IAffectedApplicationsRouteParams>();
-  const ruleset = decodeURIComponent(routeParams.ruleset);
-  const rule = decodeURIComponent(routeParams.rule);
+  const routeParams = useParams<"ruleset" | "rule">();
+  const ruleset = decodeURIComponent(routeParams.ruleset ?? "");
+  const rule = decodeURIComponent(routeParams.rule ?? "");
   const issueTitle =
     new URLSearchParams(useLocation().search).get("issueTitle") ||
     "Active rule";

--- a/client/src/app/pages/issues/issues-page.tsx
+++ b/client/src/app/pages/issues/issues-page.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
+import { useLocation, useMatch, useNavigate } from "react-router-dom";
 import {
   ButtonVariant,
   PageSection,
@@ -39,9 +39,9 @@ export type IssuesTabPath =
 export const Issues: React.FC = () => {
   const { t } = useTranslation();
   const location = useLocation();
-  const history = useHistory();
-  const singleAppTabMatch = useRouteMatch(Paths.issuesSingleAppTab);
-  const singleAppSelectedMatch = useRouteMatch(Paths.issuesSingleAppSelected);
+  const navigate = useNavigate();
+  const singleAppTabMatch = useMatch(Paths.issuesSingleAppTab);
+  const singleAppSelectedMatch = useMatch(Paths.issuesSingleAppSelected);
 
   const activeTabPath =
     singleAppTabMatch || singleAppSelectedMatch
@@ -73,7 +73,7 @@ export const Issues: React.FC = () => {
             if (pageHasFilters) {
               setNavConfirmPath(tabPath as IssuesTabPath);
             } else {
-              history.push(tabPath as IssuesTabPath);
+              navigate(tabPath as IssuesTabPath);
             }
           }}
         >
@@ -138,7 +138,7 @@ export const Issues: React.FC = () => {
         cancelBtnLabel="Cancel"
         confirmBtnVariant={ButtonVariant.primary}
         onConfirm={() => {
-          history.push(navConfirmPath!);
+          navigate(navConfirmPath!);
           setNavConfirmPath(null);
         }}
         onCancel={() => setNavConfirmPath(null)}

--- a/client/src/app/pages/review/components/review-form/review-form.tsx
+++ b/client/src/app/pages/review/components/review-form/review-form.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { FieldErrors, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { mixed, number, object, string } from "yup";
 import {
   ActionGroup,
@@ -54,7 +54,7 @@ export const ReviewForm: React.FC<IReviewFormProps> = ({
   review,
 }) => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { pushNotification } = React.useContext(NotificationsContext);
   const isArchetype = useIsArchetype();
 
@@ -148,7 +148,7 @@ export const ReviewForm: React.FC<IReviewFormProps> = ({
         });
       }
 
-      history.push(isArchetype ? Paths.archetypes : Paths.applications);
+      navigate(isArchetype ? Paths.archetypes : Paths.applications);
     } catch (error) {
       console.error("Error:", error);
       pushNotification({
@@ -275,7 +275,7 @@ export const ReviewForm: React.FC<IReviewFormProps> = ({
           aria-label="cancel"
           variant={ButtonVariant.link}
           onClick={() => {
-            history.push(isArchetype ? Paths.archetypes : Paths.applications);
+            navigate(isArchetype ? Paths.archetypes : Paths.applications);
           }}
         >
           {t("actions.cancel")}

--- a/client/src/app/pages/review/review-page.tsx
+++ b/client/src/app/pages/review/review-page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@patternfly/react-core";
 import { BanIcon } from "@patternfly/react-icons";
 
-import { Paths, ReviewRoute } from "@app/Paths";
+import { Paths } from "@app/Paths";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { PageHeader } from "@app/components/PageHeader";
@@ -33,7 +33,9 @@ import { ReviewForm } from "./components/review-form";
 const ReviewPage: React.FC = () => {
   const { t } = useTranslation();
 
-  const { applicationId, archetypeId } = useParams<ReviewRoute>();
+  const { applicationId, archetypeId } = useParams<
+    "applicationId" | "archetypeId"
+  >();
   const isArchetype = useIsArchetype();
 
   const { archetype } = useFetchArchetypeById(archetypeId);

--- a/client/src/app/pages/source-platforms/source-platforms.tsx
+++ b/client/src/app/pages/source-platforms/source-platforms.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   Button,
   ButtonVariant,
@@ -58,7 +58,8 @@ import { useFetchPlatformsWithTasks } from "./useFetchPlatformsWithTasks";
 
 export const SourcePlatforms: React.FC = () => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { pushNotification } = React.useContext(NotificationsContext);
 
   const { getDisplayLabel } = usePlatformKindList();
@@ -178,10 +179,10 @@ export const SourcePlatforms: React.FC = () => {
   } = tableControls;
 
   const clearFilters = () => {
-    const currentPath = history.location.pathname;
-    const newSearch = new URLSearchParams(history.location.search);
+    const currentPath = location.pathname;
+    const newSearch = new URLSearchParams(location.search);
     newSearch.delete("filters");
-    history.push(`${currentPath}`);
+    navigate(`${currentPath}`);
     filterToolbarProps.setFilterValues({});
   };
 

--- a/client/src/app/pages/tasks/TaskDetails.tsx
+++ b/client/src/app/pages/tasks/TaskDetails.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
-import { Paths, TaskDetailsAttachmentRoute } from "@app/Paths";
+import { Paths } from "@app/Paths";
 import "@app/components/simple-document-viewer/SimpleDocumentViewer.css";
 import { useFetchApplicationById } from "@app/queries/applications";
 import { formatPath } from "@app/utils/utils";
@@ -10,8 +10,9 @@ import { TaskDetailsBase } from "./TaskDetailsBase";
 
 export const TaskDetails = () => {
   const { t } = useTranslation();
-  const { taskId, attachmentId, applicationId } =
-    useParams<TaskDetailsAttachmentRoute>();
+  const { taskId, attachmentId, applicationId } = useParams<
+    "taskId" | "attachmentId" | "applicationId"
+  >();
   const currentPath = window.location.pathname;
   const isFromApplication = currentPath.includes("application") ? true : false;
   const { application } = useFetchApplicationById(applicationId);

--- a/client/src/app/pages/tasks/TaskDetailsBase.tsx
+++ b/client/src/app/pages/tasks/TaskDetailsBase.tsx
@@ -1,6 +1,6 @@
 import { type FC } from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { PageSection } from "@patternfly/react-core";
 
 import { PageHeader, PageHeaderProps } from "@app/components/PageHeader";
@@ -31,11 +31,11 @@ export const TaskDetailsBase: FC<{
   const { search } = useLocation();
   const hasMergedParam = new URLSearchParams(search).has("merged");
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const onDocumentChange = (documentId: DocumentId) =>
     typeof documentId === "number"
-      ? history.push(formatAttachmentPath(documentId))
-      : history.push({
+      ? navigate(formatAttachmentPath(documentId))
+      : navigate({
           pathname: detailsPath,
           search: documentId === "MERGED_VIEW" ? "?merged=true" : undefined,
         });

--- a/client/src/app/pages/tasks/tasks-page.tsx
+++ b/client/src/app/pages/tasks/tasks-page.tsx
@@ -1,7 +1,7 @@
 import { type FC, type ReactNode } from "react";
 import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   PageSection,
   PageSectionVariants,
@@ -64,7 +64,8 @@ export const taskStateToLabel: Record<TaskState, string> = {
 
 export const TasksPage: FC = () => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const urlParams = new URLSearchParams(window.location.search);
   const filters = urlParams.get("filters") ?? "";
@@ -208,10 +209,10 @@ export const TasksPage: FC = () => {
   };
 
   const clearFilters = () => {
-    const currentPath = history.location.pathname;
-    const newSearch = new URLSearchParams(history.location.search);
+    const currentPath = location.pathname;
+    const newSearch = new URLSearchParams(location.search);
     newSearch.delete("filters");
-    history.push(`${currentPath}`);
+    navigate(`${currentPath}`);
     filterToolbarProps.setFilterValues({});
   };
 

--- a/client/src/app/pages/tasks/useTaskActions.tsx
+++ b/client/src/app/pages/tasks/useTaskActions.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@app/Paths";
 import { Task, TaskState } from "@app/api/models";
@@ -36,7 +36,7 @@ const useAsyncTaskActions = () => {
 export const useTaskActions = (task: Task<unknown>) => {
   const { cancelTask } = useAsyncTaskActions();
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   return [
     {
@@ -54,14 +54,14 @@ export const useTaskActions = (task: Task<unknown>) => {
       onClick: () => {
         const currentPath = window.location.pathname;
         if (currentPath.includes("application")) {
-          history.push(
+          navigate(
             formatPath(Paths.applicationsTaskDetails, {
               applicationId: task.application?.id,
               taskId: task?.id,
             })
           );
         } else {
-          history.push(
+          navigate(
             formatPath(Paths.taskDetails, {
               taskId: task?.id,
             })

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "react-i18next": "^16.5.4",
         "react-markdown": "^8.0.7",
         "react-measure": "^2.5.2",
-        "react-router-dom": "^5.2.0",
+        "react-router-dom": "^6.30.3",
         "tinycolor2": "^1.6.0",
         "use-immer": "^0.11.0",
         "xmllint-wasm": "^5.0.0",
@@ -4601,6 +4601,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -14151,20 +14160,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -15655,6 +15650,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -21623,57 +21619,36 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/react-textarea-autosize": {
       "version": "8.5.9",
@@ -22068,12 +22043,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -24756,18 +24725,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "license": "MIT"
-    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -25911,12 +25868,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",


### PR DESCRIPTION
Upgrade from react-router v5 to react-router v6.  Followed the migration guide.

Refactored the was the `NavItem` components are marked as active. Now every `NavItem` runs a version of the check that react-router's `NavLink` component uses when calculating `isActive` for className functions.  This change allows a `NavItem` to be set as active for multiple paths if necessary, and follows PF5 conventions.

There should be no visible change.

Resolves: #3272

AIA Human-AI blend, Human-initiated, Reviewed, claude-4.6-opus-high v1.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated app routing to the latest routing version and updated navigation hooks across the UI.
  * Standardized route handling and redirects for more consistent navigation behavior.
  * Simplified URL param handling and strengthened parameter parsing.

* **Bug Fixes**
  * Improved detection and highlighting of active navigation items to reduce incorrect active states.
  * Preserved user-facing routes and navigation flows with no change to visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->