### PR TITLE
:seedling: Refactor application import rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/imports.ts
+++ b/client/src/app/api/rest/imports.ts
@@ -8,36 +8,31 @@ const APP_IMPORTS_SUMMARY = hub`/importsummaries`;
 const APP_IMPORTS_SUMMARY_CSV = hub`/importsummaries/download`;
 export const APP_IMPORTS_SUMMARY_UPLOAD = hub`/importsummaries/upload`;
 
-export const getApplicationsImportSummary = (): Promise<
-  ApplicationImportSummary[]
-> => axios.get(APP_IMPORTS_SUMMARY).then((response) => response.data);
+export const getApplicationsImportSummary = () =>
+  axios
+    .get<ApplicationImportSummary[]>(APP_IMPORTS_SUMMARY)
+    .then((response) => response.data);
 
-export const getApplicationImportSummaryById = (
-  id: number | string
-): Promise<ApplicationImportSummary> =>
-  axios.get(`${APP_IMPORTS_SUMMARY}/${id}`).then((response) => response.data);
+export const getApplicationImportSummaryById = (id: number | string) =>
+  axios
+    .get<ApplicationImportSummary>(`${APP_IMPORTS_SUMMARY}/${id}`)
+    .then((response) => response.data);
 
-export const deleteApplicationImportSummary = (
-  id: number
-): Promise<ApplicationImportSummary> =>
-  axios.delete(`${APP_IMPORTS_SUMMARY}/${id}`);
+export const deleteApplicationImportSummary = (id: number) =>
+  axios.delete<void>(`${APP_IMPORTS_SUMMARY}/${id}`);
 
 export const getApplicationImports = (
   importSummaryID: number,
   isValid: boolean | string
-): Promise<ApplicationImport[]> =>
+) =>
   axios
-    .get(
-      `${APP_IMPORTS}?importSummary.id=${importSummaryID}&isValid=${isValid}`
-    )
+    .get<
+      ApplicationImport[]
+    >(`${APP_IMPORTS}?importSummary.id=${importSummaryID}&isValid=${isValid}`)
     .then((response) => response.data);
 
-export const getApplicationSummaryCSV = (id: string) => {
-  return axios.get<ArrayBuffer>(
-    `${APP_IMPORTS_SUMMARY_CSV}?importSummary.id=${id}`,
-    {
-      responseType: "arraybuffer",
-      headers: { Accept: "text/csv" },
-    }
-  );
-};
+export const getApplicationSummaryCSV = (id: string) =>
+  axios.get<ArrayBuffer>(`${APP_IMPORTS_SUMMARY_CSV}?importSummary.id=${id}`, {
+    responseType: "arraybuffer",
+    headers: { Accept: "text/csv" },
+  });

--- a/client/src/app/api/rest/imports.ts
+++ b/client/src/app/api/rest/imports.ts
@@ -19,7 +19,7 @@ export const getApplicationImportSummaryById = (id: number | string) =>
     .then((response) => response.data);
 
 export const deleteApplicationImportSummary = (id: number) =>
-  axios.delete<void>(`${APP_IMPORTS_SUMMARY}/${id}`);
+  axios.delete<void>(`${APP_IMPORTS_SUMMARY}/${id}`).then(() => {});
 
 export const getApplicationImports = (
   importSummaryID: number,


### PR DESCRIPTION
Closes #3307
Part of #2630

## Summary
Move import summary/import rest functions to rest/imports.ts. GET returns typed arrays, DELETE returns void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`