### PR TITLE
:test_tube: Retry fetching exported jira issues

### DIFF
--- a/cypress/e2e/tests/migration/migration-waves/common.ts
+++ b/cypress/e2e/tests/migration/migration-waves/common.ts
@@ -96,5 +96,5 @@ export const pullJiraIssuesByWaves = (
     });
   }
 
-  return recursivePull(0);
+  return recursivePull(1);
 };

--- a/cypress/e2e/tests/migration/migration-waves/common.ts
+++ b/cypress/e2e/tests/migration/migration-waves/common.ts
@@ -1,0 +1,100 @@
+import { Jira } from "../../../models/administration/jira-connection/jira";
+import { JiraIssue } from "../../../models/administration/jira-connection/jira-api.interface";
+import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
+import { SEC } from "../../../types/constants";
+
+export const getWaveIssuesByIssueType = ({
+  jiraInstance,
+  projectName,
+  wavesMap,
+  usedAppsCount,
+}: {
+  jiraInstance: Jira;
+  projectName: string;
+  wavesMap: Record<string, MigrationWave>;
+  usedAppsCount: number;
+}): Cypress.Chainable<{
+  [k: string]: IssueWithApp[];
+}> =>
+  jiraInstance.getIssues(projectName).then((issues: JiraIssue[]) =>
+    issues.reduce(
+      (acc, issue) => {
+        const jiraType = issue.fields.issuetype.name;
+        const waveType = Object.keys(wavesMap).find(
+          (type) => type.toUpperCase() === jiraType.toUpperCase()
+        );
+
+        if (!acc[waveType]) {
+          return acc;
+        }
+
+        const apps: string[] = wavesMap[waveType].applications
+          .map((app) => app.name)
+          .slice(0, usedAppsCount);
+
+        const appForIssue = apps.find((appName) =>
+          issue.fields.summary.includes(appName)
+        );
+        if (appForIssue) {
+          acc[waveType].push({ issue, app: appForIssue });
+        }
+        return acc;
+      },
+      Object.fromEntries(
+        Object.keys(wavesMap).map((issueType): [string, IssueWithApp[]] => [
+          issueType,
+          [],
+        ])
+      )
+    )
+  );
+
+export type IssueWithApp = {
+  issue: JiraIssue;
+  app: string;
+};
+
+/**
+ * Retry pulling Jira issues for waves until the expected number of issues is reached.
+ * @returns aggregated issues by issue type if success, otherwise throws an error.
+ */
+export const pullJiraIssuesByWaves = (
+  jiraInstance: Jira,
+  projectName: string,
+  wavesMap: Record<string, MigrationWave>,
+  expectedIssuesCountPerType: number = 2,
+  maxAttempts: number = 10,
+  waitTimeInSeconds: number = 10
+): Cypress.Chainable<{
+  [k: string]: IssueWithApp[];
+}> => {
+  function recursivePull(attemptNumber: number): Cypress.Chainable<{
+    [k: string]: IssueWithApp[];
+  }> {
+    if (attemptNumber > maxAttempts) {
+      throw new Error(`Max attempts reached: ${maxAttempts}`);
+    }
+    cy.log(`Next pull in ${waitTimeInSeconds} seconds...`);
+    cy.wait(waitTimeInSeconds * SEC);
+    return getWaveIssuesByIssueType({
+      jiraInstance,
+      projectName,
+      wavesMap,
+      usedAppsCount: expectedIssuesCountPerType,
+    }).then((issuesByIssueType: Record<string, IssueWithApp[]>) => {
+      const success = Object.values(issuesByIssueType).every(
+        (issues) => issues.length === expectedIssuesCountPerType
+      );
+
+      if (success) {
+        cy.log(
+          `All data for ${Object.keys(issuesByIssueType).length} issue types ready after ${attemptNumber} attempts. `
+        );
+        return cy.wrap(issuesByIssueType);
+      }
+      return recursivePull(attemptNumber + 1);
+    });
+  }
+
+  return recursivePull(0);
+};

