### PR TITLE
:bug: Require only an assets repository to generate assets

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -957,7 +957,7 @@
     "title": "Generate Assets",
     "description_one": "Generate deployment assets for application {{first}}.",
     "description_other": "Generate deployment assets for {{count}} selected applications.",
-    "noApplicationsReady": "No applications are ready for asset generation. Applications must have completed configuration retrieval and have target platforms configured.",
+    "noApplicationsReady": "No applications are ready for asset generation. Applications must have an assets repository configured.",
     "noTasksSubmitted": "No asset generation tasks were submitted.",
     "toast": {
       "submittedOk": "Asset generation tasks submitted",
@@ -994,8 +994,8 @@
     "review": {
       "stepTitle": "Review",
       "title": "Review details",
-      "description_one": "This application is ready to use {{targetProfile}} to generate assets. Assets will be generated based on the application's discovery manifest, target profile, input parameters, and generator settings.",
-      "description_other": "These applications are ready to use {{targetProfile}} to generate assets. Assets will be generated based on the applications' discovery manifests, target profile, input parameters, and generator settings.",
+      "description_one": "This application is ready to use {{targetProfile}} to generate assets. Assets will be generated based on the application's profile, target profile, input parameters, and generator settings.",
+      "description_other": "These applications are ready to use {{targetProfile}} to generate assets. Assets will be generated based on the applications' profiles, target profile, input parameters, and generator settings.",
       "selectedApplications_one": "Selected application",
       "selectedApplications_other": "Selected applications ({{count}})"
     },

--- a/client/src/app/pages/applications/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/useDecoratedApplications.ts
@@ -170,11 +170,7 @@ const decorateApplications = (
       isReadyForRetrieveConfigurations:
         !!app.platform && !!app.coordinates?.content,
 
-      isReadyForGenerateAssets:
-        !!app.platform &&
-        !!app.coordinates?.content &&
-        (app.manifests?.length ?? 0) > 0 &&
-        !!app.assets,
+      isReadyForGenerateAssets: !!app.assets,
 
       direct: {
         identities: app.identities

--- a/client/src/app/pages/applications/useDecoratedApplications.ts
+++ b/client/src/app/pages/applications/useDecoratedApplications.ts
@@ -170,7 +170,7 @@ const decorateApplications = (
       isReadyForRetrieveConfigurations:
         !!app.platform && !!app.coordinates?.content,
 
-      isReadyForGenerateAssets: !!app.assets,
+      isReadyForGenerateAssets: !!app.assets?.kind && !!app.assets?.url,
 
       direct: {
         identities: app.identities


### PR DESCRIPTION
Relaxed the readiness condition to only require an assets repository.

Resolves: https://redhat.atlassian.net/browse/MTA-6788

AIA Entirely AI, Human-initiated, Reviewed, claude-4.6-opus-high v1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Generate Assets" wizard messaging for assets repository configuration requirements.
  * Changed asset generation descriptions to reference application profile(s) instead of discovery manifests.

* **Bug Fixes**
  * Simplified application readiness criteria for asset generation based on assets configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->