### PR TITLE
:test_tube: Interop Dockerfile: WORKDIR to cypress after root install

### DIFF
--- a/cypress/dockerfiles/interop/Dockerfile
+++ b/cypress/dockerfiles/interop/Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir /tmp/tackle-ui-tests
 WORKDIR /tmp/tackle-ui-tests
 COPY . .
 RUN npm install .
+WORKDIR /tmp/tackle-ui-tests/cypress
 
 # Set required permissions for OpenShift usage
 RUN chgrp -R 0 /tmp && \


### PR DESCRIPTION
**Summary**
After installing dependencies from the repository root (`npm install .`), set `WORKDIR `to the Cypress package directory so the default process working directory matches what OpenShift CI expects when running the mta-tests-ui step (scripts, .env, npm run mergereports, etc.—same as local runs from cypress/).

**Why**
Interop image builds use repo root as Docker context (see` openshift/release: context_dir: .` and `dockerfile_path: cypress/dockerfiles/interop/Dockerfile`). Install runs at `/tmp/tackle-ui-tests `(repo root); without a final WORKDIR under cypress, commands in the test step would run from the wrong directory.

**Change**
Add `WORKDIR /tmp/tackle-ui-tests/cypress` after `RUN npm install .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal build configuration for testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->