### PR TITLE
:test_tube: Check only for HTML in the negative Jira connection test

### DIFF
--- a/cypress/e2e/tests/administration/jira-connection/miscellaneous.test.ts
+++ b/cypress/e2e/tests/administration/jira-connection/miscellaneous.test.ts
@@ -84,34 +84,35 @@ describe(
       jiraStageConnectionIncorrect = new Jira(jiraStageConnectionDataIncorrect);
     });
 
-    it("Validating error when Jira Cloud Instance is not connected", () => {
+    const validateCodeContent = (connection: Jira) => {
       /**
          Implements MTA-362 - Add JIRA instance with invalid credentials
          Automates https://issues.redhat.com/browse/MTA-991
          */
-      jiraCloudConnectionIncorrect.create();
-      jiraCloudConnectionIncorrect.validateState(expectedToFail);
-      clickByText(button, "Not connected");
-      cy.get("#code-content").then(($code) => {
-        expect($code.text()).to.contain("request failed.");
-        expect($code.text().toLowerCase()).not.to.contain("html");
-        expect($code.text()).not.to.contain("403");
-      });
+      connection.create();
+      connection.validateState(expectedToFail);
+
+      // scope to the right table row
+      cy.get(`[data-item-name="${connection.name}"]`)
+        .first()
+        .within(() => {
+          clickByText(button, "Not connected");
+        });
+
+      cy.get("#code-content")
+        // wait for message - initial message is empty
+        .contains(/\w+/)
+        .then(($code) => {
+          expect($code.text().toLowerCase()).not.to.contain("html");
+        });
+    };
+
+    it("Validating error when Jira Cloud Instance is not connected", () => {
+      validateCodeContent(jiraCloudConnectionIncorrect);
     });
 
     it("Validating error when Jira Stage Instance is not connected", () => {
-      /**
-         Implements MTA-362 - Add JIRA instance with invalid credentials
-         Automates https://issues.redhat.com/browse/MTA-991
-         */
-      jiraStageConnectionIncorrect.create();
-      jiraStageConnectionIncorrect.validateState(expectedToFail);
-      clickByText(button, "Not connected");
-      cy.get("#code-content").then(($code) => {
-        expect($code.text()).to.contain("request failed.");
-        expect($code.text().toLowerCase()).not.to.contain("html");
-        expect($code.text()).not.to.contain("403");
-      });
+      validateCodeContent(jiraStageConnectionIncorrect);
     });
 
     after("Clean up data", () => {


### PR DESCRIPTION
The original issue MT-991 was only about displaying HTML. However the check in in the test made assumptions also about the returned error message.

Improvements:
1. check the status for the right connection
2. wait until the message is displayed

Reference-Url: https://redhat.atlassian.net/browse/MTA-991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated duplicated Jira connection tests into a shared test flow to reduce repetition.
  * Made interaction targeting more specific to the relevant connection row.
  * Added waiting for displayed code/error content to appear before asserting.
  * Relaxed assertions to avoid checking specific error text or HTTP codes and to validate trimmed content formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->