### PR TITLE
feat: Migrator admin page + application-centric migration flow

### DIFF
--- a/Dockerfile.poc
+++ b/Dockerfile.poc
@@ -1,0 +1,20 @@
+FROM --platform=linux/amd64 node:22-slim AS builder
+
+WORKDIR /app
+COPY . .
+
+RUN npm clean-install --ignore-scripts --no-audit && \
+    npm run build && \
+    npm run dist
+
+# Runner
+FROM --platform=linux/amd64 node:22-slim
+
+WORKDIR /opt/app-root/dist
+COPY --from=builder /app/dist/ .
+RUN chmod +x ./entrypoint.sh && chmod -R g=u /opt/app-root/dist && mkdir -p /opt/app-root/src && touch /opt/app-root/src/ca.crt && chmod -R g=u /opt/app-root/src
+
+ENV DEBUG=1
+EXPOSE 8080
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -264,4 +264,5 @@ export enum TablePersistenceKeyPrefix {
   platformApplications = "pa",
   generatorCollections = "gc",
   generators = "g",
+  migrators = "mi",
 }

--- a/client/src/app/Paths.ts
+++ b/client/src/app/Paths.ts
@@ -79,6 +79,7 @@ export const AdminPaths = {
   jira: "/jira",
   sourcePlatforms: "/source-platforms",
   assetGenerators: "/asset-generators",
+  migrators: "/migrators",
 } as const;
 
 export type AdminPathValues = (typeof AdminPaths)[keyof typeof AdminPaths];

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -90,6 +90,8 @@ const AssetGenerators = lazy(
   () => import("./pages/asset-generators/asset-generators")
 );
 
