### PR TITLE
:bug: Update qs to 6.14.1 to address CVE-2025-15284

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21271,9 +21271,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "overrides": {
     "follow-redirects": "^1.15.6",
+    "qs": "^6.14.1",
     "webpack-dev-server": {
       "express": "$express"
     }


### PR DESCRIPTION
Fixes: MTA-6533

Covers CVE-2025-15284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution configuration to improve build stability and package compatibility.
  * Adjusted package override settings to reduce potential regressions and ensure consistent behavior across environments.
  * No functional or UI changes; runtime behavior for end users remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->