### PR TITLE
:seedling: Refactor task groups rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/task-groups.ts
+++ b/client/src/app/api/rest/task-groups.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosPromise } from "axios";
+import axios from "axios";
 
 import { New, Taskgroup } from "../models";
 import { HEADERS, hub } from "../rest";
@@ -9,14 +9,11 @@ export const createTaskgroup = (obj: New<Taskgroup>) =>
   axios.post<Taskgroup>(TASKGROUPS, obj).then((response) => response.data);
 
 export const submitTaskgroup = (obj: Taskgroup) =>
-  axios
-    .put<void>(`${TASKGROUPS}/${obj.id}/submit`, obj)
-    .then((response) => response.data);
+  axios.put<void>(`${TASKGROUPS}/${obj.id}/submit`, obj);
 
-export const deleteTaskgroup = (id: number): AxiosPromise =>
-  axios.delete(`${TASKGROUPS}/${id}`);
+export const deleteTaskgroup = (id: number) =>
+  axios.delete<void>(`${TASKGROUPS}/${id}`);
 
-// returns a 204 and no content with a successful upload
 export const uploadFileTaskgroup = ({
   id,
   path,
@@ -39,6 +36,4 @@ export const removeFileTaskgroup = ({
 }: {
   id: number;
   path: string;
-}) => {
-  return axios.delete<Taskgroup>(`${TASKGROUPS}/${id}/bucket/${path}`);
-};
+}) => axios.delete<void>(`${TASKGROUPS}/${id}/bucket/${path}`);

--- a/client/src/app/api/rest/task-groups.ts
+++ b/client/src/app/api/rest/task-groups.ts
@@ -25,9 +25,11 @@ export const uploadFileTaskgroup = ({
 }) => {
   const formData = new FormData();
   formData.append("file", file);
-  return axios.post<void>(`${TASKGROUPS}/${id}/bucket/${path}`, formData, {
-    headers: HEADERS.form,
-  }).then(() => {});
+  return axios
+    .post<void>(`${TASKGROUPS}/${id}/bucket/${path}`, formData, {
+      headers: HEADERS.form,
+    })
+    .then(() => {});
 };
 
 export const removeFileTaskgroup = ({

--- a/client/src/app/api/rest/task-groups.ts
+++ b/client/src/app/api/rest/task-groups.ts
@@ -9,10 +9,10 @@ export const createTaskgroup = (obj: New<Taskgroup>) =>
   axios.post<Taskgroup>(TASKGROUPS, obj).then((response) => response.data);
 
 export const submitTaskgroup = (obj: Taskgroup) =>
-  axios.put<void>(`${TASKGROUPS}/${obj.id}/submit`, obj);
+  axios.put<void>(`${TASKGROUPS}/${obj.id}/submit`, obj).then(() => {});
 
 export const deleteTaskgroup = (id: number) =>
-  axios.delete<void>(`${TASKGROUPS}/${id}`);
+  axios.delete<void>(`${TASKGROUPS}/${id}`).then(() => {});
 
 export const uploadFileTaskgroup = ({
   id,
@@ -27,7 +27,7 @@ export const uploadFileTaskgroup = ({
   formData.append("file", file);
   return axios.post<void>(`${TASKGROUPS}/${id}/bucket/${path}`, formData, {
     headers: HEADERS.form,
-  });
+  }).then(() => {});
 };
 
 export const removeFileTaskgroup = ({
@@ -36,4 +36,4 @@ export const removeFileTaskgroup = ({
 }: {
   id: number;
   path: string;
-}) => axios.delete<void>(`${TASKGROUPS}/${id}/bucket/${path}`);
+}) => axios.delete<void>(`${TASKGROUPS}/${id}/bucket/${path}`).then(() => {});

--- a/client/src/app/components/CustomRuleFilesUpload.tsx
+++ b/client/src/app/components/CustomRuleFilesUpload.tsx
@@ -278,7 +278,7 @@ function useFileUploader(
   );
 
   const { mutate: uploadTaskgroupFile } = useUploadTaskgroupFileMutation(
-    (_, { file }) => {
+    ({ file }) => {
       const ruleFileContext = fileContextRef.current.get(file.name);
       onSuccess(file, undefined, ruleFileContext);
       fileContextRef.current.delete(file.name);

--- a/client/src/app/queries/taskgroups.ts
+++ b/client/src/app/queries/taskgroups.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 
 import { Taskgroup } from "@app/api/models";
 import {
@@ -37,13 +37,13 @@ export const useSubmitTaskgroupMutation = (
 };
 
 export const useRemoveTaskgroupFileMutation = (
-  successCallback?: (data: AxiosResponse<Taskgroup>) => void,
+  successCallback?: () => void,
   errorCallback?: (err: AxiosError) => void
 ) => {
   return useMutation({
     mutationFn: removeFileTaskgroup,
-    onSuccess: (data) => {
-      successCallback?.(data);
+    onSuccess: () => {
+      successCallback?.();
     },
     onError: (err: AxiosError) => {
       errorCallback?.(err);
@@ -52,10 +52,7 @@ export const useRemoveTaskgroupFileMutation = (
 };
 
 export const useUploadTaskgroupFileMutation = (
-  successCallback?: (
-    data: AxiosResponse<void>,
-    params: Parameters<typeof uploadFileTaskgroup>[0]
-  ) => void,
+  successCallback?: (params: Parameters<typeof uploadFileTaskgroup>[0]) => void,
   errorCallback?: (
     err: AxiosError,
     params: Parameters<typeof uploadFileTaskgroup>[0]
@@ -63,8 +60,8 @@ export const useUploadTaskgroupFileMutation = (
 ) => {
   return useMutation({
     mutationFn: uploadFileTaskgroup,
-    onSuccess: (response, params) => {
-      successCallback?.(response, params);
+    onSuccess: (_, params) => {
+      successCallback?.(params);
     },
     onError: (err: AxiosError, params) => {
       errorCallback?.(err, params);


### PR DESCRIPTION
Closes #3308
Part of #2630

## Summary
Move task group rest functions to rest/task-groups.ts. POST returns Taskgroup, PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task-group file upload, removal, submission, and deletion handling for operations that do not return response content.
  * Fixed upload success callbacks to consistently receive the uploaded file and relevant parameters.
  * Simplified removal success callbacks to run without requiring response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->