### PR TITLE
:seedling: Refactor tickets rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/tickets.ts
+++ b/client/src/app/api/rest/tickets.ts
@@ -15,9 +15,9 @@ export const createTickets = (payload: New<Ticket>, applications: Ref[]) =>
         ...payload,
         application: { id: app.id, name: app.name },
       };
-      return axios.post<Ticket>(TICKETS, appPayload).then((r) => r.data);
+      return axios.post<Ticket>(TICKETS, appPayload).then(() => {});
     })
   );
 
 export const deleteTicket = (id: number) =>
-  axios.delete<void>(`${TICKETS}/${id}`);
+  axios.delete<void>(`${TICKETS}/${id}`).then(() => {});

--- a/client/src/app/api/rest/tickets.ts
+++ b/client/src/app/api/rest/tickets.ts
@@ -5,20 +5,19 @@ import { hub } from "../rest";
 
 const TICKETS = hub`/tickets`;
 
-export const createTickets = (payload: New<Ticket>, applications: Ref[]) => {
-  return Promise.all(
+export const getTickets = () =>
+  axios.get<Ticket[]>(TICKETS).then((response) => response.data);
+
+export const createTickets = (payload: New<Ticket>, applications: Ref[]) =>
+  Promise.all(
     applications.map((app) => {
       const appPayload: New<Ticket> = {
         ...payload,
         application: { id: app.id, name: app.name },
       };
-      return axios.post(TICKETS, appPayload);
+      return axios.post<Ticket>(TICKETS, appPayload).then((r) => r.data);
     })
   );
-};
 
-export const getTickets = (): Promise<Ticket[]> =>
-  axios.get(TICKETS).then((response) => response.data);
-
-export const deleteTicket = (id: number): Promise<Ticket> =>
-  axios.delete(`${TICKETS}/${id}`);
+export const deleteTicket = (id: number) =>
+  axios.delete<void>(`${TICKETS}/${id}`);

--- a/client/src/app/queries/migration-waves.ts
+++ b/client/src/app/queries/migration-waves.ts
@@ -117,14 +117,14 @@ export const useDeleteAllMigrationWavesMutation = (
 };
 
 export const useDeleteTicketMutation = (
-  onSuccess?: (res: unknown) => void,
+  onSuccess?: () => void,
   onError?: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: deleteTicket,
-    onSuccess: (res) => {
-      onSuccess?.(res);
+    onSuccess: () => {
+      onSuccess?.();
       queryClient.invalidateQueries({ queryKey: [MigrationWavesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TicketsQueryKey] });
     },


### PR DESCRIPTION
Closes #3312
Part of #2630

## Summary
Move ticket rest functions to rest/tickets.ts. POST returns Ticket[], DELETE returns void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`