+const Migrators = lazy(() => import("./pages/migrators/migrators"));
+
 export interface IRoute<T> {
   path: T;
   comp: ComponentType;
@@ -323,6 +325,11 @@ export const administrationRoutes: IRoute<AdminPathValues>[] = [
   {
     comp: AssetGenerators,
     path: Paths.assetGenerators,
+    exact: false,
+  },
+  {
+    comp: Migrators,
+    path: Paths.migrators,
     exact: false,
   },
 ];

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -1019,6 +1019,34 @@ export interface Generator {
   /** all profiles currently referencing this generator */ profiles?: Ref[];
 }
 
+export interface MigratorSourceRepository {
+  url: string;
+  branch?: string;
+  identity?: Ref;
+}
+
+export interface MigratorAssetRepository {
+  url: string;
+  branch: string;
+  identity?: Ref;
+}
+
+export interface MigratorPallet {
+  yaml?: string;
+  archetype?: Ref;
+  skills?: string[];
+}
+
+export interface MigratorConfig {
+  id: number;
+  name: string;
+  description?: string;
+  sourceRepository: MigratorSourceRepository;
+  assetRepository: MigratorAssetRepository;
+  pallet?: MigratorPallet;
+  migrationTarget?: string;
+}
+
 // Could use https://www.npmjs.com/package/@types/json-schema in future if needed
 export interface JsonSchemaObject {
   $schema?: "https://json-schema.org/draft/2020-12/schema" | string;

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -104,6 +104,7 @@ export * from "./rest/job-functions";
 export * from "./rest/migration-waves";
 export * from "./rest/platforms";
 export * from "./rest/schemas";
+export * from "./rest/migrators";
 export * from "./rest/tasks";
 
 /**

--- a/client/src/app/api/rest/migrators.ts
+++ b/client/src/app/api/rest/migrators.ts
@@ -5,21 +5,56 @@ import { hub } from "../rest";
 
 const MIGRATORS = hub`/migrators`;
 
-export const getMigrators = () =>
-  axios.get<MigratorConfig[]>(MIGRATORS).then(({ data }) => data);
+// In-memory store for local dev when Hub API doesn't have /migrators yet
+let localStore: MigratorConfig[] = [];
+let nextId = 1;
+const USE_LOCAL_FALLBACK = true;
 
-export const getMigratorById = (id: number | string) =>
-  axios.get<MigratorConfig>(`${MIGRATORS}/${id}`).then(({ data }) => data);
+export const getMigrators = async (): Promise<MigratorConfig[]> => {
+  if (USE_LOCAL_FALLBACK) return [...localStore];
+  return axios.get<MigratorConfig[]>(MIGRATORS).then(({ data }) => data);
+};
 
-export const createMigrator = (migrator: New<MigratorConfig>) => {
+export const getMigratorById = async (
+  id: number | string
+): Promise<MigratorConfig | undefined> => {
+  if (USE_LOCAL_FALLBACK) return localStore.find((m) => m.id === Number(id));
+  return axios
+    .get<MigratorConfig>(`${MIGRATORS}/${id}`)
+    .then(({ data }) => data);
+};
+
+export const createMigrator = async (
+  migrator: New<MigratorConfig>
+): Promise<MigratorConfig> => {
+  if (USE_LOCAL_FALLBACK) {
+    const created: MigratorConfig = {
+      ...migrator,
+      id: nextId++,
+    } as MigratorConfig;
+    localStore.push(created);
+    return created;
+  }
   return axios
     .post<MigratorConfig>(MIGRATORS, migrator)
     .then((res) => res.data);
 };
 
-export const updateMigrator = (migrator: MigratorConfig) => {
-  return axios.put<void>(`${MIGRATORS}/${migrator.id}`, migrator);
+export const updateMigrator = async (
+  migrator: MigratorConfig
+): Promise<void> => {
+  if (USE_LOCAL_FALLBACK) {
+    const idx = localStore.findIndex((m) => m.id === migrator.id);
+    if (idx !== -1) localStore[idx] = { ...migrator };
+    return;
+  }
+  await axios.put<void>(`${MIGRATORS}/${migrator.id}`, migrator);
 };
 
-export const deleteMigrator = (id: number) =>
-  axios.delete<void>(`${MIGRATORS}/${id}`);
+export const deleteMigrator = async (id: number): Promise<void> => {
+  if (USE_LOCAL_FALLBACK) {
+    localStore = localStore.filter((m) => m.id !== id);
+    return;
+  }
+  await axios.delete<void>(`${MIGRATORS}/${id}`);
+};

--- a/client/src/app/api/rest/migrators.ts
+++ b/client/src/app/api/rest/migrators.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+
+import { MigratorConfig, New } from "../models";
+import { hub } from "../rest";
+
+const MIGRATORS = hub`/migrators`;
+
+export const getMigrators = () =>
+  axios.get<MigratorConfig[]>(MIGRATORS).then(({ data }) => data);
+
+export const getMigratorById = (id: number | string) =>
+  axios.get<MigratorConfig>(`${MIGRATORS}/${id}`).then(({ data }) => data);
+
+export const createMigrator = (migrator: New<MigratorConfig>) => {
+  return axios
+    .post<MigratorConfig>(MIGRATORS, migrator)
+    .then((res) => res.data);
+};
+
+export const updateMigrator = (migrator: MigratorConfig) => {
+  return axios.put<void>(`${MIGRATORS}/${migrator.id}`, migrator);
+};
+
+export const deleteMigrator = (id: number) =>
+  axios.delete<void>(`${MIGRATORS}/${id}`);

--- a/client/src/app/layout/SidebarApp/SidebarApp.tsx
+++ b/client/src/app/layout/SidebarApp/SidebarApp.tsx
@@ -330,6 +330,11 @@ export const AdminSidebar = ({
           </NavLink>
         </NavItem>
         <NavItem>
+          <NavLink to={AdminPaths.migrators} activeClassName="pf-m-current">
+            Migrators
+          </NavLink>
+        </NavItem>
+        <NavItem>
           <NavLink to={UniversalPaths.tasks} activeClassName="pf-m-current">
             {t("sidebar.tasks")}
           </NavLink>

--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -101,6 +101,7 @@ import { ApplicationFormModal } from "../application-form";
 import { ApplicationIdentityModal } from "../application-identity-form/application-identity-modal";
 import { ImportApplicationsForm } from "../components/import-applications-form";
 import { GenerateAssetsWizard } from "../generate-assets-wizard";
+import { MigrateModal } from "../migrate-modal/migrate-modal";
 import { RetrieveConfigWizard } from "../retrieve-config-wizard";
 import {
   DecoratedApplication,
@@ -148,6 +149,7 @@ export const ApplicationsTable: FC = () => {
     useState<DecoratedApplication | null>(null);
 
   const [isAnalyzeModalOpen, setAnalyzeModalOpen] = useState(false);
+  const [isMigrateModalOpen, setMigrateModalOpen] = useState(false);
   const [retrieveConfigApplications, setRetrieveConfigApplications] = useState<
     DecoratedApplication[] | null
   >(null);
@@ -1016,6 +1018,18 @@ export const ApplicationsTable: FC = () => {
                   </ToolbarItem>
                 </RBAC>
               </ToolbarItem>
+              <ToolbarItem>
+                <Button
+                  type="button"
+                  id="migrate-application"
+                  aria-label="Migrate Application"
+                  variant={ButtonVariant.secondary}
+                  onClick={() => setMigrateModalOpen(true)}
+                  isDisabled={selectedRows.length < 1}
+                >
+                  Migrate
+                </Button>
+              </ToolbarItem>
             </ToolbarGroup>
             <ToolbarGroup variant="icon-button-group">
               {toolbarKebabItems.length ? (
@@ -1327,6 +1341,15 @@ export const ApplicationsTable: FC = () => {
           isOpen={true}
           onClose={() => {
             setAnalyzeModalOpen(false);
+          }}
+        />
+      )}
+      {isMigrateModalOpen && (
+        <MigrateModal
+          applications={selectedRows}
+          isOpen={true}
+          onClose={() => {
+            setMigrateModalOpen(false);
           }}
         />
       )}

--- a/client/src/app/pages/applications/migrate-modal/migrate-modal.tsx
+++ b/client/src/app/pages/applications/migrate-modal/migrate-modal.tsx
@@ -1,0 +1,179 @@
+import React, { useCallback, useState } from "react";
+import {
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  Text,
+  TextContent,
+} from "@patternfly/react-core";
+
+import { MigratorConfig, Taskgroup } from "@app/api/models";
+import { createTaskgroup, submitTaskgroup } from "@app/api/rest";
+import { FilterSelectOptionProps } from "@app/components/FilterToolbar/FilterToolbar";
+import TypeaheadSelect from "@app/components/FilterToolbar/components/TypeaheadSelect";
+import { useNotifications } from "@app/components/NotificationsContext";
+import { useFetchMigrators } from "@app/queries/migrators";
+
+export interface MigrateModalProps {
+  applications: Array<{ id: number; name: string }>;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const MigrateModal: React.FC<MigrateModalProps> = ({
+  applications,
+  isOpen,
+  onClose,
+}) => {
+  const { pushNotification } = useNotifications();
+  const { migrators } = useFetchMigrators();
+  const [selectedMigratorId, setSelectedMigratorId] = useState<string>("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const migratorOptions: FilterSelectOptionProps[] = (migrators || []).map(
+    (m) => ({
+      value: String(m.id),
+      label: `${m.name}${m.migrationTarget ? ` (${m.migrationTarget})` : ""}`,
+    })
+  );
+
+  const selectedMigrator = migrators.find(
+    (m) => String(m.id) === selectedMigratorId
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!selectedMigrator) return;
+    setIsSubmitting(true);
+
+    try {
+      const taskgroupPayload = {
+        name: `migration-${selectedMigrator.name}-${Date.now()}`,
+        addon: "kai",
+        data: {
+          sourceRepository: selectedMigrator.sourceRepository,
+          assetRepository: selectedMigrator.assetRepository,
+          migrationTarget: selectedMigrator.migrationTarget,
+          pallet: selectedMigrator.pallet,
+        },
+        tasks: applications.map((app) => ({
+          name: `${selectedMigrator.name}-${app.name}`,
+          data: {},
+          application: { id: app.id, name: app.name },
+        })),
+      } as unknown as Taskgroup;
+
+      const created = await createTaskgroup(taskgroupPayload);
+      await submitTaskgroup(created);
+
+      pushNotification({
+        title: `Migration submitted for ${applications.length} application(s) using "${selectedMigrator.name}". Check Tasks for progress.`,
+        variant: "success",
+      });
+      onClose();
+    } catch (error) {
+      pushNotification({
+        title: `Failed to submit migration: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
+        variant: "danger",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [selectedMigrator, applications, pushNotification, onClose]);
+
+  return (
+    <Modal
+      title="Run Migration"
+      variant={ModalVariant.medium}
+      isOpen={isOpen}
+      onClose={onClose}
+      actions={[
+        <Button
+          key="submit"
+          variant={ButtonVariant.primary}
+          onClick={handleSubmit}
+          isDisabled={!selectedMigrator || isSubmitting}
+          isLoading={isSubmitting}
+        >
+          Run Migration
+        </Button>,
+        <Button
+          key="cancel"
+          variant={ButtonVariant.link}
+          onClick={onClose}
+          isDisabled={isSubmitting}
+        >
+          Cancel
+        </Button>,
+      ]}
+    >
+      <TextContent>
+        <Text component="p">
+          Select a migrator configuration to run against{" "}
+          <strong>
+            {applications.length} application
+            {applications.length !== 1 ? "s" : ""}
+          </strong>
+          :
+        </Text>
+        <Text component="small">
+          {applications.map((a) => a.name).join(", ")}
+        </Text>
+      </TextContent>
+
+      <Form style={{ marginTop: 16 }}>
+        <FormGroup label="Migrator" fieldId="migrator-select" isRequired>
+          <TypeaheadSelect
+            placeholderText="Select a migrator configuration..."
+            toggleId="migrator-select-toggle"
+            toggleAriaLabel="Migrator config select"
+            ariaLabel="migrator"
+            value={selectedMigratorId}
+            options={migratorOptions}
+            onSelect={(selection) => setSelectedMigratorId(selection ?? "")}
+          />
+        </FormGroup>
+      </Form>
+
+      {selectedMigrator && (
+        <TextContent style={{ marginTop: 16 }}>
+          <Text component="small">
+            <strong>Source:</strong>{" "}
+            {selectedMigrator.sourceRepository?.url || "—"}
+            {selectedMigrator.sourceRepository?.branch
+              ? ` (${selectedMigrator.sourceRepository.branch})`
+              : ""}
+          </Text>
+          <Text component="small">
+            <strong>Asset Output:</strong>{" "}
+            {selectedMigrator.assetRepository?.url || "—"} →{" "}
+            {selectedMigrator.assetRepository?.branch || "—"}
+          </Text>
+          {selectedMigrator.migrationTarget && (
+            <Text component="small">
+              <strong>Target:</strong> {selectedMigrator.migrationTarget}
+            </Text>
+          )}
+        </TextContent>
+      )}
+
+      {migrators.length === 0 && (
+        <TextContent style={{ marginTop: 16 }}>
+          <Text
+            component="small"
+            style={{ color: "var(--pf-v5-global--warning-color--100)" }}
+          >
+            No migrator configurations found. Create one in Admin → Migrators
+            first.
+          </Text>
+        </TextContent>
+      )}
+    </Modal>
+  );
+};
+
+export default MigrateModal;

--- a/client/src/app/pages/applications/migrate-modal/migrate-modal.tsx
+++ b/client/src/app/pages/applications/migrate-modal/migrate-modal.tsx
@@ -51,7 +51,7 @@ export const MigrateModal: React.FC<MigrateModalProps> = ({
     try {
       const taskgroupPayload = {
         name: `migration-${selectedMigrator.name}-${Date.now()}`,
-        addon: "kai",
+        kind: "migration",
         data: {
           sourceRepository: selectedMigrator.sourceRepository,
           assetRepository: selectedMigrator.assetRepository,
@@ -59,7 +59,7 @@ export const MigrateModal: React.FC<MigrateModalProps> = ({
           pallet: selectedMigrator.pallet,
         },
         tasks: applications.map((app) => ({
-          name: `${selectedMigrator.name}-${app.name}`,
+          name: `${selectedMigrator.name}.${app.name}.migration`,
           data: {},
           application: { id: app.id, name: app.name },
         })),

--- a/client/src/app/pages/applications/migrate-modal/migrate-modal.tsx
+++ b/client/src/app/pages/applications/migrate-modal/migrate-modal.tsx
@@ -1,14 +1,20 @@
 import React, { useCallback, useState } from "react";
 import {
+  Alert,
   Button,
   ButtonVariant,
   Form,
   FormGroup,
   Modal,
   ModalVariant,
+  Spinner,
   Text,
   TextContent,
 } from "@patternfly/react-core";
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from "@patternfly/react-icons";
 
 import { MigratorConfig, Taskgroup } from "@app/api/models";
 import { createTaskgroup, submitTaskgroup } from "@app/api/rest";
@@ -23,6 +29,12 @@ export interface MigrateModalProps {
   onClose: () => void;
 }
 
+type SubmitStatus =
+  | { phase: "idle" }
+  | { phase: "submitting" }
+  | { phase: "success"; taskgroupId: number; taskgroupName: string }
+  | { phase: "error"; message: string };
+
 export const MigrateModal: React.FC<MigrateModalProps> = ({
   applications,
   isOpen,
@@ -31,7 +43,7 @@ export const MigrateModal: React.FC<MigrateModalProps> = ({
   const { pushNotification } = useNotifications();
   const { migrators } = useFetchMigrators();
   const [selectedMigratorId, setSelectedMigratorId] = useState<string>("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [status, setStatus] = useState<SubmitStatus>({ phase: "idle" });
 
   const migratorOptions: FilterSelectOptionProps[] = (migrators || []).map(
     (m) => ({
@@ -44,9 +56,15 @@ export const MigrateModal: React.FC<MigrateModalProps> = ({
     (m) => String(m.id) === selectedMigratorId
   );
 
+  const handleClose = () => {
+    setStatus({ phase: "idle" });
+    setSelectedMigratorId("");
+    onClose();
+  };
+
   const handleSubmit = useCallback(async () => {
     if (!selectedMigrator) return;
-    setIsSubmitting(true);
+    setStatus({ phase: "submitting" });
 
     try {
       const taskgroupPayload = {
@@ -68,109 +86,193 @@ export const MigrateModal: React.FC<MigrateModalProps> = ({
       const created = await createTaskgroup(taskgroupPayload);
       await submitTaskgroup(created);
 
+      setStatus({
+        phase: "success",
+        taskgroupId: created.id,
+        taskgroupName: created.name,
+      });
+
       pushNotification({
-        title: `Migration submitted for ${applications.length} application(s) using "${selectedMigrator.name}". Check Tasks for progress.`,
+        title: `Migration submitted for ${applications.length} application(s)`,
         variant: "success",
       });
-      onClose();
     } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setStatus({ phase: "error", message });
+
       pushNotification({
-        title: `Failed to submit migration: ${
-          error instanceof Error ? error.message : "Unknown error"
-        }`,
+        title: `Failed to submit migration: ${message}`,
         variant: "danger",
       });
-    } finally {
-      setIsSubmitting(false);
     }
-  }, [selectedMigrator, applications, pushNotification, onClose]);
+  }, [selectedMigrator, applications, pushNotification]);
 
   return (
     <Modal
       title="Run Migration"
       variant={ModalVariant.medium}
       isOpen={isOpen}
-      onClose={onClose}
-      actions={[
-        <Button
-          key="submit"
-          variant={ButtonVariant.primary}
-          onClick={handleSubmit}
-          isDisabled={!selectedMigrator || isSubmitting}
-          isLoading={isSubmitting}
-        >
-          Run Migration
-        </Button>,
-        <Button
-          key="cancel"
-          variant={ButtonVariant.link}
-          onClick={onClose}
-          isDisabled={isSubmitting}
-        >
-          Cancel
-        </Button>,
-      ]}
+      onClose={handleClose}
+      actions={
+        status.phase === "success"
+          ? [
+              <Button
+                key="done"
+                variant={ButtonVariant.primary}
+                onClick={handleClose}
+              >
+                Done
+              </Button>,
+            ]
+          : [
+              <Button
+                key="submit"
+                variant={ButtonVariant.primary}
+                onClick={handleSubmit}
+                isDisabled={!selectedMigrator || status.phase === "submitting"}
+                isLoading={status.phase === "submitting"}
+              >
+                Run Migration
+              </Button>,
+              <Button
+                key="cancel"
+                variant={ButtonVariant.link}
+                onClick={handleClose}
+                isDisabled={status.phase === "submitting"}
+              >
+                Cancel
+              </Button>,
+            ]
+      }
     >
-      <TextContent>
-        <Text component="p">
-          Select a migrator configuration to run against{" "}
-          <strong>
-            {applications.length} application
-            {applications.length !== 1 ? "s" : ""}
-          </strong>
-          :
-        </Text>
-        <Text component="small">
-          {applications.map((a) => a.name).join(", ")}
-        </Text>
-      </TextContent>
-
-      <Form style={{ marginTop: 16 }}>
-        <FormGroup label="Migrator" fieldId="migrator-select" isRequired>
-          <TypeaheadSelect
-            placeholderText="Select a migrator configuration..."
-            toggleId="migrator-select-toggle"
-            toggleAriaLabel="Migrator config select"
-            ariaLabel="migrator"
-            value={selectedMigratorId}
-            options={migratorOptions}
-            onSelect={(selection) => setSelectedMigratorId(selection ?? "")}
-          />
-        </FormGroup>
-      </Form>
-
-      {selectedMigrator && (
-        <TextContent style={{ marginTop: 16 }}>
-          <Text component="small">
-            <strong>Source:</strong>{" "}
-            {selectedMigrator.sourceRepository?.url || "—"}
-            {selectedMigrator.sourceRepository?.branch
-              ? ` (${selectedMigrator.sourceRepository.branch})`
-              : ""}
-          </Text>
-          <Text component="small">
-            <strong>Asset Output:</strong>{" "}
-            {selectedMigrator.assetRepository?.url || "—"} →{" "}
-            {selectedMigrator.assetRepository?.branch || "—"}
-          </Text>
-          {selectedMigrator.migrationTarget && (
+      {/* Success state */}
+      {status.phase === "success" && (
+        <Alert
+          variant="success"
+          isInline
+          title="Migration submitted successfully"
+          style={{ marginBottom: 16 }}
+        >
+          <TextContent>
             <Text component="small">
-              <strong>Target:</strong> {selectedMigrator.migrationTarget}
+              <CheckCircleIcon
+                style={{ color: "var(--pf-v5-global--success-color--100)" }}
+              />{" "}
+              TaskGroup <strong>#{status.taskgroupId}</strong> created and
+              submitted.
             </Text>
-          )}
-        </TextContent>
+            <Text component="small">
+              Name: <code>{status.taskgroupName}</code>
+            </Text>
+            <Text component="small">
+              Kind: <code>migration</code> | State: <strong>Ready</strong>
+            </Text>
+            <Text component="small">
+              {applications.length} application(s) queued for migration using
+              &quot;{selectedMigrator?.name}&quot;.
+            </Text>
+          </TextContent>
+        </Alert>
       )}
 
