### PR TITLE
:seedling: Add sync-labels scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "port-forward:hub": "kubectl port-forward svc/tackle-hub -n konveyor-tackle 9002:8080",
     "port-forward:keycloak": "kubectl port-forward svc/tackle-keycloak-sso -n konveyor-tackle 9001:8080",
     "port-forward:llm-proxy": "kubectl port-forward svc/llm-proxy -n konveyor-tackle 9004:8321",
-    "port-forward": "concurrently -c auto 'npm:port-forward:*'"
+    "port-forward": "concurrently -c auto 'npm:port-forward:*'",
+    "sync-labels:check": "ts-node --project scripts/sync-labels/tsconfig.json scripts/sync-labels/check-issues.ts"
   },
   "workspaces": [
     "common",

--- a/scripts/sync-labels/check-issues.ts
+++ b/scripts/sync-labels/check-issues.ts
@@ -1,0 +1,551 @@
+#!/usr/bin/env node
+/**
+ * check-issues.ts
+ *
+ * CLI script that discovers all issues tracked in the Konveyor planning
+ * project, compares their project field values (Status, Priority, Kind) to
+ * their GitHub labels, and reports where labels need to be added or removed.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=<pat> node --loader ts-node/esm \
+ *     --project scripts/sync-labels/tsconfig.json \
+ *     scripts/sync-labels/check-issues.ts \
+ *     [--org konveyor] [--project-number 67] [--repo tackle2-ui]
+ *
+ * Or via npm:
+ *   GITHUB_TOKEN=<pat> npm run sync-labels:check [-- --repo tackle2-ui]
+ *
+ * Required environment variables:
+ *   GITHUB_TOKEN  — a token with `read:project` and `read:org` scopes
+ *
+ * Optional CLI flags (all have defaults):
+ *   --org            GitHub organization login        (default: konveyor)
+ *   --project-number GitHub Project number            (default: 67)
+ *   --repo           Filter to a single repo name     (default: tackle2-ui)
+ *   --all-repos      Include issues from all repos in the project
+ *   --include-closed Include closed issues            (default: open only)
+ */
+
+import process from "node:process";
+
+import {
+  type LabelDiffResult,
+  computeLabelDiff,
+  isNoop,
+  summarizeManagedLabels,
+} from "./label-projection";
+import {
+  FIELDS_QUERY,
+  type ProjectIssueItem,
+  REPO_FIELDS_QUERY,
+  type RawProjectResponse,
+  type RawRepoResponse,
+  parseProjectItems,
+  parseRepoIssues,
+} from "./project-fields";
+
+// ── CLI argument parsing ───────────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): {
+  org: string;
+  projectNumber: number;
+  repo: string | undefined;
+  allRepos: boolean;
+  includeClosed: boolean;
+  apply: boolean;
+} {
+  const args = argv.slice(2);
+  const get = (flag: string): string | undefined => {
+    const i = args.indexOf(flag);
+    return i !== -1 ? args[i + 1] : undefined;
+  };
+
+  return {
+    org: get("--org") ?? "konveyor",
+    projectNumber: parseInt(get("--project-number") ?? "67", 10),
+    repo: args.includes("--all-repos")
+      ? undefined
+      : (get("--repo") ?? "tackle2-ui"),
+    allRepos: args.includes("--all-repos"),
+    includeClosed: args.includes("--include-closed"),
+    apply: args.includes("--apply"),
+  };
+}
+
+// ── GraphQL client (native fetch) ─────────────────────────────────────────────
+
+async function graphql<T>(
+  token: string,
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "konveyor-label-sync-check/1.0",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
+  }
+
+  const json = (await res.json()) as {
+    data?: T;
+    errors?: Array<{ message: string }>;
+  };
+
+  if (json.errors?.length) {
+    throw new Error(
+      `GraphQL errors:\n${json.errors.map((e) => `  • ${e.message}`).join("\n")}`
+    );
+  }
+
+  if (!json.data) throw new Error("GraphQL response contained no data");
+  return json.data;
+}
+
+// ── REST helpers (label apply) ────────────────────────────────────────────────
+
+const GITHUB_REST = "https://api.github.com";
+const REST_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/vnd.github+json",
+  "User-Agent": "konveyor-label-sync-check/1.0",
+};
+
+async function restAddLabels(
+  token: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  labels: string[]
+): Promise<void> {
+  const res = await fetch(
+    `${GITHUB_REST}/repos/${owner}/${repo}/issues/${issueNumber}/labels`,
+    {
+      method: "POST",
+      headers: { ...REST_HEADERS, Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ labels }),
+    }
+  );
+  if (!res.ok)
+    throw new Error(
+      `add labels on #${issueNumber}: ${res.status} ${res.statusText}`
+    );
+}
+
+async function restRemoveLabel(
+  token: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string
+): Promise<void> {
+  const res = await fetch(
+    `${GITHUB_REST}/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(label)}`,
+    {
+      method: "DELETE",
+      headers: { ...REST_HEADERS, Authorization: `Bearer ${token}` },
+    }
+  );
+  // 404 means the label wasn't present — treat as success
+  if (!res.ok && res.status !== 404)
+    throw new Error(
+      `remove "${label}" from #${issueNumber}: ${res.status} ${res.statusText}`
+    );
+}
+
+export interface ApplyResult {
+  success: boolean;
+  /** Error message if success is false. */
+  error?: string;
+}
+
+/**
+ * Apply the computed label diffs to GitHub issues via the REST API.
+ * Issues with no diff are skipped.  Errors per issue are captured and
+ * returned rather than thrown so the caller can report partial failures.
+ *
+ * @returns A map of issueNumber → ApplyResult for every issue that had changes.
+ */
+async function applyLabelDiffs(
+  token: string,
+  entries: ReportEntry[]
+): Promise<Map<number, ApplyResult>> {
+  const results = new Map<number, ApplyResult>();
+
+  for (const { item, result } of entries) {
+    if (isNoop(result.diff)) continue;
+
+    process.stderr.write(
+      `  Applying #${item.issueNumber} (+[${result.diff.toAdd.join(", ")}]` +
+        ` -[${result.diff.toRemove.join(", ")}])...\n`
+    );
+
+    try {
+      if (result.diff.toAdd.length > 0) {
+        await restAddLabels(
+          token,
+          item.owner,
+          item.repo,
+          item.issueNumber,
+          result.diff.toAdd
+        );
+      }
+      for (const label of result.diff.toRemove) {
+        await restRemoveLabel(
+          token,
+          item.owner,
+          item.repo,
+          item.issueNumber,
+          label
+        );
+      }
+      results.set(item.issueNumber, { success: true });
+    } catch (e) {
+      results.set(item.issueNumber, {
+        success: false,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Repo-scoped strategy: queries issues from a specific repository and finds
+ * their field values in the target project.  The repo filter is in the GraphQL
+ * variables; only issues belonging to that project are returned.
+ */
+async function fetchAllRepoIssues(
+  token: string,
+  org: string,
+  repo: string,
+  projectNumber: number
+): Promise<{ projectTitle: string; items: ProjectIssueItem[] }> {
+  const allItems: ProjectIssueItem[] = [];
+  let cursor: string | null = null;
+  let projectTitle = "";
+
+  do {
+    const data: RawRepoResponse = await graphql<RawRepoResponse>(
+      token,
+      REPO_FIELDS_QUERY,
+      {
+        org,
+        repo,
+        cursor,
+      }
+    );
+
+    const { nodes, pageInfo } = data.organization.repository.issues;
+    const { items: page, projectTitle: title } = parseRepoIssues(
+      nodes,
+      projectNumber,
+      org,
+      repo
+    );
+
+    if (title && !projectTitle) projectTitle = title;
+    allItems.push(...page);
+    cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+
+    process.stderr.write(
+      `  Fetched page (${nodes.length} issues, ${allItems.length} in project so far)...\n`
+    );
+  } while (cursor !== null);
+
+  return { projectTitle, items: allItems };
+}
+
+/**
+ * Project-scoped strategy: queries all items in the project.
+ * Used for --all-repos when no specific repository is targeted.
+ */
+async function fetchAllProjectItems(
+  token: string,
+  org: string,
+  projectNumber: number
+): Promise<{ projectTitle: string; items: ProjectIssueItem[] }> {
+  const allItems: ProjectIssueItem[] = [];
+  let cursor: string | null = null;
+  let projectTitle = "";
+
+  do {
+    const data: RawProjectResponse = await graphql<RawProjectResponse>(
+      token,
+      FIELDS_QUERY,
+      {
+        org,
+        number: projectNumber,
+        cursor,
+      }
+    );
+
+    const project: RawProjectResponse["organization"]["projectV2"] =
+      data.organization.projectV2;
+    projectTitle = project.title;
+    const { nodes, pageInfo }: typeof project.items = project.items;
+
+    allItems.push(...parseProjectItems(nodes));
+    cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+
+    process.stderr.write(
+      `  Fetched page (${nodes.length} items, ${allItems.length} total so far)...\n`
+    );
+  } while (cursor !== null);
+
+  return { projectTitle, items: allItems };
+}
+
+// ── Report formatting ─────────────────────────────────────────────────────────
+
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const CYAN = "\x1b[36m";
+
+function fmt(color: string, text: string): string {
+  return `${color}${text}${RESET}`;
+}
+
+interface ReportEntry {
+  item: ProjectIssueItem;
+  result: LabelDiffResult;
+}
+
+function printReport(
+  projectTitle: string,
+  org: string,
+  projectNumber: number,
+  entries: ReportEntry[],
+  opts: { includeClosed: boolean; apply: boolean },
+  applyResults?: Map<number, ApplyResult>
+): void {
+  const needsUpdate = entries.filter((e) => !isNoop(e.result.diff));
+  const upToDate = entries.filter(
+    (e) => isNoop(e.result.diff) && e.result.warnings.length === 0
+  );
+  const warningsOnly = entries.filter(
+    (e) => isNoop(e.result.diff) && e.result.warnings.length > 0
+  );
+  const failed = applyResults
+    ? [...applyResults.values()].filter((r) => !r.success)
+    : [];
+
+  console.log();
+  console.log(
+    fmt(
+      BOLD,
+      opts.apply ? `Label Sync Apply Report` : `Label Sync Check Report`
+    )
+  );
+  console.log(
+    fmt(DIM, `Project: ${projectTitle} (${org}/projects/${projectNumber})`)
+  );
+  console.log(fmt(DIM, `Issues checked: ${entries.length}`));
+  if (opts.apply) {
+    console.log(
+      fmt(DIM, `Mode: apply — label changes have been written to GitHub`)
+    );
+  } else {
+    console.log(fmt(DIM, `Mode: dry-run — pass --apply to write changes`));
+  }
+  console.log();
+
+  // ── Issues with label changes ──────────────────────────────────────────
+  if (needsUpdate.length === 0) {
+    console.log(
+      fmt(GREEN, `✔  All ${entries.length} issues have up-to-date labels.`)
+    );
+  } else {
+    const actionVerb = opts.apply ? "updated" : "need label updates";
+    const headerColor = opts.apply && failed.length === 0 ? GREEN : RED;
+    console.log(
+      fmt(
+        BOLD + headerColor,
+        `${opts.apply ? "✔" : "✖"}  ${needsUpdate.length} issue(s) ${actionVerb}:`
+      )
+    );
+    console.log();
+
+    for (const { item, result } of needsUpdate) {
+      const applyResult = applyResults?.get(item.issueNumber);
+      const applyTag = applyResult
+        ? applyResult.success
+          ? fmt(GREEN, " [applied]")
+          : fmt(RED, ` [FAILED: ${applyResult.error}]`)
+        : "";
+      const stateTag =
+        item.issueState === "CLOSED" ? fmt(DIM, " [closed]") : "";
+      console.log(
+        `  ${fmt(BOLD, `#${item.issueNumber}`)}${stateTag}${applyTag}  ${item.issueTitle}`
+      );
+      console.log(`  ${fmt(DIM, item.issueUrl)}`);
+
+      const fieldSummary = [
+        item.fields.status ? `Status="${item.fields.status}"` : "Status=?",
+        item.fields.priority
+          ? `Priority="${item.fields.priority}"`
+          : "Priority=?",
+      ].join("  ");
+      console.log(`  ${fmt(DIM, `Fields: ${fieldSummary}`)}`);
+      console.log(
+        `  ${fmt(DIM, `Current managed labels: ${summarizeManagedLabels(item.currentLabels)}`)}`
+      );
+
+      for (const label of result.diff.toAdd) {
+        console.log(`    ${fmt(GREEN, `+ ${label}`)}`);
+      }
+      for (const label of result.diff.toRemove) {
+        console.log(`    ${fmt(RED, `- ${label}`)}`);
+      }
+
+      for (const w of result.warnings) {
+        console.log(`    ${fmt(YELLOW, `⚠  ${w.message}`)}`);
+      }
+
+      console.log();
+    }
+  }
+
+  // ── Warnings only (no label changes but unmapped values) ──────────────
+  if (warningsOnly.length > 0) {
+    console.log(
+      fmt(
+        YELLOW,
+        `⚠  ${warningsOnly.length} issue(s) have unmapped field values (labels unchanged):`
+      )
+    );
+    for (const { item, result } of warningsOnly) {
+      console.log(`  ${fmt(BOLD, `#${item.issueNumber}`)}  ${item.issueTitle}`);
+      for (const w of result.warnings) {
+        console.log(`    ${fmt(YELLOW, `⚠  ${w.message}`)}`);
+      }
+    }
+    console.log();
+  }
+
+  // ── Up to date ────────────────────────────────────────────────────────
+  if (upToDate.length > 0) {
+    console.log(
+      fmt(DIM, `✔  ${upToDate.length} issue(s) already have correct labels.`)
+    );
+  }
+
+  // ── Unrecognized field names summary ──────────────────────────────────
+  const allUnknownFields = new Set<string>();
+  for (const { item } of entries) {
+    for (const f of item.unknownFieldNames) allUnknownFields.add(f);
+  }
+  if (allUnknownFields.size > 0) {
+    console.log();
+    console.log(
+      fmt(
+        CYAN,
+        `ℹ  Unrecognized project field names (not mapped in mappings.ts): ` +
+          `${[...allUnknownFields].join(", ")}`
+      )
+    );
+    console.log(
+      fmt(
+        DIM,
+        `  If any of these are "Status" or "Priority", update FIELD_NAMES in mappings.ts.`
+      )
+    );
+  }
+
+  console.log();
+
+  // Exit codes:
+  //   dry-run: exit 1 if any issues need updates (useful in CI)
+  //   apply:   exit 1 if any applies failed
+  if (opts.apply) {
+    if (failed.length > 0) process.exitCode = 1;
+  } else {
+    if (needsUpdate.length > 0) process.exitCode = 1;
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error(
+      "Error: GITHUB_TOKEN environment variable is required.\n" +
+        "Create a token with read:project and read:org scopes at https://github.com/settings/tokens\n" +
+        "\nUsage:\n" +
+        "  GITHUB_TOKEN=<token> npm run sync-labels:check [-- --org konveyor --project-number 67 --repo tackle2-ui [--apply]]"
+    );
+    process.exit(1);
+  }
+
+  const opts = parseArgs(process.argv);
+
+  process.stderr.write(
+    `Fetching project ${opts.org}/projects/${opts.projectNumber}` +
+      (opts.repo ? ` (filtering to repo: ${opts.repo})` : " (all repos)") +
+      "...\n"
+  );
+
+  const { projectTitle, items } = opts.repo
+    ? await fetchAllRepoIssues(token, opts.org, opts.repo, opts.projectNumber)
+    : await fetchAllProjectItems(token, opts.org, opts.projectNumber);
+
+  // Filter out closed issues unless --include-closed is set, then sort by issue number
+  const filtered = (
+    opts.includeClosed ? items : items.filter((i) => i.issueState === "OPEN")
+  ).sort((a, b) => a.issueNumber - b.issueNumber);
+
+  if (filtered.length === 0) {
+    console.log(
+      `No ${opts.includeClosed ? "" : "open "}issues found in project` +
+        (opts.repo ? ` for repo "${opts.repo}"` : "") +
+        "."
+    );
+    return;
+  }
+
+  process.stderr.write(`Processing ${filtered.length} issues...\n`);
+
+  const entries: ReportEntry[] = filtered.map((item) => ({
+    item,
+    result: computeLabelDiff(item.fields, item.currentLabels),
+  }));
+
+  let applyResults: Map<number, ApplyResult> | undefined;
+  if (opts.apply) {
+    const toApply = entries.filter((e) => !isNoop(e.result.diff));
+    if (toApply.length === 0) {
+      process.stderr.write(`No label changes to apply.\n`);
+    } else {
+      process.stderr.write(
+        `Applying label diffs to ${toApply.length} issue(s)...\n`
+      );
+      applyResults = await applyLabelDiffs(token, toApply);
+    }
+  }
+
+  printReport(
+    projectTitle,
+    opts.org,
+    opts.projectNumber,
+    entries,
+    opts,
+    applyResults
+  );
+}
+
+main().catch((err) => {
+  console.error(`\nFatal error: ${(err as Error).message}`);
+  process.exit(1);
+});

--- a/scripts/sync-labels/label-projection.ts
+++ b/scripts/sync-labels/label-projection.ts
@@ -1,0 +1,203 @@
+/**
+ * label-projection.ts
+ *
+ * Pure functions — no API calls, no side effects.
+ * Given the current project field values for an issue and its current labels,
+ * computes exactly which labels need to be added or removed.
+ *
+ * This module is designed to be importable from both the CLI check script and
+ * a future GitHub Actions workflow (e.g. via actions/github-script).
+ */
+
+import {
+  FIELD_NAMES,
+  MANAGED_LABEL_PREFIXES,
+  NEEDS_LABELS,
+  PRIORITY_LABEL_MAP,
+  STATUS_TRIAGE_MAP,
+  normalizeFieldValue,
+} from "./mappings";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** The subset of project field values relevant to label sync. */
+export interface ProjectItemFields {
+  /** Value of the project "Status" field, e.g. "In Progress". */
+  status?: string;
+  /** Value of the project "Priority" field, e.g. "Major". */
+  priority?: string;
+}
+
+/** The set of label changes needed to bring an issue into sync. */
+export interface LabelDiff {
+  toAdd: string[];
+  toRemove: string[];
+}
+
+/**
+ * A warning produced when a field value has no entry in the mapping tables.
+ * The `needs-*` default label for that family is applied in this case.
+ */
+export interface MappingWarning {
+  field: "status" | "priority" | "kind";
+  value: string;
+  message: string;
+}
+
+/** Full result from computeLabelDiff. */
+export interface LabelDiffResult {
+  diff: LabelDiff;
+  warnings: MappingWarning[];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** The complete set of needs-* labels this tool manages. */
+const NEEDS_LABEL_SET = new Set<string>(Object.values(NEEDS_LABELS));
+
+/**
+ * Returns true if the label belongs to one of the managed families —
+ * either a prefixed label (triage/*, priority/*, kind/*) or a needs-* label.
+ */
+function isManaged(label: string): boolean {
+  return (
+    MANAGED_LABEL_PREFIXES.some((prefix) => label.startsWith(prefix)) ||
+    NEEDS_LABEL_SET.has(label)
+  );
+}
+
+/** Returns all labels from `currentLabels` that start with `prefix`. */
+function labelsWithPrefix(currentLabels: string[], prefix: string): string[] {
+  return currentLabels.filter((l) => l.startsWith(prefix));
+}
+
+// ── Core computation ──────────────────────────────────────────────────────────
+
+/**
+ * Compute the label additions and removals needed so that the issue's labels
+ * reflect the given project field values.
+ *
+ * Managed labels (triage/*, priority/*, and the needs-* defaults) are the only
+ * ones ever added or removed.  kind/* labels and all other labels are untouched
+ * since the project has no Kind field — those labels are managed via issue type
+ * or direct labelling.
+ *
+ * When a field has no value (undefined) or its value is not in the mapping
+ * table, the corresponding `NEEDS_LABELS` default is applied:
+ *   - status undefined/unmapped   → needs-triage
+ *   - priority undefined/unmapped → needs-priority
+ *
+ * @param fields        Current project field values for the issue.
+ * @param currentLabels All labels currently on the issue.
+ * @returns The diff to apply and any warnings about unmapped field values.
+ */
+export function computeLabelDiff(
+  fields: ProjectItemFields,
+  currentLabels: string[]
+): LabelDiffResult {
+  const toAdd: string[] = [];
+  const toRemove: string[] = [];
+  const warnings: MappingWarning[] = [];
+
+  // ── Status → triage/* or needs-triage ──────────────────────────────────
+  {
+    let expectedLabel: string = NEEDS_LABELS.triage; // default when unset or unmapped
+
+    if (fields.status !== undefined) {
+      const normalized = normalizeFieldValue(fields.status);
+      if (Object.prototype.hasOwnProperty.call(STATUS_TRIAGE_MAP, normalized)) {
+        expectedLabel = STATUS_TRIAGE_MAP[normalized];
+      } else {
+        warnings.push({
+          field: "status",
+          value: fields.status,
+          message:
+            `"${fields.status}" (normalized: "${normalized}") is not in ` +
+            `${FIELD_NAMES.status} mapping (STATUS_TRIAGE_MAP). ` +
+            `Defaulting to "${NEEDS_LABELS.triage}".`,
+        });
+      }
+    }
+
+    if (expectedLabel.startsWith("triage/")) {
+      // Accepted — ensure the correct triage/* label, remove needs-triage
+      if (!currentLabels.includes(expectedLabel)) toAdd.push(expectedLabel);
+      for (const l of labelsWithPrefix(currentLabels, "triage/")) {
+        if (l !== expectedLabel) toRemove.push(l);
+      }
+      if (currentLabels.includes(NEEDS_LABELS.triage))
+        toRemove.push(NEEDS_LABELS.triage);
+    } else {
+      // Not yet accepted — ensure needs-triage, remove any triage/* labels
+      if (!currentLabels.includes(NEEDS_LABELS.triage))
+        toAdd.push(NEEDS_LABELS.triage);
+      for (const l of labelsWithPrefix(currentLabels, "triage/"))
+        toRemove.push(l);
+    }
+  }
+
+  // ── Priority → priority/* or needs-priority ────────────────────────────
+  {
+    let expectedLabel: string = NEEDS_LABELS.priority; // default when unset or unmapped
+
+    if (fields.priority !== undefined) {
+      const normalized = normalizeFieldValue(fields.priority);
+      if (
+        Object.prototype.hasOwnProperty.call(PRIORITY_LABEL_MAP, normalized)
+      ) {
+        expectedLabel = PRIORITY_LABEL_MAP[normalized];
+      } else {
+        warnings.push({
+          field: "priority",
+          value: fields.priority,
+          message:
+            `"${fields.priority}" (normalized: "${normalized}") is not in ` +
+            `${FIELD_NAMES.priority} mapping (PRIORITY_LABEL_MAP). ` +
+            `Defaulting to "${NEEDS_LABELS.priority}".`,
+        });
+      }
+    }
+
+    if (expectedLabel.startsWith("priority/")) {
+      if (!currentLabels.includes(expectedLabel)) toAdd.push(expectedLabel);
+      for (const l of labelsWithPrefix(currentLabels, "priority/")) {
+        if (l !== expectedLabel) toRemove.push(l);
+      }
+      if (currentLabels.includes(NEEDS_LABELS.priority))
+        toRemove.push(NEEDS_LABELS.priority);
+    } else {
+      if (!currentLabels.includes(NEEDS_LABELS.priority))
+        toAdd.push(NEEDS_LABELS.priority);
+      for (const l of labelsWithPrefix(currentLabels, "priority/"))
+        toRemove.push(l);
+    }
+  }
+
+  // Deduplicate (a label can't be both added and removed)
+  const toRemoveSet = new Set(toRemove.filter((l) => !toAdd.includes(l)));
+
+  return {
+    diff: {
+      toAdd: [...new Set(toAdd)],
+      toRemove: [...toRemoveSet],
+    },
+    warnings,
+  };
+}
+
+/**
+ * Returns true if the diff has no changes to make.
+ */
+export function isNoop(diff: LabelDiff): boolean {
+  return diff.toAdd.length === 0 && diff.toRemove.length === 0;
+}
+
+/**
+ * Returns a human-readable summary of the managed labels on an issue —
+ * useful for reporting which labels are currently set vs. expected.
+ */
+export function summarizeManagedLabels(currentLabels: string[]): string {
+  const managed = currentLabels.filter(isManaged);
+  if (managed.length === 0) return "(none)";
+  return managed.join(", ");
+}

--- a/scripts/sync-labels/mappings.ts
+++ b/scripts/sync-labels/mappings.ts
@@ -1,0 +1,109 @@
+/**
+ * mappings.ts
+ *
+ * Authoritative mapping tables between GitHub Projects V2 field option names
+ * and the corresponding GitHub issue labels used in this repo.
+ *
+ * These maps are the single source of truth for both the CLI check script and
+ * any future workflow that syncs project fields ↔ labels.  Update them here
+ * whenever a new project field option or label is added.
+ *
+ * Key = exact string as it appears in the GitHub Project UI field option.
+ * Value = exact label name as it appears on GitHub issues.
+ */
+
+/**
+ * Project "Status" field option → expected triage/* label.
+ *
+ * When the status is "New" (not yet triaged) the issue should carry
+ * `needs-triage`.  For all other mapped statuses the issue is considered
+ * accepted and should carry `triage/accepted`.
+ * Any status option not present in this map is treated as unmapped and will
+ * receive the `NEEDS_LABELS.triage` default.
+ */
+export const STATUS_TRIAGE_MAP: Record<string, string> = {
+  New: "needs-triage",
+  Backlog: "triage/accepted",
+  Ready: "triage/accepted",
+  "In progress": "triage/accepted",
+  Testing: "triage/accepted",
+  Done: "triage/accepted",
+  Verified: "triage/accepted",
+};
+
+/**
+ * Project "Priority" field option → priority/* label.
+ *
+ * These match the priority dropdown options defined in the bug issue template.
+ */
+export const PRIORITY_LABEL_MAP: Record<string, string> = {
+  Blocker: "priority/blocker",
+  Urgent: "priority/critical",
+  High: "priority/major",
+  Medium: "priority/normal",
+  Low: "priority/minor",
+};
+
+/**
+ * Project "Kind" (or "Type") field option → kind/* label.
+ *
+ * NOTE: The planning project does not have a Kind/Type field.  Kind labels
+ * are managed via the issue's type or by direct labelling and are not synced
+ * by this tool.  This map is kept for reference only and is not used.
+ */
+// export const KIND_LABEL_MAP: Record<string, string> = { ... };
+
+/**
+ * The set of label prefixes managed by this sync tool.
+ * Only labels whose names start with one of these prefixes are ever added or
+ * removed — all other labels on an issue are left untouched.
+ *
+ * kind/* labels are intentionally excluded: the project has no Kind field, so
+ * kind labels are set via issue type or direct labelling and not touched here.
+ */
+export const MANAGED_LABEL_PREFIXES = ["triage/", "priority/"] as const;
+
+/**
+ * Default "needs-*" label applied to each managed family when the
+ * corresponding project field has no value or an unmapped value.
+ *
+ * These are paired with the three mapping tables:
+ *   STATUS_TRIAGE_MAP  → NEEDS_LABELS.triage   ("needs-triage")
+ *   PRIORITY_LABEL_MAP → NEEDS_LABELS.priority  ("needs-priority")
+ *   KIND_LABEL_MAP     → NEEDS_LABELS.kind       ("needs-kind")
+ */
+export const NEEDS_LABELS = {
+  triage: "needs-triage",
+  priority: "needs-priority",
+} as const;
+
+/**
+ * Project field names to look for in the fieldValues response.
+ * Must match the exact field name strings in the GitHub Project.
+ */
+export const FIELD_NAMES = {
+  status: "Status",
+  priority: "Priority",
+} as const;
+
+/**
+ * Strip leading emoji characters and surrounding whitespace from a project
+ * field option value before looking it up in a mapping table.
+ *
+ * GitHub Projects often prefixes option names with an emoji in the UI
+ * (e.g. "🐛 Bug", "🔥 Critical", "🔄 In Progress").  The mapping keys are
+ * defined without emoji so that adding or reordering decorators in the project
+ * UI doesn't require changes here.
+ *
+ * Uses the Unicode `Extended_Pictographic` property which covers emoji
+ * pictographs without accidentally matching digits (unlike `\p{Emoji}`).
+ */
+export function normalizeFieldValue(value: string): string {
+  return value
+    .replace(
+      // eslint-disable-next-line no-misleading-character-class
+      /^[\p{Extended_Pictographic}\u{FE0F}\u{20E3}\u{1F3FB}-\u{1F3FF}\s]+/u,
+      ""
+    )
+    .trim();
+}

--- a/scripts/sync-labels/package.json
+++ b/scripts/sync-labels/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/scripts/sync-labels/project-fields.ts
+++ b/scripts/sync-labels/project-fields.ts
@@ -1,0 +1,322 @@
+/**
+ * project-fields.ts
+ *
+ * GitHub Projects V2 GraphQL layer.
+ *
+ * Two query strategies are provided:
+ *
+ *  REPO_FIELDS_QUERY / parseRepoIssues
+ *    Preferred when a specific repo is known.  Queries issues directly from
+ *    the repository so the repo filter lives in the GraphQL variables, then
+ *    plucks field values from each issue's projectItems for the target project.
+ *
+ *  FIELDS_QUERY / parseProjectItems
+ *    Used for the --all-repos case.  Queries all items in the project and
+ *    returns every issue regardless of repository.
+ *
+ * No HTTP calls are made here.  The caller supplies the GraphQL execution
+ * function and passes raw responses to the parser functions.
+ */
+
+import type { ProjectItemFields } from "./label-projection";
+import { FIELD_NAMES } from "./mappings";
+
+// ── Shared field-value extraction helper ──────────────────────────────────────
+
+function extractFields(
+  fieldValueNodes: Array<RawFieldValue | Record<string, never>>
+): { fields: ProjectItemFields; unknownFieldNames: string[] } {
+  const fields: ProjectItemFields = {};
+  const unknownFieldNames: string[] = [];
+
+  for (const fv of fieldValueNodes) {
+    const fieldName = (fv as RawFieldValue).field?.name;
+    const fieldValue = (fv as RawFieldValue).name;
+
+    if (!fieldName || !fieldValue) continue;
+
+    if (fieldName === FIELD_NAMES.status) {
+      fields.status = fieldValue;
+    } else if (fieldName === FIELD_NAMES.priority) {
+      fields.priority = fieldValue;
+    } else if (!unknownFieldNames.includes(fieldName)) {
+      unknownFieldNames.push(fieldName);
+    }
+  }
+
+  return { fields, unknownFieldNames };
+}
+
+// ── Shared raw field-value type ───────────────────────────────────────────────
+
+export interface RawFieldValue {
+  name?: string;
+  field?: {
+    id?: string;
+    name?: string;
+  };
+}
+
+/** The fieldValues fragment used in both queries. */
+const FIELD_VALUES_FRAGMENT = /* graphql */ `
+  fieldValues(first: 20) {
+    nodes {
+      ... on ProjectV2ItemFieldSingleSelectValue {
+        name
+        field {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+// ── Strategy 1: Repo-scoped query (preferred) ─────────────────────────────────
+
+/**
+ * Queries issues from a specific repository and fetches their project item
+ * field values via the `projectItems` connection on each issue.  The repo
+ * filter is expressed as a GraphQL variable, not post-processing.
+ *
+ * Variables:
+ *   $org    (String!) — organization login
+ *   $repo   (String!) — repository name, e.g. "tackle2-ui"
+ *   $cursor (String)  — pagination cursor (null for first page)
+ *
+ * Client-side: filter project items by `project.number` to isolate the
+ * target project, since `projectItems` has no project-number filter argument.
+ */
+export const REPO_FIELDS_QUERY = /* graphql */ `
+  query RepoIssues($org: String!, $repo: String!, $cursor: String) {
+    organization(login: $org) {
+      repository(name: $repo) {
+        issues(first: 50, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            number
+            title
+            url
+            state
+            labels(first: 30) {
+              nodes { name }
+            }
+            projectItems(includeArchived: false, first: 10) {
+              nodes {
+                project {
+                  number
+                  title
+                }
+                ${FIELD_VALUES_FRAGMENT}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export interface RawRepoProjectItem {
+  project: { number: number; title: string };
+  fieldValues: { nodes: Array<RawFieldValue | Record<string, never>> };
+}
+
+export interface RawRepoIssueNode {
+  number: number;
+  title: string;
+  url: string;
+  state: "OPEN" | "CLOSED";
+  labels: { nodes: Array<{ name: string }> };
+  projectItems: { nodes: RawRepoProjectItem[] };
+}
+
+export interface RawRepoResponse {
+  organization: {
+    repository: {
+      issues: {
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: RawRepoIssueNode[];
+      };
+    };
+  };
+}
+
+/**
+ * Convert raw repo-query issue nodes into normalized ProjectIssueItem records.
+ * Issues that are not in the target project are skipped.
+ *
+ * @param issueNodes   Raw issue nodes from the REPO_FIELDS_QUERY response.
+ * @param projectNumber  The project number to match against each issue's projectItems.
+ * @param owner        Repository owner login (already known from query variables).
+ * @param repo         Repository name (already known from query variables).
+ */
+export function parseRepoIssues(
+  issueNodes: RawRepoIssueNode[],
+  projectNumber: number,
+  owner: string,
+  repo: string
+): { items: ProjectIssueItem[]; projectTitle: string } {
+  const items: ProjectIssueItem[] = [];
+  let projectTitle = "";
+
+  for (const issue of issueNodes) {
+    const projectItem = issue.projectItems.nodes.find(
+      (pi) => pi.project.number === projectNumber
+    );
+    if (!projectItem) continue;
+
+    if (!projectTitle) projectTitle = projectItem.project.title;
+
+    const currentLabels = issue.labels.nodes.map((l) => l.name);
+    const { fields, unknownFieldNames } = extractFields(
+      projectItem.fieldValues.nodes
+    );
+
+    items.push({
+      issueNumber: issue.number,
+      issueTitle: issue.title,
+      issueUrl: issue.url,
+      issueState: issue.state,
+      repo,
+      owner,
+      currentLabels,
+      fields,
+      unknownFieldNames,
+    });
+  }
+
+  return { items, projectTitle };
+}
+
+// ── Strategy 2: Project-scoped query (all repos) ──────────────────────────────
+
+/**
+ * Paginated query that fetches all items in a GitHub Project V2.
+ * Used for the --all-repos case where no specific repository is targeted.
+ *
+ * Variables:
+ *   $org    (String!) — organization login
+ *   $number (Int!)    — project number
+ *   $cursor (String)  — pagination cursor (null for first page)
+ */
+export const FIELDS_QUERY = /* graphql */ `
+  query ProjectItems($org: String!, $number: Int!, $cursor: String) {
+    organization(login: $org) {
+      projectV2(number: $number) {
+        title
+        items(first: 50, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            id
+            type
+            content {
+              ... on Issue {
+                number
+                title
+                url
+                state
+                repository {
+                  name
+                  owner { login }
+                }
+                labels(first: 30) {
+                  nodes { name }
+                }
+              }
+            }
+            ${FIELD_VALUES_FRAGMENT}
+          }
+        }
+      }
+    }
+  }
+`;
+
+export interface RawIssueContent {
+  number: number;
+  title: string;
+  url: string;
+  state: "OPEN" | "CLOSED";
+  repository: { name: string; owner: { login: string } };
+  labels: { nodes: Array<{ name: string }> };
+}
+
+export interface RawProjectItem {
+  id: string;
+  type: string;
+  content: RawIssueContent | null;
+  fieldValues: { nodes: Array<RawFieldValue | Record<string, never>> };
+}
+
+export interface RawProjectResponse {
+  organization: {
+    projectV2: {
+      title: string;
+      items: {
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: RawProjectItem[];
+      };
+    };
+  };
+}
+
+// ── Normalized output type ────────────────────────────────────────────────────
+
+/** A project issue item normalized for use by the label sync logic. */
+export interface ProjectIssueItem {
+  issueNumber: number;
+  issueTitle: string;
+  issueUrl: string;
+  issueState: "OPEN" | "CLOSED";
+  /** Repository name (without owner), e.g. "tackle2-ui". */
+  repo: string;
+  /** Repository owner login, e.g. "konveyor". */
+  owner: string;
+  /** All label names currently on the issue. */
+  currentLabels: string[];
+  /** Project field values extracted from the project item. */
+  fields: ProjectItemFields;
+  /**
+   * Field names found in fieldValues that did not match any of the known
+   * field names (Status, Priority, Kind/Type).
+   */
+  unknownFieldNames: string[];
+}
+
+/**
+ * Convert raw project-query item nodes into normalized ProjectIssueItem records.
+ * Used by the --all-repos path.
+ */
+export function parseProjectItems(nodes: RawProjectItem[]): ProjectIssueItem[] {
+  const results: ProjectIssueItem[] = [];
+
+  for (const node of nodes) {
+    if (node.type !== "ISSUE" || !node.content) continue;
+    const content = node.content;
+    const currentLabels = content.labels.nodes.map((l) => l.name);
+    const { fields, unknownFieldNames } = extractFields(node.fieldValues.nodes);
+
+    results.push({
+      issueNumber: content.number,
+      issueTitle: content.title,
+      issueUrl: content.url,
+      issueState: content.state,
+      repo: content.repository.name,
+      owner: content.repository.owner.login,
+      currentLabels,
+      fields,
+      unknownFieldNames,
+    });
+  }
+
+  return results;
+}

--- a/scripts/sync-labels/tsconfig.json
+++ b/scripts/sync-labels/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "include": ["./**/*.ts"],
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
This adds a set of scripts to sync GitHub Project fields to issue labels.  Currently only the Status and Priority fields are synced.

Assisted-by: Cursor:claude-4.6-sonnet-medium-thinking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sync-labels:check` npm script to audit and synchronize GitHub issue labels based on project field values (Status, Priority).

* **Chores**
  * Minor npm script punctuation adjustment for `port-forward`.
  * Added configuration and supporting modules for label synchronization tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->