### PR TITLE
:ghost: Stop using jmh app and use the gradle8 instead

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/analysis/gradle_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/gradle_analysis.test.ts
@@ -47,10 +47,10 @@ describe(["@tier1"], "Gradle Analysis", () => {
   });
 
   // Automates TC 532
-  it("Bug MTA-6211: Analysis for Gradle JMH application", function () {
+  it("Bug MTA-6211: Analysis for Gradle application (gradle8-example)", function () {
     const application = new Analysis(
-      getRandomApplicationData("JMH Gradle", {
-        sourceData: this.appData["jmh-gradle-example"],
+      getRandomApplicationData("Gradle 8 Example", {
+        sourceData: this.appData["gradle8-example"],
       }),
       {
         source: "Source code + dependencies",
@@ -58,7 +58,7 @@ describe(["@tier1"], "Gradle Analysis", () => {
         target: [],
       }
     );
-    application.customRule = ["jmh-gradle-annotation-state-test-rule.yaml"];
+    application.customRule = ["gradle8-serializable-test-rule.yaml"];
     application.create();
     applications.push(application);
     cy.wait("@getApplication");
@@ -68,10 +68,10 @@ describe(["@tier1"], "Gradle Analysis", () => {
   });
 
   // Automates TC 546
-  it("Bug MTA-6211: Analysis for Gradle JMH application with Open Source libraries", function () {
+  it("Bug MTA-6211: Analysis for Gradle application with Open Source libraries (gradle8-example)", function () {
     const application = new Analysis(
-      getRandomApplicationData("JMH Gradle OS libs", {
-        sourceData: this.appData["jmh-gradle-example"],
+      getRandomApplicationData("Gradle 8 Example OS libs", {
+        sourceData: this.appData["gradle8-example"],
       }),
       {
         source: "Source code + dependencies",
@@ -79,7 +79,7 @@ describe(["@tier1"], "Gradle Analysis", () => {
         openSourceLibraries: true,
       }
     );
-    application.customRule = ["jmh-gradle-serializable-test-rule.yaml"];
+    application.customRule = ["gradle8-serializable-test-rule.yaml"];
     application.create();
     applications.push(application);
     cy.wait("@getApplication");

--- a/cypress/fixtures/application.json
+++ b/cypress/fixtures/application.json
@@ -81,6 +81,10 @@
     "repoType": "Git",
     "sourceRepo": "https://github.com/melix/jmh-gradle-example"
   },
+  "gradle8-example": {
+    "repoType": "Git",
+    "sourceRepo": "https://github.com/jmle/gradle8-example"
+  },
   "python-demo-app": {
     "repoType": "Git",
     "sourceRepo": "https://github.com/Shopify/sample-django-app"

--- a/cypress/fixtures/yaml/gradle8-serializable-test-rule.yaml
+++ b/cypress/fixtures/yaml/gradle8-serializable-test-rule.yaml
@@ -1,0 +1,10 @@
+- category: mandatory
+  customVariables: []
+  description: Serializable reference test rule for https://github.com/jmle/gradle8-example
+  effort: 1
+  message: |-
+    Serializable reference test rule for https://github.com/jmle/gradle8-example
+  ruleID: serializable-reference-test-rule-gradle8
+  when:
+    java.referenced:
+      pattern: java.io.Serializable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for Gradle 8 project analysis with enhanced verification workflows.
  * Added new validation rules and test fixtures to strengthen code analysis quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->