### PR TITLE
:seedling: Refactor stakeholders rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/stakeholders.ts
+++ b/client/src/app/api/rest/stakeholders.ts
@@ -5,15 +5,14 @@ import { hub } from "../rest";
 
 const STAKEHOLDERS = hub`/stakeholders`;
 
-export const getStakeholders = (): Promise<Stakeholder[]> =>
-  axios.get(STAKEHOLDERS).then((response) => response.data);
+export const getStakeholders = () =>
+  axios.get<Stakeholder[]>(STAKEHOLDERS).then((response) => response.data);
 
-export const deleteStakeholder = (id: number): Promise<Stakeholder> =>
-  axios.delete(`${STAKEHOLDERS}/${id}`);
+export const createStakeholder = (obj: New<Stakeholder>) =>
+  axios.post<Stakeholder>(STAKEHOLDERS, obj).then((response) => response.data);
 
-export const createStakeholder = (
-  obj: New<Stakeholder>
-): Promise<Stakeholder> => axios.post(STAKEHOLDERS, obj);
+export const updateStakeholder = (obj: Stakeholder) =>
+  axios.put<void>(`${STAKEHOLDERS}/${obj.id}`, obj);
 
-export const updateStakeholder = (obj: Stakeholder): Promise<Stakeholder> =>
-  axios.put(`${STAKEHOLDERS}/${obj.id}`, obj);
+export const deleteStakeholder = (id: number) =>
+  axios.delete<void>(`${STAKEHOLDERS}/${id}`);

--- a/client/src/app/api/rest/stakeholders.ts
+++ b/client/src/app/api/rest/stakeholders.ts
@@ -12,7 +12,7 @@ export const createStakeholder = (obj: New<Stakeholder>) =>
   axios.post<Stakeholder>(STAKEHOLDERS, obj).then((response) => response.data);
 
 export const updateStakeholder = (obj: Stakeholder) =>
-  axios.put<void>(`${STAKEHOLDERS}/${obj.id}`, obj);
+  axios.put<void>(`${STAKEHOLDERS}/${obj.id}`, obj).then((r) => r.data);
 
 export const deleteStakeholder = (id: number) =>
-  axios.delete<void>(`${STAKEHOLDERS}/${id}`);
+  axios.delete<void>(`${STAKEHOLDERS}/${id}`).then((r) => r.data);

--- a/client/src/app/api/rest/stakeholders.ts
+++ b/client/src/app/api/rest/stakeholders.ts
@@ -12,7 +12,7 @@ export const createStakeholder = (obj: New<Stakeholder>) =>
   axios.post<Stakeholder>(STAKEHOLDERS, obj).then((response) => response.data);
 
 export const updateStakeholder = (obj: Stakeholder) =>
-  axios.put<void>(`${STAKEHOLDERS}/${obj.id}`, obj).then((r) => r.data);
+  axios.put<void>(`${STAKEHOLDERS}/${obj.id}`, obj).then(() => undefined);
 
 export const deleteStakeholder = (id: number) =>
-  axios.delete<void>(`${STAKEHOLDERS}/${id}`).then((r) => r.data);
+  axios.delete<void>(`${STAKEHOLDERS}/${id}`).then(() => undefined);

--- a/client/src/app/queries/stakeholders.ts
+++ b/client/src/app/queries/stakeholders.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
-import { Role, Stakeholder, StakeholderWithRole } from "@app/api/models";
+import { New, Role, Stakeholder, StakeholderWithRole } from "@app/api/models";
 import {
   createStakeholder,
   deleteStakeholder,
@@ -37,12 +37,11 @@ export const useFetchStakeholders = (
     queryFn: getStakeholders,
     onError: (error: AxiosError) => console.log("error, ", error),
     refetchInterval,
-    select: (stakeholders): StakeholderWithRole[] => {
-      const stakeholdersWithRole = stakeholders.map((stakeholder) => {
-        return { ...stakeholder, role: getRole(stakeholder) };
-      });
-      return stakeholdersWithRole;
-    },
+    select: (stakeholders): StakeholderWithRole[] =>
+      stakeholders.map((stakeholder) => ({
+        ...stakeholder,
+        role: getRole(stakeholder),
+      })),
   });
   return {
     stakeholders: data || [],
@@ -55,15 +54,15 @@ export const useFetchStakeholders = (
 };
 
 export const useCreateStakeholderMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: createStakeholder,
-    onSuccess: (res) => {
-      onSuccess(res);
+    mutationFn: (obj: New<Stakeholder>) => createStakeholder(obj),
+    onSuccess: () => {
+      onSuccess();
       queryClient.invalidateQueries({ queryKey: [StakeholdersQueryKey] });
     },
     onError,
@@ -71,15 +70,15 @@ export const useCreateStakeholderMutation = (
 };
 
 export const useUpdateStakeholderMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: updateStakeholder,
-    onSuccess: (res) => {
-      onSuccess(res);
+    onSuccess: () => {
+      onSuccess();
       queryClient.invalidateQueries({ queryKey: [StakeholdersQueryKey] });
       queryClient.invalidateQueries({ queryKey: [BusinessServicesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [MigrationWavesQueryKey] });
@@ -91,15 +90,15 @@ export const useUpdateStakeholderMutation = (
 };
 
 export const useDeleteStakeholderMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: deleteStakeholder,
-    onSuccess: (res) => {
-      onSuccess(res);
+    onSuccess: () => {
+      onSuccess();
       queryClient.invalidateQueries({ queryKey: [StakeholdersQueryKey] });
       queryClient.invalidateQueries({ queryKey: [BusinessServicesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [MigrationWavesQueryKey] });


### PR DESCRIPTION
Closes #3313
Part of #2630

## Summary
Move stakeholder rest functions to rest/stakeholders.ts. POST returns Stakeholder, PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when retrieving, creating, updating, and deleting stakeholder records.
  * Stakeholder lists now refresh reliably after successful changes.
  * Simplified success handling for stakeholder actions, reducing the chance of unexpected callback behavior.

* **Refactor**
  * Improved type safety and response handling across stakeholder-related operations for more predictable application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->