### PR TITLE
:test_tube: Split nightly e2e test on main

### DIFF
--- a/.github/workflows/nightly-main-e2e.yaml
+++ b/.github/workflows/nightly-main-e2e.yaml
@@ -10,24 +10,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nightly-auth:
-    name: "Nightly auth - all tiers"
+  nightly-e2e:
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        test_tags:
+          - "@tier2_secretsNeeded,@tier3_secretsNeeded"
+          - "@tier2_taskManager"
+          - "@ci,@tier0,@tier2_A,@tier2_B"
+          - "@tier3_A,@tier3_B,@tier3_C"
+          - "@tier3_D,@tier3_E,@tier3_F"
+        auth_required:
+          - true
+          - false
+    name: "Nightly e2e - all tiers"
     uses: ./.github/workflows/e2e-run-ui-tests.yaml
     with:
-      test_tags: "@ci,@tier0,@tier2,@tier3"
-      feature_auth_required: true
-      bundle_image: quay.io/konveyor/tackle2-operator-bundle:latest
-      ui_image: quay.io/konveyor/tackle2-ui:latest
-      install_konveyor_version: main
-      test_ref: main
-    secrets: inherit
-
-  nightly-noauth:
-    name: "Nightly noauth - all tiers"
-    uses: ./.github/workflows/e2e-run-ui-tests.yaml
-    with:
-      test_tags: "@ci,@tier0,@tier2,@tier3"
-      feature_auth_required: false
+      test_tags: ${{ matrix.test_tags }}
+      feature_auth_required: ${{ matrix.auth_required }}
       bundle_image: quay.io/konveyor/tackle2-operator-bundle:latest
       ui_image: quay.io/konveyor/tackle2-ui:latest
       install_konveyor_version: main

--- a/cypress/e2e/tests/administration/credentials/jira_crud.test.ts
+++ b/cypress/e2e/tests/administration/credentials/jira_crud.test.ts
@@ -22,54 +22,58 @@ import { CredentialType } from "../../../types/constants";
 import { CredentialsData } from "../../../types/types";
 
 // Commented Token tests as now they can't be run because of missing environment.
-describe(["@tier2", "@secretsNeeded"], "Validation of jira credentials", () => {
-  const toBeCanceled = true;
-  let validJiraBasicCredentials: CredentialsData;
-  let randomJiraBasicCredentials: CredentialsData;
-  let jiraBasicCredentials: JiraCredentials;
-  const useTestingAccount = true;
+describe(
+  ["@tier2", "@tier2_secretsNeeded"],
+  "Validation of jira credentials",
+  () => {
+    const toBeCanceled = true;
+    let validJiraBasicCredentials: CredentialsData;
+    let randomJiraBasicCredentials: CredentialsData;
+    let jiraBasicCredentials: JiraCredentials;
+    const useTestingAccount = true;
 
-  before("Login", function () {
-    login();
-    cy.visit("/");
+    before("Login", function () {
+      login();
+      cy.visit("/");
 
-    randomJiraBasicCredentials = getJiraCredentialData(
-      CredentialType.jiraBasic,
-      !useTestingAccount
-    );
+      randomJiraBasicCredentials = getJiraCredentialData(
+        CredentialType.jiraBasic,
+        !useTestingAccount
+      );
 
-    validJiraBasicCredentials = getJiraCredentialData(
-      CredentialType.jiraBasic,
-      useTestingAccount
-    );
+      validJiraBasicCredentials = getJiraCredentialData(
+        CredentialType.jiraBasic,
+        useTestingAccount
+      );
 
-    jiraBasicCredentials = new JiraCredentials(randomJiraBasicCredentials);
-  });
+      jiraBasicCredentials = new JiraCredentials(randomJiraBasicCredentials);
+    });
 
-  it("Creating Jira credentials and cancelling without saving", () => {
-    jiraBasicCredentials.create(toBeCanceled);
-  });
+    it("Creating Jira credentials and cancelling without saving", () => {
+      jiraBasicCredentials.create(toBeCanceled);
+    });
 
-  it("Creating Jira credentials", () => {
-    jiraBasicCredentials.create();
-    jiraBasicCredentials.validateValues();
-  });
+    it("Creating Jira credentials", () => {
+      jiraBasicCredentials.create();
+      jiraBasicCredentials.validateValues();
+    });
 
-  it("Editing Jira credentials and cancelling without saving", () => {
-    jiraBasicCredentials.edit(validJiraBasicCredentials, toBeCanceled);
-    jiraBasicCredentials.validateValues();
-  });
+    it("Editing Jira credentials and cancelling without saving", () => {
+      jiraBasicCredentials.edit(validJiraBasicCredentials, toBeCanceled);
+      jiraBasicCredentials.validateValues();
+    });
 
-  it("Editing Jira credentials", () => {
-    jiraBasicCredentials.edit(validJiraBasicCredentials);
-    jiraBasicCredentials.validateValues();
-  });
+    it("Editing Jira credentials", () => {
+      jiraBasicCredentials.edit(validJiraBasicCredentials);
+      jiraBasicCredentials.validateValues();
+    });
 
-  it("Delete Jira credentials and cancel deletion", () => {
-    jiraBasicCredentials.delete(toBeCanceled);
-  });
+    it("Delete Jira credentials and cancel deletion", () => {
+      jiraBasicCredentials.delete(toBeCanceled);
+    });
 
-  after("Delete Jira credentials", () => {
-    jiraBasicCredentials.delete();
-  });
-});
+    after("Delete Jira credentials", () => {
+      jiraBasicCredentials.delete();
+    });
+  }
+);

