### PR TITLE
:ghost: Update tsconfig target to es2023

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -9,8 +9,8 @@
 
     "module": "es2022",
     "moduleResolution": "bundler",
-    "target": "es2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "target": "es2023",
+    "lib": ["es2022", "es2023.array", "DOM", "DOM.Iterable"],
     "typeRoots": ["types", "node_modules/@types", "../node_modules/@types"],
 
     "strict": true,

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -9,8 +9,8 @@
 
     "module": "es2022",
     "moduleResolution": "bundler",
-    "target": "es2022",
-    "lib": ["ES2022"],
+    "target": "es2023",
+    "lib": ["es2022", "es2023.array"],
 
     "strict": true,
     "resolveJsonModule": true,

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "target": "es2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "target": "es2023",
+    "lib": ["es2022", "es2023.array", "DOM", "DOM.Iterable"],
     "module": "es2022",
     "moduleResolution": "bundler",
     "types": [


### PR DESCRIPTION
Limit the available es2023 features to widely available Array features.
Blocker from full adoption is es2023 WeakMap feature which was implemented in December 2025 by Firefox.

Compatibility table shows that Chrome added support the ECMAScript 2023 (ES14) Array features from January 2022 to February 2023. Other major browsers followed. 

Reference-Url: https://caniuse.com/mdn-javascript_builtins_array_findlast,mdn-javascript_builtins_array_findlastindex,mdn-javascript_builtins_array_toreversed,mdn-javascript_builtins_array_tosorted,mdn-javascript_builtins_array_tospliced,mdn-javascript_builtins_array_with

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project TypeScript compilation settings to target a newer JavaScript standard and refreshed included library typings. This improves compatibility with modern language features, tooling, and runtime environments across the app, test, and shared toolchains without changing any public APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->