### PR TITLE
:seedling: Refactor targets rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/targets.ts
+++ b/client/src/app/api/rest/targets.ts
@@ -12,7 +12,7 @@ export const createTarget = (obj: New<Target>) =>
   axios.post<Target>(TARGETS, obj).then((response) => response.data);
 
 export const updateTarget = (obj: Target) =>
-  axios.put<void>(`${TARGETS}/${obj.id}`, obj);
+  axios.put<void>(`${TARGETS}/${obj.id}`, obj).then(() => {});
 
 export const deleteTarget = (id: number) =>
-  axios.delete<void>(`${TARGETS}/${id}`);
+  axios.delete<void>(`${TARGETS}/${id}`).then(() => {});

--- a/client/src/app/api/rest/targets.ts
+++ b/client/src/app/api/rest/targets.ts
@@ -1,19 +1,18 @@
-import axios, { AxiosResponse } from "axios";
+import axios from "axios";
 
 import { New, Target } from "../models";
 import { hub } from "../rest";
 
 const TARGETS = hub`/targets`;
 
+export const getTargets = () =>
+  axios.get<Target[]>(TARGETS).then((response) => response.data);
+
+export const createTarget = (obj: New<Target>) =>
+  axios.post<Target>(TARGETS, obj).then((response) => response.data);
+
 export const updateTarget = (obj: Target) =>
-  axios.put<Target>(`${TARGETS}/${obj.id}`, obj);
+  axios.put<void>(`${TARGETS}/${obj.id}`, obj);
 
-export const createTarget = (
-  obj: New<Target>
-): Promise<AxiosResponse<Target>> => axios.post<Target>(TARGETS, obj);
-
-export const deleteTarget = (id: number): Promise<Target> =>
-  axios.delete(`${TARGETS}/${id}`);
-
-export const getTargets = (): Promise<Target[]> =>
-  axios.get(TARGETS).then((response) => response.data);
+export const deleteTarget = (id: number) =>
+  axios.delete<void>(`${TARGETS}/${id}`);

