### PR TITLE
:seedling: Refactor reviews rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/reviews.ts
+++ b/client/src/app/api/rest/reviews.ts
@@ -15,7 +15,7 @@ export const createReview = (obj: New<Review>) =>
   axios.post<Review>(REVIEWS, obj).then((response) => response.data);
 
 export const updateReview = (obj: Review) =>
-  axios.put<void>(`${REVIEWS}/${obj.id}`, obj);
+  axios.put<void>(`${REVIEWS}/${obj.id}`, obj).then(() => {});
 
 export const deleteReview = (id: number) =>
-  axios.delete<void>(`${REVIEWS}/${id}`);
+  axios.delete<void>(`${REVIEWS}/${id}`).then(() => {});

--- a/client/src/app/api/rest/reviews.ts
+++ b/client/src/app/api/rest/reviews.ts
@@ -5,22 +5,17 @@ import { hub } from "../rest";
 
 const REVIEWS = hub`/reviews`;
 
-export const getReviews = (): Promise<Review[]> => {
-  return axios.get(`${REVIEWS}`).then((response) => response.data);
-};
+export const getReviews = () =>
+  axios.get<Review[]>(REVIEWS).then((response) => response.data);
 
-export const getReviewById = (id: number | string): Promise<Review> => {
-  return axios.get(`${REVIEWS}/${id}`).then((response) => response.data);
-};
+export const getReviewById = (id: number | string) =>
+  axios.get<Review>(`${REVIEWS}/${id}`).then((response) => response.data);
 
-export const createReview = (obj: New<Review>): Promise<Review> => {
-  return axios.post(`${REVIEWS}`, obj);
-};
+export const createReview = (obj: New<Review>) =>
+  axios.post<Review>(REVIEWS, obj).then((response) => response.data);
 
-export const updateReview = (obj: Review): Promise<Review> => {
-  return axios.put(`${REVIEWS}/${obj.id}`, obj);
-};
+export const updateReview = (obj: Review) =>
+  axios.put<void>(`${REVIEWS}/${obj.id}`, obj);
 
-export const deleteReview = (id: number): Promise<Review> => {
-  return axios.delete(`${REVIEWS}/${id}`);
-};
+export const deleteReview = (id: number) =>
+  axios.delete<void>(`${REVIEWS}/${id}`);

--- a/client/src/app/queries/reviews.ts
+++ b/client/src/app/queries/reviews.ts
@@ -22,8 +22,8 @@ export const useFetchReviews = (
 ) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [reviewsQueryKey],
-    queryFn: () => getReviews(),
-    onError: (error) => console.log("error, ", error),
+    queryFn: getReviews,
+    onError: (error: AxiosError) => console.log("error, ", error),
     refetchInterval,
   });
   return {
@@ -69,8 +69,8 @@ export const useUpdateReviewMutation = (
       queryClient.invalidateQueries({
         queryKey: [
           reviewsByItemIdQueryKey,
-          _?.application?.id,
-          _.archetype?.id,
+          args?.application?.id,
+          args?.archetype?.id,
         ],
       });
       onSuccess?.(args?.application?.name || "");

--- a/client/src/app/queries/reviews.ts
+++ b/client/src/app/queries/reviews.ts
@@ -12,9 +12,9 @@ import {
 } from "@app/api/rest";
 
 import { ApplicationsQueryKey } from "./applications";
+import { ARCHETYPES_QUERY_KEY } from "./archetypes";
 
 const reviewQueryKey = "review";
-const reviewsByItemIdQueryKey = "reviewsByItemId";
 const reviewsQueryKey = "reviews";
 
 export const useFetchReviews = (
@@ -42,13 +42,9 @@ export const useCreateReviewMutation = (
   return useMutation({
     mutationFn: (review: New<Review>) => createReview(review),
     onSuccess: (res) => {
-      queryClient.invalidateQueries({
-        queryKey: [
-          reviewsByItemIdQueryKey,
-          res?.application?.id,
-          res?.archetype?.id,
-        ],
-      });
+      queryClient.invalidateQueries({ queryKey: [reviewsQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [ApplicationsQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [ARCHETYPES_QUERY_KEY] });
       onSuccess?.(res?.application?.name || "");
     },
     onError: (error) => {
@@ -66,13 +62,10 @@ export const useUpdateReviewMutation = (
   return useMutation({
     mutationFn: (review: Review) => updateReview(review),
     onSuccess: (_, args) => {
-      queryClient.invalidateQueries({
-        queryKey: [
-          reviewsByItemIdQueryKey,
-          args?.application?.id,
-          args?.archetype?.id,
-        ],
-      });
+      queryClient.invalidateQueries({ queryKey: [reviewsQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [reviewQueryKey, args.id] });
+      queryClient.invalidateQueries({ queryKey: [ApplicationsQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [ARCHETYPES_QUERY_KEY] });
       onSuccess?.(args?.application?.name || "");
     },
     onError: onError,
@@ -95,7 +88,9 @@ export const useDeleteReviewMutation = (
     onSuccess: (_, args) => {
       onSuccess?.(args.name);
       queryClient.invalidateQueries({ queryKey: [reviewsQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [reviewQueryKey, args.id] });
       queryClient.invalidateQueries({ queryKey: [ApplicationsQueryKey] });
+      queryClient.invalidateQueries({ queryKey: [ARCHETYPES_QUERY_KEY] });
     },
     onError,
   });


### PR DESCRIPTION
Closes #3305
Part of #2630

## Summary
Move review rest functions to rest/reviews.ts. POST returns Review, PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review creation, update, and deletion now return results consistently and better match the server response (updates/deletions no longer return stale payload data).
  * Review pages refresh more reliably after create/update/delete, with both the overall reviews list and the affected individual review view updated.
  * Related application and archetype views are refreshed alongside review changes to reduce stale information across the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->