### PR TITLE
:bug: Update follow-redirects to 1.16.0 to address CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13242,9 +13242,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "http-proxy-middleware": "^3.0.5"
   },
   "overrides": {
-    "follow-redirects": "^1.15.6",
+    "follow-redirects": "^1.16.0",
     "qs": "^6.14.1",
     "webpack-dev-server": {
       "express": "$express"


### PR DESCRIPTION
Fixes: MTA-6869, MTA-6870, MTA-6871

Covers CVE-2026-40895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to a newer patch release to improve stability and security, and to address minor connectivity and redirect-related fixes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konveyor/tackle2-ui/pull/3243)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->