### PR TITLE
[release-0.8] :bug: Update lodash and lodash-es to 4.18.1 to address CVEs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
     "immer": "^10.1.3",
     "js-yaml": "^4.1.0",
     "keycloak-js": "^26.1.0",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.18.1",
     "monaco-editor": "^0.52.2",
     "radash": "^12.1.0",
     "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "immer": "^10.1.3",
         "js-yaml": "^4.1.0",
         "keycloak-js": "^26.1.0",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.1",
         "monaco-editor": "^0.52.2",
         "radash": "^12.1.0",
         "react": "^18.3.1",
@@ -18678,15 +18678,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
@@ -25919,16 +25919,6 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "overrides": {
     "axios": "^1.15.0",
     "follow-redirects": "^1.15.6",
+    "lodash": "^4.18.1",
     "qs": "^6.14.1",
     "webpack-dev-server": {
       "express": "$express"


### PR DESCRIPTION
Fixes: MTA-6733
Fixes: MTA-6574

Covers CVE-2025-13465 and CVE-2026-4800