--- a/client/src/app/pages/migration-targets/components/custom-target-form.tsx
+++ b/client/src/app/pages/migration-targets/components/custom-target-form.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 import { unique } from "radash";
 import { useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -51,7 +51,7 @@ import defaultImage from "./default.png";
 export interface CustomTargetFormProps {
   target?: Target | null;
   targetOrder: number[];
-  onSaved: (response: AxiosResponse<Target>) => void;
+  onSaved: (target: Target) => void;
   onCancel: () => void;
 }
 
@@ -82,7 +82,7 @@ const targetRulesetsToReadFiles = (target?: Target) =>
   }) || [];
 
 const useTargetQueryHooks = (
-  onSaved: (response: AxiosResponse<Target>) => void,
+  onSaved: (target: Target) => void,
   reset: () => void
 ) => {
   const { pushNotification } = useContext(NotificationsContext);
@@ -90,9 +90,9 @@ const useTargetQueryHooks = (
   const { mutateAsync: createImageFileAsync } = useCreateFileMutation();
 
   const { mutateAsync: createTargetAsync } = useCreateTargetMutation(
-    (response: AxiosResponse<Target>) => {
+    (target: Target) => {
       // TODO: Consider any removed files and delete them from hub if necessary
-      onSaved(response);
+      onSaved(target);
       reset();
     },
     (error: AxiosError) => {
@@ -103,9 +103,9 @@ const useTargetQueryHooks = (
     }
   );
 
-  const onUpdateTargetSuccess = (response: AxiosResponse<Target>) => {
+  const onUpdateTargetSuccess = (target: Target) => {
     // TODO: Consider any removed files and delete them from hub if necessary
-    onSaved(response);
+    onSaved(target);
     reset();
   };
 
@@ -391,7 +391,7 @@ export const CustomTargetForm: React.FC<CustomTargetFormProps> = ({
       let newTargetId: number | undefined;
       try {
         const response = await createTargetAsync(payload);
-        newTargetId = response.data.id;
+        newTargetId = response.id;
       } catch {
         /* ignore */
       }

--- a/client/src/app/pages/migration-targets/migration-targets.tsx
+++ b/client/src/app/pages/migration-targets/migration-targets.tsx
@@ -15,7 +15,7 @@ import {
   arrayMove,
   rectSortingStrategy,
 } from "@dnd-kit/sortable";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 import { unique } from "radash";
 import { useTranslation } from "react-i18next";
 import {
@@ -76,7 +76,7 @@ export const MigrationTargets: FC = () => {
 
   const [activeTarget, setActiveTarget] = useState<Target | null>(null);
 
-  const onDeleteTargetSuccess = (target: Target, id: number) => {
+  const onDeleteTargetSuccess = (id: number) => {
     pushNotification({
       title: "Custom target deleted",
       variant: "success",
@@ -99,11 +99,11 @@ export const MigrationTargets: FC = () => {
     onDeleteTargetError
   );
 
-  const onCustomTargetModalSaved = async (response: AxiosResponse<Target>) => {
+  const onCustomTargetModalSaved = async (target: Target) => {
     if (targetToUpdate) {
       pushNotification({
         title: t("toastr.success.saveWhat", {
-          what: response.data.name,
+          what: target.name,
           type: t("terms.customTarget"),
         }),
         variant: "success",
@@ -111,7 +111,7 @@ export const MigrationTargets: FC = () => {
     } else {
       pushNotification({
         title: t("toastr.success.createWhat", {
-          what: response.data.name,
+          what: target.name,
           type: t("terms.customTarget"),
         }),
         variant: "success",
@@ -128,7 +128,7 @@ export const MigrationTargets: FC = () => {
 
       // Make sure the new target's provider is part of the providers filter so it can be seen
       if (filterState.filterValues["provider"]) {
-        const targetProvider = response.data.provider;
+        const targetProvider = target.provider;
         const fv = filterState.filterValues["provider"];
         const newFv = !targetProvider
           ? null

--- a/client/src/app/queries/targets.ts
+++ b/client/src/app/queries/targets.ts
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
-import { HubFile, Target } from "@app/api/models";
+import { HubFile, New, Target } from "@app/api/models";
 import {
   createFile,
   createTarget,
@@ -27,7 +27,7 @@ export const useFetchTargets = (
     refetch,
   } = useQuery<Target[]>({
     queryKey: [TargetsQueryKey],
-    queryFn: async () => await getTargets(),
+    queryFn: getTargets,
     onError: (err) => console.log(err),
     refetchInterval,
   });
@@ -67,14 +67,14 @@ export const useFetchTargets = (
 };
 
 export const useUpdateTargetMutation = (
-  onSuccess: (res: AxiosResponse<Target>) => void,
+  onSuccess: (target: Target) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
   const { isPending, mutate, error } = useMutation({
     mutationFn: updateTarget,
-    onSuccess: (res) => {
-      onSuccess(res);
+    onSuccess: (_, target) => {
+      onSuccess(target);
       queryClient.invalidateQueries({ queryKey: [TargetsQueryKey] });
     },
     onError: (err: AxiosError) => {
@@ -89,15 +89,15 @@ export const useUpdateTargetMutation = (
 };
 
 export const useDeleteTargetMutation = (
-  onSuccess: (res: Target, id: number) => void,
+  onSuccess: (id: number) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   const { isPending, mutate, error } = useMutation({
     mutationFn: deleteTarget,
-    onSuccess: (res, id) => {
-      onSuccess(res, id);
+    onSuccess: (_, id) => {
+      onSuccess(id);
       queryClient.invalidateQueries({ queryKey: [TargetsQueryKey] });
     },
     onError: (err: AxiosError) => {
@@ -113,14 +113,14 @@ export const useDeleteTargetMutation = (
 };
 
 export const useCreateTargetMutation = (
-  onSuccess: (res: AxiosResponse<Target>) => void,
+  onSuccess: (target: Target) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
   const { isPending, mutate, mutateAsync, error } = useMutation({
-    mutationFn: createTarget,
-    onSuccess: (res) => {
-      onSuccess(res);
+    mutationFn: (obj: New<Target>) => createTarget(obj),
+    onSuccess: (target) => {
+      onSuccess(target);
       queryClient.invalidateQueries({ queryKey: [TargetsQueryKey] });
     },
     onError: (err: AxiosError) => {


### PR DESCRIPTION
Closes #3309
Part of #2630

## Summary
Move target rest functions to rest/targets.ts. POST returns Target directly (not AxiosResponse<Target>), PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring to improve maintainability and simplify data handling contracts. No user-facing changes or functionality modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->