--- a/cypress/e2e/tests/administration/jira-connection/crud.test.ts
+++ b/cypress/e2e/tests/administration/jira-connection/crud.test.ts
@@ -26,7 +26,7 @@ import { CredentialType, JiraType } from "../../../types/constants";
 import { JiraConnectionData } from "../../../types/types";
 
 describe(
-  ["@tier2", "@secretsNeeded"],
+  ["@tier2", "@tier2_secretsNeeded"],
   "CRUD operations for Jira Cloud instance",
   () => {
     const toBeCanceled = true;

--- a/cypress/e2e/tests/administration/jira-connection/filter.test.ts
+++ b/cypress/e2e/tests/administration/jira-connection/filter.test.ts
@@ -31,7 +31,7 @@ import { CredentialType } from "../../../types/constants";
 import { jiraTable } from "../../../views/jira.view";
 
 describe(
-  ["@tier3", "@secretsNeeded"],
+  ["@tier3", "@tier3_secretsNeeded"],
   "Jira connection filter validations",
   () => {
     const useTestingAccount = true;

--- a/cypress/e2e/tests/administration/jira-connection/miscellaneous.test.ts
+++ b/cypress/e2e/tests/administration/jira-connection/miscellaneous.test.ts
@@ -31,94 +31,98 @@ import { Jira } from "../../../models/administration/jira-connection/jira";
 import { CredentialType, JiraType, button } from "../../../types/constants";
 import { JiraConnectionData } from "../../../types/types";
 
-describe(["@tier3", "@secretsNeeded"], "Jira connection negative tests", () => {
-  const expectedToFail = true;
-  const useTestingAccount = true;
-  const isSecure = false;
-  let jiraBasicCredential: JiraCredentials;
-  let jiraBasicCredentialInvalid: JiraCredentials;
-  let jiraBearerCredentialInvalid: JiraCredentials;
-  let jiraStageConnectionDataIncorrect: JiraConnectionData;
-  let jiraCloudConnectionDataIncorrect: JiraConnectionData;
-  let jiraCloudConnectionIncorrect: Jira;
-  let jiraStageConnectionIncorrect: Jira;
+describe(
+  ["@tier3", "@tier3_secretsNeeded"],
+  "Jira connection negative tests",
+  () => {
+    const expectedToFail = true;
+    const useTestingAccount = true;
+    const isSecure = false;
+    let jiraBasicCredential: JiraCredentials;
+    let jiraBasicCredentialInvalid: JiraCredentials;
+    let jiraBearerCredentialInvalid: JiraCredentials;
+    let jiraStageConnectionDataIncorrect: JiraConnectionData;
+    let jiraCloudConnectionDataIncorrect: JiraConnectionData;
+    let jiraCloudConnectionIncorrect: Jira;
+    let jiraStageConnectionIncorrect: Jira;
 
-  before("Login and create required credentials", function () {
-    login();
-    cy.visit("/");
-    jiraBasicCredential = new JiraCredentials(
-      getJiraCredentialData(CredentialType.jiraBasic, useTestingAccount)
-    );
-    jiraBasicCredential.create();
+    before("Login and create required credentials", function () {
+      login();
+      cy.visit("/");
+      jiraBasicCredential = new JiraCredentials(
+        getJiraCredentialData(CredentialType.jiraBasic, useTestingAccount)
+      );
+      jiraBasicCredential.create();
 
-    // Defining and creating dummy credentials to be used further in tests
-    jiraBasicCredentialInvalid = new JiraCredentials(
-      getJiraCredentialData(CredentialType.jiraBasic, !useTestingAccount)
-    );
-    jiraBasicCredentialInvalid.create();
+      // Defining and creating dummy credentials to be used further in tests
+      jiraBasicCredentialInvalid = new JiraCredentials(
+        getJiraCredentialData(CredentialType.jiraBasic, !useTestingAccount)
+      );
+      jiraBasicCredentialInvalid.create();
 
-    jiraBearerCredentialInvalid = new JiraCredentials(
-      getJiraCredentialData(CredentialType.jiraToken, !useTestingAccount)
-    );
-    jiraBearerCredentialInvalid.create();
+      jiraBearerCredentialInvalid = new JiraCredentials(
+        getJiraCredentialData(CredentialType.jiraToken, !useTestingAccount)
+      );
+      jiraBearerCredentialInvalid.create();
 
-    // Defining Jira Cloud connection data with incorrect credentials
-    jiraCloudConnectionDataIncorrect = getJiraConnectionData(
-      jiraBasicCredentialInvalid,
-      JiraType.cloud,
-      isSecure,
-      useTestingAccount
-    );
-    jiraCloudConnectionIncorrect = new Jira(jiraCloudConnectionDataIncorrect);
+      // Defining Jira Cloud connection data with incorrect credentials
+      jiraCloudConnectionDataIncorrect = getJiraConnectionData(
+        jiraBasicCredentialInvalid,
+        JiraType.cloud,
+        isSecure,
+        useTestingAccount
+      );
+      jiraCloudConnectionIncorrect = new Jira(jiraCloudConnectionDataIncorrect);
 
-    // Defining Jira Stage connection data with incorrect credentials
-    jiraStageConnectionDataIncorrect = getJiraConnectionData(
-      jiraBearerCredentialInvalid,
-      JiraType.server,
-      isSecure,
-      useTestingAccount
-    );
-    jiraStageConnectionIncorrect = new Jira(jiraStageConnectionDataIncorrect);
-  });
+      // Defining Jira Stage connection data with incorrect credentials
+      jiraStageConnectionDataIncorrect = getJiraConnectionData(
+        jiraBearerCredentialInvalid,
+        JiraType.server,
+        isSecure,
+        useTestingAccount
+      );
+      jiraStageConnectionIncorrect = new Jira(jiraStageConnectionDataIncorrect);
+    });
 
-  it("Validating error when Jira Cloud Instance is not connected", () => {
-    /**
+    it("Validating error when Jira Cloud Instance is not connected", () => {
+      /**
          Implements MTA-362 - Add JIRA instance with invalid credentials
          Automates https://issues.redhat.com/browse/MTA-991
          */
-    jiraCloudConnectionIncorrect.create();
-    jiraCloudConnectionIncorrect.validateState(expectedToFail);
-    clickByText(button, "Not connected");
-    cy.get("#code-content").then(($code) => {
-      expect($code.text()).to.contain(
-        "Client must be authenticated to access this resource."
-      );
-      expect($code.text().toLowerCase()).not.to.contain("html");
-      expect($code.text()).not.to.contain("403");
+      jiraCloudConnectionIncorrect.create();
+      jiraCloudConnectionIncorrect.validateState(expectedToFail);
+      clickByText(button, "Not connected");
+      cy.get("#code-content").then(($code) => {
+        expect($code.text()).to.contain(
+          "Client must be authenticated to access this resource."
+        );
+        expect($code.text().toLowerCase()).not.to.contain("html");
+        expect($code.text()).not.to.contain("403");
+      });
     });
-  });
 
-  it.skip("Bug Tackle-3116: Validating error when Jira Stage Instance is not connected", () => {
-    // https://github.com/konveyor/tackle2-ui/issues/3116
-    /**
+    it.skip("Bug Tackle-3116: Validating error when Jira Stage Instance is not connected", () => {
+      // https://github.com/konveyor/tackle2-ui/issues/3116
+      /**
          Implements MTA-362 - Add JIRA instance with invalid credentials
          Automates https://issues.redhat.com/browse/MTA-991
          */
-    jiraStageConnectionIncorrect.create();
-    jiraStageConnectionIncorrect.validateState(expectedToFail);
-    clickByText(button, "Not connected");
-    cy.get("#code-content").then(($code) => {
-      expect($code.text()).to.contain(
-        "Client must be authenticated to access this resource."
-      );
-      expect($code.text().toLowerCase()).not.to.contain("html");
-      expect($code.text()).not.to.contain("403");
+      jiraStageConnectionIncorrect.create();
+      jiraStageConnectionIncorrect.validateState(expectedToFail);
+      clickByText(button, "Not connected");
+      cy.get("#code-content").then(($code) => {
+        expect($code.text()).to.contain(
+          "Client must be authenticated to access this resource."
+        );
+        expect($code.text().toLowerCase()).not.to.contain("html");
+        expect($code.text()).not.to.contain("403");
+      });
     });
-  });
 
-  after("Clean up data", () => {
-    deleteAllJiraConnections();
-    deleteAllCredentials();
-    deleteApplicationTableRows();
-  });
-});
+    after("Clean up data", () => {
+      deleteAllJiraConnections();
+      deleteAllCredentials();
+      deleteApplicationTableRows();
+    });
+  }
+);

--- a/cypress/e2e/tests/administration/repository/git.test.ts
+++ b/cypress/e2e/tests/administration/repository/git.test.ts
@@ -33,7 +33,7 @@ let source_credential: CredentialsSourceControlUsername;
 const applicationsList: Analysis[] = [];
 
 describe(
-  ["@tier1", "@secretsNeeded"],
+  ["@tier1", "@tier1_secretsNeeded"],
   "Test secure and insecure git repository analysis",
   () => {
     before("Login", function () {

--- a/cypress/e2e/tests/administration/repository/maven.test.ts
+++ b/cypress/e2e/tests/administration/repository/maven.test.ts
@@ -39,7 +39,7 @@ let maven_credential;
 const applicationsList: Analysis[] = [];
 
 describe(
-  ["@tier1", "@secretsNeeded"],
+  ["@tier1", "@tier1_secretsNeeded"],
   "Test secure and insecure maven repository analysis",
   () => {
     before("Login", function () {

--- a/cypress/e2e/tests/administration/repository/subversion.test.ts
+++ b/cypress/e2e/tests/administration/repository/subversion.test.ts
@@ -31,7 +31,7 @@ import { analysisDetailsEditor } from "../../../views/analysis.view";
 // Skipping until bug https://github.com/konveyor/tackle2-hub/issues/988  is fixed.
 
 describe.skip(
-  ["@tier1", "@secretsNeeded"],
+  ["@tier1", "@tier1_secretsNeeded"],
   "Bug MTA-988: Test secure and insecure svn repository analysis",
   () => {
     const subversionConfiguration = new SubversionConfiguration();

--- a/cypress/e2e/tests/custom-metrics/application_metrics.test.ts
+++ b/cypress/e2e/tests/custom-metrics/application_metrics.test.ts
@@ -23,7 +23,7 @@ let applicationList: Array<Application> = [];
 let count = 0;
 
 describe(
-  ["@tier2", "@secretsNeeded"],
+  ["@tier2", "@tier2_secretsNeeded"],
   "Custom Metrics - Count the current number of applications in inventory",
   function () {
     beforeEach("Get the current gauge value", function () {

--- a/cypress/e2e/tests/custom-metrics/assessment_metrics.test.ts
+++ b/cypress/e2e/tests/custom-metrics/assessment_metrics.test.ts
@@ -32,7 +32,7 @@ let counter: number;
 const fileName = "Legacy Pathfinder";
 
 describe(
-  ["@tier2", "@secretsNeeded"],
+  ["@tier2", "@tier2_secretsNeeded"],
   "Custom Metrics - The total number of initiated assessments",
   function () {
     before("Login and create test data", function () {

--- a/cypress/e2e/tests/custom-metrics/task_metrics.test.ts
+++ b/cypress/e2e/tests/custom-metrics/task_metrics.test.ts
@@ -30,7 +30,7 @@ const metricName = "konveyor_tasks_initiated_total";
 const applicationList: Array<Application> = [];
 
 describe(
-  ["@tier2", "@secretsNeeded"],
+  ["@tier2", "@tier2_secretsNeeded"],
   "Custom Metrics - Count the total number of initiated tasks",
   function () {
     before("Log in and clear state", function () {

--- a/cypress/e2e/tests/migration/applicationinventory/applications/manage_credentials_many_apps.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/applications/manage_credentials_many_apps.test.ts
@@ -31,7 +31,7 @@ const sourceApplicationsList: Array<Analysis> = [];
 const mavenApplicationsList: Array<Analysis> = [];
 
 describe(
-  ["@tier2", "@secretsNeeded"],
+  ["@tier2", "@tier2_secretsNeeded"],
   "Manage credentials source analysis",
   () => {
     before("Login", function () {

--- a/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
@@ -57,7 +57,7 @@ let projectName = "";
  * This suite is almost identical to jira_datacenter but putting both tests in the same suite would make the code harder to read
  */
 describe(
-  ["@tier2", "@secretsNeeded"],
+  ["@tier2", "@tier2_secretsNeeded"],
   "Export Migration Wave to Jira Cloud",
   function () {
     before("Create test data", function () {

--- a/cypress/e2e/tests/migration/migration-waves/unlink_application.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/unlink_application.test.ts
@@ -55,7 +55,7 @@ let migrationWave: MigrationWave;
 let projectName = "";
 
 describe(
-  ["@tier3", "@secretsNeeded"],
+  ["@tier3", "@tier3_secretsNeeded"],
   "Unlink application from exported migration waves",
   function () {
     before("Create test data", function () {

--- a/cypress/e2e/tests/migration/task-manager/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/miscellaneous.test.ts
@@ -33,7 +33,7 @@ import * as commonView from "../../../views/common.view";
 import { TaskManagerColumns } from "../../../views/taskmanager.view";
 
 describe(
-  ["@tier2", "@taskManager"],
+  ["@tier2", "@tier2_taskManager"],
   "Actions in Task Manager Page",
   function () {
     let bookServerApp: Analysis;


### PR DESCRIPTION
Splitting the nightly test suite will  allow re-running parts that failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Restructured nightly E2E test execution to use a matrix strategy, enabling parallel execution of multiple test configurations with configurable parallelism limits.
  * Updated test suite classifications with tier-specific tagging for improved test organization and filtering across the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->