### PR TITLE
:seedling: Refactor assessments rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/assessments.ts
+++ b/client/src/app/api/rest/assessments.ts
@@ -15,11 +15,11 @@ export const getAssessmentsByItemId = (
   if (!itemId) return Promise.resolve([]);
   if (isArchetype) {
     return axios
-      .get(hub`/archetypes/${itemId}/assessments`)
+      .get<Assessment[]>(hub`/archetypes/${itemId}/assessments`)
       .then((response) => response.data);
   } else {
     return axios
-      .get(hub`/applications/${itemId}/assessments`)
+      .get<Assessment[]>(hub`/applications/${itemId}/assessments`)
       .then((response) => response.data);
   }
 };
@@ -30,25 +30,25 @@ export const createAssessment = (
 ): Promise<Assessment> => {
   if (isArchetype) {
     return axios
-      .post(hub`/archetypes/${obj?.archetype?.id}/assessments`, obj)
+      .post<Assessment>(hub`/archetypes/${obj?.archetype?.id}/assessments`, obj)
       .then((response) => response.data);
   } else {
     return axios
-      .post(hub`/applications/${obj?.application?.id}/assessments`, obj)
+      .post<Assessment>(
+        hub`/applications/${obj?.application?.id}/assessments`,
+        obj
+      )
       .then((response) => response.data);
   }
 };
 
-export const updateAssessment = (obj: Assessment): Promise<Assessment> => {
-  return axios
-    .put(`${ASSESSMENTS}/${obj.id}`, obj)
+export const updateAssessment = (obj: Assessment) =>
+  axios.put<void>(`${ASSESSMENTS}/${obj.id}`, obj);
+
+export const getAssessmentById = (id: number | string) =>
+  axios
+    .get<Assessment>(`${ASSESSMENTS}/${id}`)
     .then((response) => response.data);
-};
 
-export const getAssessmentById = (id: number | string): Promise<Assessment> => {
-  return axios.get(`${ASSESSMENTS}/${id}`).then((response) => response.data);
-};
-
-export const deleteAssessment = (id: number) => {
-  return axios.delete<void>(`${ASSESSMENTS}/${id}`);
-};
+export const deleteAssessment = (id: number) =>
+  axios.delete<void>(`${ASSESSMENTS}/${id}`);

--- a/client/src/app/api/rest/assessments.ts
+++ b/client/src/app/api/rest/assessments.ts
@@ -43,7 +43,7 @@ export const createAssessment = (
 };
 
 export const updateAssessment = (obj: Assessment) =>
-  axios.put<void>(`${ASSESSMENTS}/${obj.id}`, obj);
+  axios.put<void>(`${ASSESSMENTS}/${obj.id}`, obj).then(() => {});
 
 export const getAssessmentById = (id: number | string) =>
   axios
@@ -51,4 +51,4 @@ export const getAssessmentById = (id: number | string) =>
     .then((response) => response.data);
 
 export const deleteAssessment = (id: number) =>
-  axios.delete<void>(`${ASSESSMENTS}/${id}`);
+  axios.delete<void>(`${ASSESSMENTS}/${id}`).then(() => {});


### PR DESCRIPTION
Closes #3306
Part of #2630

## Summary
Move assessment rest functions to rest/assessments.ts. POST (via archetype/application sub-routes) returns Assessment, PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal assessment API type handling for more consistent responses.
  * Preserved existing assessment retrieval, creation, updating, and deletion endpoints and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->