### PR TITLE
:sparkles: Use IDs based on categoryKey for filter toolbars

### DIFF
--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -204,7 +204,7 @@ export const FilterToolbar = <TItem, TFilterCategoryKey extends string>({
               onOpenChange={(flag) => setIsCategoryDropdownOpen(flag)}
               toggle={(toggleRef) => (
                 <MenuToggle
-                  id="filtered-by"
+                  ouiaId="filtered-by"
                   ref={toggleRef}
                   onClick={() =>
                     setIsCategoryDropdownOpen(!isCategoryDropdownOpen)

--- a/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
@@ -61,13 +61,14 @@ export const SelectFilterControl = <TItem, TFilterCategoryKey extends string>({
     >
       <SimpleSelect
         isScrollable={isScrollable}
+        isFullWidth={false}
         options={category.selectOptions}
         value={filterValue?.[0]}
         onSelect={onFilterSelect}
         ariaLabel={category.title}
         isDisabled={isDisabled}
         placeholderText="Any"
-        toggleId="select-filter-value-select"
+        toggleId={`select-filter-value-${category.categoryKey}`}
         toggleAriaLabel="Select"
       />
     </ToolbarFilter>

--- a/client/src/app/components/FilterToolbar/components/SimpleSelect.tsx
+++ b/client/src/app/components/FilterToolbar/components/SimpleSelect.tsx
@@ -11,8 +11,7 @@ import {
 import { FilterSelectOptionProps } from "../FilterToolbar";
 
 export interface SimpleSelectProps {
-  id?: string;
-  isScrollable: boolean;
+  isScrollable?: boolean;
   options: FilterSelectOptionProps[];
   value?: string;
   onSelect: (value: string) => void;
@@ -26,14 +25,13 @@ export interface SimpleSelectProps {
 }
 
 const SimpleSelect: FC<SimpleSelectProps> = ({
-  id,
-  isScrollable,
+  isScrollable = true,
   options,
   value: selectedValue,
   onSelect,
   placeholderText = "Select...",
   isDisabled,
-  isFullWidth,
+  isFullWidth = true,
   ariaLabel,
   toggleId,
   toggleAriaLabel,
@@ -69,7 +67,7 @@ const SimpleSelect: FC<SimpleSelectProps> = ({
   };
   return (
     <Select
-      id={id}
+      ouiaId={`${toggleId}-select`}
       isScrollable={isScrollable}
       aria-label={ariaLabel ?? toggleAriaLabel}
       toggle={toggle}

--- a/client/src/app/components/FilterToolbar/components/SimpleSelect.tsx
+++ b/client/src/app/components/FilterToolbar/components/SimpleSelect.tsx
@@ -19,7 +19,7 @@ export interface SimpleSelectProps {
   isDisabled?: boolean;
   isFullWidth?: boolean;
   ariaLabel?: string;
-  toggleId?: string;
+  toggleId: string;
   toggleAriaLabel?: string;
   toggleStatus?: MenuToggleProps["status"];
 }

--- a/client/src/app/components/analysis/steps/custom-rules.tsx
+++ b/client/src/app/components/analysis/steps/custom-rules.tsx
@@ -251,12 +251,9 @@ export const CustomRules: React.FC<CustomRulesProps> = ({
               isRequired
               renderInput={({ field: { value, name, onChange } }) => (
                 <SimpleSelect
-                  id="repo-type-select"
                   toggleId="repo-type-select-toggle"
                   toggleAriaLabel="Repository type select dropdown toggle"
-                  isScrollable
                   ariaLabel={name}
-                  isFullWidth
                   value={value ?? undefined}
                   options={repositoryTypeOptions}
                   onSelect={(selection) => {

--- a/client/src/app/components/repository-fields/RepositoryFields.tsx
+++ b/client/src/app/components/repository-fields/RepositoryFields.tsx
@@ -92,7 +92,6 @@ export const RepositoryFields = <TFormValues extends FieldValues>({
         isRequired={isTypeRequired}
         renderInput={({ field: { value, name, onChange } }) => (
           <SimpleSelect
-            isScrollable
             toggleId={toggleIds.type || `${prefix}-repo-type-toggle`}
             toggleAriaLabel="Type select dropdown toggle"
             ariaLabel={name}

--- a/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
+++ b/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
@@ -73,6 +73,7 @@ const ViewArchetypes: React.FC = () => {
         <ConditionalRender when={!archetype} then={<AppPlaceholder />}>
           {application?.archetypes && application?.archetypes?.length > 1 && (
             <SimpleSelect
+              toggleId="select-archetype-toggle"
               ariaLabel="Select an archetype"
               isFullWidth={false}
               value={activeArchetype ? String(activeArchetype.id) : undefined}

--- a/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
+++ b/client/src/app/pages/assessment/components/view-archetypes/view-archetypes-page.tsx
@@ -73,9 +73,8 @@ const ViewArchetypes: React.FC = () => {
         <ConditionalRender when={!archetype} then={<AppPlaceholder />}>
           {application?.archetypes && application?.archetypes?.length > 1 && (
             <SimpleSelect
-              id="archetype-select"
-              isScrollable
               ariaLabel="Select an archetype"
+              isFullWidth={false}
               value={activeArchetype ? String(activeArchetype.id) : undefined}
               options={archetypeOptions}
               onSelect={(value) => {

--- a/client/src/app/pages/asset-generators/components/generator-form/generator-form-repository.tsx
+++ b/client/src/app/pages/asset-generators/components/generator-form/generator-form-repository.tsx
@@ -54,11 +54,9 @@ export const GeneratorFormRepository: React.FC = () => {
         isRequired
         renderInput={({ field: { value, name, onChange } }) => (
           <SimpleSelect
-            isScrollable
             toggleId="repo-type-toggle"
             toggleAriaLabel="Type select dropdown toggle"
             ariaLabel={name}
-            isFullWidth
             value={value ?? undefined}
             options={REPOSITORY_KIND_OPTIONS}
             onSelect={(selection) => {

--- a/client/src/app/pages/controls/tags/components/tag-category-form.tsx
+++ b/client/src/app/pages/controls/tags/components/tag-category-form.tsx
@@ -168,12 +168,9 @@ export const TagCategoryForm: React.FC<TagCategoryFormProps> = ({
         isRequired
         renderInput={({ field: { value, name, onChange } }) => (
           <SimpleSelect
-            isScrollable
             placeholderText={t("composed.selectOne", {
               what: t("terms.color").toLowerCase(),
             })}
-            id="type-select"
-            isFullWidth
             toggleId="type-select-toggle"
             toggleAriaLabel="Type select dropdown toggle"
             ariaLabel={name}

--- a/client/src/app/pages/identities/components/identity-form/identity-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/identity-form.tsx
@@ -376,9 +376,6 @@ export const IdentityForm: React.FC<IdentityFormProps> = ({
           isRequired
           renderInput={({ field: { value, name, onChange } }) => (
             <SimpleSelect
-              isScrollable
-              isFullWidth
-              id="type-select"
               toggleId="type-select-toggle"
               toggleAriaLabel="Type select dropdown toggle"
               ariaLabel={name}

--- a/client/src/app/pages/identities/components/identity-form/kind-source-form.tsx
+++ b/client/src/app/pages/identities/components/identity-form/kind-source-form.tsx
@@ -54,9 +54,6 @@ export const KindSourceForm: React.FC<{
         fieldId="user-credentials-select"
         renderInput={({ field: { value, name, onChange } }) => (
           <SimpleSelect
-            isScrollable
-            isFullWidth
-            id="user-credentials-select"
             toggleId="user-credentials-select-toggle"
             toggleAriaLabel="User credentials select dropdown toggle"
             ariaLabel={name}

--- a/client/src/app/pages/migration-targets/components/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/components/custom-target-form.tsx
@@ -443,9 +443,6 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
         fieldId="provider-type-select"
         renderInput={({ field: { value, name, onChange } }) => (
           <SimpleSelect
-            isScrollable
-            isFullWidth
-            id="provider-type-select"
             toggleId="provider-type-select-toggle"
             toggleAriaLabel="Provider type select dropdown toggle"
             ariaLabel={name}
@@ -593,9 +590,6 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
             isRequired
             renderInput={({ field: { value, name, onChange } }) => (
               <SimpleSelect
-                isScrollable
-                isFullWidth
-                id="repo-type-select"
                 toggleId="repo-type-select-toggle"
                 toggleAriaLabel="Repository type select dropdown toggle"
                 ariaLabel={name}

--- a/client/src/app/pages/proxies/proxy-form.tsx
+++ b/client/src/app/pages/proxies/proxy-form.tsx
@@ -276,9 +276,6 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                 fieldState: { isDirty, error, isTouched },
               }) => (
                 <SimpleSelect
-                  isScrollable
-                  isFullWidth
-                  id="httpIdentity"
                   toggleId="http-proxy-credentials-select-toggle"
                   ariaLabel="HTTP proxy credentials"
                   value={value || undefined}
@@ -365,8 +362,6 @@ export const ProxyForm: React.FC<ProxyFormProps> = ({
                 fieldState: { isDirty, error, isTouched },
               }) => (
                 <SimpleSelect
-                  isScrollable
-                  isFullWidth
                   toggleId="https-proxy-credentials-select-toggle"
                   ariaLabel="HTTPS proxy credentials"
                   value={value ? value : undefined}

--- a/cypress/e2e/models/administration/credentials/credentials.ts
+++ b/cypress/e2e/models/administration/credentials/credentials.ts
@@ -29,6 +29,14 @@ import {
   trTag,
   unsetAsDefaultAction,
 } from "../../../types/constants";
+import {
+  categoryCreatedBy,
+  categoryDefaultCredential,
+  categoryName,
+  categoryType,
+  filterCategory,
+  filterSelectType,
+} from "../../../types/filter-categories";
 import { CredentialsData } from "../../../types/types";
 import * as commonView from "../../../views/common.view";
 import {
@@ -37,12 +45,6 @@ import {
   credentialNameInput,
   defaultIcon,
   descriptionInput,
-  filterCatCreatedBy,
-  filterCatDefaultCredential,
-  filterCatType,
-  filterCategory,
-  filterSelectType,
-  filteredBy,
   isDefaultCheckbox,
   modalBoxBody,
   passwordInput,
@@ -216,26 +218,32 @@ export class Credentials {
   }
 
   static ApplyFilterByName(value: string) {
-    selectFromDropList(filteredBy, filterCategory);
+    selectFromDropList(commonView.filteredBy, filterCategory(categoryName));
     inputText(commonView.searchInput, value);
     click(commonView.searchButton);
   }
 
   static applyFilterByType(type: string) {
-    selectFromDropList(filteredBy, filterCatType);
-    selectFromDropListByText(filterSelectType, type);
+    selectFromDropList(commonView.filteredBy, filterCategory(categoryType));
+    selectFromDropListByText(filterSelectType(categoryType), type);
   }
 
   static applyFilterCreatedBy(value: string) {
-    selectFromDropList(filteredBy, filterCatCreatedBy);
+    selectFromDropList(
+      commonView.filteredBy,
+      filterCategory(categoryCreatedBy)
+    );
     inputText(commonView.searchInput, value);
     click(commonView.searchButton);
   }
 
   static applyFilterDefaultCredential(value: DefaultCredentialFilter) {
-    selectFromDropList(filteredBy, filterCatDefaultCredential);
+    selectFromDropList(
+      commonView.filteredBy,
+      filterCategory(categoryDefaultCredential)
+    );
     selectFromDropListByText(
-      filterSelectType,
+      filterSelectType(categoryDefaultCredential),
       value,
       commonView.actionMenuItem
     );

--- a/cypress/e2e/models/administration/jira-connection/jira.ts
+++ b/cypress/e2e/models/administration/jira-connection/jira.ts
@@ -24,17 +24,15 @@ import {
   tdTag,
   trTag,
 } from "../../../types/constants";
+import { categoryName, filterCategory } from "../../../types/filter-categories";
 import { JiraConnectionData } from "../../../types/types";
 import {
   confirmButton,
   confirmCancelButton,
+  filteredBy,
   navLink,
 } from "../../../views/common.view";
-import {
-  filterCategory,
-  filteredBy,
-  searchButton,
-} from "../../../views/credentials.view";
+import { searchButton } from "../../../views/credentials.view";
 import { searchInput } from "../../../views/issue.view";
 import {
   createJiraButton,
@@ -274,7 +272,7 @@ export class Jira {
   }
 
   static applyFilterByName(value: string) {
-    selectFromDropList(filteredBy, filterCategory);
+    selectFromDropList(filteredBy, filterCategory(categoryName));
     inputText(searchInput, value);
     click(searchButton);
   }

--- a/cypress/e2e/tests/administration/questionnaires/filter.test.ts
+++ b/cypress/e2e/tests/administration/questionnaires/filter.test.ts
@@ -28,8 +28,8 @@ import {
   clearAllFilters,
   cloudNative,
   legacyPathfinder,
-  name,
 } from "../../../types/constants";
+import { categoryName } from "../../../types/filter-categories";
 
 const yamlFileName = "questionnaire_import/cloud-native.yaml";
 const assessmentQuestionnaireList: Array<string> = [];
@@ -55,14 +55,14 @@ describe(
 
       let searchInput = assessmentQuestionnaireList[0];
 
-      applySearchFilter(name, searchInput);
+      applySearchFilter(categoryName, searchInput);
       exists(assessmentQuestionnaireList[0]);
       notExists(assessmentQuestionnaireList[1]);
       clickByText(button, clearAllFilters);
 
       searchInput = assessmentQuestionnaireList[1];
 
-      applySearchFilter(name, searchInput);
+      applySearchFilter(categoryName, searchInput);
       exists(assessmentQuestionnaireList[1]);
       notExists(assessmentQuestionnaireList[0]);
       clickByText(button, clearAllFilters);

--- a/cypress/e2e/tests/migration/applicationinventory/applications/filter.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/applications/filter.test.ts
@@ -43,18 +43,21 @@ import { Tag } from "../../../../models/migration/controls/tags";
 import {
   CredentialType,
   UserCredentials,
-  archetypes,
-  artifact,
   button,
   clearAllFilters,
-  credentialType,
   git,
-  name,
-  repositoryType,
-  risk,
   subversion,
-  tags,
 } from "../../../../types/constants";
+import {
+  categoryArchetypes,
+  categoryBinary,
+  categoryBusinessService,
+  categoryIdentities,
+  categoryName,
+  categoryRepositoryType,
+  categoryRisk,
+  categoryTags,
+} from "../../../../types/filter-categories";
 import * as commonView from "../../../../views/common.view";
 import {
   filterDropDownContainer,
@@ -129,7 +132,7 @@ describe(
       filterApplicationsBySubstring();
 
       // Enter an exact existing name and assert
-      applySearchFilter(name, applicationsList[1].name);
+      applySearchFilter(categoryName, applicationsList[1].name);
       exists(applicationsList[1].name);
       notExists(applicationsList[0].name);
       clickByText(button, clearAllFilters);
@@ -137,7 +140,7 @@ describe(
 
     it("Business service filter validations", function () {
       const validSearchInput = applicationsList[0].business;
-      applySearchFilter("Business service", validSearchInput);
+      applySearchFilter(categoryBusinessService, validSearchInput);
 
       exists(applicationsList[0].business);
       clickByText(button, clearAllFilters);
@@ -147,13 +150,13 @@ describe(
       Application.open();
 
       const validSearchInput = applicationsList[0].tags[0];
-      applySearchFilter(tags, validSearchInput);
+      applySearchFilter(categoryTags, validSearchInput);
 
       exists(applicationsList[0].name);
       notExists(applicationsList[1].name);
       clickByText(button, clearAllFilters);
 
-      applySearchFilter(tags, applicationsList[1].tags[0]);
+      applySearchFilter(categoryTags, applicationsList[1].tags[0]);
       exists(applicationsList[1].name);
       notExists(applicationsList[0].name);
       clickByText(button, clearAllFilters);
@@ -176,14 +179,14 @@ describe(
       application.manageCredentials(null, maven_credential.name);
       exists(application.name);
 
-      applySearchFilter(credentialType, "Maven");
+      applySearchFilter(categoryIdentities, "Maven");
       exists(application.name);
       clickByText(button, clearAllFilters);
 
       application.manageCredentials(source_credential.name, null);
       exists(application.name);
 
-      applySearchFilter(credentialType, "Source");
+      applySearchFilter(categoryIdentities, "Source");
       exists(application.name);
       clickByText(button, clearAllFilters);
     });
@@ -208,14 +211,14 @@ describe(
 
       // Apply repository type filter check with Git
       // Check Application exists and application1 doesn't exist
-      applySearchFilter(repositoryType, git);
+      applySearchFilter(categoryRepositoryType, git);
       exists(application.name);
       notExists(application1.name);
       clickByText(button, clearAllFilters);
 
       // Apply repository type filter check with Subversion
       // Check Application1 exists and application doesn't exist
-      applySearchFilter(repositoryType, subversion);
+      applySearchFilter(categoryRepositoryType, subversion);
       exists(application1.name);
       notExists(application.name);
       clickByText(button, clearAllFilters);
@@ -236,14 +239,14 @@ describe(
 
       // Apply artifact filter check with associated artifact field
       // Check application exists and applicationList[0] doesn't exist
-      applySearchFilter(artifact, "Associated artifact");
+      applySearchFilter(categoryBinary, "Associated artifact");
       exists(application.name);
       notExists(applicationsList[0].name);
       clickByText(button, clearAllFilters);
 
       // Apply artifact filter check with 'No associated artifact' field
       // Check applicationList[0] exists and application doesn't exist
-      applySearchFilter(artifact, "No associated artifact");
+      applySearchFilter(categoryBinary, "No associated artifact");
       exists(applicationsList[0].name);
       notExists(application.name);
       clickByText(button, clearAllFilters);
@@ -261,13 +264,13 @@ describe(
       application.verifyStatus("assessment", "Completed");
 
       // Apply search filter Risk - Low
-      applySearchFilter(risk, "Low");
+      applySearchFilter(categoryRisk, "Low");
       exists(application.name);
       notExists(application1.name);
       clickByText(button, clearAllFilters);
 
       // apply search filter Risk - Unassessed
-      applySearchFilter(risk, "Unassessed");
+      applySearchFilter(categoryRisk, "Unassessed");
       exists(application1.name);
       notExists(application.name);
       clickByText(button, clearAllFilters);
@@ -295,7 +298,7 @@ describe(
       application1.create();
       cy.get("@getApplication");
       const validSearchInput = archetype1.name;
-      applySearchFilter("Archetypes", validSearchInput);
+      applySearchFilter(categoryArchetypes, validSearchInput);
       exists(application1.name);
       clickByText(button, clearAllFilters);
 
@@ -308,7 +311,7 @@ describe(
       );
       archetype2.create();
       Application.open();
-      selectFilter(archetypes);
+      selectFilter(categoryArchetypes);
       cy.get(filterDropDownContainer).find(searchMenuToggle).click();
       notExists(archetype2.name);
 
@@ -336,7 +339,7 @@ const filterApplicationsBySubstring = (): void => {
   const [firstAppSubstring, secondAppSubstring] = applicationsList.map((app) =>
     app.name.substring(0, 12)
   );
-  selectFilter(name);
+  selectFilter(categoryName);
   if (firstAppSubstring === secondAppSubstring) {
     cy.get(commonView.inputText)
       .click()
@@ -353,7 +356,7 @@ const filterApplicationsBySubstring = (): void => {
         exists(applicationsList[1].name);
       });
   } else {
-    applySearchFilter(name, firstAppSubstring);
+    applySearchFilter(categoryName, firstAppSubstring);
     exists(applicationsList[0].name);
     notExists(applicationsList[1].name);
   }

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/review/filter.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/review/filter.test.ts
@@ -75,11 +75,7 @@ describe(
     identifiedRisksFilterValidations.forEach((validation) => {
       it(`Filtering identified risks by ${validation.name}`, function () {
         const commonActions = () => {
-          applySelectFilter(
-            validation.id,
-            new RegExp(`^${validation.name}$`),
-            validation.text
-          );
+          applySelectFilter(validation.id, validation.id, validation.text);
           exists(validation.should);
           notExists(validation.shouldNot);
           clearAllFilters();

--- a/cypress/e2e/tests/migration/applicationinventory/manageimports/filter.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/manageimports/filter.test.ts
@@ -29,7 +29,7 @@ import {
 } from "../../../../../utils/utils";
 import { Application } from "../../../../models/migration/applicationinventory/application";
 import { button, clearAllFilters } from "../../../../types/constants";
-import { FileName } from "../../../../views/applicationinventory.view";
+import { categoryFileName } from "../../../../types/filter-categories";
 
 const filePath = "app_import/csv/";
 const filesToImport = [
@@ -66,7 +66,7 @@ describe(
 
       // Enter an existing file name substring and apply it as search filter
       const validSearchInput = filesToImport[0].substring(0, 5);
-      applySearchFilter(FileName, validSearchInput);
+      applySearchFilter(categoryFileName, validSearchInput);
 
       // Assert that application import row(s) containing the search text is/are displayed
       exists(filesToImport[0]);
@@ -77,7 +77,7 @@ describe(
       clickByText(button, clearAllFilters);
 
       // Enter a non-existing file name substring and apply it as search filter
-      applySearchFilter(FileName, invalidSearchInput);
+      applySearchFilter(categoryFileName, invalidSearchInput);
       cy.get("h2").contains("No import summary available");
     });
 

--- a/cypress/e2e/tests/migration/archetypes/filter.test.ts
+++ b/cypress/e2e/tests/migration/archetypes/filter.test.ts
@@ -25,7 +25,8 @@ import {
   notExists,
 } from "../../../../utils/utils";
 import { Archetype } from "../../../models/migration/archetypes/archetype";
-import { button, clearAllFilters, name } from "../../../types/constants";
+import { button, clearAllFilters } from "../../../types/constants";
+import { categoryName } from "../../../types/filter-categories";
 
 let archetypeList: Archetype[];
 
@@ -43,14 +44,14 @@ describe(["@tier3", "@tier3_D"], "Archetype filter validation", () => {
 
     let searchInput = archetypeList[0].name;
 
-    applySearchFilter(name, searchInput);
+    applySearchFilter(categoryName, searchInput);
     exists(archetypeList[0].name);
     notExists(archetypeList[1].name);
     clickByText(button, clearAllFilters);
 
     searchInput = archetypeList[1].name;
 
-    applySearchFilter(name, searchInput);
+    applySearchFilter(categoryName, searchInput);
     exists(archetypeList[1].name);
     notExists(archetypeList[0].name);
     clickByText(button, clearAllFilters);

--- a/cypress/e2e/tests/migration/controls/businessservices/filter.test.ts
+++ b/cypress/e2e/tests/migration/controls/businessservices/filter.test.ts
@@ -25,13 +25,12 @@ import {
 } from "../../../../../utils/utils";
 import { BusinessServices } from "../../../../models/migration/controls/businessservices";
 import { Stakeholders } from "../../../../models/migration/controls/stakeholders";
+import { button, clearAllFilters } from "../../../../types/constants";
 import {
-  button,
-  clearAllFilters,
-  createdBy,
-  description,
-  name,
-} from "../../../../types/constants";
+  categoryDescription,
+  categoryName,
+  categoryOwner,
+} from "../../../../types/filter-categories";
 
 let businessServicesList: Array<BusinessServices> = [];
 let stakeholdersList: Array<Stakeholders> = [];
@@ -56,7 +55,7 @@ describe(
 
       // Enter an existing display name substring and assert
       const validSearchInput = businessServicesList[0].name.substring(0, 3);
-      applySearchFilter(name, validSearchInput);
+      applySearchFilter(categoryName, validSearchInput);
       exists(businessServicesList[0].name);
 
       if (businessServicesList[1].name.indexOf(validSearchInput) >= 0) {
@@ -65,14 +64,14 @@ describe(
       clickByText(button, clearAllFilters);
 
       // Enter an existing exact name and assert
-      applySearchFilter(name, businessServicesList[1].name);
+      applySearchFilter(categoryName, businessServicesList[1].name);
       exists(businessServicesList[1].name);
       notExists(businessServicesList[0].name);
 
       clickByText(button, clearAllFilters);
 
       // Enter a non-existing name substring and apply it as search filter
-      applySearchFilter(name, invalidSearchInput);
+      applySearchFilter(categoryName, invalidSearchInput);
       cy.get("h2").contains("No business service available");
       clickByText(button, clearAllFilters);
     });
@@ -85,7 +84,7 @@ describe(
         0,
         8
       );
-      applySearchFilter(description, validSearchInput);
+      applySearchFilter(categoryDescription, validSearchInput);
       exists(businessServicesList[0].description);
 
       if (businessServicesList[1].description.indexOf(validSearchInput) >= 0) {
@@ -94,14 +93,17 @@ describe(
       clickByText(button, clearAllFilters);
 
       // Enter an existing exact description and assert
-      applySearchFilter(description, businessServicesList[1].description);
+      applySearchFilter(
+        categoryDescription,
+        businessServicesList[1].description
+      );
       exists(businessServicesList[1].description);
       notExists(businessServicesList[0].description);
 
       clickByText(button, clearAllFilters);
 
       // Enter a non-existing description substring and apply it as search filter
-      applySearchFilter(description, invalidSearchInput);
+      applySearchFilter(categoryDescription, invalidSearchInput);
       cy.get("h2").contains("No business service available");
       clickByText(button, clearAllFilters);
     });
@@ -111,7 +113,7 @@ describe(
 
       // Enter an existing owner substring and assert
       const validSearchInput = businessServicesList[0].owner.substring(0, 3);
-      applySearchFilter(createdBy, validSearchInput);
+      applySearchFilter(categoryOwner, validSearchInput);
       exists(businessServicesList[0].owner);
 
       if (businessServicesList[1].owner.indexOf(validSearchInput) >= 0) {
@@ -120,14 +122,14 @@ describe(
       clickByText(button, clearAllFilters);
 
       // Enter an existing exact owner and assert
-      applySearchFilter(createdBy, businessServicesList[1].owner);
+      applySearchFilter(categoryOwner, businessServicesList[1].owner);
       exists(businessServicesList[1].owner);
       notExists(businessServicesList[0].owner);
 
       clickByText(button, clearAllFilters);
 
       // Enter a non-attached owner substring and apply it as search filter
-      applySearchFilter(createdBy, stakeholdersList[2].name);
+      applySearchFilter(categoryOwner, stakeholdersList[2].name);
       cy.get("h2").contains("No business service available");
       clickByText(button, clearAllFilters);
     });

--- a/cypress/e2e/tests/migration/controls/jobfunctions/filter.test.ts
+++ b/cypress/e2e/tests/migration/controls/jobfunctions/filter.test.ts
@@ -24,7 +24,8 @@ import {
   login,
 } from "../../../../../utils/utils";
 import { Jobfunctions } from "../../../../models/migration/controls/jobfunctions";
-import { button, clearAllFilters, name } from "../../../../types/constants";
+import { button, clearAllFilters } from "../../../../types/constants";
+import { categoryName } from "../../../../types/filter-categories";
 
 const jobFunctionsList: Array<Jobfunctions> = [];
 const invalidSearchInput = String(data.getRandomNumber());
@@ -51,16 +52,16 @@ describe(
 
       // Enter an existing display name substring and assert
       const validSearchInput = jobFunctionsList[0].name.substring(0, 3);
-      applySearchFilter(name, validSearchInput);
+      applySearchFilter(categoryName, validSearchInput);
       exists(jobFunctionsList[0].name);
       clickByText(button, clearAllFilters);
 
-      applySearchFilter(name, jobFunctionsList[1].name);
+      applySearchFilter(categoryName, jobFunctionsList[1].name);
       exists(jobFunctionsList[1].name);
       clickByText(button, clearAllFilters);
 
       // Enter a non-existing display name substring and apply it as search filter
-      applySearchFilter(name, invalidSearchInput);
+      applySearchFilter(categoryName, invalidSearchInput);
       cy.get("h2").contains("No job function available");
       clickByText(button, clearAllFilters);
     });

--- a/cypress/e2e/tests/migration/controls/stakeholdergroups/filter.test.ts
+++ b/cypress/e2e/tests/migration/controls/stakeholdergroups/filter.test.ts
@@ -33,12 +33,14 @@ import { Stakeholders } from "../../../../models/migration/controls/stakeholders
 import {
   button,
   clearAllFilters,
-  description,
-  name,
-  stakeholders,
   tdTag,
   trTag,
 } from "../../../../types/constants";
+import {
+  categoryDescription,
+  categoryName,
+  categoryStakeholders,
+} from "../../../../types/filter-categories";
 
 let stakeholdersList: Array<Stakeholders> = [];
 let stakeholderGroupsList: Array<Stakeholdergroups> = [];
@@ -67,7 +69,7 @@ describe(
       cy.get("@getStakeholderGroups");
 
       const validSearchInput = stakeholderGroupsList[0].name.substring(0, 5);
-      applySearchFilter(name, validSearchInput);
+      applySearchFilter(categoryName, validSearchInput);
       exists(stakeholderGroupsList[0].name);
       if (stakeholderGroupsList[1].name.indexOf(validSearchInput) >= 0) {
         exists(stakeholderGroupsList[1].name);
@@ -75,7 +77,7 @@ describe(
 
       clickByText(button, clearAllFilters);
       cy.get("@getStakeholderGroups");
-      applySearchFilter(name, invalidSearchInput);
+      applySearchFilter(categoryName, invalidSearchInput);
       cy.get("h2").contains("No stakeholder group available");
       clickByText(button, clearAllFilters);
       cy.get("@getStakeholderGroups");
@@ -89,7 +91,7 @@ describe(
         0,
         3
       );
-      applySearchFilter(description, validSearchInput);
+      applySearchFilter(categoryDescription, validSearchInput);
 
       // Assert that stakeholder groups row(s) containing the search text is/are displayed
       exists(stakeholderGroupsList[0].description);
@@ -99,7 +101,7 @@ describe(
 
       clickByText(button, clearAllFilters);
       cy.get("@getStakeholderGroups");
-      applySearchFilter(description, invalidSearchInput);
+      applySearchFilter(categoryDescription, invalidSearchInput);
       cy.get("h2").contains("No stakeholder group available");
       clickByText(button, clearAllFilters);
       cy.get("@getStakeholderGroups");
@@ -113,7 +115,7 @@ describe(
         0,
         3
       );
-      applySearchFilter(stakeholders, validSearchInput);
+      applySearchFilter(categoryStakeholders, validSearchInput);
 
       selectItemsPerPage(100);
       cy.get(tdTag)
@@ -131,7 +133,7 @@ describe(
 
       clickByText(button, clearAllFilters);
       cy.get("@getStakeholderGroups");
-      applySearchFilter(stakeholders, invalidSearchInput);
+      applySearchFilter(categoryStakeholders, invalidSearchInput);
       cy.get("h2").contains("No stakeholder group available");
       clickByText(button, clearAllFilters);
       cy.get("@getStakeholderGroups");

--- a/cypress/e2e/tests/migration/controls/stakeholders/filter.test.ts
+++ b/cypress/e2e/tests/migration/controls/stakeholders/filter.test.ts
@@ -33,13 +33,15 @@ import { Stakeholders } from "../../../../models/migration/controls/stakeholders
 import {
   button,
   clearAllFilters,
-  email,
-  group,
-  jobFunction,
-  name,
   tdTag,
   trTag,
 } from "../../../../types/constants";
+import {
+  categoryEmail,
+  categoryJobFunction,
+  categoryName,
+  categoryStakeholderGroups,
+} from "../../../../types/filter-categories";
 import * as commonView from "../../../../views/common.view";
 import { stakeHoldersTable } from "../../../../views/stakeholders.view";
 
@@ -66,7 +68,7 @@ describe(["@tier3", "@tier3_C"], "Stakeholder filter validations", function () {
 
     // Enter an existing email substring and apply it as search filter
     const validSearchInput = stakeholdersList[0].email.substring(0, 5);
-    applySearchFilter(email, validSearchInput);
+    applySearchFilter(categoryEmail, validSearchInput);
     exists(stakeholdersList[0].email, stakeHoldersTable);
     if (stakeholdersList[1].email.indexOf(validSearchInput) >= 0) {
       exists(stakeholdersList[1].email, stakeHoldersTable);
@@ -74,7 +76,7 @@ describe(["@tier3", "@tier3_C"], "Stakeholder filter validations", function () {
     clickByText(button, clearAllFilters);
 
     // Enter a non-existing email substring and apply it as search filter
-    applySearchFilter(email, invalidSearchInput);
+    applySearchFilter(categoryEmail, invalidSearchInput);
     cy.get("h2").contains("No stakeholder available");
     clickByText(button, clearAllFilters);
   });
@@ -84,7 +86,7 @@ describe(["@tier3", "@tier3_C"], "Stakeholder filter validations", function () {
 
     // Enter an existing display name substring and apply it as search filter
     const validSearchInput = stakeholdersList[0].name.substring(0, 3);
-    applySearchFilter(name, validSearchInput);
+    applySearchFilter(categoryName, validSearchInput);
     exists(stakeholdersList[0].name, stakeHoldersTable);
     if (stakeholdersList[1].name.indexOf(validSearchInput) >= 0) {
       exists(stakeholdersList[1].name, stakeHoldersTable);
@@ -92,7 +94,7 @@ describe(["@tier3", "@tier3_C"], "Stakeholder filter validations", function () {
     clickByText(button, clearAllFilters);
 
     // Enter a non-existing display name substring and apply it as search filter
-    applySearchFilter(name, invalidSearchInput);
+    applySearchFilter(categoryName, invalidSearchInput);
     cy.get("h2").contains("No stakeholder available");
     clickByText(button, clearAllFilters);
   });
@@ -102,7 +104,7 @@ describe(["@tier3", "@tier3_C"], "Stakeholder filter validations", function () {
 
     // Enter an existing job function substring and apply it as search filter
     const validSearchInput = stakeholdersList[0].jobfunction.substring(0, 3);
-    applySearchFilter(jobFunction, validSearchInput);
+    applySearchFilter(categoryJobFunction, validSearchInput);
     selectItemsPerPage(100);
     cy.get(tdTag)
       .contains(stakeholdersList[0].email)
@@ -116,7 +118,7 @@ describe(["@tier3", "@tier3_C"], "Stakeholder filter validations", function () {
     clickByText(button, clearAllFilters);
 
     // Enter a non-existing job function substring and apply it as search filter
-    applySearchFilter(jobFunction, invalidSearchInput);
+    applySearchFilter(categoryJobFunction, invalidSearchInput);
     cy.get("h2").contains("No stakeholder available");
     clickByText(button, clearAllFilters);
   });
@@ -126,7 +128,7 @@ describe(["@tier3", "@tier3_C"], "Stakeholder filter validations", function () {
 
     // Enter an existing group substring and apply it as search filter
     const validSearchInput = stakeholdersList[0].groups[0].substring(0, 3);
-    applySearchFilter(group, validSearchInput);
+    applySearchFilter(categoryStakeholderGroups, validSearchInput);
     selectItemsPerPage(100);
     cy.get(tdTag)
       .contains(stakeholdersList[0].email)
@@ -143,7 +145,7 @@ describe(["@tier3", "@tier3_C"], "Stakeholder filter validations", function () {
     clickByText(button, clearAllFilters);
 
     // Enter a non-existing group substring and apply it as search filter
-    applySearchFilter(group, invalidSearchInput);
+    applySearchFilter(categoryStakeholderGroups, invalidSearchInput);
     cy.get("h2").contains("No stakeholder available");
     clickByText(button, clearAllFilters);
   });

--- a/cypress/e2e/tests/migration/controls/tags/tag/filter.test.ts
+++ b/cypress/e2e/tests/migration/controls/tags/tag/filter.test.ts
@@ -26,7 +26,8 @@ import {
 } from "../../../../../../utils/utils";
 import { TagCategory } from "../../../../../models/migration/controls/tagcategory";
 import { Tag } from "../../../../../models/migration/controls/tags";
-import { name, tdTag } from "../../../../../types/constants";
+import { tdTag } from "../../../../../types/constants";
+import { categoryTags } from "../../../../../types/filter-categories";
 
 describe(["@tier3", "@tier3_C"], "Tags filter validations", function () {
   const tagCategory = new TagCategory(data.getRandomWord(5), data.getColor());
@@ -42,22 +43,21 @@ describe(["@tier3", "@tier3_C"], "Tags filter validations", function () {
   it("Name filter validations", function () {
     const validSearchInputTag = tag.name.substring(0, 3);
     const validSearchInputTagCategory = tagCategory.name.substring(0, 3);
-    const filterType = name;
 
     Tag.openList();
-    applySelectFilter("tags", filterType, validSearchInputTag);
+    applySelectFilter(categoryTags, categoryTags, validSearchInputTag);
     expandRowDetails(tag.tagCategory);
     existsWithinRow(tag.tagCategory, tdTag, tag.name);
     closeRowDetails(tag.tagCategory);
 
-    applySelectFilter("tags", filterType, validSearchInputTagCategory);
+    applySelectFilter(categoryTags, categoryTags, validSearchInputTagCategory);
     exists(validSearchInputTagCategory);
 
     clearAllFilters();
 
     // Enter a non-existing tag name substring and apply it as search filter
     const invalidSearchInput = String(data.getRandomNumber(111111, 222222));
-    applySelectFilter("tags", filterType, invalidSearchInput, false);
+    applySelectFilter(categoryTags, categoryTags, invalidSearchInput, false);
   });
 
   after("Cleanup", function () {

--- a/cypress/e2e/tests/migration/controls/tags/tagcategory/filter.test.ts
+++ b/cypress/e2e/tests/migration/controls/tags/tagcategory/filter.test.ts
@@ -22,7 +22,8 @@ import {
   exists,
 } from "../../../../../../utils/utils";
 import { TagCategory } from "../../../../../models/migration/controls/tagcategory";
-import { button, clearAllFilters, color } from "../../../../../types/constants";
+import { button, clearAllFilters } from "../../../../../types/constants";
+import { categoryColor } from "../../../../../types/filter-categories";
 
 describe(
   ["@tier3", "@tier3_C"],
@@ -37,7 +38,7 @@ describe(
 
       // Enter an existing tag category color substring and apply it as search filter
       const validSearchInput = data.getColor();
-      applySearchFilter(color, validSearchInput);
+      applySearchFilter(categoryColor, validSearchInput);
       exists(validSearchInput);
 
       clickByText(button, clearAllFilters);
@@ -45,7 +46,7 @@ describe(
 
       // Enter a non-existing tag type color substring and apply it as search filter
       const invalidSearchInput = String(data.getRandomWord(3));
-      applySearchFilter(color, invalidSearchInput);
+      applySearchFilter(categoryColor, invalidSearchInput);
       cy.get("h2").contains("No tags available");
       clickByText(button, clearAllFilters);
     });

--- a/cypress/e2e/tests/migration/dynamic-report/dependencies/filter_sorting_pagination.test.ts
+++ b/cypress/e2e/tests/migration/dynamic-report/dependencies/filter_sorting_pagination.test.ts
@@ -140,7 +140,7 @@ describe(
     });
 
     it("Filtering dependencies by Archetype", function () {
-      Dependencies.applyFilter(dependencyFilter.archetype, archetype.name);
+      Dependencies.applyFilter(dependencyFilter.archetypes, archetype.name);
       this.analysisData["source_analysis_on_bookserverapp"][
         "dependencies"
       ].forEach((dependency: AppDependency) => {

--- a/cypress/e2e/tests/migration/dynamic-report/issues/filter_sorting_pagination.test.ts
+++ b/cypress/e2e/tests/migration/dynamic-report/issues/filter_sorting_pagination.test.ts
@@ -131,7 +131,7 @@ describe(
     });
 
     it("All issues - Filtering issues by Archetype", function () {
-      Issues.applyFilter(dynamicReportFilter.archetype, archetypeName);
+      Issues.applyFilter(dynamicReportFilter.archetypes, archetypeName);
       this.analysisData["source+dep_on_coolStore_app"]["issues"].forEach(
         (issue: AppIssue) => {
           Issues.validateFilter(issue);

--- a/cypress/e2e/tests/migration/migration-waves/filter.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/filter.test.ts
@@ -21,7 +21,8 @@ import {
   login,
 } from "../../../../utils/utils";
 import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
-import { button, clearAllFilters, name } from "../../../types/constants";
+import { button, clearAllFilters } from "../../../types/constants";
+import { categoryName } from "../../../types/filter-categories";
 import { MigrationWaveView } from "../../../views/migration-wave.view";
 
 let migrationWavesList: Array<MigrationWave> = [];
@@ -41,7 +42,7 @@ describe(
 
       // Enter an existing display name substring and assert
       const validSearchInput = migrationWavesList[0].name.substring(0, 3);
-      applySearchFilter(name, validSearchInput);
+      applySearchFilter(categoryName, validSearchInput);
       cy.get("td").should("contain", migrationWavesList[0].name);
       if (migrationWavesList[1].name.indexOf(validSearchInput) >= 0) {
         cy.get("td").should("contain", migrationWavesList[1].name);
@@ -49,13 +50,13 @@ describe(
       clickByText(button, clearAllFilters);
 
       // Enter an existing exact name and assert
-      applySearchFilter(name, migrationWavesList[1].name);
+      applySearchFilter(categoryName, migrationWavesList[1].name);
       cy.get("td").should("contain", migrationWavesList[1].name);
       cy.get("td").should("not.contain", migrationWavesList[0].name);
       clickByText(button, clearAllFilters);
 
       // Enter a non-existing name substring and apply it as search filter
-      applySearchFilter(name, String(data.getRandomNumber()));
+      applySearchFilter(categoryName, String(data.getRandomNumber()));
 
       // Assert that no search results are found
       cy.get(MigrationWaveView.migrationWavesTable)

--- a/cypress/e2e/tests/migration/migration-waves/filter_applications.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/filter_applications.test.ts
@@ -25,13 +25,15 @@ import { Stakeholders } from "../../../models/migration/controls/stakeholders";
 import { Tag } from "../../../models/migration/controls/tags";
 import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
 import {
-  businessServiceLower,
   button,
   clearAllFilters,
   manageApplications,
-  name,
-  owner,
 } from "../../../types/constants";
+import {
+  categoryBusinessService,
+  categoryName,
+  categoryOwner,
+} from "../../../types/filter-categories";
 
 const now = new Date();
 now.setDate(now.getDate() + 1);
@@ -98,13 +100,13 @@ describe(
       cy.contains(manageApplications).click();
 
       // Enter an existing exact name and apply it as search filter
-      applySearchFilter(name, applicationsList[1].name, true, 1);
+      applySearchFilter(categoryName, applicationsList[1].name, true, 1);
       cy.get("td").should("contain", applicationsList[1].name);
       cy.get("td").should("not.contain", applicationsList[0].name);
       clickByText(button, clearAllFilters);
 
       // Enter a non-existing app name and apply it as search filter
-      applySearchFilter(name, String(data.getRandomNumber()), true, 1);
+      applySearchFilter(categoryName, String(data.getRandomNumber()), true, 1);
       cy.get("td").should("not.contain", applicationsList[1].name);
       cy.get("td").should("not.contain", applicationsList[0].name);
       clickByText(button, clearAllFilters);
@@ -130,7 +132,7 @@ describe(
 
       // Apply BS associated with applicationsList[1].name as search filter
       applySearchFilter(
-        businessServiceLower,
+        categoryBusinessService,
         applicationsList[1].business,
         true,
         1
@@ -141,7 +143,7 @@ describe(
 
       // Apply BS associated with applicationsList[0].name as search filter
       applySearchFilter(
-        businessServiceLower,
+        categoryBusinessService,
         applicationsList[0].business,
         true,
         1
@@ -170,13 +172,13 @@ describe(
       cy.contains(manageApplications).click();
 
       // Apply owner associated with applicationsList[1].name as search filter
-      applySearchFilter(owner, stakeholders[1].name, true, 1);
+      applySearchFilter(categoryOwner, stakeholders[1].name, true, 1);
       cy.get("td").should("contain", applicationsList[1].name);
       cy.get("td").should("not.contain", applicationsList[0].name);
       clickByText(button, clearAllFilters);
 
       // Apply owner associated with applicationsList[0].name as search filter
-      applySearchFilter(owner, stakeholders[0].name, true, 1);
+      applySearchFilter(categoryOwner, stakeholders[0].name, true, 1);
       cy.get("td").should("not.contain", applicationsList[1].name);
       cy.get("td").should("contain", applicationsList[0].name);
       clickByText(button, clearAllFilters);

--- a/cypress/e2e/tests/migration/reports-tab/filter.test.ts
+++ b/cypress/e2e/tests/migration/reports-tab/filter.test.ts
@@ -73,11 +73,7 @@ describe(["@tier3", "@tier3_D"], "Reports Tab filter validations", function () {
   identifiedRisksFilterValidations.forEach((validation) => {
     it(`Filtering identified risks by ${validation.name}`, function () {
       Reports.open(100);
-      applySelectFilter(
-        validation.id,
-        new RegExp(`^${validation.name}$`),
-        validation.text
-      );
+      applySelectFilter(validation.id, validation.id, validation.text);
       exists(validation.should);
       notExists(validation.shouldNot);
       clearAllFilters();

--- a/cypress/e2e/types/constants.ts
+++ b/cypress/e2e/types/constants.ts
@@ -1,3 +1,20 @@
+import {
+  categoryApplication,
+  categoryApplicationId,
+  categoryApplicationName,
+  categoryBusinessServiceName,
+  categoryCategory,
+  categoryCreateUser,
+  categoryId,
+  categoryKind,
+  categoryName,
+  categoryProvider,
+  categorySource,
+  categoryStatus,
+  categoryTagId,
+  categoryTarget,
+} from "./filter-categories";
+
 /*
 Copyright © 2021 the Konveyor Contributors (https://konveyor.io/)
 
@@ -38,7 +55,6 @@ export const confidence = "Confidence";
 export const createNewButton = "Create new";
 export const criticality = "Criticality";
 export const credentials = "Credentials";
-export const credentialType = "Credential type";
 export const setAsDefaultAction = "Set as default";
 export const unsetAsDefaultAction = "Remove default";
 export const deleteAction = "Delete";
@@ -203,22 +219,22 @@ export enum SortType {
 }
 
 export enum dynamicReportFilter {
-  applicationName = "Application name",
-  archetype = "Archetype",
-  bs = "Business service",
-  tags = "Tags",
-  category = "Category",
-  source = "Source",
-  target = "Target",
+  applicationName = categoryApplicationName,
+  archetypes = categoryApplicationId,
+  bs = categoryBusinessServiceName,
+  tags = categoryTagId,
+  category = categoryCategory,
+  source = categorySource,
+  target = categoryTarget,
 }
 
 export enum dependencyFilter {
-  appName = "Application name",
-  archetype = "Archetype",
-  bs = "Business service",
-  tags = "Tags",
-  deppName = "Name",
-  language = "Language",
+  appName = categoryApplicationName,
+  archetypes = categoryApplicationId,
+  bs = categoryBusinessServiceName,
+  tags = categoryTagId,
+  deppName = categoryName,
+  language = categoryProvider,
 }
 
 export enum Languages {
@@ -246,11 +262,11 @@ export enum TaskKind {
 }
 
 export enum TaskFilter {
-  applicationName = "Application",
-  id = "ID",
-  status = "Status",
-  kind = "Kind",
-  createdBy = "Created By",
+  applicationName = categoryApplication,
+  id = categoryId,
+  status = categoryStatus,
+  kind = categoryKind,
+  createdBy = categoryCreateUser,
 }
 
 export enum appInventoryKebab {

--- a/cypress/e2e/types/constants.ts
+++ b/cypress/e2e/types/constants.ts
@@ -1,3 +1,18 @@
+/*
+Copyright © 2021 the Konveyor Contributors (https://konveyor.io/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 import {
   categoryApplication,
   categoryApplicationId,
@@ -14,22 +29,6 @@ import {
   categoryTagId,
   categoryTarget,
 } from "./filter-categories";
-
-/*
-Copyright © 2021 the Konveyor Contributors (https://konveyor.io/)
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 export const sourceCode = "Source code";
 export const answer = "Answer";
 export const applicationName = "Application name";

--- a/cypress/e2e/types/filter-categories.ts
+++ b/cypress/e2e/types/filter-categories.ts
@@ -1,0 +1,42 @@
+export const categoryType = "type";
+export const categoryCreatedBy = "createdBy";
+export const categoryDefaultCredential = "";
+export const categoryName = "name";
+export const categoryOwner = "owner";
+export const categoryRepositoryType = "repository";
+export const categoryBinary = "binary";
+export const categoryStakeholderGroups = "stakeholderGroups";
+export const categoryBusinessService = "businessService";
+export const categoryIdentities = "identities";
+export const categoryProvider = "provider";
+export const categoryColor = "color";
+export const categoryEmail = "email";
+export const categoryJobFunction = "jobFunction";
+export const categoryDescription = "description";
+export const categoryStakeholders = "stakeholders";
+export const categoryFileName = "filename";
+export const categoryArchetypes = "archetypes";
+export const categoryId = "id";
+export const categoryStatus = "state";
+export const categoryKind = "kind";
+export const categoryCreateUser = "createUser";
+export const categoryApplication = "application";
+export const categoryApplicationName = "application.name";
+export const categoryBusinessServiceName = "businessService.name";
+export const categoryTagId = "tag.id";
+export const categoryRisk = "risk";
+export const categoryTags = "tags";
+export const categoryCategory = "category";
+export const categorySource = "source";
+export const categoryTarget = "target";
+export const categoryApplicationId = "application.id";
+export const filterSelectType = (categoryKey: string) =>
+  `[data-ouia-component-id="select-filter-value-${categoryKey}"]`;
+/**
+ * Main filter dropdown is based on the HTML id attribute
+ * ouiaId is passed (as of PF5) to the wrapping <li> element
+ * which has no onClick handler
+ */
+export const filterCategory = (categoryKey: string) =>
+  // this syntax works with dots in the categoryKey
+  `[id="filter-category-${categoryKey}"]`;

--- a/cypress/e2e/views/common.view.ts
+++ b/cypress/e2e/views/common.view.ts
@@ -25,7 +25,7 @@ export const removeButton = "button[aria-label='Remove']";
 export const clearAllButton = "button[aria-label='Clear all']";
 export const controlsForm = "form.pf-v5-c-form";
 export const itemsPerPageMenu = "div.pf-c-options-menu";
-export const filteredBy = "#filtered-by";
+export const filteredBy = '[data-ouia-component-id="filtered-by"]';
 export const itemsPerPageMenuOptions = "ul.pf-v5-c-menu__list";
 export const expandRow = "button[aria-label=Details]";
 export const successAlertMessage = ".pf-m-success";

--- a/cypress/e2e/views/credentials.view.ts
+++ b/cypress/e2e/views/credentials.view.ts
@@ -23,13 +23,6 @@ export const privatePassphraseInput =
   "input[aria-label='Private Key Passphrase']";
 export const createBtn = "#create-credential-button";
 export const selectType = '[data-ouia-component-id="type-select-toggle"]';
-export const filteredBy = "#filtered-by";
-export const filterCategory = "#filter-category-name";
-export const filterCatType = "#filter-category-type";
-export const filterCatCreatedBy = "#filter-category-createdBy";
-export const filterSelectType =
-  '[data-ouia-component-id="select-filter-value-select"]';
-export const filterCatDefaultCredential = "#filter-category-";
 export const searchButton = "#search-button";
 export const modalBoxBody = "#confirm-dialog";
 export const defaultIcon = "svg.pf-v5-svg";

--- a/cypress/e2e/views/custom-migration-target.view.ts
+++ b/cypress/e2e/views/custom-migration-target.view.ts
@@ -25,5 +25,5 @@ export enum CustomMigrationTargetView {
   cardContainer = 'div[class*="gallery"][class*="gutter"]',
   filterLanguageDropdown = "#filter-control-provider-Languages",
   formLanguageDropdown = '[data-ouia-component-id="provider-type-select-toggle"]',
-  formLanguageDropdownOptions = "#provider-type-select",
+  formLanguageDropdownOptions = '[data-ouia-component-id="provider-type-select-toggle-select"]',
 }

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -46,7 +46,6 @@ import {
   button,
   confidence,
   criticality,
-  dynamicReportFilter,
   groupCount,
   memberCount,
   migration,
@@ -57,6 +56,10 @@ import {
   tdTag,
   trTag,
 } from "../e2e/types/constants";
+import {
+  filterCategory,
+  filterSelectType,
+} from "../e2e/types/filter-categories";
 import {
   AppIssue,
   JiraConnectionData,
@@ -110,19 +113,14 @@ import {
   removeButton,
   searchButton,
   sideDrawer,
-  span,
   standardFilter,
   submitButton,
   successAlertMessage,
   taskDetailsEditor,
 } from "../e2e/views/common.view";
-import { filterSelectType } from "../e2e/views/credentials.view";
 import {
-  bsFilterName,
-  searchInput,
   searchMenuToggle,
   singleApplicationColumns,
-  tagFilterName,
 } from "../e2e/views/issue.view";
 import * as loginView from "../e2e/views/login.view";
 import { navMenu, navTab } from "../e2e/views/menu.view";
@@ -536,25 +534,17 @@ export function notExists(value: string, tableSelector = appTable): void {
   });
 }
 
-export function selectFilter(filterName: string, eq = 0): void {
+export function selectFilter(categoryKey: string, eq = 0): void {
   if (eq === 0) {
     cy.get(filteredBy).click();
-    clickWithinByText(
-      'div[class="pf-v5-c-menu__content"]',
-      "button",
-      filterName
-    );
+    cy.get(filterCategory(categoryKey)).click();
     return;
   }
   cy.get("div.pf-m-filter-group")
     .eq(eq)
     .within(() => {
       cy.get(filteredBy).click();
-      clickWithinByText(
-        'div[class="pf-v5-c-menu__content"]',
-        "button",
-        filterName
-      );
+      cy.get(filterCategory(categoryKey)).click();
     });
 }
 
@@ -565,46 +555,6 @@ export function filterInputText(searchTextValue: string, value: number): void {
 
 export function clearAllFilters(): void {
   cy.contains(button, "Clear all filters").click({ force: true });
-}
-
-export function filterIssueBy(
-  filterType: dynamicReportFilter,
-  filterValue: string | string[]
-): void {
-  let selector = "";
-  selectFilter(filterType);
-  const isApplicableFilter =
-    filterType === dynamicReportFilter.applicationName ||
-    filterType === dynamicReportFilter.category ||
-    filterType === dynamicReportFilter.source ||
-    filterType === dynamicReportFilter.target;
-
-  if (isApplicableFilter) {
-    if (Array.isArray(filterValue)) {
-      filterValue.forEach((current) => {
-        inputText(searchInput, current);
-        click(searchButton);
-      });
-    } else {
-      inputText(searchInput, filterValue);
-      click(searchButton);
-    }
-  } else {
-    if (filterType == dynamicReportFilter.bs) {
-      selector = bsFilterName;
-    } else if (filterType == dynamicReportFilter.tags) {
-      selector = tagFilterName;
-    }
-    click(selector);
-    if (Array.isArray(filterValue)) {
-      filterValue.forEach((name) => {
-        clickByText(span, name);
-      });
-    } else {
-      clickByText(span, filterValue);
-    }
-    click(selector);
-  }
 }
 
 export function validateSingleApplicationIssue(issue: AppIssue): void {
@@ -658,8 +608,8 @@ export function applySearchFilter(
         cy.get(standardFilter).contains(searchTextValue).click();
       });
     } else {
-      if ($container.find(filterSelectType).length > 0) {
-        cy.get(filterSelectType).click();
+      if ($container.find(filterSelectType(filterName)).length > 0) {
+        cy.get(filterSelectType(filterName)).click();
         filterValue.forEach((searchTextValue) => {
           cy.get(standardFilter).contains(searchTextValue).click();
         });


### PR DESCRIPTION
Resolves: https://github.com/konveyor/tackle2-ui/issues/3200

Changes:
1. drop selectors based on human readable labels
2. use PF specific data test IDs (ouiaId) where possible

Note that main filter dropdown that toggles between categories
need to continue using HTML id prop because ouiaId is applied
to the outer li tag (which has no onClick callback).

For SimpleSelect additionally:
1. enable isScrollable and isFullWidth by default as it's widely used
2. remove id prop and replace the only actual usage with ouiaId

Reference-Url: https://www.patternfly.org/developer-resources/open-ui-automation/#ouia-compliant-patternfly-5-components
Assisted-by: Cursor:claude-4.6-opus-high

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated dropdown components with refined default behaviors for better consistency across the application.
  * Refactored internal filter infrastructure to use category-based identifiers for improved test maintainability.
  * Transitioned from ID-based to attribute-based selectors for enhanced automation stability.

* **Chores**
  * Consolidated filter helper utilities for cleaner test code and reduced duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->