### PR TITLE
:sparkles: Update dev masquerade to include "no auth" as the default

### DIFF
--- a/client/src/app/auth/MasqueradeAuthStrategy.tsx
+++ b/client/src/app/auth/MasqueradeAuthStrategy.tsx
@@ -15,9 +15,8 @@ import { MasqueradeDevPanel } from "./MasqueradeDevPanel";
 import {
   MASQUERADE_PRESETS,
   MasqueradePreset,
-  getMasqueradeRoles,
-  getMasqueradeScopes,
-  setMasqueradePreset,
+  getCurrentPreset,
+  setCurrentPreset,
 } from "./masquerade";
 import type { AuthState } from "./types";
 
@@ -47,48 +46,33 @@ export const useMasqueradeDispatch = (): MasqueradeDispatchFn => {
  * :important: Note: Masquerade only applies to UI code and is not used for API requests.
  * With auth disabled, all API requests are understood by the backend as being made with
  * the admin role.
- *
- * Strategy contract: renders children inside AuthStateContext.Provider with a
- * fully-resolved AuthState. Reads roles and scopes from masquerade.ts, which
- * consults localStorage overrides and build-time env vars in that order,
- * defaulting to admin-level access.
- *
- * This strategy provides MasqueradeDevPanel as its ToolbarContent. The dev
- * panel calls the dispatch function from MasqueradeDispatchContext to switch
- * personas. Because roles/scopes are held in React state, all context
- * consumers (useAuth, useHasRealmRoles, etc.) re-render automatically —
- * no page reload required.
- *
- * Since the MasqueradeAuthStrategy is only selected when NODE_ENV !== "production", this
- * file is tree-shaken from production bundles.
  */
 export const MasqueradeAuthStrategy: React.FC<AuthProviderProps> = ({
   children,
 }) => {
-  const [roles, setRoles] = useState(getMasqueradeRoles);
-  const [scopes, setScopes] = useState(getMasqueradeScopes);
+  const [preset, setPreset] = useState<MasqueradePreset>(getCurrentPreset);
 
-  const switchPreset = useCallback((preset: MasqueradePreset) => {
-    setMasqueradePreset(preset);
-    setRoles(MASQUERADE_PRESETS[preset].roles.slice());
-    setScopes(MASQUERADE_PRESETS[preset].scopes.slice());
+  const switchPreset = useCallback((next: MasqueradePreset) => {
+    setCurrentPreset(next);
+    setPreset(next);
   }, []);
 
-  const authState: AuthState = useMemo(
-    () => ({
+  const authState: AuthState = useMemo(() => {
+    const { roles, scopes, allScopesGranted } = MASQUERADE_PRESETS[preset];
+
+    return {
       isLoaded: true,
       isAuthenticated: true,
       username: "developer",
-      realmRoles: roles,
-      scopes,
-      allScopesGranted: false,
+      realmRoles: roles.slice(),
+      scopes: scopes.slice(),
+      allScopesGranted,
       signIn: () => undefined,
       signOut: () => undefined,
-      manageAccount: () => undefined,
+      manageAccount: undefined,
       ToolbarContent: MasqueradeDevPanel,
-    }),
-    [roles, scopes]
-  );
+    };
+  }, [preset]);
 
   return (
     <MasqueradeDispatchContext.Provider value={switchPreset}>

--- a/client/src/app/auth/MasqueradeDevPanel.tsx
+++ b/client/src/app/auth/MasqueradeDevPanel.tsx
@@ -30,9 +30,8 @@ import {
  */
 export const MasqueradeDevPanel: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [currentPreset, setCurrentPreset] = useState<MasqueradePreset | null>(
-    getCurrentPreset
-  );
+  const [currentPreset, setCurrentPreset] =
+    useState<MasqueradePreset>(getCurrentPreset);
   const switchPreset = useMasqueradeDispatch();
   const { realmRoles: activeRoles } = useAuth();
 
@@ -42,10 +41,7 @@ export const MasqueradeDevPanel: React.FC = () => {
     setIsOpen(false);
   };
 
-  const presetLabel =
-    currentPreset && MASQUERADE_PRESETS[currentPreset]
-      ? MASQUERADE_PRESETS[currentPreset].label
-      : "Dev";
+  const presetLabel = MASQUERADE_PRESETS[currentPreset].label;
 
   return (
     <ToolbarItem>

--- a/client/src/app/auth/NoAuthStrategy.tsx
+++ b/client/src/app/auth/NoAuthStrategy.tsx
@@ -15,7 +15,7 @@ const NO_AUTH_STATE: AuthState = {
   allScopesGranted: true,
   signIn: () => undefined,
   signOut: () => undefined,
-  manageAccount: () => undefined,
+  manageAccount: undefined,
   ToolbarContent: null,
 };
 

--- a/client/src/app/auth/OidcToolbarItem.tsx
+++ b/client/src/app/auth/OidcToolbarItem.tsx
@@ -55,14 +55,16 @@ export const OidcToolbarItem: React.FC = () => {
       >
         <DropdownGroup key="sso">
           <DropdownList>
-            <DropdownItem
-              id="manage-account"
-              key="sso_user_management"
-              component="button"
-              onClick={() => manageAccount()}
-            >
-              {t("actions.manageAccount")}
-            </DropdownItem>
+            {manageAccount && (
+              <DropdownItem
+                id="manage-account"
+                key="sso_user_management"
+                component="button"
+                onClick={() => manageAccount()}
+              >
+                {t("actions.manageAccount")}
+              </DropdownItem>
+            )}
             <DropdownItem
               id="logout"
               key="sso_logout"

--- a/client/src/app/auth/masquerade.ts
+++ b/client/src/app/auth/masquerade.ts
@@ -15,7 +15,7 @@ const LS_PRESET_KEY = "tackle-masquerade-preset";
 export const MASQUERADE_PRESETS = {
   noAuth: {
     label: "No Auth",
-    roles: [] as string[],
+    roles: ["tackle-admin", "tackle-architect", "tackle-migrator"] as string[],
     scopes: [] as string[],
     allScopesGranted: true,
   },

--- a/client/src/app/auth/masquerade.ts
+++ b/client/src/app/auth/masquerade.ts
@@ -1,151 +1,72 @@
 /**
- * Masquerade support for development environments where AUTH_REQUIRED is false.
+ * Masquerade preset management for development environments where
+ * AUTH_REQUIRED is false.
  *
- * Allows developers to exercise RBAC-gated UI without a live OIDC provider
- * by providing synthetic realm roles and scopes through:
- *   1. Build-time environment variables (MASQUERADE_ROLES, MASQUERADE_SCOPES)
- *   2. Runtime localStorage overrides (gated so they cannot activate when auth is on)
- *
- * The localStorage key format is:
- *   tackle-masquerade-roles  → comma-separated role names
- *   tackle-masquerade-scopes → space-separated scope strings
- *
- * This module MUST NOT be imported in any code path that runs when AUTH_REQUIRED=true.
- * The AuthProvider enforces this at runtime.
+ * The selected preset is persisted in localStorage. On first load (no key
+ * present), "noAuth" is used as the default — giving full access with no
+ * role constraints. Roles and scopes flow out via the MasqueradeAuthStrategy.
  */
 
 import { isAuthRequired } from "@app/Constants";
 
-const LS_ROLES_KEY = "tackle-masquerade-roles";
-const LS_SCOPES_KEY = "tackle-masquerade-scopes";
+const LS_PRESET_KEY = "tackle-masquerade-preset";
 
 /** Available preset personas for the dev panel. */
 export const MASQUERADE_PRESETS = {
+  noAuth: {
+    label: "No Auth",
+    roles: [] as string[],
+    scopes: [] as string[],
+    allScopesGranted: true,
+  },
   admin: {
     label: "Admin",
     roles: ["tackle-admin", "tackle-architect", "tackle-migrator"],
     scopes: [] as string[],
+    allScopesGranted: false,
   },
   architect: {
     label: "Architect",
     roles: ["tackle-architect", "tackle-migrator"],
     scopes: [] as string[],
+    allScopesGranted: false,
   },
   migrator: {
     label: "Migrator",
     roles: ["tackle-migrator"],
     scopes: [] as string[],
+    allScopesGranted: false,
   },
 } as const;
 
 export type MasqueradePreset = keyof typeof MASQUERADE_PRESETS;
 
-/**
- * Read the active masquerade roles.
- * Safety: returns [] if auth is required, so this can never leak into prod.
- * In production builds, localStorage overrides are also ignored — the build-time
- * env var or the admin default is always used, so stale dev-session values stored
- * in the browser cannot change the effective roles.
- */
-export const getMasqueradeRoles = (): string[] => {
-  if (isAuthRequired) return [];
+const DEFAULT_PRESET: MasqueradePreset = "noAuth";
 
-  // 1. localStorage override — only in development builds.
-  // process.env.NODE_ENV is replaced by webpack at build time, so this branch is
-  // dead code in production bundles and the localStorage read never happens.
-  if (process.env.NODE_ENV !== "production") {
-    try {
-      const lsRoles = window.localStorage.getItem(LS_ROLES_KEY);
-      if (lsRoles)
-        return lsRoles
-          .split(",")
-          .map((r) => r.trim())
-          .filter(Boolean);
-    } catch {
-      // localStorage unavailable (e.g. private browsing in some browsers)
-    }
-  }
+/** Read the currently-selected preset from localStorage (defaults to noAuth). */
+export const getCurrentPreset = (): MasqueradePreset => {
+  if (isAuthRequired) return DEFAULT_PRESET;
 
-  // 2. Build-time env var (webpack DefinePlugin injects MASQUERADE_ROLES)
-  const envRoles =
-    typeof process !== "undefined" && process.env.MASQUERADE_ROLES
-      ? process.env.MASQUERADE_ROLES
-      : "";
-  if (envRoles)
-    return envRoles
-      .split(",")
-      .map((r) => r.trim())
-      .filter(Boolean);
-
-  // 3. Default: all roles (developer convenience)
-  return MASQUERADE_PRESETS.admin.roles.slice();
-};
-
-/**
- * Read the active masquerade scopes.
- * Safety: returns [] if auth is required.
- * In production builds, localStorage overrides are ignored (same reason as roles).
- */
-export const getMasqueradeScopes = (): string[] => {
-  if (isAuthRequired) return [];
-
-  if (process.env.NODE_ENV !== "production") {
-    try {
-      const lsScopes = window.localStorage.getItem(LS_SCOPES_KEY);
-      if (lsScopes) return lsScopes.split(" ").filter(Boolean);
-    } catch {
-      // ignore
-    }
-  }
-
-  const envScopes =
-    typeof process !== "undefined" && process.env.MASQUERADE_SCOPES
-      ? process.env.MASQUERADE_SCOPES
-      : "";
-  if (envScopes) return envScopes.split(" ").filter(Boolean);
-
-  return [];
-};
-
-/** Persist a masquerade preset to localStorage. */
-export const setMasqueradePreset = (preset: MasqueradePreset): void => {
-  if (isAuthRequired) return; // safety guard
-  const { roles } = MASQUERADE_PRESETS[preset];
   try {
-    window.localStorage.setItem(LS_ROLES_KEY, roles.join(","));
-    window.localStorage.removeItem(LS_SCOPES_KEY);
+    const stored = window.localStorage.getItem(LS_PRESET_KEY);
+    if (stored && stored in MASQUERADE_PRESETS) {
+      return stored as MasqueradePreset;
+    }
+  } catch {
+    // localStorage unavailable
+  }
+
+  // No key present — initialize with the default.
+  setCurrentPreset(DEFAULT_PRESET);
+  return DEFAULT_PRESET;
+};
+
+/** Persist the selected preset to localStorage. */
+export const setCurrentPreset = (preset: MasqueradePreset): void => {
+  if (isAuthRequired) return;
+  try {
+    window.localStorage.setItem(LS_PRESET_KEY, preset);
   } catch {
     // ignore
   }
-};
-
-/** Clear all masquerade overrides (reverts to env-var defaults). */
-export const clearMasquerade = (): void => {
-  try {
-    window.localStorage.removeItem(LS_ROLES_KEY);
-    window.localStorage.removeItem(LS_SCOPES_KEY);
-  } catch {
-    // ignore
-  }
-};
-
-/** Return the current preset name that matches localStorage, or null. */
-export const getCurrentPreset = (): MasqueradePreset | null => {
-  try {
-    const lsRoles = window.localStorage.getItem(LS_ROLES_KEY);
-    if (!lsRoles) return "admin"; // default
-    const roles = lsRoles
-      .split(",")
-      .map((r) => r.trim())
-      .sort()
-      .join(",");
-    for (const [key, def] of Object.entries(MASQUERADE_PRESETS)) {
-      if (def.roles.slice().sort().join(",") === roles) {
-        return key as MasqueradePreset;
-      }
-    }
-  } catch {
-    // ignore
-  }
-  return null;
 };

--- a/client/src/app/auth/masquerade.ts
+++ b/client/src/app/auth/masquerade.ts
@@ -49,7 +49,7 @@ export const getCurrentPreset = (): MasqueradePreset => {
 
   try {
     const stored = window.localStorage.getItem(LS_PRESET_KEY);
-    if (stored && stored in MASQUERADE_PRESETS) {
+    if (stored && Object.hasOwn(MASQUERADE_PRESETS, stored)) {
       return stored as MasqueradePreset;
     }
   } catch {

--- a/client/src/app/auth/types.ts
+++ b/client/src/app/auth/types.ts
@@ -26,8 +26,8 @@ export interface AuthState {
   signIn: () => void;
   /** Sign out — ends the OIDC session. No-op when auth is disabled. */
   signOut: () => void;
-  /** Open the IdP account-management page. No-op when auth is disabled. */
-  manageAccount: () => void;
+  /** If set, opens the IdP account-management page. */
+  manageAccount?: () => void;
 
   /** Strategy-specific toolbar content rendered in the masthead user area. */
   ToolbarContent: ComponentType | null;


### PR DESCRIPTION
Followup: #3202
Supports: #3237, #3238

This change updates the masquerade strategy to include a "no auth" preset. This preset gives full access with no role/scope constraints.

In a future change, the roles (admin, architect, migrator) will be updated to contain the appropriate scopes. To match the HUB OIDC permissions model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Authentication masquerade rewritten to a preset-based model with a single persisted preset and a new "noAuth" default.
  * Initialization simplified so the current preset is always available and UI state derives directly from the selected preset.
  * Auth state now exposes an optional manageAccount callback.

* **Bug Fixes**
  * "Manage account" menu item only appears when available.
  * Dev persona label logic simplified and more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->