-      {migrators.length === 0 && (
-        <TextContent style={{ marginTop: 16 }}>
-          <Text
-            component="small"
-            style={{ color: "var(--pf-v5-global--warning-color--100)" }}
-          >
-            No migrator configurations found. Create one in Admin → Migrators
-            first.
-          </Text>
-        </TextContent>
+      {/* Error state */}
+      {status.phase === "error" && (
+        <Alert
+          variant="danger"
+          isInline
+          title="Migration submission failed"
+          style={{ marginBottom: 16 }}
+        >
+          <TextContent>
+            <Text component="small">
+              <ExclamationCircleIcon
+                style={{ color: "var(--pf-v5-global--danger-color--100)" }}
+              />{" "}
+              {status.message}
+            </Text>
+          </TextContent>
+        </Alert>
+      )}
+
+      {/* Submitting state */}
+      {status.phase === "submitting" && (
+        <Alert
+          variant="info"
+          isInline
+          title="Submitting migration..."
+          style={{ marginBottom: 16 }}
+        >
+          <Spinner size="md" /> Creating TaskGroup and submitting to Hub...
+        </Alert>
+      )}
+
+      {/* Form — only show when idle or error */}
+      {(status.phase === "idle" || status.phase === "error") && (
+        <>
+          <TextContent>
+            <Text component="p">
+              Select a migrator configuration to run against{" "}
+              <strong>
+                {applications.length} application
+                {applications.length !== 1 ? "s" : ""}
+              </strong>
+              :
+            </Text>
+            <Text component="small">
+              {applications.map((a) => a.name).join(", ")}
+            </Text>
+          </TextContent>
+
+          <Form style={{ marginTop: 16 }}>
+            <FormGroup label="Migrator" fieldId="migrator-select" isRequired>
+              <TypeaheadSelect
+                placeholderText="Select a migrator configuration..."
+                toggleId="migrator-select-toggle"
+                toggleAriaLabel="Migrator config select"
+                ariaLabel="migrator"
+                value={selectedMigratorId}
+                options={migratorOptions}
+                onSelect={(selection) => setSelectedMigratorId(selection ?? "")}
+              />
+            </FormGroup>
+          </Form>
+
+          {selectedMigrator && (
+            <TextContent style={{ marginTop: 16 }}>
+              <Text component="small">
+                <strong>Source:</strong>{" "}
+                {selectedMigrator.sourceRepository?.url || "—"}
+                {selectedMigrator.sourceRepository?.branch
+                  ? ` (${selectedMigrator.sourceRepository.branch})`
+                  : ""}
+              </Text>
+              <Text component="small">
+                <strong>Asset Output:</strong>{" "}
+                {selectedMigrator.assetRepository?.url || "—"} →{" "}
+                {selectedMigrator.assetRepository?.branch || "—"}
+              </Text>
+              {selectedMigrator.migrationTarget && (
+                <Text component="small">
+                  <strong>Target:</strong> {selectedMigrator.migrationTarget}
+                </Text>
+              )}
+            </TextContent>
+          )}
+
+          {migrators.length === 0 && (
+            <TextContent style={{ marginTop: 16 }}>
+              <Text
+                component="small"
+                style={{
+                  color: "var(--pf-v5-global--warning-color--100)",
+                }}
+              >
+                No migrator configurations found. Create one in Admin →
+                Migrators first.
+              </Text>
+            </TextContent>
+          )}
+        </>
       )}
     </Modal>
   );

--- a/client/src/app/pages/migrators/components/index.ts
+++ b/client/src/app/pages/migrators/components/index.ts
@@ -1,0 +1,2 @@
+export { default as MigratorDetailDrawer } from "./migrator-detail-drawer";
+export { MigratorForm, default as MigratorFormDefault } from "./migrator-form";

--- a/client/src/app/pages/migrators/components/migrator-detail-drawer.tsx
+++ b/client/src/app/pages/migrators/components/migrator-detail-drawer.tsx
@@ -1,0 +1,185 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Tab,
+  TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  Title,
+} from "@patternfly/react-core";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+import { MigratorConfig } from "@app/api/models";
+import { PageDrawerContent } from "@app/components/PageDrawerContext";
+
+export interface IMigratorDetailDrawerProps {
+  onCloseClick: () => void;
+  migrator: MigratorConfig | null;
+}
+
+enum TabKey {
+  Details = 0,
+  Pallet,
+}
+
+const MigratorDetailDrawer: React.FC<IMigratorDetailDrawerProps> = ({
+  onCloseClick,
+  migrator,
+}) => {
+  const { t } = useTranslation();
+
+  const [activeTabKey, setActiveTabKey] = React.useState<TabKey>(
+    TabKey.Details
+  );
+
+  return (
+    <PageDrawerContent
+      isExpanded={!!migrator}
+      onCloseClick={onCloseClick}
+      focusKey={migrator?.id}
+      pageKey="migrator-details"
+      header={
+        <TextContent>
+          <Text component="small" className={spacing.mb_0}>
+            Migrator Details
+          </Text>
+          <Title headingLevel="h2" size="lg" className={spacing.mtXs}>
+            {migrator?.name}
+          </Title>
+        </TextContent>
+      }
+    >
+      <div>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={(_event, tabKey) => setActiveTabKey(tabKey as TabKey)}
+        >
+          <Tab
+            eventKey={TabKey.Details}
+            title={<TabTitleText>{t("terms.details")}</TabTitleText>}
+          >
+            <DetailsTab migrator={migrator} />
+          </Tab>
+          <Tab
+            eventKey={TabKey.Pallet}
+            title={<TabTitleText>Pallet</TabTitleText>}
+          >
+            <PalletTab migrator={migrator} />
+          </Tab>
+        </Tabs>
+      </div>
+    </PageDrawerContent>
+  );
+};
+
+export default MigratorDetailDrawer;
+
+const DetailsTab: React.FC<{ migrator: MigratorConfig | null }> = ({
+  migrator,
+}) => {
+  const { t } = useTranslation();
+
+  if (!migrator) {
+    return null;
+  }
+
+  return (
+    <DescriptionList>
+      {migrator.description && (
+        <Text component="small">{migrator.description}</Text>
+      )}
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Migration Target</DescriptionListTerm>
+        <DescriptionListDescription>
+          {migrator.migrationTarget || t("terms.notAvailable")}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Source Repository</DescriptionListTerm>
+        <DescriptionListDescription>
+          {migrator.sourceRepository?.url || t("terms.notAvailable")}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Source Branch</DescriptionListTerm>
+        <DescriptionListDescription>
+          {migrator.sourceRepository?.branch || "main"}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Asset Repository</DescriptionListTerm>
+        <DescriptionListDescription>
+          {migrator.assetRepository?.url || t("terms.notAvailable")}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Asset Output Branch</DescriptionListTerm>
+        <DescriptionListDescription>
+          {migrator.assetRepository?.branch || t("terms.notAvailable")}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+    </DescriptionList>
+  );
+};
+
+const PalletTab: React.FC<{ migrator: MigratorConfig | null }> = ({
+  migrator,
+}) => {
+  if (!migrator?.pallet) {
+    return <Text component="small">No pallet configuration defined.</Text>;
+  }
+
+  return (
+    <DescriptionList>
+      {migrator.pallet.archetype && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Archetype</DescriptionListTerm>
+          <DescriptionListDescription>
+            {migrator.pallet.archetype.name}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+
+      {migrator.pallet.skills && migrator.pallet.skills.length > 0 && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Skills</DescriptionListTerm>
+          <DescriptionListDescription>
+            {migrator.pallet.skills.join(", ")}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+
+      {migrator.pallet.yaml && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Pallet YAML</DescriptionListTerm>
+          <DescriptionListDescription>
+            <pre
+              style={{
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                maxHeight: 300,
+                overflow: "auto",
+                background: "var(--pf-v5-global--BackgroundColor--200)",
+                padding: "var(--pf-v5-global--spacer--sm)",
+                borderRadius: 4,
+                fontSize: "0.85em",
+              }}
+            >
+              {migrator.pallet.yaml}
+            </pre>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+    </DescriptionList>
+  );
+};

--- a/client/src/app/pages/migrators/components/migrator-form.tsx
+++ b/client/src/app/pages/migrators/components/migrator-form.tsx
@@ -1,0 +1,426 @@
+import { useMemo } from "react";
+import * as React from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { AxiosError } from "axios";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import * as yup from "yup";
+import {
+  ActionGroup,
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  TextArea,
+  Title,
+} from "@patternfly/react-core";
+
+import type { MigratorConfig, New, Ref } from "@app/api/models";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { FilterSelectOptionProps } from "@app/components/FilterToolbar/FilterToolbar";
+import TypeaheadSelect from "@app/components/FilterToolbar/components/TypeaheadSelect";
+import {
+  HookFormPFGroupController,
+  HookFormPFTextInput,
+} from "@app/components/HookFormPFFields";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import { useFetchIdentities } from "@app/queries/identities";
+import {
+  useCreateMigratorMutation,
+  useFetchMigrators,
+  useUpdateMigratorMutation,
+} from "@app/queries/migrators";
+import { matchItemsToRef } from "@app/utils/model-utils";
+import { duplicateNameCheck, getAxiosErrorMessage } from "@app/utils/utils";
+
+export interface MigratorFormValues {
+  name: string;
+  description?: string;
+  sourceRepoUrl: string;
+  sourceBranch: string;
+  sourceCredentials?: string;
+  assetRepoUrl: string;
+  assetBranch: string;
+  assetCredentials?: string;
+  migrationTarget?: string;
+  palletYaml?: string;
+}
+
+export interface MigratorFormProps {
+  migrator?: MigratorConfig | null;
+  onClose: () => void;
+}
+
+const MIGRATION_TARGETS = ["quarkus", "spring-boot", "liberty", "eap"];
+
+export const MigratorForm: React.FC<MigratorFormProps> = ({ ...rest }) => {
+  const { isDataReady } = useMigratorFormData();
+  return (
+    <ConditionalRender when={!isDataReady} then={<AppPlaceholder />}>
+      <MigratorFormRenderer {...rest} />
+    </ConditionalRender>
+  );
+};
+
+const MigratorFormRenderer: React.FC<MigratorFormProps> = ({
+  migrator = null,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+
+  const {
+    existingMigrators,
+    identities,
+    createMigrator,
+    updateMigrator,
+    identityToRef,
+  } = useMigratorFormData({
+    onActionSuccess: onClose,
+  });
+
+  const identityOptions: FilterSelectOptionProps[] = useMemo(
+    () =>
+      (identities || []).map((id) => ({
+        value: id.name,
+        label: id.name,
+      })),
+    [identities]
+  );
+
+  const validationSchema = useMemo(
+    () =>
+      yup.object().shape({
+        name: yup
+          .string()
+          .trim()
+          .required(t("validation.required"))
+          .min(3, t("validation.minLength", { length: 3 }))
+          .max(120, t("validation.maxLength", { length: 120 }))
+          .test(
+            "Duplicate name",
+            t("validation.duplicateName", { type: "migrator" }),
+            (value) =>
+              existingMigrators
+                ? duplicateNameCheck(existingMigrators, migrator, value ?? "")
+                : false
+          ),
+        description: yup
+          .string()
+          .trim()
+          .max(250, t("validation.maxLength", { length: 250 })),
+        sourceRepoUrl: yup.string().trim().required(t("validation.required")),
+        sourceBranch: yup
+          .string()
+          .trim()
+          .max(100, t("validation.maxLength", { length: 100 })),
+        sourceCredentials: yup.string().trim().nullable(),
+        assetRepoUrl: yup.string().trim().required(t("validation.required")),
+        assetBranch: yup.string().trim().required(t("validation.required")),
+        assetCredentials: yup.string().trim().nullable(),
+        migrationTarget: yup.string().trim(),
+        palletYaml: yup.string().trim(),
+      }),
+    [t, existingMigrators, migrator]
+  );
+
+  const defaultValues = useMemo(
+    () =>
+      !migrator
+        ? {
+            name: "",
+            description: "",
+            sourceRepoUrl: "",
+            sourceBranch: "main",
+            sourceCredentials: "",
+            assetRepoUrl: "",
+            assetBranch: "migration-output",
+            assetCredentials: "",
+            migrationTarget: "",
+            palletYaml: "",
+          }
+        : {
+            name: migrator.name,
+            description: migrator.description || "",
+            sourceRepoUrl: migrator.sourceRepository?.url || "",
+            sourceBranch: migrator.sourceRepository?.branch || "main",
+            sourceCredentials: migrator.sourceRepository?.identity?.name || "",
+            assetRepoUrl: migrator.assetRepository?.url || "",
+            assetBranch: migrator.assetRepository?.branch || "",
+            assetCredentials: migrator.assetRepository?.identity?.name || "",
+            migrationTarget: migrator.migrationTarget || "",
+            palletYaml: migrator.pallet?.yaml || "",
+          },
+    [migrator]
+  );
+
+  const formMethods = useForm<MigratorFormValues>({
+    defaultValues,
+    resolver: yupResolver(validationSchema),
+    mode: "all",
+  });
+
+  const {
+    handleSubmit,
+    formState: { isSubmitting, isValidating, isValid, isDirty },
+    control,
+  } = formMethods;
+
+  const onValidSubmit = (values: MigratorFormValues) => {
+    const payload: New<MigratorConfig> = {
+      name: values.name.trim(),
+      description: values.description?.trim() || undefined,
+      sourceRepository: {
+        url: values.sourceRepoUrl.trim(),
+        branch: values.sourceBranch?.trim() || "main",
+        identity: identityToRef(values.sourceCredentials),
+      },
+      assetRepository: {
+        url: values.assetRepoUrl.trim(),
+        branch: values.assetBranch.trim(),
+        identity: identityToRef(values.assetCredentials),
+      },
+      migrationTarget: values.migrationTarget?.trim() || undefined,
+      pallet: values.palletYaml?.trim()
+        ? { yaml: values.palletYaml.trim() }
+        : undefined,
+    };
+
+    if (migrator) {
+      updateMigrator({
+        id: migrator.id,
+        ...payload,
+      });
+    } else {
+      createMigrator(payload);
+    }
+  };
+
+  return (
+    <FormProvider {...formMethods}>
+      <Form onSubmit={handleSubmit(onValidSubmit)} id="migrator-form">
+        <HookFormPFTextInput
+          control={control}
+          name="name"
+          label={t("terms.name")}
+          fieldId="migrator-name"
+          isRequired
+        />
+
+        <HookFormPFTextInput
+          control={control}
+          name="description"
+          label={t("terms.description")}
+          fieldId="migrator-description"
+        />
+
+        <HookFormPFGroupController
+          control={control}
+          name="migrationTarget"
+          label="Migration Target"
+          fieldId="migrator-migration-target"
+          renderInput={({ field: { value, name, onChange } }) => (
+            <TypeaheadSelect
+              placeholderText="Select a migration target..."
+              toggleId="migration-target-toggle"
+              toggleAriaLabel="Migration target select dropdown toggle"
+              ariaLabel={name}
+              value={value}
+              options={MIGRATION_TARGETS.map(
+                (t): FilterSelectOptionProps => ({ value: t, label: t })
+              )}
+              onSelect={(selection) => onChange(selection ?? "")}
+            />
+          )}
+        />
+
+        {/* Source Repository Section */}
+        <Title headingLevel="h3" size="md" style={{ marginTop: 16 }}>
+          Source Repository
+        </Title>
+
+        <HookFormPFTextInput
+          control={control}
+          name="sourceRepoUrl"
+          label="Repository URL"
+          fieldId="migrator-source-repo-url"
+          isRequired
+        />
+
+        <HookFormPFTextInput
+          control={control}
+          name="sourceBranch"
+          label="Branch"
+          fieldId="migrator-source-branch"
+        />
+
+        <HookFormPFGroupController
+          control={control}
+          name="sourceCredentials"
+          label="Credentials"
+          fieldId="migrator-source-credentials"
+          renderInput={({ field: { value, name, onChange } }) => (
+            <TypeaheadSelect
+              placeholderText="Select credentials..."
+              toggleId="source-credentials-toggle"
+              toggleAriaLabel="Source credentials select dropdown toggle"
+              ariaLabel={name}
+              value={value}
+              options={identityOptions}
+              onSelect={(selection) => onChange(selection ?? "")}
+            />
+          )}
+        />
+
+        {/* Asset Repository Section */}
+        <Title headingLevel="h3" size="md" style={{ marginTop: 16 }}>
+          Asset Repository
+        </Title>
+
+        <HookFormPFTextInput
+          control={control}
+          name="assetRepoUrl"
+          label="Repository URL"
+          fieldId="migrator-asset-repo-url"
+          isRequired
+        />
+
+        <HookFormPFTextInput
+          control={control}
+          name="assetBranch"
+          label="Output Branch"
+          fieldId="migrator-asset-branch"
+          isRequired
+        />
+
+        <HookFormPFGroupController
+          control={control}
+          name="assetCredentials"
+          label="Credentials"
+          fieldId="migrator-asset-credentials"
+          renderInput={({ field: { value, name, onChange } }) => (
+            <TypeaheadSelect
+              placeholderText="Select credentials..."
+              toggleId="asset-credentials-toggle"
+              toggleAriaLabel="Asset credentials select dropdown toggle"
+              ariaLabel={name}
+              value={value}
+              options={identityOptions}
+              onSelect={(selection) => onChange(selection ?? "")}
+            />
+          )}
+        />
+
+        {/* Pallet YAML Section */}
+        <HookFormPFGroupController
+          control={control}
+          name="palletYaml"
+          label="Pallet YAML"
+          fieldId="migrator-pallet-yaml"
+          renderInput={({ field: { value, onChange } }) => (
+            <FormGroup fieldId="migrator-pallet-yaml-input">
+              <TextArea
+                id="migrator-pallet-yaml-input"
+                value={value}
+                onChange={(_event, val) => onChange(val)}
+                aria-label="Pallet YAML"
+                rows={8}
+                resizeOrientation="vertical"
+                placeholder={`# Define your pallet configuration\nskills:\n  - java-ee-to-quarkus\narchetype: default`}
+                style={{ fontFamily: "monospace", fontSize: "0.85em" }}
+              />
+            </FormGroup>
+          )}
+        />
+
+        <ActionGroup>
+          <Button
+            type="submit"
+            id="submit"
+            aria-label="submit"
+            variant={ButtonVariant.primary}
+            isDisabled={!isValid || isSubmitting || isValidating || !isDirty}
+          >
+            {!migrator ? t("actions.create") : t("actions.save")}
+          </Button>
+          <Button
+            type="button"
+            id="cancel"
+            aria-label="cancel"
+            variant={ButtonVariant.link}
+            isDisabled={isSubmitting || isValidating}
+            onClick={onClose}
+          >
+            {t("actions.cancel")}
+          </Button>
+        </ActionGroup>
+      </Form>
+    </FormProvider>
+  );
+};
+
+const useMigratorFormData = ({
+  onActionSuccess,
+  onActionFail,
+}: {
+  onActionSuccess?: () => void;
+  onActionFail?: () => void;
+} = {}) => {
+  const { t } = useTranslation();
+  const { pushNotification } = React.useContext(NotificationsContext);
+
+  const { identities, isSuccess: isIdentitiesSuccess } = useFetchIdentities();
+  const { migrators: existingMigrators, isSuccess: isMigratorsSuccess } =
+    useFetchMigrators();
+
+  const onCreateSuccess = () => {
+    pushNotification({
+      title: t("toastr.success.createWhat", {
+        type: t("terms.new"),
+        what: "migrator",
+      }),
+      variant: "success",
+    });
+    onActionSuccess?.();
+  };
+
+  const onUpdateSuccess = (_id: number) => {
+    pushNotification({
+      title: t("toastr.success.save", {
+        type: "migrator",
+      }),
+      variant: "success",
+    });
+    onActionSuccess?.();
+  };
+
+  const onCreateUpdateError = (error: AxiosError) => {
+    pushNotification({
+      title: getAxiosErrorMessage(error),
+      variant: "danger",
+    });
+    onActionFail?.();
+  };
+
+  const { mutate: createMigrator } = useCreateMigratorMutation(
+    onCreateSuccess,
+    onCreateUpdateError
+  );
+
+  const { mutate: updateMigrator } = useUpdateMigratorMutation(
+    onUpdateSuccess,
+    onCreateUpdateError
+  );
+
+  return {
+    existingMigrators,
+    identities,
+    isDataReady: isMigratorsSuccess && isIdentitiesSuccess,
+    createMigrator,
+    updateMigrator,
+    identityToRef: (name?: string): Ref | undefined =>
+      matchItemsToRef(identities, ({ name }) => name, name),
+  };
+};
+
+export default MigratorForm;

--- a/client/src/app/pages/migrators/components/migrator-form.tsx
+++ b/client/src/app/pages/migrators/components/migrator-form.tsx
@@ -34,6 +34,8 @@ import {
 import { matchItemsToRef } from "@app/utils/model-utils";
 import { duplicateNameCheck, getAxiosErrorMessage } from "@app/utils/utils";
 
+import PalletEditor from "./pallet-editor";
+
 export interface MigratorFormValues {
   name: string;
   description?: string;
@@ -311,25 +313,17 @@ const MigratorFormRenderer: React.FC<MigratorFormProps> = ({
           )}
         />
 
-        {/* Pallet YAML Section */}
+        {/* Pallet Configuration */}
         <HookFormPFGroupController
           control={control}
           name="palletYaml"
-          label="Pallet YAML"
+          label=""
           fieldId="migrator-pallet-yaml"
           renderInput={({ field: { value, onChange } }) => (
-            <FormGroup fieldId="migrator-pallet-yaml-input">
-              <TextArea
-                id="migrator-pallet-yaml-input"
-                value={value}
-                onChange={(_event, val) => onChange(val)}
-                aria-label="Pallet YAML"
-                rows={8}
-                resizeOrientation="vertical"
-                placeholder={`# Define your pallet configuration\nskills:\n  - java-ee-to-quarkus\narchetype: default`}
-                style={{ fontFamily: "monospace", fontSize: "0.85em" }}
-              />
-            </FormGroup>
+            <PalletEditor
+              value={value || ""}
+              onChange={(val) => onChange(val)}
+            />
           )}
         />
 

--- a/client/src/app/pages/migrators/components/pallet-editor.tsx
+++ b/client/src/app/pages/migrators/components/pallet-editor.tsx
@@ -1,0 +1,408 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Button,
+  ButtonVariant,
+  FormGroup,
+  Switch,
+  Text,
+  TextArea,
+  TextContent,
+  TextInput,
+  Title,
+} from "@patternfly/react-core";
+import { PlusCircleIcon, TrashIcon } from "@patternfly/react-icons";
+import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+export interface PalletSource {
+  name: string;
+  type: "git" | "hub";
+  url?: string;
+  ref?: string;
+  paths?: string[];
+}
+
+export interface PalletConfig {
+  sources: PalletSource[];
+  agents?: {
+    auto_detect?: boolean;
+  };
+  hub?: {
+    url?: string;
+  };
+}
+
+interface PalletEditorProps {
+  value: string;
+  onChange: (yaml: string) => void;
+}
+
+const EMPTY_SOURCE: PalletSource = {
+  name: "",
+  type: "git",
+  url: "",
+  ref: "",
+  paths: [],
+};
+
+const DEFAULT_PLACEHOLDER = `sources:
+  - name: my-skills
+    type: git
+    url: https://github.com/org/skills
+    paths:
+      - skills/java-ee-to-quarkus
+
+agents:
+  auto_detect: true`;
+
+/**
+ * Parse pallet YAML into structured config.
+ * Simple parser — handles the known pallet.yaml shape.
+ */
+function parsePalletYaml(yaml: string): PalletConfig | null {
+  try {
+    if (!yaml.trim()) return { sources: [], agents: { auto_detect: true } };
+
+    const config: PalletConfig = { sources: [] };
+    const lines = yaml.split("\n");
+    let currentSource: PalletSource | null = null;
+    let inSources = false;
+    let inPaths = false;
+    let inAgents = false;
+    let inHub = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      if (trimmed === "sources:") {
+        inSources = true;
+        inAgents = false;
+        inHub = false;
+        inPaths = false;
+        continue;
+      }
+      if (trimmed === "agents:") {
+        inAgents = true;
+        inSources = false;
+        inHub = false;
+        inPaths = false;
+        if (currentSource) {
+          config.sources.push(currentSource);
+          currentSource = null;
+        }
+        config.agents = {};
+        continue;
+      }
+      if (trimmed === "hub:") {
+        inHub = true;
+        inSources = false;
+        inAgents = false;
+        inPaths = false;
+        config.hub = {};
+        continue;
+      }
+
+      if (inSources) {
+        if (trimmed.startsWith("- name:")) {
+          if (currentSource) config.sources.push(currentSource);
+          currentSource = {
+            ...EMPTY_SOURCE,
+            name: trimmed.replace("- name:", "").trim(),
+          };
+          inPaths = false;
+          continue;
+        }
+        if (currentSource) {
+          if (trimmed.startsWith("type:")) {
+            currentSource.type = trimmed.replace("type:", "").trim() as
+              | "git"
+              | "hub";
+          } else if (trimmed.startsWith("url:")) {
+            currentSource.url = trimmed.replace("url:", "").trim();
+          } else if (trimmed.startsWith("ref:")) {
+            currentSource.ref = trimmed.replace("ref:", "").trim();
+          } else if (trimmed === "paths:") {
+            inPaths = true;
+            currentSource.paths = [];
+          } else if (inPaths && trimmed.startsWith("- ")) {
+            currentSource.paths = currentSource.paths || [];
+            currentSource.paths.push(trimmed.replace("- ", "").trim());
+          }
+        }
+      }
+
+      if (inAgents) {
+        if (trimmed.startsWith("auto_detect:")) {
+          config.agents = config.agents || {};
+          config.agents.auto_detect = trimmed.includes("true");
+        }
+      }
+
+      if (inHub) {
+        if (trimmed.startsWith("url:")) {
+          config.hub = config.hub || {};
+          config.hub.url = trimmed.replace("url:", "").trim();
+        }
+      }
+    }
+
+    if (currentSource) config.sources.push(currentSource);
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Serialize structured config back to YAML.
+ */
+function serializePalletYaml(config: PalletConfig): string {
+  const lines: string[] = [];
+
+  if (config.hub?.url) {
+    lines.push("hub:");
+    lines.push(`  url: ${config.hub.url}`);
+    lines.push("");
+  }
+
+  if (config.sources.length > 0) {
+    lines.push("sources:");
+    for (const source of config.sources) {
+      if (!source.name) continue;
+      lines.push(`  - name: ${source.name}`);
+      lines.push(`    type: ${source.type || "git"}`);
+      if (source.url) lines.push(`    url: ${source.url}`);
+      if (source.ref) lines.push(`    ref: ${source.ref}`);
+      if (source.paths && source.paths.length > 0) {
+        lines.push("    paths:");
+        for (const p of source.paths) {
+          if (p.trim()) lines.push(`      - ${p}`);
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  if (config.agents) {
+    lines.push("agents:");
+    if (config.agents.auto_detect !== undefined) {
+      lines.push(`  auto_detect: ${config.agents.auto_detect}`);
+    }
+  }
+
+  return lines.join("\n").trim() + "\n";
+}
+
+export const PalletEditor: React.FC<PalletEditorProps> = ({
+  value,
+  onChange,
+}) => {
+  const [mode, setMode] = useState<"form" | "yaml">("form");
+
+  const config = useMemo(() => parsePalletYaml(value), [value]);
+
+  const updateConfig = useCallback(
+    (updater: (draft: PalletConfig) => void) => {
+      const current = parsePalletYaml(value) || {
+        sources: [],
+        agents: { auto_detect: true },
+      };
+      updater(current);
+      onChange(serializePalletYaml(current));
+    },
+    [value, onChange]
+  );
+
+  const addSource = () => {
+    updateConfig((draft) => {
+      draft.sources.push({
+        name: `source-${draft.sources.length + 1}`,
+        type: "git",
+        url: "",
+        paths: [],
+      });
+    });
+  };
+
+  const removeSource = (index: number) => {
+    updateConfig((draft) => {
+      draft.sources.splice(index, 1);
+    });
+  };
+
+  const updateSource = (
+    index: number,
+    field: keyof PalletSource,
+    val: string | string[]
+  ) => {
+    updateConfig((draft) => {
+      const source = draft.sources[index];
+      if (!source) return;
+      if (field === "paths") {
+        source.paths = val as string[];
+      } else {
+        (source as unknown as Record<string, unknown>)[field] = val;
+      }
+    });
+  };
+
+  const toggleAutoDetect = (checked: boolean) => {
+    updateConfig((draft) => {
+      draft.agents = draft.agents || {};
+      draft.agents.auto_detect = checked;
+    });
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 8,
+        }}
+      >
+        <Title headingLevel="h4" size="md">
+          Pallet Configuration
+        </Title>
+        <Switch
+          id="pallet-mode-toggle"
+          label="YAML"
+          labelOff="Form"
+          isChecked={mode === "yaml"}
+          onChange={(_event, checked) => setMode(checked ? "yaml" : "form")}
+          isReversed
+        />
+      </div>
+
+      {mode === "yaml" ? (
+        <FormGroup fieldId="pallet-yaml-raw">
+          <TextArea
+            id="pallet-yaml-raw"
+            value={value}
+            onChange={(_event, val) => onChange(val)}
+            aria-label="Pallet YAML"
+            rows={12}
+            resizeOrientation="vertical"
+            placeholder={DEFAULT_PLACEHOLDER}
+            style={{ fontFamily: "monospace", fontSize: "0.85em" }}
+          />
+        </FormGroup>
+      ) : (
+        <div>
+          {/* Sources */}
+          <TextContent className={spacing.mbSm}>
+            <Text component="small" style={{ fontWeight: 600 }}>
+              Sources
+            </Text>
+          </TextContent>
+
+          {(config?.sources || []).map((source, idx) => (
+            <div
+              key={idx}
+              style={{
+                border: "1px solid var(--pf-v5-global--BorderColor--100)",
+                borderRadius: 4,
+                padding: 12,
+                marginBottom: 8,
+                position: "relative",
+              }}
+            >
+              <Button
+                variant="plain"
+                icon={<TrashIcon />}
+                onClick={() => removeSource(idx)}
+                isDanger
+                style={{ position: "absolute", top: 4, right: 4 }}
+                aria-label="Remove source"
+              />
+
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  gap: 8,
+                }}
+              >
+                <FormGroup label="Name" fieldId={`source-name-${idx}`}>
+                  <TextInput
+                    id={`source-name-${idx}`}
+                    value={source.name}
+                    onChange={(_event, val) => updateSource(idx, "name", val)}
+                  />
+                </FormGroup>
+                <FormGroup label="Type" fieldId={`source-type-${idx}`}>
+                  <TextInput
+                    id={`source-type-${idx}`}
+                    value={source.type}
+                    onChange={(_event, val) => updateSource(idx, "type", val)}
+                  />
+                </FormGroup>
+              </div>
+
+              <FormGroup label="URL" fieldId={`source-url-${idx}`}>
+                <TextInput
+                  id={`source-url-${idx}`}
+                  value={source.url || ""}
+                  onChange={(_event, val) => updateSource(idx, "url", val)}
+                  placeholder="https://github.com/org/skills"
+                />
+              </FormGroup>
+
+              <FormGroup label="Ref (branch/tag)" fieldId={`source-ref-${idx}`}>
+                <TextInput
+                  id={`source-ref-${idx}`}
+                  value={source.ref || ""}
+                  onChange={(_event, val) => updateSource(idx, "ref", val)}
+                  placeholder="main"
+                />
+              </FormGroup>
+
+              <FormGroup
+                label="Paths (one per line)"
+                fieldId={`source-paths-${idx}`}
+              >
+                <TextArea
+                  id={`source-paths-${idx}`}
+                  value={(source.paths || []).join("\n")}
+                  onChange={(_event, val) =>
+                    updateSource(
+                      idx,
+                      "paths",
+                      val.split("\n").filter((l) => l.trim())
+                    )
+                  }
+                  rows={3}
+                  placeholder={`skills/java-ee-to-quarkus\nagents`}
+                  style={{ fontFamily: "monospace", fontSize: "0.85em" }}
+                />
+              </FormGroup>
+            </div>
+          ))}
+
+          <Button
+            variant={ButtonVariant.link}
+            icon={<PlusCircleIcon />}
+            onClick={addSource}
+            style={{ marginBottom: 12 }}
+          >
+            Add Source
+          </Button>
+
+          {/* Agents */}
+          <FormGroup fieldId="pallet-auto-detect" label="Agent Settings">
+            <Switch
+              id="pallet-auto-detect"
+              label="Auto-detect agents"
+              isChecked={config?.agents?.auto_detect ?? true}
+              onChange={(_event, checked) => toggleAutoDetect(checked)}
+            />
+          </FormGroup>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PalletEditor;

--- a/client/src/app/pages/migrators/migrators.tsx
+++ b/client/src/app/pages/migrators/migrators.tsx
@@ -99,7 +99,6 @@ const Migrators: FC = () => {
     async (migrator: MigratorConfig) => {
       setIsRunning(true);
       try {
-        // Create a TaskGroup targeting the kai addon
         const taskgroupPayload = {
           name: `migration-${migrator.name}-${Date.now()}`,
           kind: "migration",
@@ -120,7 +119,7 @@ const Migrators: FC = () => {
         await submitTaskgroup(created);
 
         pushNotification({
-          title: `Migration "${migrator.name}" submitted successfully. Check Tasks for progress.`,
+          title: `Migration "${migrator.name}" submitted — TaskGroup #${created.id} (${created.state || "Ready"})`,
           variant: "success",
         });
       } catch (error) {

--- a/client/src/app/pages/migrators/migrators.tsx
+++ b/client/src/app/pages/migrators/migrators.tsx
@@ -102,7 +102,7 @@ const Migrators: FC = () => {
         // Create a TaskGroup targeting the kai addon
         const taskgroupPayload = {
           name: `migration-${migrator.name}-${Date.now()}`,
-          addon: "kai",
+          kind: "migration",
           data: {
             sourceRepository: migrator.sourceRepository,
             assetRepository: migrator.assetRepository,

--- a/client/src/app/pages/migrators/migrators.tsx
+++ b/client/src/app/pages/migrators/migrators.tsx
@@ -1,0 +1,447 @@
+import { FC, useCallback, useState } from "react";
+import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import {
+  Button,
+  ButtonVariant,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  Modal,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  Tooltip,
+} from "@patternfly/react-core";
+import {
+  CubesIcon,
+  PencilAltIcon,
+  PlayIcon,
+  TrashIcon,
+} from "@patternfly/react-icons";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
+import { TablePersistenceKeyPrefix } from "@app/Constants";
+import { MigratorConfig, Taskgroup } from "@app/api/models";
+import { createTaskgroup, submitTaskgroup } from "@app/api/rest";
+import { AppPlaceholder } from "@app/components/AppPlaceholder";
+import { ConditionalRender } from "@app/components/ConditionalRender";
+import { ConfirmDialog } from "@app/components/ConfirmDialog";
+import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
+import { useNotifications } from "@app/components/NotificationsContext";
+import { SimplePagination } from "@app/components/SimplePagination";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+import {
+  useDeleteMigratorMutation,
+  useFetchMigrators,
+} from "@app/queries/migrators";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
+import MigratorDetailDrawer from "./components/migrator-detail-drawer";
+import MigratorForm from "./components/migrator-form";
+
+const Migrators: FC = () => {
+  const { t } = useTranslation();
+  const history = useHistory();
+  const { pushNotification } = useNotifications();
+
+  const [openCreateMigrator, setOpenCreateMigrator] = useState<boolean>(false);
+  const [migratorToEdit, setMigratorToEdit] = useState<MigratorConfig | null>(
+    null
+  );
+  const [migratorToDelete, setMigratorToDelete] =
+    useState<MigratorConfig | null>(null);
+  const [migratorToRun, setMigratorToRun] = useState<MigratorConfig | null>(
+    null
+  );
+  const [isRunning, setIsRunning] = useState(false);
+
+  const { migrators, isLoading, fetchError } = useFetchMigrators();
+
+  const onError = useCallback(
+    (error: AxiosError) => {
+      pushNotification({
+        title: getAxiosErrorMessage(error),
+        variant: "danger",
+      });
+    },
+    [pushNotification]
+  );
+
+  const onDeleteSuccess = useCallback(
+    (migratorDeleted: MigratorConfig) => {
+      pushNotification({
+        title: `Successfully deleted migrator "${migratorDeleted.name}"`,
+        variant: "success",
+      });
+    },
+    [pushNotification]
+  );
+
+  const { mutate: deleteMigrator } = useDeleteMigratorMutation(
+    onDeleteSuccess,
+    onError
+  );
+
+  const handleRunMigration = useCallback(
+    async (migrator: MigratorConfig) => {
+      setIsRunning(true);
+      try {
+        // Create a TaskGroup targeting the kai addon
+        const taskgroupPayload = {
+          name: `migration-${migrator.name}-${Date.now()}`,
+          addon: "kai",
+          data: {
+            sourceRepository: migrator.sourceRepository,
+            assetRepository: migrator.assetRepository,
+            migrationTarget: migrator.migrationTarget,
+            pallet: migrator.pallet,
+          },
+          tasks: [] as Array<{
+            name: string;
+            data?: unknown;
+            application: { id: number; name: string };
+          }>,
+        } as unknown as Taskgroup;
+
+        const created = await createTaskgroup(taskgroupPayload);
+        await submitTaskgroup(created);
+
+        pushNotification({
+          title: `Migration "${migrator.name}" submitted successfully. Check Tasks for progress.`,
+          variant: "success",
+        });
+      } catch (error) {
+        pushNotification({
+          title: `Failed to run migration: ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`,
+          variant: "danger",
+        });
+      } finally {
+        setIsRunning(false);
+        setMigratorToRun(null);
+      }
+    },
+    [pushNotification]
+  );
+
+  const getSortValues = useCallback(
+    (migrator: MigratorConfig) => ({
+      name: migrator.name ?? "",
+      sourceRepo: migrator.sourceRepository?.url ?? "",
+      assetRepo: migrator.assetRepository?.url ?? "",
+      migrationTarget: migrator.migrationTarget ?? "",
+    }),
+    []
+  );
+
+  const tableControls = useLocalTableControls({
+    tableName: "migrators-table",
+    persistTo: "urlParams",
+    persistenceKeyPrefix: TablePersistenceKeyPrefix.migrators,
+    idProperty: "id",
+    dataNameProperty: "name",
+    items: migrators || [],
+    isLoading: isLoading,
+    hasActionsColumn: true,
+    columnNames: {
+      name: t("terms.name"),
+      sourceRepo: "Source Repository",
+      assetRepo: "Asset Repository",
+      migrationTarget: "Migration Target",
+    },
+    isFilterEnabled: true,
+    isSortEnabled: true,
+    isPaginationEnabled: true,
+    isActiveItemEnabled: true,
+    filterCategories: [
+      {
+        categoryKey: "name",
+        title: t("terms.name"),
+        type: FilterType.search,
+        placeholderText:
+          t("actions.filterBy", {
+            what: t("terms.name").toLowerCase(),
+          }) + "...",
+        getItemValue: (migrator: MigratorConfig) => {
+          return migrator?.name ?? "";
+        },
+      },
+      {
+        categoryKey: "sourceRepo",
+        title: "Source Repository",
+        type: FilterType.search,
+        placeholderText: "Filter by source repository...",
+        getItemValue: (migrator: MigratorConfig) => {
+          return migrator?.sourceRepository?.url ?? "";
+        },
+      },
+    ],
+    sortableColumns: ["name", "sourceRepo", "assetRepo", "migrationTarget"],
+    getSortValues,
+    initialSort: { columnKey: "name", direction: "asc" },
+  });
+
+  const {
+    currentPageItems,
+    numRenderedColumns,
+    propHelpers: {
+      toolbarProps,
+      filterToolbarProps,
+      paginationToolbarItemProps,
+      paginationProps,
+      tableProps,
+      getThProps,
+      getTrProps,
+      getTdProps,
+    },
+    activeItemDerivedState: { activeItem, clearActiveItem },
+  } = tableControls;
+
+  const clearFilters = useCallback(() => {
+    const currentPath = history.location.pathname;
+    const newSearch = new URLSearchParams(history.location.search);
+    newSearch.delete("filters");
+    history.push(`${currentPath}?${newSearch.toString()}`);
+    filterToolbarProps.setFilterValues({});
+  }, [history, filterToolbarProps]);
+
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <TextContent>
+          <Text component="h1">Migrators</Text>
+        </TextContent>
+      </PageSection>
+      <PageSection>
+        <ConditionalRender
+          when={isLoading && !(migrators || fetchError)}
+          then={<AppPlaceholder />}
+        >
+          <div
+            style={{
+              backgroundColor: "var(--pf-v5-global--BackgroundColor--100)",
+            }}
+          >
+            <Toolbar {...toolbarProps} clearAllFilters={clearFilters}>
+              <ToolbarContent>
+                <FilterToolbar {...filterToolbarProps} />
+                <ToolbarGroup variant="button-group">
+                  <ToolbarItem>
+                    <Button
+                      type="button"
+                      id="create-new-migrator"
+                      aria-label="Create new migrator"
+                      variant={ButtonVariant.primary}
+                      onClick={() => setOpenCreateMigrator(true)}
+                    >
+                      New Migrator
+                    </Button>
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarItem {...paginationToolbarItemProps}>
+                  <SimplePagination
+                    idPrefix="migrators-table"
+                    isTop
+                    paginationProps={paginationProps}
+                  />
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
+
+            <Table
+              {...tableProps}
+              id="migrators-table"
+              aria-label="migrators table"
+            >
+              <Thead>
+                <Tr>
+                  <TableHeaderContentWithControls {...tableControls}>
+                    <Th {...getThProps({ columnKey: "name" })} />
+                    <Th {...getThProps({ columnKey: "sourceRepo" })} />
+                    <Th {...getThProps({ columnKey: "assetRepo" })} />
+                    <Th {...getThProps({ columnKey: "migrationTarget" })} />
+                  </TableHeaderContentWithControls>
+                </Tr>
+              </Thead>
+              <ConditionalTableBody
+                isLoading={isLoading}
+                isError={!!fetchError}
+                isNoData={currentPageItems.length === 0}
+                noDataEmptyState={
+                  <EmptyState variant="sm">
+                    <EmptyStateHeader
+                      titleText="No migrators configured"
+                      headingLevel="h2"
+                      icon={<EmptyStateIcon icon={CubesIcon} />}
+                    />
+                    <EmptyStateBody>
+                      Create a migrator to define source and asset repositories,
+                      migration targets, and pallet configurations for running
+                      AI-assisted migrations.
+                    </EmptyStateBody>
+                  </EmptyState>
+                }
+                numRenderedColumns={numRenderedColumns}
+              >
+                <Tbody>
+                  {currentPageItems?.map((migrator, rowIndex) => (
+                    <Tr key={migrator.id} {...getTrProps({ item: migrator })}>
+                      <TableRowContentWithControls
+                        {...tableControls}
+                        item={migrator}
+                        rowIndex={rowIndex}
+                      >
+                        <Td
+                          {...getTdProps({ columnKey: "name" })}
+                          modifier="truncate"
+                        >
+                          {migrator.name}
+                        </Td>
+                        <Td
+                          {...getTdProps({ columnKey: "sourceRepo" })}
+                          modifier="truncate"
+                        >
+                          {migrator.sourceRepository?.url}
+                        </Td>
+                        <Td
+                          {...getTdProps({ columnKey: "assetRepo" })}
+                          modifier="truncate"
+                        >
+                          {migrator.assetRepository?.url}
+                        </Td>
+                        <Td
+                          {...getTdProps({ columnKey: "migrationTarget" })}
+                          modifier="truncate"
+                        >
+                          {migrator.migrationTarget || "—"}
+                        </Td>
+
+                        <Td isActionCell id="run-action">
+                          <Tooltip content="Run Migration">
+                            <Button
+                              variant="plain"
+                              icon={<PlayIcon />}
+                              onClick={() => setMigratorToRun(migrator)}
+                            />
+                          </Tooltip>
+                        </Td>
+
+                        <Td isActionCell id="pencil-action">
+                          <Tooltip content={t("actions.edit")}>
+                            <Button
+                              variant="plain"
+                              icon={<PencilAltIcon />}
+                              onClick={() => setMigratorToEdit(migrator)}
+                            />
+                          </Tooltip>
+                        </Td>
+
+                        <Td isActionCell id="delete-action">
+                          <Tooltip content={t("actions.delete")}>
+                            <Button
+                              variant="plain"
+                              icon={<TrashIcon />}
+                              onClick={() => setMigratorToDelete(migrator)}
+                              isDanger={true}
+                            />
+                          </Tooltip>
+                        </Td>
+                      </TableRowContentWithControls>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </ConditionalTableBody>
+            </Table>
+            <SimplePagination
+              idPrefix="migrators-table"
+              isTop={false}
+              paginationProps={paginationProps}
+            />
+          </div>
+        </ConditionalRender>
+      </PageSection>
+
+      <MigratorDetailDrawer
+        migrator={activeItem}
+        onCloseClick={clearActiveItem}
+      />
+
+      {/* Create modal */}
+      <Modal
+        title="New Migrator"
+        variant="medium"
+        isOpen={openCreateMigrator}
+        onClose={() => setOpenCreateMigrator(false)}
+      >
+        <MigratorForm
+          key={openCreateMigrator ? 1 : 0}
+          onClose={() => setOpenCreateMigrator(false)}
+        />
+      </Modal>
+
+      {/* Edit modal */}
+      <Modal
+        title="Edit Migrator"
+        variant="medium"
+        isOpen={!!migratorToEdit}
+        onClose={() => setMigratorToEdit(null)}
+      >
+        <MigratorForm
+          key={migratorToEdit?.id ?? -1}
+          migrator={migratorToEdit}
+          onClose={() => setMigratorToEdit(null)}
+        />
+      </Modal>
+
+      {/* Run migration confirm modal */}
+      <ConfirmDialog
+        title={`Run Migration: ${migratorToRun?.name ?? ""}`}
+        isOpen={!!migratorToRun}
+        titleIconVariant="info"
+        message={`This will create a TaskGroup and submit it to the Hub API, triggering the kai addon container to perform the migration.\n\nSource: ${migratorToRun?.sourceRepository?.url ?? ""}\nTarget: ${migratorToRun?.migrationTarget ?? "not specified"}\nAsset Output: ${migratorToRun?.assetRepository?.url ?? ""} (${migratorToRun?.assetRepository?.branch ?? ""})`}
+        confirmBtnVariant={ButtonVariant.primary}
+        confirmBtnLabel="Run Migration"
+        cancelBtnLabel={t("actions.cancel")}
+        onCancel={() => setMigratorToRun(null)}
+        onClose={() => setMigratorToRun(null)}
+        onConfirm={() => migratorToRun && handleRunMigration(migratorToRun)}
+        inProgress={isRunning}
+      />
+
+      {/* Delete confirm modal */}
+      <ConfirmDialog
+        title={`Delete migrator "${migratorToDelete?.name ?? ""}"?`}
+        isOpen={!!migratorToDelete}
+        titleIconVariant="warning"
+        message={t("dialog.message.delete")}
+        confirmBtnVariant={ButtonVariant.danger}
+        confirmBtnLabel={t("actions.delete")}
+        cancelBtnLabel={t("actions.cancel")}
+        onCancel={() => setMigratorToDelete(null)}
+        onClose={() => setMigratorToDelete(null)}
+        onConfirm={() => {
+          if (migratorToDelete) {
+            deleteMigrator(migratorToDelete);
+            setMigratorToDelete(null);
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default Migrators;

--- a/client/src/app/queries/migrators.ts
+++ b/client/src/app/queries/migrators.ts
@@ -1,0 +1,102 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { MigratorConfig } from "@app/api/models";
+import {
+  createMigrator,
+  deleteMigrator,
+  getMigratorById,
+  getMigrators,
+  updateMigrator,
+} from "@app/api/rest";
+
+export const MIGRATORS_QUERY_KEY = "migrators";
+export const MIGRATOR_QUERY_KEY = "migrator";
+
+export const useFetchMigrators = (
+  refetchInterval: number | false = DEFAULT_REFETCH_INTERVAL
+) => {
+  const { isLoading, isSuccess, error, refetch, data } = useQuery({
+    queryKey: [MIGRATORS_QUERY_KEY],
+    queryFn: getMigrators,
+    onError: (error: AxiosError) => console.log(error),
+    refetchInterval,
+  });
+
+  return {
+    migrators: data || [],
+    isLoading,
+    isSuccess,
+    fetchError: error,
+    refetch,
+  };
+};
+
+export const useFetchMigratorById = (id?: number | string) => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [MIGRATOR_QUERY_KEY, id],
+    queryFn: () =>
+      id === undefined ? Promise.resolve(undefined) : getMigratorById(id),
+    onError: (error: AxiosError) => console.log("error, ", error),
+    enabled: id !== undefined,
+  });
+
+  return {
+    migrator: data,
+    isLoading,
+    fetchError: error,
+  };
+};
+
+export const useCreateMigratorMutation = (
+  onSuccess: () => void,
+  onError: (err: AxiosError) => void
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createMigrator,
+    onSuccess: () => {
+      onSuccess();
+      queryClient.invalidateQueries({ queryKey: [MIGRATORS_QUERY_KEY] });
+    },
+    onError: onError,
+  });
+};
+
+export const useUpdateMigratorMutation = (
+  onSuccess: (id: number) => void,
+  onError: (err: AxiosError) => void
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateMigrator,
+    onSuccess: (_, { id }) => {
+      onSuccess(id);
+      queryClient.invalidateQueries({ queryKey: [MIGRATORS_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MIGRATOR_QUERY_KEY, id] });
+    },
+    onError: onError,
+  });
+};
+
+export const useDeleteMigratorMutation = (
+  onSuccess: (migrator: MigratorConfig) => void,
+  onError: (err: AxiosError) => void
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (migrator: MigratorConfig) => deleteMigrator(migrator.id),
+    onSuccess: (_, migrator) => {
+      onSuccess(migrator);
+      queryClient.invalidateQueries({ queryKey: [MIGRATORS_QUERY_KEY] });
+      queryClient.invalidateQueries({
+        queryKey: [MIGRATOR_QUERY_KEY, migrator.id],
+      });
+    },
+    onError: onError,
+  });
+};

--- a/client/src/mocks/stub-new-work/index.ts
+++ b/client/src/mocks/stub-new-work/index.ts
@@ -5,6 +5,7 @@ import { config } from "../config";
 import applications from "./applications";
 import archetypes from "./archetypes";
 import assessments from "./assessments";
+import migrators from "./migrators";
 import questionnaires from "./questionnaires";
 
 const enableMe = (me: string) =>
@@ -20,6 +21,7 @@ const enabledStubs: RestHandler[] = [
   ...(enableMe("assessments") ? assessments : []),
   ...(enableMe("questionnaires") ? questionnaires : []),
   ...(enableMe("applications") ? applications : []),
+  ...migrators,
 ].filter(Boolean);
 
 export default enabledStubs;

--- a/client/src/mocks/stub-new-work/migrators.ts
+++ b/client/src/mocks/stub-new-work/migrators.ts
@@ -1,0 +1,45 @@
+import { rest } from "msw";
+
+import { MigratorConfig } from "@app/api/models";
+
+let nextId = 1;
+const migrators: MigratorConfig[] = [];
+
+const handlers = [
+  rest.get("/hub/migrators", (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(migrators));
+  }),
+
+  rest.get("/hub/migrators/:id", (req, res, ctx) => {
+    const id = Number(req.params.id);
+    const migrator = migrators.find((m) => m.id === id);
+    if (!migrator) return res(ctx.status(404));
+    return res(ctx.status(200), ctx.json(migrator));
+  }),
+
+  rest.post("/hub/migrators", async (req, res, ctx) => {
+    const body = await req.json();
+    const created: MigratorConfig = { ...body, id: nextId++ };
+    migrators.push(created);
+    return res(ctx.status(201), ctx.json(created));
+  }),
+
+  rest.put("/hub/migrators/:id", async (req, res, ctx) => {
+    const id = Number(req.params.id);
+    const body = await req.json();
+    const idx = migrators.findIndex((m) => m.id === id);
+    if (idx === -1) return res(ctx.status(404));
+    migrators[idx] = { ...body, id };
+    return res(ctx.status(204));
+  }),
+
+  rest.delete("/hub/migrators/:id", (req, res, ctx) => {
+    const id = Number(req.params.id);
+    const idx = migrators.findIndex((m) => m.id === id);
+    if (idx === -1) return res(ctx.status(404));
+    migrators.splice(idx, 1);
+    return res(ctx.status(204));
+  }),
+];
+
+export default handlers;

--- a/customresource-extension.yaml
+++ b/customresource-extension.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: konveyor-tackle
 spec:
   container:
-    image: quay.io/konveyor/tackle2-addon-kai:latest
+    image: quay.io/dymurray/tackle2-addon-kai:latest
     imagePullPolicy: Always
     name: addon
     resources:

--- a/customresource-extension.yaml
+++ b/customresource-extension.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tackle.konveyor.io/v1alpha1
+kind: Addon
+metadata:
+  generation: 1
+  name: kai
+  namespace: konveyor-tackle
+spec:
+  container:
+    image: quay.io/konveyor/tackle2-addon-kai:latest
+    imagePullPolicy: Always
+    name: addon
+    resources:
+      limits:
+        cpu: "2"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+  task: migration

--- a/customresource-extension.yaml
+++ b/customresource-extension.yaml
@@ -1,5 +1,13 @@
 ---
 apiVersion: tackle.konveyor.io/v1alpha1
+kind: Task
+metadata:
+  name: migration
+  namespace: konveyor-tackle
+spec:
+  priority: 10
+---
+apiVersion: tackle.konveyor.io/v1alpha1
 kind: Addon
 metadata:
   generation: 1


### PR DESCRIPTION
## Summary

Adds a new **Migrator** admin page and an application-centric **"Migrate"** button to the Applications table, enabling UI-driven migration via the `kai` addon.

## End-to-End Flow

1. **Admin → Migrators** → Define migrator configurations (source repo, asset repo, migration target, pallet YAML, credentials)
2. **Applications → Select app(s) → "Migrate"** → Pick a migrator config from dropdown → Submit
3. Creates a **TaskGroup** with `kind: "migration"` targeting the `kai` addon → Hub schedules addon container

## What's Included

### New: Migrator Admin Page (`/migrators`)
- Full CRUD table (create, edit, delete migrator configs)
- Form fields: name, description, source repo (URL/branch/credentials), asset repo (URL/branch/credentials), migration target, pallet YAML
- Detail drawer with config overview and pallet tab
- "Run Migration" standalone action per migrator

### New: "Migrate" Button on Applications Table
- Appears next to existing "Analyze" button
- Opens modal: select a migrator config → shows config summary → "Run Migration"
- Creates TaskGroup with per-app tasks referencing the selected migrator

### New: K8s Custom Resources
- `customresource-extension.yaml` — Task CR (`migration`) + Addon CR (`kai`) for Hub registration

### API Layer
- `client/src/app/api/rest/migrators.ts` — REST client with local dev fallback (`USE_LOCAL_FALLBACK` flag)
- `client/src/app/queries/migrators.ts` — React Query hooks
- `client/src/app/api/models.ts` — `MigratorConfig`, `MigratorSourceRepository`, `MigratorAssetRepository`, `MigratorPallet` interfaces

## Local Dev Setup

```bash
# Apply CRs to minikube (required for TaskGroup submission)
kubectl apply -f customresource-extension.yaml

# Start dev server
npm run start:dev
```

The migrators page uses an in-memory store by default (`USE_LOCAL_FALLBACK=true` in `rest/migrators.ts`) since the Hub doesn't have a `/migrators` endpoint yet. Flip to `false` when backend is ready.

## Files Changed
- **New:** `pages/migrators/` (page, form, detail drawer, components)
- **New:** `pages/applications/migrate-modal/migrate-modal.tsx`
- **New:** `api/rest/migrators.ts`, `queries/migrators.ts`
- **New:** `mocks/stub-new-work/migrators.ts` (MSW mock handler)
- **New:** `customresource-extension.yaml`
- **Modified:** `Paths.ts`, `Routes.tsx`, `SidebarApp.tsx` (routing + nav)
- **Modified:** `models.ts` (new interfaces)
- **Modified:** `Constants.ts` (table persistence key)
- **Modified:** `applications-table.tsx` (Migrate button + modal)

## TODO
- [ ] Hub backend: `/migrators` CRUD endpoint
- [ ] Addon image: `quay.io/konveyor/tackle2-addon-kai:latest`
- [ ] Sync TaskGroup `data` shape with addon's expected `Data{}` struct
- [ ] i18n translation keys (currently using English defaults)
- [ ] E2E tests