### PR TITLE
:bug: Display application discovery manifest as YAML content (#3184)

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -169,6 +169,13 @@ export interface Application {
   effort?: number;
 }
 
+export interface ApplicationManifest {
+  id: number;
+  content: JsonDocument;
+  secret?: JsonDocument;
+  application: Ref;
+}
+
 export interface Review {
   id: number;
   proposedAction: ProposedAction;
@@ -369,29 +376,34 @@ export interface Task<DataType> {
   attached?: TaskAttachment[];
 }
 
-export interface AnalysisTask
-  extends Omit<Task<AnalysisTaskData>, "application" | "platform"> {
+export interface AnalysisTask extends Omit<
+  Task<AnalysisTaskData>,
+  "application" | "platform"
+> {
   kind: "analysis";
   application: Ref;
 }
 
-export interface ApplicationManifestTask
-  extends Omit<Task<EmptyObject>, "application" | "platform"> {
+export interface ApplicationManifestTask extends Omit<
+  Task<EmptyObject>,
+  "application" | "platform"
+> {
   kind: "application-manifest";
   application: Ref;
 }
 
-export interface ApplicationAssetGenerationTask
-  extends Omit<Task<AssetGenerationTaskData>, "application" | "platform"> {
+export interface ApplicationAssetGenerationTask extends Omit<
+  Task<AssetGenerationTaskData>,
+  "application" | "platform"
+> {
   kind: "asset-generation";
   application: Ref;
 }
 
-export interface PlatformApplicationImportTask
-  extends Omit<
-    Task<PlatformApplicationImportTaskData>,
-    "application" | "platform"
-  > {
+export interface PlatformApplicationImportTask extends Omit<
+  Task<PlatformApplicationImportTaskData>,
+  "application" | "platform"
+> {
   kind: "application-import";
   platform: Ref;
 }
@@ -895,8 +907,10 @@ export interface InitialAssessment {
   archetype?: Ref;
   questionnaire: Ref;
 }
-export interface Assessment
-  extends Pick<Questionnaire, "thresholds" | "sections" | "riskMessages"> {
+export interface Assessment extends Pick<
+  Questionnaire,
+  "thresholds" | "sections" | "riskMessages"
+> {
   name: string;
   id: number;
   application?: Ref;
@@ -971,8 +985,7 @@ export interface AssessmentWithSectionOrder extends Assessment {
   sections: SectionWithQuestionOrder[];
 }
 
-export interface AssessmentWithArchetypeApplications
-  extends AssessmentWithSectionOrder {
+export interface AssessmentWithArchetypeApplications extends AssessmentWithSectionOrder {
   archetypeApplications: Ref[];
 }
 export interface AssessmentsWithArchetype {

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -376,34 +376,29 @@ export interface Task<DataType> {
   attached?: TaskAttachment[];
 }
 
-export interface AnalysisTask extends Omit<
-  Task<AnalysisTaskData>,
-  "application" | "platform"
-> {
+export interface AnalysisTask
+  extends Omit<Task<AnalysisTaskData>, "application" | "platform"> {
   kind: "analysis";
   application: Ref;
 }
 
-export interface ApplicationManifestTask extends Omit<
-  Task<EmptyObject>,
-  "application" | "platform"
-> {
+export interface ApplicationManifestTask
+  extends Omit<Task<EmptyObject>, "application" | "platform"> {
   kind: "application-manifest";
   application: Ref;
 }
 
-export interface ApplicationAssetGenerationTask extends Omit<
-  Task<AssetGenerationTaskData>,
-  "application" | "platform"
-> {
+export interface ApplicationAssetGenerationTask
+  extends Omit<Task<AssetGenerationTaskData>, "application" | "platform"> {
   kind: "asset-generation";
   application: Ref;
 }
 
-export interface PlatformApplicationImportTask extends Omit<
-  Task<PlatformApplicationImportTaskData>,
-  "application" | "platform"
-> {
+export interface PlatformApplicationImportTask
+  extends Omit<
+    Task<PlatformApplicationImportTaskData>,
+    "application" | "platform"
+  > {
   kind: "application-import";
   platform: Ref;
 }
@@ -907,10 +902,8 @@ export interface InitialAssessment {
   archetype?: Ref;
   questionnaire: Ref;
 }
-export interface Assessment extends Pick<
-  Questionnaire,
-  "thresholds" | "sections" | "riskMessages"
-> {
+export interface Assessment
+  extends Pick<Questionnaire, "thresholds" | "sections" | "riskMessages"> {
   name: string;
   id: number;
   application?: Ref;
@@ -985,7 +978,8 @@ export interface AssessmentWithSectionOrder extends Assessment {
   sections: SectionWithQuestionOrder[];
 }
 
-export interface AssessmentWithArchetypeApplications extends AssessmentWithSectionOrder {
+export interface AssessmentWithArchetypeApplications
+  extends AssessmentWithSectionOrder {
   archetypeApplications: Ref[];
 }
 export interface AssessmentsWithArchetype {

--- a/client/src/app/api/rest/applications.ts
+++ b/client/src/app/api/rest/applications.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { Application, JsonDocument, New } from "../models";
+import { Application, ApplicationManifest, New } from "../models";
 import { hub, template } from "../rest";
 
 const APPLICATIONS = hub`/applications`;
@@ -24,7 +24,9 @@ export const getApplicationById = (id: number | string) =>
 
 export const getApplicationManifest = (applicationId: number | string) =>
   axios
-    .get<JsonDocument>(template(APPLICATION_MANIFEST, { id: applicationId }))
+    .get<ApplicationManifest>(
+      template(APPLICATION_MANIFEST, { id: applicationId })
+    )
     .then((response) => response.data);
 
 export const getApplications = () =>

--- a/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaAsCodeEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import * as jsYaml from "js-yaml";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
   EmptyState,
@@ -11,8 +12,6 @@ import {
 import { JsonSchemaObject } from "@app/api/models";
 
 import { jsonSchemaToYupSchema } from "./utils";
-
-export { Language } from "@patternfly/react-code-editor";
 
 type ControlledEditor = {
   focus: () => void;
@@ -32,7 +31,27 @@ export interface ISchemaAsCodeEditorProps {
    * Set to "100%" to make the editor take up the full height of its container.
    */
   height?: string;
+  /** Language for the editor. Defaults to Language.json. */
+  editorLanguage?: Language.json | Language.yaml;
 }
+
+const jsonDocumentToCode = (
+  jsonDocument: object,
+  editorLanguage: Language.json | Language.yaml
+) => {
+  return editorLanguage === Language.yaml
+    ? jsYaml.dump(jsonDocument, { indent: 2 })
+    : JSON.stringify(jsonDocument, null, 2);
+};
+
+const codeToJsonDocument = (
+  code: string,
+  editorLanguage: Language.json | Language.yaml
+): unknown => {
+  return editorLanguage === Language.yaml
+    ? jsYaml.load(code)
+    : JSON.parse(code);
+};
 
 export const SchemaAsCodeEditor = ({
   id,
@@ -41,13 +60,13 @@ export const SchemaAsCodeEditor = ({
   onDocumentChanged,
   isReadOnly = false,
   height = "600px",
+  editorLanguage = Language.json,
 }: ISchemaAsCodeEditorProps) => {
   const editorRef = useRef<ControlledEditor>();
 
-  const [currentCode, setCurrentCode] = useState(
-    JSON.stringify(jsonDocument, null, 2)
+  const [currentCode, setCurrentCode] = useState(() =>
+    jsonDocumentToCode(jsonDocument, editorLanguage)
   );
-  // const [documentIsValid, setDocumentIsValid] = React.useState(true);
 
   const focusMovedOnSelectedDocumentChange = useRef<boolean>(false);
   useEffect(() => {
@@ -72,12 +91,17 @@ export const SchemaAsCodeEditor = ({
     setCurrentCode(newValue);
     if (onDocumentChanged) {
       try {
-        const asJson = JSON.parse(newValue);
-        if (!validator || validator.isValidSync(asJson)) {
-          onDocumentChanged(asJson);
+        const parsed = codeToJsonDocument(newValue, editorLanguage);
+
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          (!validator || validator.isValidSync(parsed))
+        ) {
+          onDocumentChanged(parsed as object);
         }
-      } catch (error) {
-        // ignore invalid JSON, the change will be ignored
+      } catch {
+        // ignore invalid document, the change will be ignored
       }
     }
   };
@@ -93,11 +117,15 @@ export const SchemaAsCodeEditor = ({
       isReadOnly={isReadOnly}
       height={height}
       downloadFileName="my-schema-download"
-      language={Language.json}
+      language={editorLanguage}
       code={currentCode}
+      options={{
+        fontFamily: '"Red Hat Mono", "Courier New", Courier, monospace',
+      }}
       onChange={handleCodeChange}
       onEditorDidMount={(editor, monaco) => {
         editorRef.current = editor as ControlledEditor;
+        document.fonts?.ready?.then(() => monaco.editor.remeasureFonts());
         if (jsonSchema) {
           monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
             validate: true,

--- a/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
+++ b/client/src/app/components/schema-defined-fields/SchemaDefinedFields.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Language } from "@patternfly/react-code-editor";
 import { Panel, PanelHeader, PanelMain, Switch } from "@patternfly/react-core";
 
 import { JsonSchemaObject } from "@app/api/models";
@@ -7,7 +8,6 @@ import { SchemaAsCodeEditor } from "./SchemaAsCodeEditor";
 import { SchemaAsFields } from "./SchemaAsFields";
 import { isComplexSchema } from "./utils";
 
-export { Language } from "@patternfly/react-code-editor";
 export interface ISchemaDefinedFieldProps {
   id?: string;
   className?: string;
@@ -15,6 +15,8 @@ export interface ISchemaDefinedFieldProps {
   jsonSchema?: JsonSchemaObject;
   onDocumentChanged?: (newJsonDocument: object) => void;
   isReadOnly?: boolean;
+  /** Language for the editor if the document/schema cannot render as fields. Defaults to Language.json. */
+  editorLanguage?: Language.json | Language.yaml;
 }
 
 export const SchemaDefinedField = ({
@@ -24,6 +26,7 @@ export const SchemaDefinedField = ({
   jsonSchema,
   onDocumentChanged,
   isReadOnly = false,
+  editorLanguage = Language.json,
 }: ISchemaDefinedFieldProps) => {
   const [isJsonView, setIsJsonView] = useState<boolean>(
     !jsonSchema || isComplexSchema(jsonSchema)
@@ -45,7 +48,7 @@ export const SchemaDefinedField = ({
         <PanelHeader>
           <Switch
             id={`${id}-json-toggle`}
-            label="JSON"
+            label={editorLanguage === Language.json ? "JSON" : "YAML"}
             isChecked={isJsonView}
             onChange={() => setIsJsonView(!isJsonView)}
           />
@@ -60,6 +63,7 @@ export const SchemaDefinedField = ({
             jsonDocument={jsonDocument}
             jsonSchema={jsonSchema}
             onDocumentChanged={onChangeHandler}
+            editorLanguage={editorLanguage}
           />
         ) : (
           <SchemaAsFields

--- a/client/src/app/devtools/schema-defined/schema-defined-page.tsx
+++ b/client/src/app/devtools/schema-defined/schema-defined-page.tsx
@@ -71,6 +71,9 @@ export const SchemaDefinedPage: React.FC = () => {
   const [parsedSchema, setParsedSchema] = useState<
     JsonSchemaObject | undefined
   >(example1 as JsonSchemaObject);
+  const [editorLanguage, setEditorLanguage] = useState<
+    Language.json | Language.yaml
+  >(Language.json);
 
   const [currentDocument, setCurrentDocument] = useState<object | null>(null);
 
@@ -146,6 +149,40 @@ export const SchemaDefinedPage: React.FC = () => {
     );
   };
 
+  const EditorActions = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <Dropdown
+        onSelect={() => setIsOpen(false)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            isExpanded={isOpen}
+            onClick={() => setIsOpen((current) => !current)}
+            variant="plain"
+          >
+            <EllipsisVIcon aria-hidden="true" />
+          </MenuToggle>
+        )}
+        isOpen={isOpen}
+        onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+      >
+        <DropdownList>
+          {[Language.json, Language.yaml].map((language, index) => (
+            <DropdownItem
+              key={`language-${index}`}
+              onClick={() =>
+                setEditorLanguage(language as Language.json | Language.yaml)
+              }
+            >
+              {language === Language.json ? "JSON" : "YAML"}
+            </DropdownItem>
+          ))}
+        </DropdownList>
+      </Dropdown>
+    );
+  };
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -198,12 +235,15 @@ export const SchemaDefinedPage: React.FC = () => {
 
               <GridItem span={6}>
                 <Card isFullHeight isCompact>
-                  <CardTitle>SchemaDefinedFields</CardTitle>
+                  <CardHeader actions={{ actions: <EditorActions /> }}>
+                    <CardTitle>SchemaDefinedFields</CardTitle>
+                  </CardHeader>
                   <CardBody className="full-height-container">
                     <SchemaDefinedField
                       id="demo-schema-field"
                       jsonDocument={currentDocument ?? {}}
                       jsonSchema={parsedSchema}
+                      editorLanguage={editorLanguage}
                       onDocumentChanged={handleDocumentChange}
                     />
                   </CardBody>

--- a/client/src/app/pages/applications/application-detail-drawer/tab-platform-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-platform-content.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
+import { Language } from "@patternfly/react-code-editor";
 
 import { EmptyTextMessage } from "@app/components/EmptyTextMessage";
 import {
@@ -58,8 +59,12 @@ export const TabPlatformContent: React.FC<{
       </DrawerTabContentSection>
 
       <DrawerTabContentSection label={t("terms.applicationDiscoveryManifest")}>
-        {manifest ? (
-          <SchemaDefinedField isReadOnly jsonDocument={manifest} />
+        {manifest?.content ? (
+          <SchemaDefinedField
+            isReadOnly
+            jsonDocument={manifest.content}
+            editorLanguage={Language.yaml}
+          />
         ) : (
           <EmptyTextMessage />
         )}


### PR DESCRIPTION
MTA-6774: The manifest drawer was rendering the full database record as JSON. Now extracts only the `content` field and renders it as YAML using js-yaml. Also fixes Monaco space-width rendering in Firefox by pinning the editor font family.

## Summary by CodeRabbit

* **New Features**
  * Code editor now supports switching between JSON and YAML highlighting with a UI dropdown and uses consistent monospace styling.
  * Dev tools and schema editor propagate the selected language for improved editing and display.

* **Bug Fixes**
  * Manifest tab only shows the manifest editor when manifest content exists, otherwise displays an empty message.

---------

Assisted-by: Cursor:claude-sonnet-4-5