### PR TITLE
:bug: Fix createTickets() by returning all promises

### DIFF
--- a/.github/workflows/e2e-repo-main.yaml
+++ b/.github/workflows/e2e-repo-main.yaml
@@ -15,6 +15,9 @@ on:
       install_konveyor_version:
         type: string
         default: main
+      image_ref:
+        type: string
+        default: main
       test_ref:
         type: string
         default: main
@@ -32,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.test_ref }}
+          ref: ${{ inputs.image_ref }}
 
       - name: Build UI image
         id: build-ui-image

--- a/.github/workflows/e2e-repo-main.yaml
+++ b/.github/workflows/e2e-repo-main.yaml
@@ -31,6 +31,8 @@ jobs:
       ui_image: ${{ steps.build-ui-image.outputs.ui_image }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.test_ref }}
 
       - name: Build UI image
         id: build-ui-image

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -365,16 +365,15 @@ export const getTrackerProjectIssuetypes = (
 // Tickets
 //
 export const createTickets = (payload: New<Ticket>, applications: Ref[]) => {
-  const promises: AxiosPromise[] = [];
-
-  applications.map((app) => {
-    const appPayload: New<Ticket> = {
-      ...payload,
-      application: { id: app.id, name: app.name },
-    };
-    return [...promises, axios.post(TICKETS, appPayload)];
-  });
-  return Promise.all<AxiosPromise<Ticket>>(promises);
+  return Promise.all(
+    applications.map((app) => {
+      const appPayload: New<Ticket> = {
+        ...payload,
+        application: { id: app.id, name: app.name },
+      };
+      return axios.post(TICKETS, appPayload);
+    })
+  );
 };
 
 export const getTickets = (): Promise<Ticket[]> =>

--- a/client/src/app/pages/applications/application-detail-drawer/tab-details-content.tsx
+++ b/client/src/app/pages/applications/application-detail-drawer/tab-details-content.tsx
@@ -344,6 +344,8 @@ const MigrationWaveDetails: React.FC<{
           >
             <Button
               variant="link"
+              ouiaId="unlink-ticket-button"
+              aria-label={t("message.unlinkTicket")}
               icon={<UnlinkIcon />}
               onClick={() => deleteTicket(matchingTicket.id)}
             />

--- a/client/src/app/queries/tickets.ts
+++ b/client/src/app/queries/tickets.ts
@@ -24,7 +24,10 @@ export const useCreateTicketsMutation = (
       queryClient.invalidateQueries({ queryKey: [TicketsQueryKey] });
       onSuccess();
     },
-    onError: onError,
+    onError: (err: AxiosError) => {
+      queryClient.invalidateQueries({ queryKey: [TicketsQueryKey] });
+      onError(err);
+    },
   });
 };
 

--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -961,15 +961,9 @@ export class Application {
   unlinkJiraTicket(): void {
     Application.open();
     sidedrawerTab(this.name, details);
-    cy.contains("small", "Ticket")
-      .next()
-      .children("div")
-      .eq(0)
-      .children("button.pf-m-link")
-      .eq(0)
-      .click({ force: true });
-    // Need to wait until the application is unlinked from Jira and reflected in the wave
-    cy.wait(3 * SEC);
+    cy.get("[data-ouia-component-id='unlink-ticket-button']").click({
+      force: true,
+    });
     this.closeApplicationDetails();
   }
   validateOverrideAssessmentMessage(archetypes: Archetype[]): void {

--- a/cypress/e2e/tests/migration/migration-waves/unlink_application.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/unlink_application.test.ts
@@ -145,13 +145,13 @@ describe(
     });
 
     // Automates Polarion TC 415
-    it.skip("Bug Tackle-3111: Export to Jira Cloud and unlink applications from App Inventory", function () {
-      // https://github.com/konveyor/tackle2-ui/issues/3111
+    it("Export to Jira Cloud and unlink applications from App Inventory", function () {
       exportWave().then(() => {
         Application.open(true);
         applications.forEach((app) => app.unlinkJiraTicket());
         Jira.openList();
-        cy.get(tdTag)
+        // wait for the apps to be unlinked
+        cy.get(tdTag, { timeout: 120 * SEC })
           .contains(jiraCloudInstance.name)
           .closest(trTag)
           .within(() => {


### PR DESCRIPTION
Before, createTickets() never collected the per-application 
Axios promises that where built inside the map callback.
As a result Promise.all resolved immediately with an empty 
array and the UI wasn't refreshed to show
the created Jira tickets.

Additional changes:
1. uncomment the test that verifies fixed functionality 
2. simplify the test by using data test ID for the unlink
   button
3. Build the image for the e2e-repo-main workflow 
   from the image_ref (before it was always main)

Fixes: #3111 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility for unlink-ticket controls with descriptive labels.
  * Improved error handling and recovery for ticket creation operations with query invalidation on failures.
* **Tests**
  * Re-enabled and updated an end-to-end test for unlinking applications; increased selector timeout for reliability.
* **Chores**
  * CI workflow: added a configurable image reference input to allow selecting which image ref to use during builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konveyor/tackle2-ui/pull/3269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->