--- a/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
@@ -174,18 +174,20 @@ describe(
     });
 
     after("Clear test data", function () {
-      getWaveIssuesByIssueType({
-        jiraInstance: jiraCloudInstance,
-        projectName,
-        wavesMap,
-        usedAppsCount: 2,
-      }).then((issuesByIssueType) => {
-        jiraCloudInstance.deleteIssues(
-          Object.values(issuesByIssueType).flatMap((issues) =>
-            issues.map((issue) => issue.issue.id)
-          )
-        );
-      });
+      if (projectName) {
+        getWaveIssuesByIssueType({
+          jiraInstance: jiraCloudInstance,
+          projectName,
+          wavesMap,
+          usedAppsCount: 2,
+        }).then((issuesByIssueType) => {
+          jiraCloudInstance.deleteIssues(
+            Object.values(issuesByIssueType).flatMap((issues) =>
+              issues.map((issue) => issue.issue.id)
+            )
+          );
+        });
+      }
       getAuthHeaders().then((headers) => {
         MigrationWave.deleteAllViaApi(headers);
         Application.deleteAllViaApi(headers);

--- a/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
@@ -26,15 +26,15 @@ import {
 import { JiraCredentials } from "../../../models/administration/credentials/JiraCredentials";
 import { Credentials } from "../../../models/administration/credentials/credentials";
 import { Jira } from "../../../models/administration/jira-connection/jira";
-import { JiraIssue } from "../../../models/administration/jira-connection/jira-api.interface";
 import { Application } from "../../../models/migration/applicationinventory/application";
 import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
 import {
   CredentialType,
   JiraIssueTypes,
   JiraType,
-  SEC,
 } from "../../../types/constants";
+
+import { getWaveIssuesByIssueType, pullJiraIssuesByWaves } from "./common";
 
 const now = new Date();
 now.setDate(now.getDate() + 1);
@@ -160,32 +160,32 @@ describe(
       });
     });
 
-    Object.values(JiraIssueTypes).forEach((issueType) => {
-      it(`Assert exports for ${issueType}`, function () {
-        cy.wait(30 * SEC); // Enough time to create both tasks and for them to be available in the Jira API
-        jiraCloudInstance.getIssues(projectName).then((issues: JiraIssue[]) => {
-          const waveIssues = issues.filter((issue) => {
-            return (
-              (issue.fields.summary.includes(
-                wavesMap[issueType].applications[0].name
-              ) ||
-                issue.fields.summary.includes(
-                  wavesMap[issueType].applications[1].name
-                )) &&
-              issue.fields.issuetype.name.toUpperCase() ===
-                (issueType as string).toUpperCase()
-            );
+    it("Assert exports for all issue types", function () {
+      pullJiraIssuesByWaves(jiraCloudInstance, projectName, wavesMap).then(
+        (issuesByIssueType) => {
+          Object.entries(issuesByIssueType).forEach(([issueType, issues]) => {
+            expect(
+              Cypress._.uniqBy(issues, ({ app }) => app),
+              `Issues for ${issueType} are not exported`
+            ).to.have.length(2);
           });
-          Application.open();
-
-          jiraCloudInstance.deleteIssues(waveIssues.map((issue) => issue.id));
-
-          expect(waveIssues).to.have.length(2);
-        });
-      });
+        }
+      );
     });
 
     after("Clear test data", function () {
+      getWaveIssuesByIssueType({
+        jiraInstance: jiraCloudInstance,
+        projectName,
+        wavesMap,
+        usedAppsCount: 2,
+      }).then((issuesByIssueType) => {
+        jiraCloudInstance.deleteIssues(
+          Object.values(issuesByIssueType).flatMap((issues) =>
+            issues.map((issue) => issue.issue.id)
+          )
+        );
+      });
       getAuthHeaders().then((headers) => {
         MigrationWave.deleteAllViaApi(headers);
         Application.deleteAllViaApi(headers);

--- a/cypress/e2e/tests/migration/migration-waves/export_to_jira_datacenter.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export_to_jira_datacenter.test.ts
@@ -25,15 +25,15 @@ import {
 } from "../../../../utils/utils";
 import { JiraCredentials } from "../../../models/administration/credentials/JiraCredentials";
 import { Jira } from "../../../models/administration/jira-connection/jira";
-import { JiraIssue } from "../../../models/administration/jira-connection/jira-api.interface";
 import { Application } from "../../../models/migration/applicationinventory/application";
 import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
 import {
   CredentialType,
   JiraIssueTypes,
   JiraType,
-  SEC,
 } from "../../../types/constants";
+
+import { pullJiraIssuesByWaves } from "./common";
 
 const now = new Date();
 now.setDate(now.getDate() + 1);
@@ -133,28 +133,25 @@ describe(
       });
 
       it(`Assert exports for ${issueType}`, function () {
-        cy.wait(40 * SEC); // Enough time to create both tasks and for them to be available in the Jira API
-        jiraInstance.getIssues(projectName).then((issues: JiraIssue[]) => {
-          const waveIssues = issues.filter((issue) => {
-            return (
-              (issue.fields.summary.includes(
-                wave.applications[0].name.trim()
-              ) ||
-                issue.fields.summary.includes(
-                  wave.applications[1].name.trim()
-                )) &&
-              issue.fields.issuetype.name.toUpperCase() ===
-                (issueType as string).toUpperCase()
-            );
+        const expectedIssuesCountPerType = 2;
+        pullJiraIssuesByWaves(
+          jiraInstance,
+          projectName,
+          { [issueType]: wave },
+          expectedIssuesCountPerType
+        ).then((issuesByIssueType) => {
+          Object.entries(issuesByIssueType).forEach(([issueType, issues]) => {
+            expect(
+              Cypress._.uniqBy(issues, ({ app }) => app),
+              `Issues for ${issueType} are not exported`
+            ).to.have.length(expectedIssuesCountPerType);
           });
-
-          expect(waveIssues).to.have.length(2);
-          wave.delete();
         });
       });
     });
 
     after("Clear test data", function () {
+      wave.delete();
       deleteAllMigrationWaves();
       deleteApplicationTableRows();
       deleteAllCredentials();

--- a/cypress/e2e/tests/migration/migration-waves/export_to_jira_datacenter.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export_to_jira_datacenter.test.ts
@@ -151,7 +151,6 @@ describe(
     });
 
     after("Clear test data", function () {
-      wave.delete();
       deleteAllMigrationWaves();
       deleteApplicationTableRows();
       deleteAllCredentials();


### PR DESCRIPTION
1. Repeat the request until the expected number of issues is retrieved.
2. Fail the test if max number of attempts is reached
3. Ensure that the cleanup is executed after the test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added helpers to gather and group Jira issues by migration wave for end-to-end verification.
  * Built-in retry and configurable wait behavior to reduce flakiness; removed hard-coded waits.
  * Consolidated export verification to use the new helpers and assert two unique apps per issue type.
  * Centralized and more reliable cleanup of created Jira issues in test teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->