### PR TITLE
:sparkles: Add `/oidc` proxy for Hub OIDC provider

### DIFF
--- a/client/src/app/auth/OidcAuthStrategy.tsx
+++ b/client/src/app/auth/OidcAuthStrategy.tsx
@@ -83,8 +83,9 @@ const AuthReadyGate: React.FC<AuthProviderProps> = ({ children }) => {
       auth.signoutRedirect({
         post_logout_redirect_uri: window.location.origin,
       }),
-    manageAccount: () =>
-      window.open(accountManagementUrl, "_blank", "noopener"),
+    manageAccount: accountManagementUrl
+      ? () => window.open(accountManagementUrl, "_blank", "noopener")
+      : undefined,
     ToolbarContent: OidcToolbarItem,
   };
 

--- a/client/src/app/auth/userManager.ts
+++ b/client/src/app/auth/userManager.ts
@@ -2,9 +2,13 @@
  * Creates and exports a single shared UserManager instance (from oidc-client-ts).
  * The UserManager handles PKCE token storage, refresh, and silent-renew.
  *
- * OIDC authority is derived from the env vars:
- *   authority = /auth/realms/{KEYCLOAK_REALM}
- *   client_id = KEYCLOAK_CLIENT_ID
+ * OIDC authority is derived from env vars in priority order:
+ *   1. OIDC_ISSUER (Hub built-in OIDC, e.g. https://host/oidc) — set by operator
+ *   2. /auth/realms/{KEYCLOAK_REALM} — legacy Keycloak path
+ *
+ * Client ID priority:
+ *   1. OIDC_CLIENT_ID (e.g. "web-ui") — set by operator
+ *   2. KEYCLOAK_CLIENT_ID — legacy Keycloak client
  */
 import {
   UserManager,
@@ -14,11 +18,18 @@ import {
 
 import { ENV } from "@app/env";
 
-const realm = ENV.KEYCLOAK_REALM || "tackle";
-const clientId = ENV.KEYCLOAK_CLIENT_ID || "tackle-ui";
+const keycloakRealm = ENV.KEYCLOAK_REALM || "tackle";
+const clientId = ENV.OIDC_CLIENT_ID || ENV.KEYCLOAK_CLIENT_ID || "tackle-ui";
+
+// When OIDC_ISSUER is set (Hub OIDC), derive the authority path from it so
+// oidc-client-ts uses a relative URL and discovery works through the /oidc proxy.
+// Fallback to the legacy Keycloak path when OIDC_ISSUER is not configured.
+const authority = ENV.OIDC_ISSUER
+  ? new URL(ENV.OIDC_ISSUER).pathname
+  : `/auth/realms/${keycloakRealm}`;
 
 const settings: UserManagerSettings = {
-  authority: `/auth/realms/${realm}`,
+  authority,
   client_id: clientId,
   redirect_uri: window.location.origin,
   post_logout_redirect_uri: window.location.origin,
@@ -32,5 +43,10 @@ const settings: UserManagerSettings = {
 
 export const userManager = new UserManager(settings);
 
-/** URL of the IdP account-management page (Keycloak-specific). */
-export const accountManagementUrl = `/auth/realms/${realm}/account`;
+/**
+ * URL of the IdP account-management page.
+ * Only available for Keycloak-backed deployments; undefined when using Hub OIDC.
+ */
+export const accountManagementUrl: string | undefined = ENV.OIDC_ISSUER
+  ? undefined
+  : `/auth/realms/${keycloakRealm}/account`;

--- a/common/src/environment.ts
+++ b/common/src/environment.ts
@@ -24,7 +24,7 @@ export type KonveyorEnvType = {
 
   /**
    * SSO / Keycloak realm (to support upgrading from Keycloak to Hub OIDC)
-   * @deprecated use OIDC configurations instead (OIDC_CLIENT_ID)
+   * @deprecated use OIDC configurations instead (OIDC_ISSUER)
    */
   KEYCLOAK_REALM: string;
 

--- a/common/src/environment.ts
+++ b/common/src/environment.ts
@@ -22,10 +22,16 @@ export type KonveyorEnvType = {
   /** Enable RBAC authentication/authorization */
   AUTH_REQUIRED: "true" | "false";
 
-  /** SSO / Keycloak realm */
+  /**
+   * SSO / Keycloak realm (to support upgrading from Keycloak to Hub OIDC)
+   * @deprecated use OIDC configurations instead (OIDC_CLIENT_ID)
+   */
   KEYCLOAK_REALM: string;
 
-  /** SSO / Keycloak client id */
+  /**
+   * SSO / Keycloak client id (to support upgrading from Keycloak to Hub OIDC)
+   * @deprecated use OIDC configurations instead (OIDC_CLIENT_ID)
+   */
   KEYCLOAK_CLIENT_ID: string;
 
   /** UI upload file size limit in megabytes (MB), suffixed with "m" */
@@ -37,7 +43,10 @@ export type KonveyorEnvType = {
   /** The listen port for the UI's server */
   PORT?: string;
 
-  /** Target URL for the UI server's `/auth` proxy */
+  /**
+   * Target URL for the UI server's `/auth` proxy (to support upgrading from Keycloak to Hub OIDC)
+   * @deprecated use OIDC configurations instead (OIDC_ISSUER)
+   */
   KEYCLOAK_SERVER_URL?: string;
 
   /** Target URL for the UI server's `/hub` proxy */
@@ -48,6 +57,12 @@ export type KonveyorEnvType = {
 
   /** Location of branding files (relative paths computed from the project source root) */
   BRANDING?: string;
+
+  /** Hub OIDC issuer URL (full external URL, e.g. https://host/oidc). When set, the UI uses Hub's built-in OIDC provider instead of Keycloak. */
+  OIDC_ISSUER?: string;
+
+  /** OIDC client ID for the UI (e.g. "web-ui"). When set alongside OIDC_ISSUER, overrides KEYCLOAK_CLIENT_ID. */
+  OIDC_CLIENT_ID?: string;
 };
 
 /**
@@ -82,6 +97,8 @@ export const buildKonveyorEnv = ({
   TACKLE_HUB_URL,
   KAI_LLM_PROXY_URL,
   BRANDING,
+  OIDC_ISSUER,
+  OIDC_CLIENT_ID,
 }: Partial<KonveyorEnvType> = {}): KonveyorEnvType => ({
   NODE_ENV,
   PORT,
@@ -99,6 +116,8 @@ export const buildKonveyorEnv = ({
   TACKLE_HUB_URL,
   KAI_LLM_PROXY_URL,
   BRANDING,
+  OIDC_ISSUER,
+  OIDC_CLIENT_ID,
 });
 
 /**

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,12 +16,12 @@ if [[ $AUTH_REQUIRED != "false" ]]; then
   fi
 
   if [[ -n "$OIDC_ISSUER" && -z "$OIDC_CLIENT_ID" ]]; then
-      echo "You must provide OIDC_CLIENT_ID environment variable" 1>&2
-      exit 1
+    echo "You must provide OIDC_CLIENT_ID environment variable" 1>&2
+    exit 1
   elif [[ -z "$OIDC_ISSUER" && -n "$OIDC_CLIENT_ID" ]]; then
     echo "You must provide OIDC_ISSUER environment variable" 1>&2
     exit 1
-  else
+  elif [[ -n "$OIDC_ISSUER" && -n "$OIDC_CLIENT_ID" ]]; then
     # Legacy Keycloak mode: all three Keycloak vars are required.
     if [[ -z "$KEYCLOAK_REALM" ]]; then
       echo "You must provide KEYCLOAK_REALM environment variable" 1>&2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,17 +8,33 @@ if [[ -z "$TACKLE_HUB_URL" ]]; then
 fi
 
 if [[ $AUTH_REQUIRED != "false" ]]; then
-  if [[ -z "$KEYCLOAK_REALM" ]]; then
-    echo "You must provide KEYCLOAK_REALM environment variable" 1>&2
+  if [[ -z "$OIDC_ISSUER" && -z "$OIDC_CLIENT_ID" && -z "$KEYCLOAK_REALM" && -z "$KEYCLOAK_CLIENT_ID" && -z "$KEYCLOAK_SERVER_URL" ]]; then
+    echo "Further configuration via environment variables is required to enable authentication."
+    echo "For Hub OIDC deployments, you must provide OIDC_ISSUER and OIDC_CLIENT_ID."
+    echo "For legacy Keycloak deployments, you must provide KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID, and KEYCLOAK_SERVER_URL."
     exit 1
   fi
-  if [[ -z "$KEYCLOAK_CLIENT_ID" ]]; then
-    echo "You must provide KEYCLOAK_CLIENT_ID environment variable" 1>&2
-    exit 1
-  fi
-  if [[ -z "$KEYCLOAK_SERVER_URL" ]]; then
-    echo "You must provide KEYCLOAK_SERVER_URL environment variable" 1>&2
-    exit 1
+
+  if [[ -n "$OIDC_ISSUER" ]]; then
+    # Hub OIDC mode: OIDC_ISSUER is set by the operator;
+    if [[ -z "$OIDC_CLIENT_ID" ]]; then
+      echo "You must provide OIDC_CLIENT_ID environment variable" 1>&2
+      exit 1
+    fi
+  else
+    # Legacy Keycloak mode: all three Keycloak vars are required.
+    if [[ -z "$KEYCLOAK_REALM" ]]; then
+      echo "You must provide KEYCLOAK_REALM environment variable" 1>&2
+      exit 1
+    fi
+    if [[ -z "$KEYCLOAK_CLIENT_ID" ]]; then
+      echo "You must provide KEYCLOAK_CLIENT_ID environment variable" 1>&2
+      exit 1
+    fi
+    if [[ -z "$KEYCLOAK_SERVER_URL" ]]; then
+      echo "You must provide KEYCLOAK_SERVER_URL environment variable" 1>&2
+      exit 1
+    fi
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ if [[ $AUTH_REQUIRED != "false" ]]; then
   elif [[ -z "$OIDC_ISSUER" && -n "$OIDC_CLIENT_ID" ]]; then
     echo "You must provide OIDC_ISSUER environment variable" 1>&2
     exit 1
-  elif [[ -n "$OIDC_ISSUER" && -n "$OIDC_CLIENT_ID" ]]; then
+  elif [[ -z "$OIDC_ISSUER" && -z "$OIDC_CLIENT_ID" ]]; then
     # Legacy Keycloak mode: all three Keycloak vars are required.
     if [[ -z "$KEYCLOAK_REALM" ]]; then
       echo "You must provide KEYCLOAK_REALM environment variable" 1>&2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,18 +9,18 @@ fi
 
 if [[ $AUTH_REQUIRED != "false" ]]; then
   if [[ -z "$OIDC_ISSUER" && -z "$OIDC_CLIENT_ID" && -z "$KEYCLOAK_REALM" && -z "$KEYCLOAK_CLIENT_ID" && -z "$KEYCLOAK_SERVER_URL" ]]; then
-    echo "Further configuration via environment variables is required to enable authentication."
-    echo "For Hub OIDC deployments, you must provide OIDC_ISSUER and OIDC_CLIENT_ID."
-    echo "For legacy Keycloak deployments, you must provide KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID, and KEYCLOAK_SERVER_URL."
+    echo "Further configuration via environment variables is required to enable authentication." 1>&2
+    echo "For Hub OIDC deployments, you must provide OIDC_ISSUER and OIDC_CLIENT_ID." 1>&2
+    echo "For legacy Keycloak deployments, you must provide KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID, and KEYCLOAK_SERVER_URL." 1>&2
     exit 1
   fi
 
-  if [[ -n "$OIDC_ISSUER" ]]; then
-    # Hub OIDC mode: OIDC_ISSUER is set by the operator;
-    if [[ -z "$OIDC_CLIENT_ID" ]]; then
+  if [[ -n "$OIDC_ISSUER" && -z "$OIDC_CLIENT_ID" ]]; then
       echo "You must provide OIDC_CLIENT_ID environment variable" 1>&2
       exit 1
-    fi
+  elif [[ -z "$OIDC_ISSUER" && -n "$OIDC_CLIENT_ID" ]]; then
+    echo "You must provide OIDC_ISSUER environment variable" 1>&2
+    exit 1
   else
     # Legacy Keycloak mode: all three Keycloak vars are required.
     if [[ -z "$KEYCLOAK_REALM" ]]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "axios": "^1.16.1",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
-        "http-proxy-middleware": "^3.0.5"
+        "http-proxy-middleware": "~4.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^29.0.3",
@@ -6012,6 +6012,7 @@
       "version": "1.17.16",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
       "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -13032,6 +13033,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -14842,6 +14844,7 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.0",
@@ -14868,20 +14871,19 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.0.0.tgz",
+      "integrity": "sha512-wuHwaUtmC0XzJNHqRp41zXtt5ojpHbusXGhq6781VvnjWUYPu7opmOF3eomGNujT07kEOnHWZyV9UZzKimVCKA==",
       "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.15",
-        "debug": "^4.3.6",
-        "http-proxy": "^1.18.1",
+        "debug": "^4.4.3",
+        "httpxy": "^0.5.1",
         "is-glob": "^4.0.3",
-        "is-plain-object": "^5.0.0",
+        "is-plain-obj": "^4.1.0",
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
       }
     },
     "node_modules/http-signature": {
@@ -14945,6 +14947,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/httpxy": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.3.tgz",
+      "integrity": "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -15807,15 +15815,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -22455,6 +22454,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "axios": "^1.16.1",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
-    "http-proxy-middleware": "^3.0.5"
+    "http-proxy-middleware": "~4.0.0"
   },
   "overrides": {
     "follow-redirects": "^1.16.0",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -29,6 +29,7 @@ app.set("x-powered-by", false);
 
 // Setup proxies for auth and hub
 app.use(createProxyMiddleware(proxies.auth));
+app.use(createProxyMiddleware(proxies.oidc));
 app.use(createProxyMiddleware(proxies.hub));
 app.use(createProxyMiddleware(proxies.kai));
 app.use(createProxyMiddleware(proxies.kaiLLMProxy));

--- a/server/src/proxies.js
+++ b/server/src/proxies.js
@@ -15,11 +15,12 @@ const logger =
 
 /**
  * Add the Bearer token to the request if it is not already present, AND if
- * the token is part of the request as a cookie
+ * the token is part of the request as a cookie.
  *
- * TODO: Verify this is still relevant when authorization is turned on.  The query
- *       handling libraries probably already take care of this.  The cookie may
- *       not be set.
+ * Note: With Hub OIDC + react-oidc-context, tokens are stored in sessionStorage
+ * and injected into requests by Axios interceptors (initAuthInterceptors). The
+ * keycloak_cookie mechanism is a Keycloak-specific legacy retained for backward
+ * compatibility with deployments still using the /auth (Keycloak) proxy path.
  *
  * @type OnProxyEvent["proxyReq"]
  */
@@ -32,11 +33,13 @@ const addBearerTokenIfNeeded = (proxyReq, req, _res) => {
 };
 
 /**
- * TODO: Verify that if auth doesn't exist or expires that the user is redirect
- *       back to the app to login.  This handler may not be necessary with the
- *       current query handling libraries.  The idea would be to make sure if an
- *       auth token expires on a data fetch, the app pushes the user back to
- *       the login page.
+ * Server-side safety net: redirect the browser back to "/" if a non-JSON
+ * request receives a 401/Unauthorized response from the hub.
+ *
+ * Note: With Hub OIDC + react-oidc-context, client-side session management
+ * handles token expiry and re-authentication automatically. This handler
+ * remains as a fallback for non-AJAX requests (e.g. direct browser navigation
+ * to /hub/...) that would otherwise display a bare 401 response.
  *
  * @type OnProxyEvent["proxyRes"]
  */
@@ -47,6 +50,80 @@ const redirectIfUnauthorized = (proxyRes, req, res) => {
   ) {
     res.writeHead(302, { Location: "/" }).end();
     proxyRes?.destroy();
+  }
+};
+
+/**
+ * Set the RFC 7239 `Forwarded` header and the legacy `X-Forwarded-*` headers
+ * on the proxied request, but only when an upstream proxy has not already set
+ * them.  This covers three deployment scenarios:
+ *
+ *  1. Dev (direct access) — no upstream proxy; no forwarded headers on the
+ *     incoming request.  We set them all so Hub sees the correct client context.
+ *
+ *  2. Vanilla K8s (e.g. minikube + ingress-nginx) — the ingress controller sets
+ *     X-Forwarded-For/Proto/Host before the request reaches the pod.  We
+ *     preserve those values and derive the RFC 7239 Forwarded header from them.
+ *
+ *  3. OpenShift — HAProxy at the edge sets X-Forwarded-For/Host and also
+ *     injects a Forwarded header.  We do not overwrite any of them (the same
+ *     Forwarded header that broke Keycloak on OpenShift when set by the auth
+ *     proxy is already correctly present).
+ *
+ * Notes:
+ * - IPv6 addresses in the Forwarded `for=` token are bracketed and quoted per
+ *   RFC 7239 §6.
+ * - `req.socket.encrypted` is used instead of `req.protocol` for the protocol
+ *   fallback, because `req.protocol` in Express reflects the internal pod
+ *   connection (always `http` inside Kubernetes), not the external protocol.
+ *
+ * @type OnProxyEvent["proxyReq"]
+ */
+const setForwardedHeader = (proxyReq, req, _res) => {
+  // --- X-Forwarded-* (legacy, set only if absent) ---
+  if (!req.headers["x-forwarded-for"] && req.socket.remoteAddress) {
+    proxyReq.setHeader("X-Forwarded-For", req.socket.remoteAddress);
+  }
+
+  if (!req.headers["x-real-ip"] && req.socket.remoteAddress) {
+    proxyReq.setHeader("X-Real-IP", req.socket.remoteAddress);
+  }
+
+  if (!req.headers["x-forwarded-host"] && req.headers.host) {
+    proxyReq.setHeader("X-Forwarded-Host", req.headers.host);
+  }
+
+  if (!req.headers["x-forwarded-proto"]) {
+    proxyReq.setHeader(
+      "X-Forwarded-Proto",
+      req.socket.encrypted ? "https" : "http"
+    );
+  }
+
+  // --- RFC 7239 Forwarded (set only if absent) ---
+  if (!req.headers["forwarded"]) {
+    const parts = [];
+
+    if (req.socket.remoteAddress) {
+      const ip = req.socket.remoteAddress;
+      // IPv6 addresses must be bracketed and quoted per RFC 7239 §6
+      const forValue = ip.includes(":") ? `"[${ip}]"` : ip;
+      parts.push(`for=${forValue}`);
+    }
+
+    if (req.headers.host) {
+      parts.push(`host="${req.headers.host}"`);
+    }
+
+    // Use x-forwarded-proto when already present (set by upstream or by us
+    // above); fall back to the socket's encryption state.
+    const proto =
+      String(req.headers["x-forwarded-proto"] ?? "")
+        .split(",")[0]
+        .trim() || (req.socket.encrypted ? "https" : "http");
+    parts.push(`proto=${proto}`);
+
+    proxyReq.setHeader("Forwarded", parts.join(";"));
   }
 };
 
@@ -89,6 +166,18 @@ export default {
     },
   },
 
+  oidc: {
+    pathFilter: "/oidc",
+    target: KONVEYOR_ENV.TACKLE_HUB_URL || "http://localhost:9002",
+    logger,
+
+    changeOrigin: true,
+
+    on: {
+      proxyReq: setForwardedHeader,
+    },
+  },
+
   hub: {
     pathFilter: "/hub",
     target: KONVEYOR_ENV.TACKLE_HUB_URL || "http://localhost:9002",
@@ -104,6 +193,7 @@ export default {
       proxyRes: redirectIfUnauthorized,
     },
   },
+
   kai: {
     pathFilter: "/kai",
     target: KONVEYOR_ENV.TACKLE_HUB_URL || "http://localhost:9002",
@@ -119,6 +209,7 @@ export default {
       proxyRes: redirectIfUnauthorized,
     },
   },
+
   kaiLLMProxy: {
     pathFilter: "/llm-proxy",
     target: KONVEYOR_ENV.KAI_LLM_PROXY_URL || "http://localhost:9004",

--- a/server/src/proxies.js
+++ b/server/src/proxies.js
@@ -54,24 +54,25 @@ const redirectIfUnauthorized = (proxyRes, req, res) => {
 };
 
 /**
- * Set the RFC 7239 `Forwarded` header and the legacy `X-Forwarded-*` headers
- * on the proxied request, but only when an upstream proxy has not already set
- * them.  This covers three deployment scenarios:
+ * Set the RFC 7239 `Forwarded` header on the proxied request, but only when an
+ * upstream proxy has not already set one.  This covers three deployment
+ * scenarios:
  *
- *  1. Dev (direct access) — no upstream proxy; no forwarded headers on the
- *     incoming request.  We set them all so Hub sees the correct client context.
+ *  1. Dev (direct access) — no upstream proxy; no forwarded headers arrive.
+ *     We derive `for`, `host`, and `proto` from the socket/request directly.
  *
- *  2. Vanilla K8s (e.g. minikube + ingress-nginx) — the ingress controller sets
- *     X-Forwarded-For/Proto/Host before the request reaches the pod.  We
- *     preserve those values and derive the RFC 7239 Forwarded header from them.
+ *  2. Vanilla K8s (e.g. minikube + ingress-nginx) — the ingress controller
+ *     sets `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host`
+ *     before the request reaches the pod, but does not set `Forwarded`.  We
+ *     synthesize the RFC 7239 header from those legacy values so Hub gets a
+ *     standard header that reflects the real client context.
  *
- *  3. OpenShift — HAProxy at the edge sets X-Forwarded-For/Host and also
- *     injects a Forwarded header.  We do not overwrite any of them (the same
- *     Forwarded header that broke Keycloak on OpenShift when set by the auth
- *     proxy is already correctly present).
+ *  3. OpenShift — HAProxy at the edge injects a `Forwarded` header itself.
+ *     We leave it untouched (this avoids the duplicate-header problem that
+ *     previously broke Keycloak on OpenShift).
  *
  * Notes:
- * - IPv6 addresses in the Forwarded `for=` token are bracketed and quoted per
+ * - IPv6 addresses in the `for=` token are bracketed and quoted per
  *   RFC 7239 §6.
  * - `req.socket.encrypted` is used instead of `req.protocol` for the protocol
  *   fallback, because `req.protocol` in Express reflects the internal pod
@@ -80,51 +81,31 @@ const redirectIfUnauthorized = (proxyRes, req, res) => {
  * @type OnProxyEvent["proxyReq"]
  */
 const setForwardedHeader = (proxyReq, req, _res) => {
-  // --- X-Forwarded-* (legacy, set only if absent) ---
-  if (!req.headers["x-forwarded-for"] && req.socket.remoteAddress) {
-    proxyReq.setHeader("X-Forwarded-For", req.socket.remoteAddress);
+  if (req.headers["forwarded"]) return;
+
+  const parts = [];
+
+  const clientIp =
+    String(req.headers["x-forwarded-for"] ?? "")
+      .split(",")[0]
+      .trim() || req.socket.remoteAddress;
+  if (clientIp) {
+    const forValue = clientIp.includes(":") ? `"[${clientIp}]"` : clientIp;
+    parts.push(`for=${forValue}`);
   }
 
-  if (!req.headers["x-real-ip"] && req.socket.remoteAddress) {
-    proxyReq.setHeader("X-Real-IP", req.socket.remoteAddress);
+  const host = req.headers["x-forwarded-host"] ?? req.headers.host;
+  if (host) {
+    parts.push(`host="${host}"`);
   }
 
-  if (!req.headers["x-forwarded-host"] && req.headers.host) {
-    proxyReq.setHeader("X-Forwarded-Host", req.headers.host);
-  }
+  const proto =
+    String(req.headers["x-forwarded-proto"] ?? "")
+      .split(",")[0]
+      .trim() || (req.socket.encrypted ? "https" : "http");
+  parts.push(`proto=${proto}`);
 
-  if (!req.headers["x-forwarded-proto"]) {
-    proxyReq.setHeader(
-      "X-Forwarded-Proto",
-      req.socket.encrypted ? "https" : "http"
-    );
-  }
-
-  // --- RFC 7239 Forwarded (set only if absent) ---
-  if (!req.headers["forwarded"]) {
-    const parts = [];
-
-    if (req.socket.remoteAddress) {
-      const ip = req.socket.remoteAddress;
-      // IPv6 addresses must be bracketed and quoted per RFC 7239 §6
-      const forValue = ip.includes(":") ? `"[${ip}]"` : ip;
-      parts.push(`for=${forValue}`);
-    }
-
-    if (req.headers.host) {
-      parts.push(`host="${req.headers.host}"`);
-    }
-
-    // Use x-forwarded-proto when already present (set by upstream or by us
-    // above); fall back to the socket's encryption state.
-    const proto =
-      String(req.headers["x-forwarded-proto"] ?? "")
-        .split(",")[0]
-        .trim() || (req.socket.encrypted ? "https" : "http");
-    parts.push(`proto=${proto}`);
-
-    proxyReq.setHeader("Forwarded", parts.join(";"));
-  }
+  proxyReq.setHeader("Forwarded", parts.join(";"));
 };
 
 /** @type Record<string, Options> */


### PR DESCRIPTION
Resolves: #3237

Add the `/oidc` proxy to support the Hub OIDC provider. Both the legacy Keycloak provider and the Hub OIDC provider are supported.

Summary of changes:
  - Added support for the new `/oidc` proxy including properly handling the forwarded headers under various deployment scenarios.

  - OIDC env vars are now preferred over Keycloak env vars.

  - Updated entrypoint.sh to support both Keycloak and Hub OIDC deployments.

  - `userManager.ts` now derives OIDC authority and client ID from the new OIDC vars first, falling back to the legacy Keycloak values.

  - `AuthState.manageAccount` can now be undefined, and when using Hub OIDC, the account management page is not available.

  - Upgraded `http-proxy-middleware` to version 4.0.0 which including a switch to the modern `httpxy` package from the old `http-proxy` package.

Assisted-by: Cursor:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OIDC authentication support and an OIDC proxy path.
  * Introduced preset-based masquerade mode with a dedicated "noAuth" preset.

* **Refactor**
  * Authentication state now derives from persisted masquerade presets and exposes account-management only when available.

* **Chores**
  * Tightened auth config validation and improved proxy header handling.
  * Updated proxy middleware dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->