### PR TITLE
:seedling: Ignore AI mdc files and configurations in e2e and image build workflows

### DIFF
--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -9,8 +9,8 @@ on:
     paths-ignore:
       - "docs/**"
       - "hack/**"
-      - "*.md"
-      - "*.mdc"
+      - "**/*.md"
+      - "**/*.mdc"
       - ".coderabbit.yaml"
     branches:
       - "main"
@@ -38,6 +38,9 @@ on:
 #       - 'main'
 #       - 'release-*'
 ##
+
+permissions:
+  contents: read
 
 concurrency:
   group: ci-global-${{ github.ref }}-${{ inputs.checkout_ref || 'main'}}

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -1,4 +1,4 @@
-name: CI (global konveyor CI)
+name: CI (e2e tests)
 
 on:
   push:
@@ -10,6 +10,8 @@ on:
       - "docs/**"
       - "hack/**"
       - "*.md"
+      - "*.mdc"
+      - ".coderabbit.yaml"
     branches:
       - "main"
 

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -6,6 +6,8 @@ on:
       - "docs/**"
       - "hack/**"
       - "*.md"
+      - "*.mdc"
+      - ".coderabbit.yaml"
     branches:
       - "main"
       - "release-*"

--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -5,8 +5,8 @@ on:
     paths-ignore:
       - "docs/**"
       - "hack/**"
-      - "*.md"
-      - "*.mdc"
+      - "**/*.md"
+      - "**/*.mdc"
       - ".coderabbit.yaml"
     branches:
       - "main"
@@ -27,7 +27,7 @@ jobs:
 
       - name: What files changed?
         id: changed
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v46
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
           files: |
             Dockerfile

--- a/.github/workflows/nightly-main-ci-e2e-tests.yaml
+++ b/.github/workflows/nightly-main-ci-e2e-tests.yaml
@@ -1,4 +1,4 @@
-name: Nightly CI (global konveyor CI @main)
+name: Nightly CI (e2e tests @main)
 
 on:
   schedule:
@@ -8,4 +8,4 @@ on:
 
 jobs:
   nightly:
-    uses: ./.github/workflows/ci-global.yml
+    uses: ./.github/workflows/ci-e2e-tests.yml


### PR DESCRIPTION
Ignore changes to AI .mdc files and changes in .coderabbit.yaml files in e2e and image build workflows.  Like changes to documentation markdown, these files will not cause changes that impact image build or e2e test runs and can be ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflows: reduced unnecessary pipeline runs by ignoring non-build documentation/config changes, renamed e2e workflows for clarity, and adjusted nightly job reuse to target the e2e test workflow. These changes speed up feedback and reduce wasted CI resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->