### PR TITLE
:sparkles: Use shared MulitSelect implementation in filters

### DIFF
--- a/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -1,20 +1,4 @@
-import * as React from "react";
-import {
-  Badge,
-  Button,
-  Label,
-  MenuToggle,
-  MenuToggleElement,
-  Select,
-  SelectList,
-  SelectOption,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
-  ToolbarChip,
-  ToolbarFilter,
-} from "@patternfly/react-core";
-import { TimesIcon } from "@patternfly/react-icons";
+import { ToolbarChip, ToolbarFilter } from "@patternfly/react-core";
 
 import { IFilterControlProps } from "./FilterControl";
 import {
@@ -23,6 +7,7 @@ import {
 } from "./FilterToolbar";
 
 import "./select-overrides.css";
+import { MultiSelect } from "./components/MultiSelect";
 
 export interface IMultiselectFilterControlProps<TItem>
   extends IFilterControlProps<TItem, string> {
@@ -38,23 +23,9 @@ export const MultiselectFilterControl = <TItem,>({
   setFilterValue,
   showToolbarItem,
   isDisabled = false,
-  isScrollable = false,
 }: IMultiselectFilterControlProps<TItem>): JSX.Element | null => {
-  const [isFilterDropdownOpen, setIsFilterDropdownOpen] = React.useState(false);
-  const [inputValue, setInputValue] = React.useState<string>("");
-  const textInputRef = React.useRef<HTMLInputElement>();
-
-  const idPrefix = `filter-control-${category.categoryKey}`;
-  const withPrefix = (id: string) => `${idPrefix}-${id}`;
+  const idPrefix = `filter-control-${category.categoryKey}-group`;
   const defaultGroup = category.title;
-
-  const filteredOptions = category.selectOptions?.filter(
-    ({ label, value, groupLabel }) =>
-      [label ?? value, groupLabel]
-        .filter(Boolean)
-        .map((it) => it.toLocaleLowerCase())
-        .some((it) => it.includes(inputValue?.trim().toLowerCase() ?? ""))
-  );
 
   const [firstGroup, ...otherGroups] = [
     ...new Set([
@@ -123,108 +94,6 @@ export const MultiselectFilterControl = <TItem,>({
     setFilterValue(newFilterValue);
   };
 
-  const {
-    focusedItemIndex,
-    getFocusedItem,
-    clearFocusedItemIndex,
-    moveFocusedItemIndex,
-  } = useFocusHandlers({
-    filteredOptions,
-  });
-
-  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (event.key) {
-      case "Enter":
-        if (!isFilterDropdownOpen) {
-          setIsFilterDropdownOpen(true);
-        } else if (getFocusedItem()?.value) {
-          onSelect(getFocusedItem()?.value);
-        }
-        textInputRef?.current?.focus();
-        break;
-      case "Tab":
-      case "Escape":
-        setIsFilterDropdownOpen(false);
-        clearFocusedItemIndex();
-        break;
-      case "ArrowUp":
-      case "ArrowDown":
-        event.preventDefault();
-        if (isFilterDropdownOpen) {
-          moveFocusedItemIndex(event.key);
-        } else {
-          setIsFilterDropdownOpen(true);
-        }
-        break;
-      default:
-        break;
-    }
-  };
-
-  const onTextInputChange = (
-    _event: React.FormEvent<HTMLInputElement>,
-    value: string
-  ) => {
-    setInputValue(value);
-    if (!isFilterDropdownOpen) {
-      setIsFilterDropdownOpen(true);
-    }
-  };
-
-  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      variant="typeahead"
-      onClick={() => {
-        setIsFilterDropdownOpen(!isFilterDropdownOpen);
-      }}
-      isExpanded={isFilterDropdownOpen}
-      isDisabled={isDisabled || !category.selectOptions.length}
-      isFullWidth
-    >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={inputValue}
-          onClick={() => {
-            setIsFilterDropdownOpen(!isFilterDropdownOpen);
-          }}
-          onChange={onTextInputChange}
-          onKeyDown={onInputKeyDown}
-          id={withPrefix("typeahead-select-input")}
-          autoComplete="off"
-          innerRef={textInputRef}
-          placeholder={category.placeholderText}
-          aria-activedescendant={
-            getFocusedItem()
-              ? withPrefix(`option-${focusedItemIndex}`)
-              : undefined
-          }
-          role="combobox"
-          isExpanded={isFilterDropdownOpen}
-          aria-controls={withPrefix("select-typeahead-listbox")}
-        />
-
-        <TextInputGroupUtilities>
-          {!!inputValue && (
-            <Button
-              variant="plain"
-              onClick={() => {
-                setInputValue("");
-                textInputRef?.current?.focus();
-              }}
-              aria-label="Clear input value"
-            >
-              <TimesIcon aria-hidden />
-            </Button>
-          )}
-          {filterValue?.length ? (
-            <Badge isRead>{filterValue.length}</Badge>
-          ) : null}
-        </TextInputGroupUtilities>
-      </TextInputGroup>
-    </MenuToggle>
-  );
-
   const withGroupPrefix = (group: string) =>
     group === category.title ? group : `${category.title}/${group}`;
 
@@ -240,45 +109,20 @@ export const MultiselectFilterControl = <TItem,>({
           key={withGroupPrefix(firstGroup)}
           showToolbarItem={showToolbarItem}
         >
-          <Select
-            isScrollable={isScrollable}
+          <MultiSelect
             aria-label={category.title}
-            toggle={toggle}
-            selected={filterValue}
-            onOpenChange={(isOpen) => setIsFilterDropdownOpen(isOpen)}
-            onSelect={(_, selection) => onSelect(selection as string)}
-            isOpen={isFilterDropdownOpen}
-          >
-            <SelectList id={withPrefix("select-typeahead-listbox")}>
-              {filteredOptions.map(
-                ({ groupLabel, label, value, optionProps = {} }, index) => (
-                  <SelectOption
-                    {...optionProps}
-                    {...(!optionProps.isDisabled && { hasCheckbox: true })}
-                    key={value}
-                    id={withPrefix(`option-${index}`)}
-                    value={value}
-                    isFocused={focusedItemIndex === index}
-                    isSelected={filterValue?.includes(value)}
-                  >
-                    {!!groupLabel && <Label>{groupLabel}</Label>}{" "}
-                    {label ?? value}
-                  </SelectOption>
-                )
-              )}
-              {filteredOptions.length === 0 && (
-                <SelectOption
-                  isDisabled
-                  hasCheckbox={false}
-                  key={NO_RESULTS}
-                  value={NO_RESULTS}
-                  isSelected={false}
-                >
-                  {`No results found for "${inputValue}"`}
-                </SelectOption>
-              )}
-            </SelectList>
-          </Select>
+            values={filterValue ?? undefined}
+            onSelect={onSelect}
+            toggleId={`filter-for-${category.categoryKey}`}
+            toggleAriaLabel={category.title}
+            isDisabled={isDisabled || !category.selectOptions.length}
+            hasCheckbox={true}
+            hasBadge={true}
+            placeholderText={category.placeholderText}
+            showSelectedInToggle={false}
+            closeMenuOnSelect={false}
+            options={category.selectOptions}
+          />
         </ToolbarFilter>
       }
       {otherGroups.map((groupName) => (
@@ -296,47 +140,4 @@ export const MultiselectFilterControl = <TItem,>({
       ))}
     </>
   );
-};
-
-const useFocusHandlers = ({
-  filteredOptions,
-}: {
-  filteredOptions: FilterSelectOptionProps[];
-}) => {
-  const [focusedItemIndex, setFocusedItemIndex] = React.useState<number>(0);
-
-  const moveFocusedItemIndex = (key: string) =>
-    setFocusedItemIndex(calculateFocusedItemIndex(key));
-
-  const calculateFocusedItemIndex = (key: string): number => {
-    if (!filteredOptions.length) {
-      return 0;
-    }
-
-    if (key === "ArrowUp") {
-      return focusedItemIndex <= 0
-        ? filteredOptions.length - 1
-        : focusedItemIndex - 1;
-    }
-
-    if (key === "ArrowDown") {
-      return focusedItemIndex >= filteredOptions.length - 1
-        ? 0
-        : focusedItemIndex + 1;
-    }
-    return 0;
-  };
-
-  const getFocusedItem = () =>
-    filteredOptions[focusedItemIndex] &&
-    !filteredOptions[focusedItemIndex]?.optionProps?.isDisabled
-      ? filteredOptions[focusedItemIndex]
-      : undefined;
-
-  return {
-    moveFocusedItemIndex,
-    focusedItemIndex,
-    getFocusedItem,
-    clearFocusedItemIndex: () => setFocusedItemIndex(0),
-  };
 };

--- a/client/src/app/components/FilterToolbar/SearchFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/SearchFilterControl.tsx
@@ -43,9 +43,9 @@ export const SearchFilterControl = <TItem, TFilterCategoryKey extends string>({
     setFilterValue(trimmedValue ? [trimmedValue.replace(/\s+/g, " ")] : []);
   };
 
-  const id = `${category.categoryKey}-input`;
   return (
     <ToolbarFilter
+      id={`filter-control-${category.categoryKey}`}
       chips={filterValue || []}
       deleteChip={() => setFilterValue([])}
       categoryName={category.title}
@@ -54,8 +54,7 @@ export const SearchFilterControl = <TItem, TFilterCategoryKey extends string>({
       <InputGroup>
         <InputGroupItem isFill>
           <TextInput
-            name={id}
-            id="search-input"
+            ouiaId={`search-for-${category.categoryKey}-input`}
             type={isNumeric ? "number" : "search"}
             onChange={(_, value) => setInputValue(value)}
             aria-label={`${category.title} filter`}
@@ -71,7 +70,7 @@ export const SearchFilterControl = <TItem, TFilterCategoryKey extends string>({
         <InputGroupItem>
           <Button
             variant={ButtonVariant.control}
-            id="search-button"
+            ouiaId={`search-for-${category.categoryKey}-button`}
             aria-label="search button for search input"
             onClick={onFilterSubmit}
             isDisabled={isDisabled}

--- a/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/SelectFilterControl.tsx
@@ -68,7 +68,7 @@ export const SelectFilterControl = <TItem, TFilterCategoryKey extends string>({
         ariaLabel={category.title}
         isDisabled={isDisabled}
         placeholderText="Any"
-        toggleId={`select-filter-value-${category.categoryKey}`}
+        toggleId={`filter-for-${category.categoryKey}`}
         toggleAriaLabel="Select"
       />
     </ToolbarFilter>

--- a/client/src/app/components/FilterToolbar/components/MultiSelect.tsx
+++ b/client/src/app/components/FilterToolbar/components/MultiSelect.tsx
@@ -19,7 +19,6 @@ import { TimesIcon } from "@patternfly/react-icons";
 import { FilterSelectOptionProps } from "../FilterToolbar";
 
 import {
-  createItemId,
   getDisplayValue,
   getStableIndex,
   noResultsId,
@@ -50,7 +49,7 @@ export interface MultiSelectProps {
   closeMenuOnSelect?: boolean;
 }
 
-export const MultiSelectBase: FC<MultiSelectProps> = ({
+export const MultiSelect: FC<MultiSelectProps> = ({
   options,
   ariaLabel,
   "aria-label": htmlAriaLabel,
@@ -237,7 +236,7 @@ export const MultiSelectBase: FC<MultiSelectProps> = ({
           {...(activeItemId && { "aria-activedescendant": activeItemId })}
           role="combobox"
           isExpanded={isFilterDropdownOpen}
-          aria-controls={createItemId("listbox", toggleId)}
+          aria-controls={`${toggleId}-listbox`}
         />
 
         <TextInputGroupUtilities>
@@ -283,14 +282,14 @@ export const MultiSelectBase: FC<MultiSelectProps> = ({
       isOpen={isFilterDropdownOpen}
       variant="typeahead"
     >
-      <SelectList id={createItemId("listbox", toggleId)}>
+      <SelectList id={`${toggleId}-listbox`}>
         {filteredOptions.map(
           ({ groupLabel, label, value, optionProps = {} }, index) => (
             <SelectOption
               {...optionProps}
               {...(!optionProps.isDisabled && { hasCheckbox })}
               key={value}
-              id={createItemId(getStableIndex(value, options), toggleId)}
+              id={`${toggleId}-${getStableIndex(value, options)}`}
               value={value}
               isFocused={focusedItemIndex === index}
               isSelected={values?.includes(value)}

--- a/client/src/app/components/FilterToolbar/components/SimpleSelect.tsx
+++ b/client/src/app/components/FilterToolbar/components/SimpleSelect.tsx
@@ -80,7 +80,7 @@ const SimpleSelect: FC<SimpleSelectProps> = ({
       isOpen={isFilterDropdownOpen}
       shouldFocusToggleOnSelect
     >
-      <SelectList>
+      <SelectList id={`${toggleId}-listbox`}>
         {options.map(({ label, value, optionProps }) => (
           <SelectOption
             {...optionProps}

--- a/client/src/app/components/FilterToolbar/components/TypeaheadSelect.tsx
+++ b/client/src/app/components/FilterToolbar/components/TypeaheadSelect.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 
-import { MultiSelectBase, MultiSelectProps } from "./MultiSelectBase";
+import { MultiSelect, MultiSelectProps } from "./MultiSelect";
 
 export type TypeaheadSelectProps = Omit<
   MultiSelectProps,
@@ -11,7 +11,7 @@ export type TypeaheadSelectProps = Omit<
 };
 
 const TypeaheadSelect: FC<TypeaheadSelectProps> = ({ value, ...props }) => (
-  <MultiSelectBase
+  <MultiSelect
     {...props}
     hasCheckbox={false}
     values={value ? [value] : []}

--- a/client/src/app/components/FilterToolbar/components/selectUtils.ts
+++ b/client/src/app/components/FilterToolbar/components/selectUtils.ts
@@ -14,11 +14,7 @@ export const toDisplayValue = (option?: FilterSelectOptionProps) => {
   return option?.label ?? option?.value ?? "";
 };
 
-export const noResultsId = (idPrefix: string) =>
-  createItemId(NO_RESULTS, idPrefix);
-
-export const createItemId = (partialId: number | string, idPrefix: string) =>
-  `select-${idPrefix}-${partialId}`;
+export const noResultsId = (idPrefix: string) => `${idPrefix}-${NO_RESULTS}`;
 
 export const getStableIndex = (
   value: unknown,

--- a/client/src/app/components/FilterToolbar/components/useFocusHandlers.tsx
+++ b/client/src/app/components/FilterToolbar/components/useFocusHandlers.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { FilterSelectOptionProps } from "../FilterToolbar";
 
-import { createItemId, getStableIndex } from "./selectUtils";
+import { getStableIndex } from "./selectUtils";
 
 export const useFocusHandlers = ({
   filteredOptions,
@@ -21,10 +21,7 @@ export const useFocusHandlers = ({
     setFocusedItemIndex(newIndex);
     setActiveItemId(
       newIndex !== null
-        ? createItemId(
-            getStableIndex(filteredOptions[newIndex]?.value, options),
-            idPrefix
-          )
+        ? `${idPrefix}-${getStableIndex(filteredOptions[newIndex]?.value, options)}`
         : null
     );
   };

--- a/client/src/app/components/analysis/steps/analysis-source.tsx
+++ b/client/src/app/components/analysis/steps/analysis-source.tsx
@@ -262,7 +262,7 @@ export const AnalysisSource: React.FC<AnalysisSourceProps> = ({
         fieldId="analysis-source"
         helperTextTestId="analysis-source-select-message"
         isRequired
-        renderInput={({ field: { value, name, onChange } }) => (
+        renderInput={({ field: { value, onChange } }) => (
           <SimpleSelect
             toggleId="analysis-source-toggle"
             toggleAriaLabel="Analysis source dropdown toggle"

--- a/cypress/e2e/models/administration/credentials/credentials.ts
+++ b/cypress/e2e/models/administration/credentials/credentials.ts
@@ -35,7 +35,9 @@ import {
   categoryName,
   categoryType,
   filterCategory,
-  filterSelectType,
+  filterToggle,
+  searchButton,
+  searchInput,
 } from "../../../types/filter-categories";
 import { CredentialsData } from "../../../types/types";
 import * as commonView from "../../../views/common.view";
@@ -219,13 +221,13 @@ export class Credentials {
 
   static ApplyFilterByName(value: string) {
     selectFromDropList(commonView.filteredBy, filterCategory(categoryName));
-    inputText(commonView.searchInput, value);
-    click(commonView.searchButton);
+    inputText(searchInput(categoryName), value);
+    click(searchButton(categoryName));
   }
 
   static applyFilterByType(type: string) {
     selectFromDropList(commonView.filteredBy, filterCategory(categoryType));
-    selectFromDropListByText(filterSelectType(categoryType), type);
+    selectFromDropListByText(filterToggle(categoryType), type);
   }
 
   static applyFilterCreatedBy(value: string) {
@@ -233,8 +235,8 @@ export class Credentials {
       commonView.filteredBy,
       filterCategory(categoryCreatedBy)
     );
-    inputText(commonView.searchInput, value);
-    click(commonView.searchButton);
+    inputText(searchInput(categoryCreatedBy), value);
+    click(searchButton(categoryCreatedBy));
   }
 
   static applyFilterDefaultCredential(value: DefaultCredentialFilter) {
@@ -243,7 +245,7 @@ export class Credentials {
       filterCategory(categoryDefaultCredential)
     );
     selectFromDropListByText(
-      filterSelectType(categoryDefaultCredential),
+      filterToggle(categoryDefaultCredential),
       value,
       commonView.actionMenuItem
     );

--- a/cypress/e2e/models/administration/jira-connection/jira.ts
+++ b/cypress/e2e/models/administration/jira-connection/jira.ts
@@ -24,7 +24,12 @@ import {
   tdTag,
   trTag,
 } from "../../../types/constants";
-import { categoryName, filterCategory } from "../../../types/filter-categories";
+import {
+  categoryName,
+  filterCategory,
+  searchButton,
+  searchInput,
+} from "../../../types/filter-categories";
 import { JiraConnectionData } from "../../../types/types";
 import {
   confirmButton,
@@ -32,8 +37,6 @@ import {
   filteredBy,
   navLink,
 } from "../../../views/common.view";
-import { searchButton } from "../../../views/credentials.view";
-import { searchInput } from "../../../views/issue.view";
 import {
   createJiraButton,
   instanceName,
@@ -273,8 +276,8 @@ export class Jira {
 
   static applyFilterByName(value: string) {
     selectFromDropList(filteredBy, filterCategory(categoryName));
-    inputText(searchInput, value);
-    click(searchButton);
+    inputText(searchInput(categoryName), value);
+    click(searchButton(categoryName));
   }
 
   public getAllProjects(): Cypress.Chainable<JiraProject[]> {

--- a/cypress/e2e/models/migration/custom-migration-targets/custom-migration-target.ts
+++ b/cypress/e2e/models/migration/custom-migration-targets/custom-migration-target.ts
@@ -20,6 +20,10 @@ import {
   deleteAction,
   editAction,
 } from "../../../types/constants";
+import {
+  categoryProvider,
+  filterToggleListbox,
+} from "../../../types/filter-categories";
 import { RulesManualFields, RulesRepositoryFields } from "../../../types/types";
 import { submitButton } from "../../../views/common.view";
 import { CustomMigrationTargetView } from "../../../views/custom-migration-target.view";
@@ -167,7 +171,7 @@ export class CustomMigrationTarget {
      * There may be a pre-selected filter so
      * the only deterministic way to eliminate pre-selected filters is to make sure there is one
      */
-    cy.get(`#filter-control-provider-select-typeahead-listbox > li`)
+    cy.get(`${filterToggleListbox(categoryProvider)} > li`)
       .contains(Languages.Java)
       .closest(".pf-v5-c-menu__list-item")
       .find("input[type=checkbox]")
@@ -177,7 +181,7 @@ export class CustomMigrationTarget {
 
     cy.get(CustomMigrationTargetView.filterLanguageDropdown).click();
 
-    cy.get(`#filter-control-provider-select-typeahead-listbox > li`)
+    cy.get(`${filterToggleListbox(categoryProvider)} > li`)
       .contains(language)
       .closest(".pf-v5-c-menu__list-item")
       .find("input[type=checkbox]")

--- a/cypress/e2e/models/migration/dynamic-report/dependencies/dependencies.ts
+++ b/cypress/e2e/models/migration/dynamic-report/dependencies/dependencies.ts
@@ -1,6 +1,7 @@
 import {
   click,
   clickByText,
+  clickWithinByText,
   getUniqueElementsFromSecondArray,
   getUrl,
   inputText,
@@ -10,10 +11,15 @@ import {
   validateTextPresence,
 } from "../../../../../utils/utils";
 import { SEC, dependencyFilter, migration } from "../../../../types/constants";
+import {
+  filterToggleListbox,
+  searchButton,
+  searchInput,
+} from "../../../../types/filter-categories";
 import { AppDependency } from "../../../../types/types";
-import { searchButton, span } from "../../../../views/common.view";
+import { span } from "../../../../views/common.view";
 import { dependencyColumns } from "../../../../views/dependency.view";
-import { archetypeFilterName, searchInput } from "../../../../views/issue.view";
+import { archetypeFilterName } from "../../../../views/issue.view";
 import { navMenu } from "../../../../views/menu.view";
 
 export class Dependencies {
@@ -44,12 +50,12 @@ export class Dependencies {
       filterType === dependencyFilter.language;
 
     if (isApplicableFilter) {
-      inputText(searchInput, filterValue);
-      click(searchButton);
+      inputText(searchInput(filterType), filterValue);
+      click(searchButton(filterType));
     } else {
       selector = archetypeFilterName;
       click(selector);
-      clickByText(span, filterValue);
+      clickWithinByText(filterToggleListbox(filterType), span, filterValue);
       click(selector);
       cy.wait(SEC);
     }

--- a/cypress/e2e/models/migration/dynamic-report/dynamic-report.ts
+++ b/cypress/e2e/models/migration/dynamic-report/dynamic-report.ts
@@ -1,6 +1,7 @@
 import {
   click,
   clickByText,
+  clickWithinByText,
   inputText,
   performWithin,
   selectFilter,
@@ -17,8 +18,14 @@ import {
   tdTag,
   trTag,
 } from "../../../types/constants";
-import { searchButton, searchInput, span } from "../../../views/common.view";
-import { searchMenuToggle, singleAppDropList } from "../../../views/issue.view";
+import {
+  filterToggle,
+  filterToggleListbox,
+  searchButton,
+  searchInput,
+} from "../../../types/filter-categories";
+import { span } from "../../../views/common.view";
+import { singleAppDropList } from "../../../views/issue.view";
 import { navMenu } from "../../../views/menu.view";
 
 export abstract class DynamicReports {
@@ -81,12 +88,12 @@ export abstract class DynamicReports {
       filterType === dynamicReportFilter.target;
 
     if (isApplicableFilter) {
-      inputText(searchInput, filterValue);
-      click(searchButton);
+      inputText(searchInput(filterType), filterValue);
+      click(searchButton(filterType));
     } else {
-      click(searchMenuToggle);
-      clickByText(span, filterValue);
-      click(searchMenuToggle);
+      click(filterToggle(filterType));
+      clickWithinByText(filterToggleListbox(filterType), span, filterValue);
+      click(filterToggle(filterType));
     }
   }
 
@@ -96,9 +103,9 @@ export abstract class DynamicReports {
   ): void {
     this.openList();
     selectFilter(filterType);
-    click(searchMenuToggle);
+    click(filterToggle(filterType));
     filterValues.forEach((filterValue) => clickByText(span, filterValue));
-    click(searchMenuToggle);
+    click(filterToggle(filterType));
   }
 
   public static validateSection(

--- a/cypress/e2e/models/migration/migration-waves/migration-wave.ts
+++ b/cypress/e2e/models/migration/migration-waves/migration-wave.ts
@@ -144,10 +144,12 @@ export class MigrationWave {
     MigrationWave.open();
     this.expandActionsMenu();
     cy.contains(manageApplications).click();
-    callWithin(modal, () => selectItemsPerPage(100));
-    cy.get(itemsSelectInsideDialog).click();
-    cy.contains(button, selectNone).click();
-    callWithin(modal, () => selectItemsPerPage(100));
+    callWithin(modal, () => {
+      selectItemsPerPage(100);
+      cy.get(itemsSelectInsideDialog).click();
+      cy.contains(button, selectNone).click();
+      selectItemsPerPage(100);
+    });
 
     this.applications.forEach((app) => {
       cy.get(tdTag)
@@ -185,10 +187,12 @@ export class MigrationWave {
     }
 
     cy.contains(manageApplications).click();
-    cy.get(itemsSelectInsideDialog).click();
-    cy.contains(button, selectNone).click();
-    clickJs(submitButton);
-    this.applications = [];
+    callWithin(modal, () => {
+      cy.get(itemsSelectInsideDialog).click();
+      cy.contains(button, selectNone).click();
+      clickJs(submitButton);
+      this.applications = [];
+    });
   }
 
   public static fillName(name: string): void {

--- a/cypress/e2e/models/migration/task-manager/task-manager.ts
+++ b/cypress/e2e/models/migration/task-manager/task-manager.ts
@@ -34,13 +34,9 @@ import {
   taskDetails,
   trTag,
 } from "../../../types/constants";
+import { searchButton, searchInput } from "../../../types/filter-categories";
 import { sideKebabMenu } from "../../../views/applicationinventory.view";
-import {
-  actionMenuItem,
-  kebabActionButton,
-  searchButton,
-  searchInput,
-} from "../../../views/common.view";
+import { actionMenuItem, kebabActionButton } from "../../../views/common.view";
 import { navMenu } from "../../../views/menu.view";
 import {
   TaskManagerColumns,
@@ -93,8 +89,8 @@ export class TaskManager {
 
   public static applyFilter(filterType: TaskFilter, filterValue: string) {
     selectFilter(filterType);
-    inputText(searchInput, filterValue);
-    click(searchButton);
+    inputText(searchInput(filterType), filterValue);
+    click(searchButton(filterType));
     cy.wait(2 * SEC);
   }
 

--- a/cypress/e2e/tests/migration/applicationinventory/applications/filter.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/applications/filter.test.ts
@@ -17,7 +17,7 @@ limitations under the License.
 
 import * as data from "../../../../../utils/data_utils";
 import {
-  applySearchFilter,
+  applySelectFilter,
   clickByText,
   createMultipleApplicationsWithBSandTags,
   createMultipleBusinessServices,
@@ -57,13 +57,10 @@ import {
   categoryRepositoryType,
   categoryRisk,
   categoryTags,
+  filterToggle,
+  filterToggleListbox,
 } from "../../../../types/filter-categories";
 import * as commonView from "../../../../views/common.view";
-import {
-  filterDropDownContainer,
-  standardFilter,
-} from "../../../../views/common.view";
-import { searchMenuToggle } from "../../../../views/issue.view";
 
 let source_credential;
 let maven_credential;
@@ -132,7 +129,7 @@ describe(
       filterApplicationsBySubstring();
 
       // Enter an exact existing name and assert
-      applySearchFilter(categoryName, applicationsList[1].name);
+      applySelectFilter(categoryName, applicationsList[1].name);
       exists(applicationsList[1].name);
       notExists(applicationsList[0].name);
       clickByText(button, clearAllFilters);
@@ -140,7 +137,7 @@ describe(
 
     it("Business service filter validations", function () {
       const validSearchInput = applicationsList[0].business;
-      applySearchFilter(categoryBusinessService, validSearchInput);
+      applySelectFilter(categoryBusinessService, validSearchInput);
 
       exists(applicationsList[0].business);
       clickByText(button, clearAllFilters);
@@ -150,13 +147,13 @@ describe(
       Application.open();
 
       const validSearchInput = applicationsList[0].tags[0];
-      applySearchFilter(categoryTags, validSearchInput);
+      applySelectFilter(categoryTags, validSearchInput);
 
       exists(applicationsList[0].name);
       notExists(applicationsList[1].name);
       clickByText(button, clearAllFilters);
 
-      applySearchFilter(categoryTags, applicationsList[1].tags[0]);
+      applySelectFilter(categoryTags, applicationsList[1].tags[0]);
       exists(applicationsList[1].name);
       notExists(applicationsList[0].name);
       clickByText(button, clearAllFilters);
@@ -179,14 +176,14 @@ describe(
       application.manageCredentials(null, maven_credential.name);
       exists(application.name);
 
-      applySearchFilter(categoryIdentities, "Maven");
+      applySelectFilter(categoryIdentities, "Maven");
       exists(application.name);
       clickByText(button, clearAllFilters);
 
       application.manageCredentials(source_credential.name, null);
       exists(application.name);
 
-      applySearchFilter(categoryIdentities, "Source");
+      applySelectFilter(categoryIdentities, "Source");
       exists(application.name);
       clickByText(button, clearAllFilters);
     });
@@ -211,14 +208,14 @@ describe(
 
       // Apply repository type filter check with Git
       // Check Application exists and application1 doesn't exist
-      applySearchFilter(categoryRepositoryType, git);
+      applySelectFilter(categoryRepositoryType, git);
       exists(application.name);
       notExists(application1.name);
       clickByText(button, clearAllFilters);
 
       // Apply repository type filter check with Subversion
       // Check Application1 exists and application doesn't exist
-      applySearchFilter(categoryRepositoryType, subversion);
+      applySelectFilter(categoryRepositoryType, subversion);
       exists(application1.name);
       notExists(application.name);
       clickByText(button, clearAllFilters);
@@ -239,14 +236,14 @@ describe(
 
       // Apply artifact filter check with associated artifact field
       // Check application exists and applicationList[0] doesn't exist
-      applySearchFilter(categoryBinary, "Associated artifact");
+      applySelectFilter(categoryBinary, "Associated artifact");
       exists(application.name);
       notExists(applicationsList[0].name);
       clickByText(button, clearAllFilters);
 
       // Apply artifact filter check with 'No associated artifact' field
       // Check applicationList[0] exists and application doesn't exist
-      applySearchFilter(categoryBinary, "No associated artifact");
+      applySelectFilter(categoryBinary, "No associated artifact");
       exists(applicationsList[0].name);
       notExists(application.name);
       clickByText(button, clearAllFilters);
@@ -264,13 +261,13 @@ describe(
       application.verifyStatus("assessment", "Completed");
 
       // Apply search filter Risk - Low
-      applySearchFilter(categoryRisk, "Low");
+      applySelectFilter(categoryRisk, "Low");
       exists(application.name);
       notExists(application1.name);
       clickByText(button, clearAllFilters);
 
       // apply search filter Risk - Unassessed
-      applySearchFilter(categoryRisk, "Unassessed");
+      applySelectFilter(categoryRisk, "Unassessed");
       exists(application1.name);
       notExists(application.name);
       clickByText(button, clearAllFilters);
@@ -298,7 +295,7 @@ describe(
       application1.create();
       cy.get("@getApplication");
       const validSearchInput = archetype1.name;
-      applySearchFilter(categoryArchetypes, validSearchInput);
+      applySelectFilter(categoryArchetypes, validSearchInput);
       exists(application1.name);
       clickByText(button, clearAllFilters);
 
@@ -312,8 +309,11 @@ describe(
       archetype2.create();
       Application.open();
       selectFilter(categoryArchetypes);
-      cy.get(filterDropDownContainer).find(searchMenuToggle).click();
-      notExists(archetype2.name);
+      cy.get(filterToggle(categoryArchetypes)).click();
+      cy.get(filterToggleListbox(categoryArchetypes)).should(
+        "not.contain",
+        archetype2.name
+      );
 
       deleteByList([archetype1, archetype2]);
       deleteByList(tags);
@@ -349,14 +349,16 @@ const filterApplicationsBySubstring = (): void => {
       .then(() => {
         [applicationsList[0].name, applicationsList[1].name].forEach(
           (substring) => {
-            cy.get(standardFilter).contains(substring).click();
+            cy.get(filterToggleListbox(categoryName))
+              .contains(substring)
+              .click();
           }
         );
         exists(applicationsList[0].name);
         exists(applicationsList[1].name);
       });
   } else {
-    applySearchFilter(categoryName, firstAppSubstring);
+    applySelectFilter(categoryName, firstAppSubstring);
     exists(applicationsList[0].name);
     notExists(applicationsList[1].name);
   }

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/review/filter.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/review/filter.test.ts
@@ -16,7 +16,7 @@ limitations under the License.
 /// <reference types="cypress" />
 
 import {
-  applySelectFilter,
+  applySelectFilterViaTextInput,
   clearAllFilters,
   clickItemInKebabMenu,
   clickKebabMenuOptionArchetype,
@@ -75,7 +75,7 @@ describe(
     identifiedRisksFilterValidations.forEach((validation) => {
       it(`Filtering identified risks by ${validation.name}`, function () {
         const commonActions = () => {
-          applySelectFilter(validation.id, validation.id, validation.text);
+          applySelectFilterViaTextInput(validation.id, validation.text);
           exists(validation.should);
           notExists(validation.shouldNot);
           clearAllFilters();

--- a/cypress/e2e/tests/migration/controls/tags/tag/filter.test.ts
+++ b/cypress/e2e/tests/migration/controls/tags/tag/filter.test.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import * as data from "../../../../../../utils/data_utils";
 import {
-  applySelectFilter,
+  applySelectFilterViaTextInput,
   clearAllFilters,
   closeRowDetails,
   exists,
@@ -45,19 +45,19 @@ describe(["@tier3", "@tier3_C"], "Tags filter validations", function () {
     const validSearchInputTagCategory = tagCategory.name.substring(0, 3);
 
     Tag.openList();
-    applySelectFilter(categoryTags, categoryTags, validSearchInputTag);
+    applySelectFilterViaTextInput(categoryTags, validSearchInputTag);
     expandRowDetails(tag.tagCategory);
     existsWithinRow(tag.tagCategory, tdTag, tag.name);
     closeRowDetails(tag.tagCategory);
 
-    applySelectFilter(categoryTags, categoryTags, validSearchInputTagCategory);
+    applySelectFilterViaTextInput(categoryTags, validSearchInputTagCategory);
     exists(validSearchInputTagCategory);
 
     clearAllFilters();
 
     // Enter a non-existing tag name substring and apply it as search filter
     const invalidSearchInput = String(data.getRandomNumber(111111, 222222));
-    applySelectFilter(categoryTags, categoryTags, invalidSearchInput, false);
+    applySelectFilterViaTextInput(categoryTags, invalidSearchInput, false);
   });
 
   after("Cleanup", function () {

--- a/cypress/e2e/tests/migration/migration-waves/filter_applications.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/filter_applications.test.ts
@@ -15,6 +15,8 @@ limitations under the License.
 import * as data from "../../../../utils/data_utils";
 import {
   applySearchFilter,
+  applySelectFilter,
+  callWithin,
   clickByText,
   getAuthHeaders,
   login,
@@ -34,6 +36,7 @@ import {
   categoryName,
   categoryOwner,
 } from "../../../types/filter-categories";
+import { modal } from "../../../views/common.view";
 
 const now = new Date();
 now.setDate(now.getDate() + 1);
@@ -98,19 +101,20 @@ describe(
       MigrationWave.open(true);
       migrationWave.expandActionsMenu();
       cy.contains(manageApplications).click();
+      callWithin(modal, () => {
+        // Enter an existing exact name and apply it as search filter
+        applySearchFilter(categoryName, applicationsList[1].name);
+        cy.get("td").should("contain", applicationsList[1].name);
+        cy.get("td").should("not.contain", applicationsList[0].name);
+        clickByText(button, clearAllFilters);
 
-      // Enter an existing exact name and apply it as search filter
-      applySearchFilter(categoryName, applicationsList[1].name, true, 1);
-      cy.get("td").should("contain", applicationsList[1].name);
-      cy.get("td").should("not.contain", applicationsList[0].name);
-      clickByText(button, clearAllFilters);
-
-      // Enter a non-existing app name and apply it as search filter
-      applySearchFilter(categoryName, String(data.getRandomNumber()), true, 1);
-      cy.get("td").should("not.contain", applicationsList[1].name);
-      cy.get("td").should("not.contain", applicationsList[0].name);
-      clickByText(button, clearAllFilters);
-      clickByText(button, "Cancel");
+        // Enter a non-existing app name and apply it as search filter
+        applySearchFilter(categoryName, String(data.getRandomNumber()));
+        cy.get("td").should("not.contain", applicationsList[1].name);
+        cy.get("td").should("not.contain", applicationsList[0].name);
+        clickByText(button, clearAllFilters);
+        clickByText(button, "Cancel");
+      });
       migrationWave.delete();
     });
 
@@ -129,29 +133,26 @@ describe(
       MigrationWave.open(true);
       migrationWave.expandActionsMenu();
       cy.contains(manageApplications).click();
+      callWithin(modal, () => {
+        // Apply BS associated with applicationsList[1].name as select filter
+        applySelectFilter(
+          categoryBusinessService,
+          applicationsList[1].business
+        );
+        cy.get("td").should("contain", applicationsList[1].name);
+        cy.get("td").should("not.contain", applicationsList[0].name);
+        clickByText(button, clearAllFilters);
 
-      // Apply BS associated with applicationsList[1].name as search filter
-      applySearchFilter(
-        categoryBusinessService,
-        applicationsList[1].business,
-        true,
-        1
-      );
-      cy.get("td").should("contain", applicationsList[1].name);
-      cy.get("td").should("not.contain", applicationsList[0].name);
-      clickByText(button, clearAllFilters);
-
-      // Apply BS associated with applicationsList[0].name as search filter
-      applySearchFilter(
-        categoryBusinessService,
-        applicationsList[0].business,
-        true,
-        1
-      );
-      cy.get("td").should("not.contain", applicationsList[1].name);
-      cy.get("td").should("contain", applicationsList[0].name);
-      clickByText(button, clearAllFilters);
-      clickByText(button, "Cancel");
+        // Apply BS associated with applicationsList[0].name as select filter
+        applySelectFilter(
+          categoryBusinessService,
+          applicationsList[0].business
+        );
+        cy.get("td").should("not.contain", applicationsList[1].name);
+        cy.get("td").should("contain", applicationsList[0].name);
+        clickByText(button, clearAllFilters);
+        clickByText(button, "Cancel");
+      });
       migrationWave.delete();
     });
 
@@ -170,19 +171,20 @@ describe(
       MigrationWave.open(true);
       migrationWave.expandActionsMenu();
       cy.contains(manageApplications).click();
+      callWithin(modal, () => {
+        // Apply owner associated with applicationsList[1].name as select filter
+        applySelectFilter(categoryOwner, stakeholders[1].name);
+        cy.get("td").should("contain", applicationsList[1].name);
+        cy.get("td").should("not.contain", applicationsList[0].name);
+        clickByText(button, clearAllFilters);
 
-      // Apply owner associated with applicationsList[1].name as search filter
-      applySearchFilter(categoryOwner, stakeholders[1].name, true, 1);
-      cy.get("td").should("contain", applicationsList[1].name);
-      cy.get("td").should("not.contain", applicationsList[0].name);
-      clickByText(button, clearAllFilters);
-
-      // Apply owner associated with applicationsList[0].name as search filter
-      applySearchFilter(categoryOwner, stakeholders[0].name, true, 1);
-      cy.get("td").should("not.contain", applicationsList[1].name);
-      cy.get("td").should("contain", applicationsList[0].name);
-      clickByText(button, clearAllFilters);
-      clickByText(button, "Cancel");
+        // Apply owner associated with applicationsList[0].name as select filter
+        applySelectFilter(categoryOwner, stakeholders[0].name);
+        cy.get("td").should("not.contain", applicationsList[1].name);
+        cy.get("td").should("contain", applicationsList[0].name);
+        clickByText(button, clearAllFilters);
+        clickByText(button, "Cancel");
+      });
       migrationWave.delete();
     });
 

--- a/cypress/e2e/tests/migration/migration-waves/sort.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/sort.test.ts
@@ -17,6 +17,7 @@ limitations under the License.
 
 import * as data from "../../../../utils/data_utils";
 import {
+  callWithin,
   cancelForm,
   clickOnSortButton,
   createMultipleBusinessServices,
@@ -37,6 +38,7 @@ import { BusinessServices } from "../../../models/migration/controls/businessser
 import { Stakeholders } from "../../../models/migration/controls/stakeholders";
 import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
 import { SortType, endDate, name, startDate } from "../../../types/constants";
+import { modal } from "../../../views/common.view";
 import { MigrationWaveView } from "../../../views/migration-wave.view";
 
 let migrationWavesList: MigrationWave[] = [];
@@ -149,59 +151,62 @@ describe(
       }
 
       migrationWavesList[0].openManageApplications();
-      const unsortedAppList = getTableColumnData("Application Name");
-      const unsortedBusinessList = getTableColumnData("Business service");
-      const unsortedOwnerList = getTableColumnData("Owner");
-      //sort asc and desc for 3 columns
-      clickOnSortButton(
-        "Business service",
-        SortType.ascending,
-        MigrationWaveView.migrationWavesTable
-      );
-      const afterAscSortBusinessList = getTableColumnData("Business service");
-      verifySortAsc(afterAscSortBusinessList, unsortedBusinessList);
+      callWithin(modal, () => {
+        const unsortedAppList = getTableColumnData("Application Name");
+        const unsortedBusinessList = getTableColumnData("Business service");
+        const unsortedOwnerList = getTableColumnData("Owner");
+        //sort asc and desc for 3 columns
+        clickOnSortButton(
+          "Business service",
+          SortType.ascending,
+          MigrationWaveView.migrationWavesTable
+        );
+        const afterAscSortBusinessList = getTableColumnData("Business service");
+        verifySortAsc(afterAscSortBusinessList, unsortedBusinessList);
 
-      clickOnSortButton(
-        "Business service",
-        SortType.descending,
-        MigrationWaveView.migrationWavesTable
-      );
-      const afterDescSortBusinessList = getTableColumnData("Business service");
-      verifySortDesc(afterDescSortBusinessList, unsortedBusinessList);
+        clickOnSortButton(
+          "Business service",
+          SortType.descending,
+          MigrationWaveView.migrationWavesTable
+        );
+        const afterDescSortBusinessList =
+          getTableColumnData("Business service");
+        verifySortDesc(afterDescSortBusinessList, unsortedBusinessList);
 
-      clickOnSortButton(
-        "Application Name",
-        SortType.ascending,
-        MigrationWaveView.migrationWavesTable
-      );
-      const afterAscSortappList = getTableColumnData("Application Name");
-      verifySortAsc(afterAscSortappList, unsortedAppList);
+        clickOnSortButton(
+          "Application Name",
+          SortType.ascending,
+          MigrationWaveView.migrationWavesTable
+        );
+        const afterAscSortappList = getTableColumnData("Application Name");
+        verifySortAsc(afterAscSortappList, unsortedAppList);
 
-      clickOnSortButton(
-        "Application Name",
-        SortType.descending,
-        MigrationWaveView.migrationWavesTable
-      );
-      const afterDescSortappList = getTableColumnData("Application Name");
-      verifySortDesc(afterDescSortappList, unsortedAppList);
+        clickOnSortButton(
+          "Application Name",
+          SortType.descending,
+          MigrationWaveView.migrationWavesTable
+        );
+        const afterDescSortappList = getTableColumnData("Application Name");
+        verifySortDesc(afterDescSortappList, unsortedAppList);
 
-      clickOnSortButton(
-        "Owner",
-        SortType.ascending,
-        MigrationWaveView.migrationWavesTable
-      );
-      const afterAscSortOwnerList = getTableColumnData("Owner");
-      verifySortAsc(afterAscSortOwnerList, unsortedOwnerList);
+        clickOnSortButton(
+          "Owner",
+          SortType.ascending,
+          MigrationWaveView.migrationWavesTable
+        );
+        const afterAscSortOwnerList = getTableColumnData("Owner");
+        verifySortAsc(afterAscSortOwnerList, unsortedOwnerList);
 
-      clickOnSortButton(
-        "Owner",
-        SortType.descending,
-        MigrationWaveView.migrationWavesTable
-      );
-      const afterDescSortOwnerList = getTableColumnData("Owner");
-      verifySortDesc(afterDescSortOwnerList, unsortedOwnerList);
+        clickOnSortButton(
+          "Owner",
+          SortType.descending,
+          MigrationWaveView.migrationWavesTable
+        );
+        const afterDescSortOwnerList = getTableColumnData("Owner");
+        verifySortDesc(afterDescSortOwnerList, unsortedOwnerList);
 
-      cancelForm();
+        cancelForm();
+      });
     });
 
     after("Perform test data clean up", function () {

--- a/cypress/e2e/tests/migration/reports-tab/filter.test.ts
+++ b/cypress/e2e/tests/migration/reports-tab/filter.test.ts
@@ -16,7 +16,7 @@ limitations under the License.
 /// <reference types="cypress" />
 
 import {
-  applySelectFilter,
+  applySelectFilterViaTextInput,
   clearAllFilters,
   createMultipleApplications,
   createMultipleStakeholders,
@@ -73,7 +73,7 @@ describe(["@tier3", "@tier3_D"], "Reports Tab filter validations", function () {
   identifiedRisksFilterValidations.forEach((validation) => {
     it(`Filtering identified risks by ${validation.name}`, function () {
       Reports.open(100);
-      applySelectFilter(validation.id, validation.id, validation.text);
+      applySelectFilterViaTextInput(validation.id, validation.text);
       exists(validation.should);
       notExists(validation.shouldNot);
       clearAllFilters();

--- a/cypress/e2e/types/filter-categories.ts
+++ b/cypress/e2e/types/filter-categories.ts
@@ -30,8 +30,7 @@ export const categoryCategory = "category";
 export const categorySource = "source";
 export const categoryTarget = "target";
 export const categoryApplicationId = "application.id";
-export const filterSelectType = (categoryKey: string) =>
-  `[data-ouia-component-id="select-filter-value-${categoryKey}"]`;
+export const categoryTagCategory = "tagCategory";
 /**
  * Main filter dropdown is based on the HTML id attribute
  * ouiaId is passed (as of PF5) to the wrapping <li> element
@@ -40,3 +39,18 @@ export const filterSelectType = (categoryKey: string) =>
 export const filterCategory = (categoryKey: string) =>
   // this syntax works with dots in the categoryKey
   `[id="filter-category-${categoryKey}"]`;
+
+export const filterToggle = (categoryKey: string) =>
+  `[data-ouia-component-id="filter-for-${categoryKey}"]`;
+
+export const filterToggleInput = (categoryKey: string) =>
+  `[id="filter-for-${categoryKey}-input"]`;
+
+export const filterToggleListbox = (categoryKey: string) =>
+  `[id="filter-for-${categoryKey}-listbox"]`;
+
+export const searchInput = (categoryKey: string) =>
+  `[data-ouia-component-id="search-for-${categoryKey}-input"]`;
+
+export const searchButton = (categoryKey: string) =>
+  `[data-ouia-component-id="search-for-${categoryKey}-button"]`;

--- a/cypress/e2e/views/analysis-profile.view.ts
+++ b/cypress/e2e/views/analysis-profile.view.ts
@@ -1,3 +1,8 @@
+import {
+  categoryProvider,
+  filterToggleListbox,
+} from "../types/filter-categories";
+
 /*
 Copyright © 2021 the Konveyor Contributors (https://konveyor.io/)
 
@@ -23,8 +28,7 @@ export const submitButton = 'button[type="submit"]';
 export const pencilAction = '[id^="pencil-action"]';
 
 // Language and target selectors
-export const languageListbox =
-  "#filter-control-provider-select-typeahead-listbox > li";
+export const languageListbox = `${filterToggleListbox(categoryProvider)} > li`;
 export const menuListItem = ".pf-v5-c-menu__list-item";
 export const checkboxInput = "input[type=checkbox]";
 export const wizardMainBody = ".pf-v5-c-wizard__main-body";

--- a/cypress/e2e/views/analysis.view.ts
+++ b/cypress/e2e/views/analysis.view.ts
@@ -1,3 +1,5 @@
+import { categoryProvider, filterToggle } from "../types/filter-categories";
+
 /*
 Copyright © 2021 the Konveyor Contributors (https://konveyor.io/)
 
@@ -55,7 +57,7 @@ export const closeWizard = ".pf-v5-c-wizard__close > .pf-v5-c-button";
 export const codeEditorControls = "div.pf-v5-c-code-editor__controls";
 export const menuToggle = "button.pf-v5-c-menu-toggle";
 export const menuList = "div.pf-v5-c-menu";
-export const languageSelectionDropdown = "#filter-control-provider-Languages";
+export const languageSelectionDropdown = filterToggle(categoryProvider);
 export const numberOfRulesColumn = "td[data-label='Number of rules']";
 export const logFilter = "span.pf-v5-c-menu-toggle__toggle-icon";
 export const analysisProfileMode = "#wizard-mode-profile";

--- a/cypress/e2e/views/applicationinventory.view.ts
+++ b/cypress/e2e/views/applicationinventory.view.ts
@@ -1,3 +1,9 @@
+import {
+  categorySource,
+  categoryTagCategory,
+  filterToggleInput,
+} from "../types/filter-categories";
+
 /*
 Copyright © 2021 the Konveyor Contributors (https://konveyor.io/)
 
@@ -82,13 +88,13 @@ export const packaging = "input[name=packaging]";
 export const createEntitiesCheckbox = "#create-entities-checkbox";
 
 //Fields related to application details page
-export enum appDetailsView {
-  applicationTag = "span.pf-v5-c-label__content",
-  closeDetailsPage = "button[aria-label='Close drawer panel']",
-  tagFilter = "#filter-control-source-typeahead-select-input",
-  tagCategory = "div[class='pf-v5-c-content'] > h4",
-  tagCategoryFilter = "#filter-control-tagCategory-typeahead-select-input",
-}
+export const appDetailsView = {
+  applicationTag: "span.pf-v5-c-label__content",
+  closeDetailsPage: "button[aria-label='Close drawer panel']",
+  tagFilter: filterToggleInput(categorySource),
+  tagCategory: "div[class='pf-v5-c-content'] > h4",
+  tagCategoryFilter: filterToggleInput(categoryTagCategory),
+};
 
 // Fields related to copy assessment modal
 export const copyAssessmentTableTd = ".pf-m-compact> tbody > tr > td";

--- a/cypress/e2e/views/common.view.ts
+++ b/cypress/e2e/views/common.view.ts
@@ -40,7 +40,6 @@ export const expandableRow = ".pf-c-expandable-row";
 export const helper = "span.pf-v5-c-helper-text__item-text";
 export const filterInput = "input[type='search']";
 export const inputText = "input[type='text']";
-export const searchButton = "button#search-button";
 export const nextPageButton = "button[aria-label='Go to next page']";
 export const prevPageButton = "button[aria-label='Go to previous page']";
 export const lastPageButton = "button[aria-label='Go to last page']";
@@ -71,21 +70,14 @@ export const saveAndReviewButton = "button[cy-data='save-and-review']";
 export const span = "span";
 export const div = "div";
 export const liTag = "li";
-export const searchInput = "#search-input";
 export const aboutButton = "#about-button";
 export const issues = "Issues";
 export const dependencies = "Dependencies";
 export const technologies = "Technologies";
-/**
- * ul[role=listbox] > li is for the Application Inventory page.
- * span.pf-c-check__label is for the Copy assessment page.
- */
-export const standardFilter =
-  "ul[role=listbox] > li, span.pf-v5-c-check__label";
+
 export const specialFilter = "#select-multi-typeahead-checkbox-listbox";
 export const filterDropDownContainer =
   "div.pf-v5-c-toolbar__group.pf-m-toggle-group.pf-m-filter-group.pf-m-show";
-export const filterDropDown = '[id^="filter-control-"]';
 export const actionSelectToggle = "span.pf-v5-c-menu-toggle__controls";
 export const radioButtonLabel = "div.pf-v5-c-radio";
 export const radioButton = '*[class^="pf-v5-c-radio__input"]';

--- a/cypress/e2e/views/credentials.view.ts
+++ b/cypress/e2e/views/credentials.view.ts
@@ -23,7 +23,6 @@ export const privatePassphraseInput =
   "input[aria-label='Private Key Passphrase']";
 export const createBtn = "#create-credential-button";
 export const selectType = '[data-ouia-component-id="type-select-toggle"]';
-export const searchButton = "#search-button";
 export const modalBoxBody = "#confirm-dialog";
 export const defaultIcon = "svg.pf-v5-svg";
 export enum credLabels {

--- a/cypress/e2e/views/custom-migration-target.view.ts
+++ b/cypress/e2e/views/custom-migration-target.view.ts
@@ -1,29 +1,34 @@
+import { categoryProvider, filterToggle } from "../types/filter-categories";
+
 export const sourcesToggle = "#sources-toggle";
 export const sourcesList = "ul#formSources-id.pf-v5-c-select__menu";
-export enum CustomMigrationTargetView {
-  createSubmitButton = "button[id='identity-form-submit']:contains('Create')",
-  editSubmitButton = "button[id='identity-form-submit']:contains('Save')",
-  actionsButton = "button[aria-label='Table toolbar actions kebab toggle']",
-  nameInput = "#name",
-  helperText = "span[class*='helper-text']",
-  descriptionInput = "#description",
-  imageInput = "#custom-migration-target-upload-image-filename",
-  imageHelper = "#custom-migration-target-upload-image-helper",
-  ruleInput = "input[accept*='text/yaml,.yml,.yaml']",
-  ruleHelper = "h4[class*='alert__title']",
-  ruleFilesToggle = "button[aria-expanded='true']",
-  takeMeThereNotification = "Take me there",
-  repositoryTypeDropdown = '[data-ouia-component-id="repo-type-select-toggle"]',
-  repositoryUrl = "#sourceRepository",
-  branch = "#branch",
-  rootPath = "#rootPath",
-  credentialsDropdown = '[data-ouia-component-id="associated-credentials-select-toggle"]',
-  credentialsInput = "#associated-credentials-select-toggle-input",
-  retrieveFromARepositoryRadio = "#repository",
-  dragButton = 'button[id*="drag-button"]',
-  card = ".pf-v5-c-card",
-  cardContainer = 'div[class*="gallery"][class*="gutter"]',
-  filterLanguageDropdown = "#filter-control-provider-Languages",
-  formLanguageDropdown = '[data-ouia-component-id="provider-type-select-toggle"]',
-  formLanguageDropdownOptions = '[data-ouia-component-id="provider-type-select-toggle-select"]',
-}
+export const CustomMigrationTargetView = {
+  createSubmitButton: "button[id='identity-form-submit']:contains('Create')",
+  editSubmitButton: "button[id='identity-form-submit']:contains('Save')",
+  actionsButton: "button[aria-label='Table toolbar actions kebab toggle']",
+  nameInput: "#name",
+  helperText: "span[class*='helper-text']",
+  descriptionInput: "#description",
+  imageInput: "#custom-migration-target-upload-image-filename",
+  imageHelper: "#custom-migration-target-upload-image-helper",
+  ruleInput: "input[accept*='text/yaml,.yml,.yaml']",
+  ruleHelper: "h4[class*='alert__title']",
+  ruleFilesToggle: "button[aria-expanded='true']",
+  takeMeThereNotification: "Take me there",
+  repositoryTypeDropdown: '[data-ouia-component-id="repo-type-select-toggle"]',
+  repositoryUrl: "#sourceRepository",
+  branch: "#branch",
+  rootPath: "#rootPath",
+  credentialsDropdown:
+    '[data-ouia-component-id="associated-credentials-select-toggle"]',
+  credentialsInput: "#associated-credentials-select-toggle-input",
+  retrieveFromARepositoryRadio: "#repository",
+  dragButton: 'button[id*="drag-button"]',
+  card: ".pf-v5-c-card",
+  cardContainer: 'div[class*="gallery"][class*="gutter"]',
+  filterLanguageDropdown: filterToggle(categoryProvider),
+  formLanguageDropdown:
+    '[data-ouia-component-id="provider-type-select-toggle"]',
+  formLanguageDropdownOptions:
+    '[data-ouia-component-id="provider-type-select-toggle-select"]',
+};

--- a/cypress/e2e/views/issue.view.ts
+++ b/cypress/e2e/views/issue.view.ts
@@ -1,9 +1,5 @@
-export const searchInput = "#search-input";
-export const bsFilterName = "#businessService\\.name-filter-value-select";
-export const tagFilterName = "#tag\\.id-filter-value-select";
 export const archetypeFilterName =
   "input[class='pf-v5-c-text-input-group__text-input']";
-export const searchMenuToggle = 'button[aria-label="Menu toggle"]';
 export const singleAppDropList =
   '[data-ouia-component-id="application-select"] button';
 export const rightSideBar = "div.pf-v5-c-drawer__panel-main";

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -58,7 +58,11 @@ import {
 } from "../e2e/types/constants";
 import {
   filterCategory,
-  filterSelectType,
+  filterToggle,
+  filterToggleInput,
+  filterToggleListbox,
+  searchButton,
+  searchInput,
 } from "../e2e/types/filter-categories";
 import {
   AppIssue,
@@ -97,8 +101,6 @@ import {
   downloadTaskButton,
   expandRow,
   expandableRow,
-  filterDropDownContainer,
-  filterInput,
   filteredBy,
   firstPageButton,
   itemsPerPageMenuOptions,
@@ -111,17 +113,12 @@ import {
   pageNumInput,
   prevPageButton,
   removeButton,
-  searchButton,
   sideDrawer,
-  standardFilter,
   submitButton,
   successAlertMessage,
   taskDetailsEditor,
 } from "../e2e/views/common.view";
-import {
-  searchMenuToggle,
-  singleApplicationColumns,
-} from "../e2e/views/issue.view";
+import { singleApplicationColumns } from "../e2e/views/issue.view";
 import * as loginView from "../e2e/views/login.view";
 import { navMenu, navTab } from "../e2e/views/menu.view";
 import { switchToggle } from "../e2e/views/reportsTab.view";
@@ -534,23 +531,9 @@ export function notExists(value: string, tableSelector = appTable): void {
   });
 }
 
-export function selectFilter(categoryKey: string, eq = 0): void {
-  if (eq === 0) {
-    cy.get(filteredBy).click();
-    cy.get(filterCategory(categoryKey)).click();
-    return;
-  }
-  cy.get("div.pf-m-filter-group")
-    .eq(eq)
-    .within(() => {
-      cy.get(filteredBy).click();
-      cy.get(filterCategory(categoryKey)).click();
-    });
-}
-
-export function filterInputText(searchTextValue: string, value: number): void {
-  cy.get(filterInput).eq(value).clear().type(searchTextValue);
-  cy.get(searchButton).eq(value).click({ force: true });
+export function selectFilter(categoryKey: string): void {
+  cy.get(filteredBy).click();
+  cy.get(filterCategory(categoryKey)).click();
 }
 
 export function clearAllFilters(): void {
@@ -572,18 +555,14 @@ export function validateSingleApplicationIssue(issue: AppIssue): void {
     });
 }
 
-export function applySelectFilter(
-  filterId: string,
-  filterName,
+export function applySelectFilterViaTextInput(
+  filterCategoryKey,
   filterText: string,
   isValid = true
 ): void {
-  const filterInput = `#filter-control-${filterId}-typeahead-select-input`;
-  selectFilter(filterName);
-  cy.get(filterInput)
-    .closest(".pf-v5-c-menu-toggle")
-    .find(".pf-v5-c-menu-toggle__button")
-    .click();
+  const filterInput = filterToggleInput(filterCategoryKey);
+  selectFilter(filterCategoryKey);
+  cy.get(filterToggle(filterCategoryKey)).click();
   inputText(filterInput, filterText);
   if (isValid) {
     clickByText(".pf-v5-c-menu__item", filterText);
@@ -593,36 +572,31 @@ export function applySelectFilter(
   cy.get(filterInput).click();
 }
 
+export function applySelectFilter(
+  filterName: string,
+  searchText: string | string[]
+): void {
+  selectFilter(filterName);
+  const filterValue = Array.isArray(searchText) ? searchText : [searchText];
+
+  cy.get(filterToggle(filterName)).click();
+  cy.get(filterToggleListbox(filterName)).within(() => {
+    filterValue.forEach((searchTextValue) => {
+      cy.contains(searchTextValue).click();
+    });
+  });
+}
+
 export function applySearchFilter(
   filterName: string,
-  searchText: string | string[],
-  identifiedRisk = false,
-  eq = 0
+  searchText: string | string[]
 ): void {
-  selectFilter(filterName, eq);
-  let filterValue = [];
-  if (!Array.isArray(searchText)) {
-    filterValue = [searchText];
-  } else filterValue = searchText;
+  selectFilter(filterName);
+  const filterValue = Array.isArray(searchText) ? searchText : [searchText];
 
-  cy.get(filterDropDownContainer).then(($container) => {
-    if ($container.find(searchMenuToggle).length > 0) {
-      cy.get(searchMenuToggle).click();
-      filterValue.forEach((searchTextValue) => {
-        cy.get(standardFilter).contains(searchTextValue).click();
-      });
-    } else {
-      if ($container.find(filterSelectType(filterName)).length > 0) {
-        cy.get(filterSelectType(filterName)).click();
-        filterValue.forEach((searchTextValue) => {
-          cy.get(standardFilter).contains(searchTextValue).click();
-        });
-      } else {
-        filterValue.forEach((searchTextValue) => {
-          filterInputText(searchTextValue, +identifiedRisk);
-        });
-      }
-    }
+  filterValue.forEach((searchTextValue) => {
+    cy.get(searchInput(filterName)).clear().type(searchTextValue);
+    cy.get(searchButton(filterName)).click({ force: true });
   });
 }
 


### PR DESCRIPTION
Share the same component between forms and filters.

Cleanup the tests:
1. Use the same pattern for toggle IDs for Select based filters.
   Based on toggle ID build consistent IDs for other elements
   inside the Select (i.e. listbox).
2. provide helpers for building selectors based on filter name
   (categoryKey). Limit the number of hardcoded global IDs.
3. fix incorrect filter types (i.e. search instead of typeahead filter)
4. cleanup placeholder text and unused props
5. scope filter selectors with callWithin(modal,...) to address scenario
   where 2 tables are visible on one screen: on the main page and inside
   model. In this scenario test IDs are duplicated.
    
Assisted-by: Cursor:claude-4.6-opus-high
Supports: https://github.com/konveyor/tackle2-ui/issues/3212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked filter controls: replaced legacy typeahead with unified multi-select, standardized toggle/listbox IDs and OUIA attributes, and simplified focus/keyboard wiring for consistent behavior.
  * Normalized selector/selector-helper usage and view exports for more predictable UI element targeting.
* **Tests**
  * Updated end-to-end tests and utilities to use parameterized filter selectors and consolidated filter interaction flows for greater reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->