### PR TITLE
[release-0.9] :bug: Update lodash to 4.18.1 to address CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17561,9 +17561,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "overrides": {
     "axios": "^1.15.0",
     "follow-redirects": "^1.15.6",
+    "lodash": "^4.18.1",
     "qs": "^6.14.1",
     "webpack-dev-server": {
       "express": "$express"


### PR DESCRIPTION
Fixes: MTA-6733
Fixes: MTA-6574

Covers CVE-2025-13465 and CVE-2026-4800