### PR TITLE
:seedling: Refactor trackers rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/trackers.ts
+++ b/client/src/app/api/rest/trackers.ts
@@ -1,35 +1,40 @@
 import axios from "axios";
 
-import { Tracker, TrackerProject, TrackerProjectIssuetype } from "../models";
+import {
+  New,
+  Tracker,
+  TrackerProject,
+  TrackerProjectIssuetype,
+} from "../models";
 import { hub } from "../rest";
 
 const TRACKERS = hub`/trackers`;
-const TRACKER_PROJECT_ISSUETYPES = "issuetypes"; // TODO: ????
-const TRACKER_PROJECTS = "projects"; // TODO: ????
+const TRACKER_PROJECTS = "projects";
+const TRACKER_PROJECT_ISSUETYPES = "issuetypes";
 
-export const getTrackers = (): Promise<Tracker[]> =>
-  axios.get(TRACKERS).then((response) => response.data);
+export const getTrackers = () =>
+  axios.get<Tracker[]>(TRACKERS).then((response) => response.data);
 
-export const createTracker = (obj: Tracker): Promise<Tracker> =>
-  axios.post(TRACKERS, obj).then((res) => res.data);
+export const createTracker = (obj: New<Tracker>) =>
+  axios.post<Tracker>(TRACKERS, obj).then((response) => response.data);
 
-export const updateTracker = (obj: Tracker): Promise<Tracker> =>
-  axios.put(`${TRACKERS}/${obj.id}`, obj);
+export const updateTracker = (obj: Tracker) =>
+  axios.put<void>(`${TRACKERS}/${obj.id}`, obj);
 
-export const deleteTracker = (id: number): Promise<Tracker> =>
-  axios.delete(`${TRACKERS}/${id}`);
+export const deleteTracker = (id: number) =>
+  axios.delete<void>(`${TRACKERS}/${id}`);
 
-export const getTrackerProjects = (id: number): Promise<TrackerProject[]> =>
+export const getTrackerProjects = (id: number) =>
   axios
-    .get(`${TRACKERS}/${id}/${TRACKER_PROJECTS}`)
+    .get<TrackerProject[]>(`${TRACKERS}/${id}/${TRACKER_PROJECTS}`)
     .then((response) => response.data);
 
 export const getTrackerProjectIssuetypes = (
   trackerId: number,
   projectId: string
-): Promise<TrackerProjectIssuetype[]> =>
+) =>
   axios
-    .get(
-      `${TRACKERS}/${trackerId}/${TRACKER_PROJECTS}/${projectId}/${TRACKER_PROJECT_ISSUETYPES}`
-    )
+    .get<
+      TrackerProjectIssuetype[]
+    >(`${TRACKERS}/${trackerId}/${TRACKER_PROJECTS}/${projectId}/${TRACKER_PROJECT_ISSUETYPES}`)
     .then((response) => response.data);

--- a/client/src/app/api/rest/trackers.ts
+++ b/client/src/app/api/rest/trackers.ts
@@ -19,10 +19,10 @@ export const createTracker = (obj: New<Tracker>) =>
   axios.post<Tracker>(TRACKERS, obj).then((response) => response.data);
 
 export const updateTracker = (obj: Tracker) =>
-  axios.put<void>(`${TRACKERS}/${obj.id}`, obj);
+  axios.put<void>(`${TRACKERS}/${obj.id}`, obj).then(() => {});
 
 export const deleteTracker = (id: number) =>
-  axios.delete<void>(`${TRACKERS}/${id}`);
+  axios.delete<void>(`${TRACKERS}/${id}`).then(() => {});
 
 export const getTrackerProjects = (id: number) =>
   axios

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -87,7 +87,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     addUpdatingTrackerId(tracker.id);
   };
 
-  const onUpdateTrackerSuccess = (_response: unknown, tracker: Tracker) => {
+  const onUpdateTrackerSuccess = (tracker: Tracker) => {
     pushNotification({
       title: t("toastr.success.save", {
         type: t("terms.instance"),

--- a/client/src/app/pages/external/jira/tracker-form.tsx
+++ b/client/src/app/pages/external/jira/tracker-form.tsx
@@ -19,7 +19,7 @@ import { QuestionCircleIcon } from "@patternfly/react-icons";
 import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import "./tracker-form.css";
-import { IdentityKind, IssueManagerKind, Tracker } from "@app/api/models";
+import { IdentityKind, IssueManagerKind, New, Tracker } from "@app/api/models";
 import { FilterSelectOptionProps } from "@app/components/FilterToolbar/FilterToolbar";
 import TypeaheadSelect from "@app/components/FilterToolbar/components/TypeaheadSelect";
 import {
@@ -48,7 +48,6 @@ const supportedIdentityKindByIssueManagerKind: Record<
 };
 
 interface FormValues {
-  id: number;
   name: string;
   url: string;
   kind?: IssueManagerKind;
@@ -117,10 +116,9 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
       (identity) => formValues?.credentialName === identity.name
     );
 
-    const payload: Tracker = {
+    const payload: New<Tracker> = {
       name: formValues.name.trim(),
       url: formValues.url.trim(),
-      id: formValues.id,
       kind: formValues.kind!,
       message: "",
       connected: false,
@@ -130,9 +128,7 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
       insecure: formValues.insecure,
     };
     if (tracker) {
-      updateTracker({
-        ...payload,
-      });
+      updateTracker({ id: tracker.id, ...payload });
     } else {
       createTracker(payload);
     }
@@ -142,7 +138,6 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
   const standardStrictURL = new RegExp(standardStrictURLRegex);
 
   const validationSchema: yup.SchemaOf<FormValues> = yup.object().shape({
-    id: yup.number().defined(),
     name: yup
       .string()
       .min(3, t("validation.minLength", { length: 3 }))
@@ -175,7 +170,6 @@ export const TrackerForm: React.FC<TrackerFormProps> = ({
     defaultValues: {
       name: tracker?.name || "",
       url: tracker?.url || "",
-      id: tracker?.id || 0,
       kind: tracker?.kind,
       credentialName: tracker?.identity?.name || "",
       insecure: tracker?.insecure || false,

--- a/client/src/app/queries/trackers.ts
+++ b/client/src/app/queries/trackers.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
-import { Tracker } from "@app/api/models";
+import { New, Tracker } from "@app/api/models";
 import {
   createTracker,
   deleteTracker,
@@ -44,7 +44,7 @@ export const useCreateTrackerMutation = (
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: createTracker,
+    mutationFn: (obj: New<Tracker>) => createTracker(obj),
     onSuccess: (tracker) => {
       onSuccess(tracker);
       queryClient.invalidateQueries({ queryKey: [TrackersQueryKey] });
@@ -54,14 +54,14 @@ export const useCreateTrackerMutation = (
 };
 
 export const useUpdateTrackerMutation = (
-  onSuccess: (response: unknown, tracker: Tracker) => void,
+  onSuccess: (tracker: Tracker) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateTracker,
-    onSuccess: (response, tracker) => {
-      onSuccess(response, tracker);
+    onSuccess: (_, tracker) => {
+      onSuccess(tracker);
       queryClient.invalidateQueries({ queryKey: [TrackersQueryKey] });
     },
     onError: onError,


### PR DESCRIPTION
Closes #3311
Part of #2630

## Summary
Move tracker rest functions to rest/trackers.ts. POST (New<Tracker>) returns Tracker, PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracker creation and update form handling.
  * Fixed tracker requests to use the correct data formats for creating, updating, and deleting trackers.
  * Tracker updates and deletions now complete without returning unnecessary response data.
  * Improved consistency of tracker-related project and issue type data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->