### PR TITLE
[release-0.8] :seedling: bump axios to 1.16.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,6 @@
     "@react-keycloak/web": "3.4.0",
     "@tanstack/react-query": "^4.40.1",
     "@tanstack/react-query-devtools": "^4.40.1",
-    "axios": "^1.15.2",
     "classnames": "^2.3.1",
     "dayjs": "^1.11.13",
     "fast-xml-parser": "^5.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cypress"
       ],
       "dependencies": {
+        "axios": "^1.16.1",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "http-proxy-middleware": "^3.0.5"
@@ -50,7 +51,7 @@
         "ts-node": "^10.9.1",
         "typescript": "~5.7.3",
         "typescript-eslint": "^8.46.2",
-        "wait-on": "^9.0.1"
+        "wait-on": "^9.0.10"
       },
       "engines": {
         "node": ">=20.12.2",
@@ -76,7 +77,6 @@
         "@react-keycloak/web": "3.4.0",
         "@tanstack/react-query": "^4.40.1",
         "@tanstack/react-query-devtools": "^4.40.1",
-        "axios": "^1.15.2",
         "classnames": "^2.3.1",
         "dayjs": "^1.11.13",
         "fast-xml-parser": "^5.7.3",
@@ -144,17 +144,6 @@
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.1",
         "webpack-merge": "^6.0.1"
-      }
-    },
-    "client/node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "client/node_modules/fast-xml-parser": {
@@ -3812,9 +3801,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/tlds": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
-      "integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5771,9 +5760,9 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7642,7 +7631,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -8214,14 +8202,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "dev": true,
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -15185,7 +15173,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -17666,9 +17653,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -17678,7 +17665,7 @@
         "@hapi/pinpoint": "^2.0.1",
         "@hapi/tlds": "^1.1.1",
         "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
+        "@standard-schema/spec": "^1.1.0"
       },
       "engines": {
         "node": ">= 20"
@@ -27517,15 +27504,15 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.3.tgz",
-      "integrity": "sha512-13zBnyYvFDW1rBvWiJ6Av3ymAaq8EDQuvxZnPIw3g04UqGi4TyoIJABmfJ6zrvKo9yeFQExNkOk7idQbDJcuKA==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.10.tgz",
+      "integrity": "sha512-rCoJEhvMr0X6alHmwc9abbrA5ZrLZFKpFQVKPNFwl2h7DapXOGdmimIHDtLOWhT4PjhZhxFEtZoQgEXbkDWdZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.13.2",
-        "joi": "^18.0.1",
-        "lodash": "^4.17.21",
+        "axios": "^1.16.0",
+        "joi": "^18.2.1",
+        "lodash": "^4.18.1",
         "minimist": "^1.2.8",
         "rxjs": "^7.8.2"
       },

--- a/package.json
+++ b/package.json
@@ -70,15 +70,15 @@
     "ts-node": "^10.9.1",
     "typescript": "~5.7.3",
     "typescript-eslint": "^8.46.2",
-    "wait-on": "^9.0.1"
+    "wait-on": "^9.0.10"
   },
   "dependencies": {
+    "axios": "^1.16.1",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "http-proxy-middleware": "^3.0.5"
   },
   "overrides": {
-    "axios": "^1.15.0",
     "follow-redirects": "^1.16.0",
     "lodash": "^4.18.1",
     "qs": "^6.14.1",


### PR DESCRIPTION
Move axios dependency to root, and bump version to 1.16.1. This brings use to current and solves a number of security vulnerabilities.