### PR TITLE
:bug: Update axios to 1.15.2 to address CVEs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "@react-keycloak/web": "3.4.0",
     "@tanstack/react-query": "^4.40.1",
     "@tanstack/react-query-devtools": "^4.40.1",
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "classnames": "^2.3.1",
     "dayjs": "^1.11.19",
     "fast-xml-parser": "^5.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "@react-keycloak/web": "3.4.0",
         "@tanstack/react-query": "^4.40.1",
         "@tanstack/react-query-devtools": "^4.40.1",
-        "axios": "^1.15.0",
+        "axios": "^1.15.2",
         "classnames": "^2.3.1",
         "dayjs": "^1.11.19",
         "fast-xml-parser": "^5.2.5",
@@ -144,6 +144,17 @@
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.3",
         "webpack-merge": "^6.0.1"
+      }
+    },
+    "client/node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "common": {
@@ -7594,20 +7605,12 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/babel-jest": {
@@ -21175,6 +21178,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/psl": {


### PR DESCRIPTION
Fixes: MTA-6878, MTA-6879, MTA-6880, MTA-6899, MTA-6900, MTA-6901

Covers CVE-2026-42033, CVE-2026-42035


Assisted-by: Claude Sonnet 4.6 (Anthropic) <ai-assistant>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated axios dependency version constraint to include the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->