### PR TITLE
[release-0.9] :bug: Update follow-redirects to 1.16.0 to address CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13241,9 +13241,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "overrides": {
     "axios": "^1.15.0",
-    "follow-redirects": "^1.15.6",
+    "follow-redirects": "^1.16.0",
     "lodash": "^4.18.1",
     "qs": "^6.14.1",
     "webpack-dev-server": {


### PR DESCRIPTION
Fixes: MTA-6869, MTA-6870, MTA-6871

Covers CVE-2026-40895