### PR TITLE
:bug: Display application discovery manifest as YAML content

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -169,6 +169,13 @@ export interface Application {
   effort?: number;
 }
 
+export interface ApplicationManifest {
+  id: number;
+  content: JsonDocument;
+  secret?: JsonDocument;
+  application: Ref;
+}
+
 export interface Review {
   id: number;
   proposedAction: ProposedAction;

--- a/client/src/app/api/rest/applications.ts
+++ b/client/src/app/api/rest/applications.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { Application, JsonDocument, New } from "../models";
+import { Application, ApplicationManifest, New } from "../models";
 import { hub, template } from "../rest";
 
 const APPLICATIONS = hub`/applications`;
@@ -24,7 +24,9 @@ export const getApplicationById = (id: number | string) =>
 
 export const getApplicationManifest = (applicationId: number | string) =>
   axios
-    .get<JsonDocument>(template(APPLICATION_MANIFEST, { id: applicationId }))
+    .get<ApplicationManifest>(
+      template(APPLICATION_MANIFEST, { id: applicationId })
+    )
     .then((response) => response.data);
 
 export const getApplications = () =>

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -45,6 +45,15 @@ const jsonDocumentToCode = (
     : JSON.stringify(jsonDocument, null, 2);
 };
 
+const codeToJsonDocument = (
+  code: string,
+  editorLanguage: Language.json | Language.yaml
+): unknown => {
+  return editorLanguage === Language.yaml
+    ? jsYaml.load(code)
+    : JSON.parse(code);
+};
+
 export const SchemaAsCodeEditor = ({
   id,
   jsonDocument,
@@ -61,10 +70,6 @@ export const SchemaAsCodeEditor = ({
     jsonDocumentToCode(jsonDocument, editorLanguage)
   );
 
-  useEffect(() => {
-    setCurrentCode(jsonDocumentToCode(jsonDocument, editorLanguage));
-  }, [jsonDocument, editorLanguage]);
-
   const focusMovedOnSelectedDocumentChange = useRef<boolean>(false);
   const focusAndHomePosition = () => {
     if (editorRef.current) {
@@ -72,7 +77,6 @@ export const SchemaAsCodeEditor = ({
       editorRef.current.setPosition({ column: 1, lineNumber: 1 });
     }
   };
-
   useEffect(() => {
     if (currentCode && !focusMovedOnSelectedDocumentChange.current) {
       focusAndHomePosition();
@@ -88,10 +92,7 @@ export const SchemaAsCodeEditor = ({
     setCurrentCode(newValue);
     if (onDocumentChanged) {
       try {
-        const parsed =
-          editorLanguage === Language.yaml
-            ? (jsYaml.load(newValue) as unknown)
-            : (JSON.parse(newValue) as unknown);
+        const parsed = codeToJsonDocument(newValue, editorLanguage);
 
         if (
           parsed &&

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -36,6 +36,15 @@ export interface ISchemaAsCodeEditorProps {
   editorLanguage?: Language.json | Language.yaml;
 }
 
+const jsonDocumentToCode = (
+  jsonDocument: object,
+  editorLanguage: Language.json | Language.yaml
+) => {
+  return editorLanguage === Language.yaml
+    ? jsYaml.dump(jsonDocument, { indent: 2 })
+    : JSON.stringify(jsonDocument, null, 2);
+};
+
 export const SchemaAsCodeEditor = ({
   id,
   jsonDocument,
@@ -48,15 +57,13 @@ export const SchemaAsCodeEditor = ({
   const { t } = useTranslation();
   const editorRef = useRef<ControlledEditor>();
 
-  const serializedDocument = useMemo(
-    () =>
-      editorLanguage === Language.yaml
-        ? jsYaml.dump(jsonDocument, { indent: 2 })
-        : JSON.stringify(jsonDocument, null, 2),
-    [jsonDocument, editorLanguage]
+  const [currentCode, setCurrentCode] = useState(() =>
+    jsonDocumentToCode(jsonDocument, editorLanguage)
   );
 
-  const [currentCode, setCurrentCode] = useState(serializedDocument);
+  useEffect(() => {
+    setCurrentCode(jsonDocumentToCode(jsonDocument, editorLanguage));
+  }, [jsonDocument, editorLanguage]);
 
   const focusMovedOnSelectedDocumentChange = useRef<boolean>(false);
   const focusAndHomePosition = () => {
@@ -118,7 +125,7 @@ export const SchemaAsCodeEditor = ({
       onChange={handleCodeChange}
       onEditorDidMount={(editor, monaco) => {
         editorRef.current = editor as ControlledEditor;
-        document.fonts.ready.then(() => monaco.editor.remeasureFonts());
+        document.fonts?.ready?.then(() => monaco.editor.remeasureFonts());
         if (jsonSchema) {
           monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
             validate: true,

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -14,8 +14,6 @@ import { JsonSchemaObject } from "@app/api/models";
 
 import { jsonSchemaToYupSchema } from "./utils";
 
-export { Language } from "@patternfly/react-code-editor";
-
 type ControlledEditor = {
   focus: () => void;
   getPosition: () => object;
@@ -34,8 +32,8 @@ export interface ISchemaAsCodeEditorProps {
    * Set to "100%" to make the editor take up the full height of its container.
    */
   height?: string;
-  /** Language for syntax highlighting. Defaults to Language.json. */
-  language?: Language;
+  /** Language for the editor. Defaults to Language.json. */
+  editorLanguage?: Language.json | Language.yaml;
 }
 
 export const SchemaAsCodeEditor = ({
@@ -45,17 +43,20 @@ export const SchemaAsCodeEditor = ({
   onDocumentChanged,
   isReadOnly = false,
   height = "600px",
-  language = Language.json,
+  editorLanguage = Language.json,
 }: ISchemaAsCodeEditorProps) => {
   const { t } = useTranslation();
   const editorRef = useRef<ControlledEditor>();
 
-  const [currentCode, setCurrentCode] = useState(
-    language === Language.yaml
-      ? jsYaml.dump(jsonDocument, { indent: 2 })
-      : JSON.stringify(jsonDocument, null, 2)
+  const serializedDocument = useMemo(
+    () =>
+      editorLanguage === Language.yaml
+        ? jsYaml.dump(jsonDocument, { indent: 2 })
+        : JSON.stringify(jsonDocument, null, 2),
+    [jsonDocument, editorLanguage]
   );
-  // const [documentIsValid, setDocumentIsValid] = React.useState(true);
+
+  const [currentCode, setCurrentCode] = useState(serializedDocument);
 
   const focusMovedOnSelectedDocumentChange = useRef<boolean>(false);
   const focusAndHomePosition = () => {
@@ -64,6 +65,7 @@ export const SchemaAsCodeEditor = ({
       editorRef.current.setPosition({ column: 1, lineNumber: 1 });
     }
   };
+
   useEffect(() => {
     if (currentCode && !focusMovedOnSelectedDocumentChange.current) {
       focusAndHomePosition();
@@ -79,12 +81,20 @@ export const SchemaAsCodeEditor = ({
     setCurrentCode(newValue);
     if (onDocumentChanged) {
       try {
-        const asJson = JSON.parse(newValue);
-        if (!validator || validator.isValidSync(asJson)) {
-          onDocumentChanged(asJson);
+        const parsed =
+          editorLanguage === Language.yaml
+            ? (jsYaml.load(newValue) as unknown)
+            : (JSON.parse(newValue) as unknown);
+
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          (!validator || validator.isValidSync(parsed))
+        ) {
+          onDocumentChanged(parsed as object);
         }
       } catch {
-        // ignore invalid JSON, the change will be ignored
+        // ignore invalid document, the change will be ignored
       }
     }
   };
@@ -100,7 +110,7 @@ export const SchemaAsCodeEditor = ({
       isReadOnly={isReadOnly}
       height={height}
       downloadFileName="my-schema-download"
-      language={language}
+      language={editorLanguage}
       code={currentCode}
       options={{
         fontFamily: '"Red Hat Mono", "Courier New", Courier, monospace',

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import * as jsYaml from "js-yaml";
 import { useTranslation } from "react-i18next";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
@@ -33,6 +34,8 @@ export interface ISchemaAsCodeEditorProps {
    * Set to "100%" to make the editor take up the full height of its container.
    */
   height?: string;
+  /** Language for syntax highlighting. Defaults to Language.json. */
+  language?: Language;
 }
 
 export const SchemaAsCodeEditor = ({
@@ -42,12 +45,15 @@ export const SchemaAsCodeEditor = ({
   onDocumentChanged,
   isReadOnly = false,
   height = "600px",
+  language = Language.json,
 }: ISchemaAsCodeEditorProps) => {
   const { t } = useTranslation();
   const editorRef = useRef<ControlledEditor>();
 
   const [currentCode, setCurrentCode] = useState(
-    JSON.stringify(jsonDocument, null, 2)
+    language === Language.yaml
+      ? jsYaml.dump(jsonDocument, { indent: 2 })
+      : JSON.stringify(jsonDocument, null, 2)
   );
   // const [documentIsValid, setDocumentIsValid] = React.useState(true);
 
@@ -94,11 +100,15 @@ export const SchemaAsCodeEditor = ({
       isReadOnly={isReadOnly}
       height={height}
       downloadFileName="my-schema-download"
-      language={Language.json}
+      language={language}
       code={currentCode}
+      options={{
+        fontFamily: '"Red Hat Mono", "Courier New", Courier, monospace',
+      }}
       onChange={handleCodeChange}
       onEditorDidMount={(editor, monaco) => {
         editorRef.current = editor as ControlledEditor;
+        document.fonts.ready.then(() => monaco.editor.remeasureFonts());
         if (jsonSchema) {
           monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
             validate: true,

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Language } from "@patternfly/react-code-editor";
 import { Panel, PanelHeader, PanelMain, Switch } from "@patternfly/react-core";
 
 import { JsonSchemaObject } from "@app/api/models";
@@ -15,6 +16,8 @@ export interface ISchemaDefinedFieldProps {
   jsonSchema?: JsonSchemaObject;
   onDocumentChanged?: (newJsonDocument: object) => void;
   isReadOnly?: boolean;
+  /** Language for syntax highlighting. Defaults to Language.json. */
+  language?: Language;
 }
 
 export const SchemaDefinedField = ({
@@ -24,6 +27,7 @@ export const SchemaDefinedField = ({
   jsonSchema,
   onDocumentChanged,
   isReadOnly = false,
+  language = Language.json,
 }: ISchemaDefinedFieldProps) => {
   const [isJsonView, setIsJsonView] = useState<boolean>(
     !jsonSchema || isComplexSchema(jsonSchema)
@@ -60,6 +64,7 @@ export const SchemaDefinedField = ({
             jsonDocument={jsonDocument}
             jsonSchema={jsonSchema}
             onDocumentChanged={onChangeHandler}
+            language={language}
           />
         ) : (
           <SchemaAsFields

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -8,7 +8,6 @@ import { SchemaAsCodeEditor } from "./SchemaAsCodeEditor";
 import { SchemaAsFields } from "./SchemaAsFields";
 import { isComplexSchema } from "./utils";
 
-export { Language } from "@patternfly/react-code-editor";
 export interface ISchemaDefinedFieldProps {
   id?: string;
   className?: string;
@@ -16,8 +15,8 @@ export interface ISchemaDefinedFieldProps {
   jsonSchema?: JsonSchemaObject;
   onDocumentChanged?: (newJsonDocument: object) => void;
   isReadOnly?: boolean;
-  /** Language for syntax highlighting. Defaults to Language.json. */
-  language?: Language;
+  /** Language for the editor if the document/schema cannot render as fields. Defaults to Language.json. */
+  editorLanguage?: Language.json | Language.yaml;
 }
 
 export const SchemaDefinedField = ({
@@ -27,7 +26,7 @@ export const SchemaDefinedField = ({
   jsonSchema,
   onDocumentChanged,
   isReadOnly = false,
-  language = Language.json,
+  editorLanguage = Language.json,
 }: ISchemaDefinedFieldProps) => {
   const [isJsonView, setIsJsonView] = useState<boolean>(
     !jsonSchema || isComplexSchema(jsonSchema)
@@ -64,7 +63,7 @@ export const SchemaDefinedField = ({
             jsonDocument={jsonDocument}
             jsonSchema={jsonSchema}
             onDocumentChanged={onChangeHandler}
-            language={language}
+            editorLanguage={editorLanguage}
           />
         ) : (
           <SchemaAsFields

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -48,7 +48,7 @@ export const SchemaDefinedField = ({
         <PanelHeader>
           <Switch
             id={`${id}-json-toggle`}
-            label="JSON"
+            label={editorLanguage === Language.json ? "JSON" : "YAML"}
             isChecked={isJsonView}
             onChange={() => setIsJsonView(!isJsonView)}
           />

--- a/client/src/app/devtools/schema-defined/schema-defined-page.tsx
+++ b/client/src/app/devtools/schema-defined/schema-defined-page.tsx
@@ -73,6 +73,9 @@ export const SchemaDefinedPage: React.FC = () => {
   const [parsedSchema, setParsedSchema] = useState<
     JsonSchemaObject | undefined
   >(example1 as JsonSchemaObject);
+  const [editorLanguage, setEditorLanguage] = useState<
+    Language.json | Language.yaml
+  >(Language.json);
 
   const [currentDocument, setCurrentDocument] = useState<object | null>(null);
 
@@ -148,6 +151,40 @@ export const SchemaDefinedPage: React.FC = () => {
     );
   };
 
+  const EditorActions = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <Dropdown
+        onSelect={() => setIsOpen(false)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            isExpanded={isOpen}
+            onClick={() => setIsOpen((current) => !current)}
+            variant="plain"
+          >
+            <EllipsisVIcon aria-hidden="true" />
+          </MenuToggle>
+        )}
+        isOpen={isOpen}
+        onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+      >
+        <DropdownList>
+          {[Language.json, Language.yaml].map((language, index) => (
+            <DropdownItem
+              key={`language-${index}`}
+              onClick={() =>
+                setEditorLanguage(language as Language.json | Language.yaml)
+              }
+            >
+              {language === Language.json ? "JSON" : "YAML"}
+            </DropdownItem>
+          ))}
+        </DropdownList>
+      </Dropdown>
+    );
+  };
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -200,12 +237,15 @@ export const SchemaDefinedPage: React.FC = () => {
 
               <GridItem span={6}>
                 <Card isFullHeight isCompact>
-                  <CardTitle>SchemaDefinedFields</CardTitle>
+                  <CardHeader actions={{ actions: <EditorActions /> }}>
+                    <CardTitle>SchemaDefinedFields</CardTitle>
+                  </CardHeader>
                   <CardBody className="full-height-container">
                     <SchemaDefinedField
                       id="demo-schema-field"
                       jsonDocument={currentDocument ?? {}}
                       jsonSchema={parsedSchema}
+                      editorLanguage={editorLanguage}
                       onDocumentChanged={handleDocumentChange}
                     />
                   </CardBody>

--- a/client/src/app/pages/applications/application-detail-drawer/tab-platform-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-platform-content.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
+import { Language } from "@patternfly/react-code-editor";
 
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import {
@@ -58,8 +59,12 @@ export const TabPlatformContent: React.FC<{
       </DrawerTabContentSection>
 
       <DrawerTabContentSection label={t("terms.applicationDiscoveryManifest")}>
-        {manifest ? (
-          <SchemaDefinedField isReadOnly jsonDocument={manifest} />
+        {manifest?.content ? (
+          <SchemaDefinedField
+            isReadOnly
+            jsonDocument={manifest.content}
+            language={Language.yaml}
+          />
         ) : (
           <EmptyTextMessage />
         )}

--- a/client/src/app/pages/applications/application-detail-drawer/tab-platform-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-platform-content.tsx
@@ -63,7 +63,7 @@ export const TabPlatformContent: React.FC<{
           <SchemaDefinedField
             isReadOnly
             jsonDocument={manifest.content}
-            language={Language.yaml}
+            editorLanguage={Language.yaml}
           />
         ) : (
           <EmptyTextMessage />


### PR DESCRIPTION
MTA-6774: The manifest drawer was rendering the full database record as JSON. Now extracts only the `content` field and renders it as YAML using js-yaml. Also fixes Monaco space-width rendering in Firefox by pinning the editor font family.

Screen shot of the application manifest only showing the content, and as yaml:
<img width="1716" height="996" alt="image" src="https://github.com/user-attachments/assets/59b802a4-c66d-466b-ad22-1fa74f11e5f5" />

Assisted-by: Cursor:claude-sonnet-4-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code editor now supports switching between JSON and YAML highlighting with a UI dropdown and uses consistent monospace styling.
  * Dev tools and schema editor propagate the selected language for improved editing and display.

* **Bug Fixes**
  * Manifest tab only shows the manifest editor when manifest content exists, otherwise displays an empty message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->