### PR TITLE
:bug: Prevent Take assessment button from flickering

### DIFF
--- a/client/src/app/pages/assessment/components/assessment-actions/components/assessment-actions-table.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/assessment-actions-table.tsx
@@ -56,7 +56,7 @@ const AssessmentActionsTable: React.FC<AssessmentActionsTableProps> = ({
         archetype={archetype}
         questionnaires={requiredQuestionnaires}
         assessments={assessments}
-        isFetching={isFetchingQuestionnaires || isFetchingAssessmentsById}
+        isLoading={isFetchingQuestionnaires || isFetchingAssessmentsById}
         tableName="Required questionnaires"
       />
       {filteredArchivedAssessments.length === 0 ? null : (
@@ -66,7 +66,7 @@ const AssessmentActionsTable: React.FC<AssessmentActionsTableProps> = ({
           isReadonly
           questionnaires={filteredArchivedQuestionnaires}
           assessments={filteredArchivedAssessments}
-          isFetching={isFetchingQuestionnaires || isFetchingAssessmentsById}
+          isLoading={isFetchingQuestionnaires || isFetchingAssessmentsById}
           tableName="Archived questionnaires"
         />
       )}

--- a/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/dynamic-assessment-actions-row.tsx
@@ -1,21 +1,9 @@
-import {
-  FunctionComponent,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
-import {
-  useIsFetching,
-  useIsMutating,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { FunctionComponent, useCallback, useContext } from "react";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
-import { Button, Spinner } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 import { TrashIcon } from "@patternfly/react-icons";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 import { Td } from "@patternfly/react-table";
 
 import { Paths } from "@app/Paths";
@@ -30,7 +18,6 @@ import { NotificationsContext } from "@app/components/NotificationsContext";
 import useIsArchetype from "@app/hooks/useIsArchetype";
 import {
   addSectionOrderToQuestions,
-  assessmentsByItemIdQueryKey,
   useCreateAssessmentMutation,
   useDeleteAssessmentMutation,
 } from "@app/queries/assessments";
@@ -66,18 +53,14 @@ const DynamicAssessmentActionsRow: FunctionComponent<
   const isArchetype = useIsArchetype();
   const history = useHistory();
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
 
   const { pushNotification } = useContext(NotificationsContext);
 
   const onSuccessHandler = () => {};
   const onErrorHandler = () => {};
 
-  const { mutateAsync: createAssessmentAsync } = useCreateAssessmentMutation(
-    isArchetype,
-    onSuccessHandler,
-    onErrorHandler
-  );
+  const { mutateAsync: createAssessmentAsync, isLoading: isCreating } =
+    useCreateAssessmentMutation(isArchetype, onSuccessHandler, onErrorHandler);
 
   const onDeleteAssessmentSuccess = (name: string) => {
     pushNotification({
@@ -86,11 +69,6 @@ const DynamicAssessmentActionsRow: FunctionComponent<
       }),
       variant: "success",
     });
-    queryClient.invalidateQueries([
-      assessmentsByItemIdQueryKey,
-      application?.id,
-      isArchetype,
-    ]);
   };
 
   const onDeleteError = (error: AxiosError) => {
@@ -103,9 +81,6 @@ const DynamicAssessmentActionsRow: FunctionComponent<
   const { mutate: deleteAssessment, isLoading: isDeleting } =
     useDeleteAssessmentMutation(onDeleteAssessmentSuccess, onDeleteError);
 
-  const isFetching = useIsFetching();
-  const isMutating = useIsMutating();
-
   const determineAction = useCallback(() => {
     if (!assessment) {
       return AssessmentAction.Take;
@@ -116,20 +91,16 @@ const DynamicAssessmentActionsRow: FunctionComponent<
     }
   }, [assessment]);
 
-  const [action, setAction] = useState(determineAction());
+  const action = determineAction();
 
-  useEffect(() => {
-    setAction(determineAction());
-  }, [determineAction, assessment]);
-
-  const determineButtonClassName = () => {
-    const action = determineAction();
+  const determineButtonClassName = useCallback(() => {
     if (action === AssessmentAction.Continue) {
       return "continue-button";
     } else if (action === AssessmentAction.Retake) {
       return "retake-button";
     }
-  };
+    return "";
+  }, [action]);
 
   const createAssessment = async () => {
     const newAssessment: InitialAssessment = {
@@ -201,21 +172,19 @@ const DynamicAssessmentActionsRow: FunctionComponent<
     <>
       <Td className="actions-col">
         <div>
-          {isReadonly ? null : !isDeleting && !isFetching && !isMutating ? (
+          {isReadonly ? null : (
             <Button
               type="button"
               variant="primary"
               className={determineButtonClassName()}
+              isDisabled={isCreating || isDeleting}
+              isLoading={isCreating || isDeleting}
               onClick={() => {
                 onHandleAssessmentAction();
               }}
             >
               {action}
             </Button>
-          ) : (
-            <Spinner role="status" size="md" className={spacing.mxLg}>
-              <span className="sr-only">Loading...</span>
-            </Spinner>
           )}
           {assessment?.status === "complete" ? (
             <Button

--- a/client/src/app/pages/assessment/components/assessment-actions/components/questionnaires-table.tsx
+++ b/client/src/app/pages/assessment/components/assessment-actions/components/questionnaires-table.tsx
@@ -23,7 +23,7 @@ import DynamicAssessmentActionsRow from "./dynamic-assessment-actions-row";
 
 interface QuestionnairesTableProps {
   tableName: string;
-  isFetching: boolean;
+  isLoading: boolean;
   isReadonly?: boolean;
   application?: Application;
   archetype?: Archetype;
@@ -38,6 +38,7 @@ const QuestionnairesTable: React.FC<QuestionnairesTableProps> = ({
   application,
   archetype,
   tableName,
+  isLoading,
 }) => {
   const tableControls = useLocalTableControls({
     tableName: "questionnaires-table",
@@ -86,6 +87,7 @@ const QuestionnairesTable: React.FC<QuestionnairesTableProps> = ({
         <ConditionalTableBody
           isNoData={questionnaires?.length === 0}
           numRenderedColumns={numRenderedColumns}
+          isLoading={isLoading}
           noDataEmptyState={
             <div>
               <NoDataEmptyState title="No Questionnaires are currently available to be taken. " />

--- a/client/src/app/pages/assessment/components/view-archetypes/components/view-archetypes-table.tsx
+++ b/client/src/app/pages/assessment/components/view-archetypes/components/view-archetypes-table.tsx
@@ -51,7 +51,7 @@ const ViewArchetypesTable: React.FC<ViewArchetypesTableProps> = ({
         archetype={archetype}
         questionnaires={requiredQuestionnaires}
         assessments={assessments}
-        isFetching={isFetchingQuestionnaires || isFetchingAssessmentsById}
+        isLoading={isFetchingQuestionnaires || isFetchingAssessmentsById}
         tableName="Required questionnaires"
       />
       {filteredArchivedAssessments.length === 0 ? null : (
@@ -60,7 +60,7 @@ const ViewArchetypesTable: React.FC<ViewArchetypesTableProps> = ({
           isReadonly
           questionnaires={filteredArchivedQuestionnaires}
           assessments={filteredArchivedAssessments}
-          isFetching={isFetchingQuestionnaires || isFetchingAssessmentsById}
+          isLoading={isFetchingQuestionnaires || isFetchingAssessmentsById}
           tableName="Archived questionnaires"
         />
       )}


### PR DESCRIPTION
Re-rendering was caused by reading the global isFetching and isMutation state.

Changes:
1. for initial loading propagate isLoading flag from the parent
2. for updates within the row use isCreating and isDeleting flags provided by the mutate methods
3. indicate loading state using isLoading state supported by Button component
4. drop duplicated cache invalidation (already triggered)
5. calculate action based on the assessment without local state

Resolves: #3207 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined loading state handling for assessment action buttons to display disabled/loading UI during data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->