### PR TITLE
:seedling: bump axios to 1.16.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,6 @@
     "@react-keycloak/web": "3.4.0",
     "@tanstack/react-query": "^4.40.1",
     "@tanstack/react-query-devtools": "^4.40.1",
-    "axios": "^1.15.2",
     "classnames": "^2.3.1",
     "dayjs": "^1.11.19",
     "fast-xml-parser": "^5.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cypress"
       ],
       "dependencies": {
+        "axios": "^1.16.0",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "http-proxy-middleware": "^3.0.5"
@@ -50,7 +51,7 @@
         "ts-node": "^10.9.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
-        "wait-on": "^9.0.5"
+        "wait-on": "^9.0.10"
       },
       "engines": {
         "node": ">=22.22.0",
@@ -76,7 +77,6 @@
         "@react-keycloak/web": "3.4.0",
         "@tanstack/react-query": "^4.40.1",
         "@tanstack/react-query-devtools": "^4.40.1",
-        "axios": "^1.15.2",
         "classnames": "^2.3.1",
         "dayjs": "^1.11.19",
         "fast-xml-parser": "^5.7.3",
@@ -145,17 +145,6 @@
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.3",
         "webpack-merge": "^6.0.1"
-      }
-    },
-    "client/node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "client/node_modules/fast-xml-parser": {
@@ -7705,13 +7694,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "dev": true,
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -16672,9 +16660,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -26648,14 +26636,14 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.5.tgz",
-      "integrity": "sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.10.tgz",
+      "integrity": "sha512-rCoJEhvMr0X6alHmwc9abbrA5ZrLZFKpFQVKPNFwl2h7DapXOGdmimIHDtLOWhT4PjhZhxFEtZoQgEXbkDWdZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.15.0",
-        "joi": "^18.1.2",
+        "axios": "^1.16.0",
+        "joi": "^18.2.1",
         "lodash": "^4.18.1",
         "minimist": "^1.2.8",
         "rxjs": "^7.8.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cypress"
       ],
       "dependencies": {
-        "axios": "^1.16.0",
+        "axios": "^1.16.1",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "http-proxy-middleware": "^3.0.5"
@@ -7132,7 +7132,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -7694,13 +7693,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -14629,7 +14629,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",

--- a/package.json
+++ b/package.json
@@ -71,9 +71,10 @@
     "ts-node": "^10.9.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
-    "wait-on": "^9.0.5"
+    "wait-on": "^9.0.10"
   },
   "dependencies": {
+    "axios": "^1.16.0",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "http-proxy-middleware": "^3.0.5"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "wait-on": "^9.0.10"
   },
   "dependencies": {
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "http-proxy-middleware": "^3.0.5"


### PR DESCRIPTION
Move axios dependency to root, and bump version to 1.16.1. This brings use to current and solves a number of security vulnerabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved axios from the client-specific dependency list to the project-level runtime dependencies.
  * Upgraded developer tooling (wait-on) to a newer patch release.
  * Consolidated dependency declarations to simplify dependency management across the project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konveyor/tackle2-ui/pull/3253)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->