### PR TITLE
:seedling: Refactor settings rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/settings.ts
+++ b/client/src/app/api/rest/settings.ts
@@ -5,11 +5,13 @@ import { hub } from "../rest";
 
 const SETTINGS = hub`/settings`;
 
-export const getSettingById = <K extends keyof SettingTypes>(
-  id: K
-): Promise<SettingTypes[K]> =>
-  axios.get(`${SETTINGS}/${id}`).then((response) => response.data);
+export const getSettingById = <K extends keyof SettingTypes>(id: K) =>
+  axios
+    .get<SettingTypes[K]>(`${SETTINGS}/${id}`)
+    .then((response) => response.data);
 
-export const updateSetting = <K extends keyof SettingTypes>(
-  obj: Setting<K>
-): Promise<Setting<K>> => axios.put(`${SETTINGS}/${obj.key}`, obj.value);
+export const updateSetting = <K extends keyof SettingTypes>(obj: Setting<K>) =>
+  axios.put<void>(
+    `${SETTINGS}/${obj.key}`,
+    typeof obj.value == "boolean" ? obj.value.toString() : obj.value
+  );

--- a/client/src/app/api/rest/settings.ts
+++ b/client/src/app/api/rest/settings.ts
@@ -11,7 +11,4 @@ export const getSettingById = <K extends keyof SettingTypes>(id: K) =>
     .then((response) => response.data);
 
 export const updateSetting = <K extends keyof SettingTypes>(obj: Setting<K>) =>
-  axios.put<void>(
-    `${SETTINGS}/${obj.key}`,
-    typeof obj.value == "boolean" ? obj.value.toString() : obj.value
-  );
+  axios.put<void>(`${SETTINGS}/${obj.key}`, obj.value).then(() => {});


### PR DESCRIPTION
Closes #3310
Part of #2630

## Summary
Move settings rest functions to rest/settings.ts. GET returns SettingTypes[K], PUT returns void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings API response handling for more consistent data retrieval.
  * Settings updates now complete without returning an unnecessary response value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->