### PR TITLE
:seedling: Refactor stakeholder groups rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/stakeholder-groups.ts
+++ b/client/src/app/api/rest/stakeholder-groups.ts
@@ -16,7 +16,7 @@ export const createStakeholderGroup = (obj: New<StakeholderGroup>) =>
     .then((response) => response.data);
 
 export const updateStakeholderGroup = (obj: StakeholderGroup) =>
-  axios.put<void>(`${STAKEHOLDER_GROUPS}/${obj.id}`, obj);
+  axios.put<void>(`${STAKEHOLDER_GROUPS}/${obj.id}`, obj).then(() => {});
 
 export const deleteStakeholderGroup = (id: number) =>
-  axios.delete<void>(`${STAKEHOLDER_GROUPS}/${id}`);
+  axios.delete<void>(`${STAKEHOLDER_GROUPS}/${id}`).then(() => {});

--- a/client/src/app/api/rest/stakeholder-groups.ts
+++ b/client/src/app/api/rest/stakeholder-groups.ts
@@ -5,18 +5,18 @@ import { hub } from "../rest";
 
 const STAKEHOLDER_GROUPS = hub`/stakeholdergroups`;
 
-export const getStakeholderGroups = (): Promise<StakeholderGroup[]> =>
-  axios.get(STAKEHOLDER_GROUPS).then((response) => response.data);
+export const getStakeholderGroups = () =>
+  axios
+    .get<StakeholderGroup[]>(STAKEHOLDER_GROUPS)
+    .then((response) => response.data);
 
-export const deleteStakeholderGroup = (id: number): Promise<StakeholderGroup> =>
-  axios.delete(`${STAKEHOLDER_GROUPS}/${id}`);
+export const createStakeholderGroup = (obj: New<StakeholderGroup>) =>
+  axios
+    .post<StakeholderGroup>(STAKEHOLDER_GROUPS, obj)
+    .then((response) => response.data);
 
-export const createStakeholderGroup = (
-  obj: New<StakeholderGroup>
-): Promise<StakeholderGroup> =>
-  axios.post(STAKEHOLDER_GROUPS, obj).then((res) => res.data);
+export const updateStakeholderGroup = (obj: StakeholderGroup) =>
+  axios.put<void>(`${STAKEHOLDER_GROUPS}/${obj.id}`, obj);
 
-export const updateStakeholderGroup = (
-  obj: StakeholderGroup
-): Promise<StakeholderGroup> =>
-  axios.put(`${STAKEHOLDER_GROUPS}/${obj.id}`, obj);
+export const deleteStakeholderGroup = (id: number) =>
+  axios.delete<void>(`${STAKEHOLDER_GROUPS}/${id}`);

--- a/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
+++ b/client/src/app/pages/controls/stakeholder-groups/components/stakeholder-group-form.tsx
@@ -91,7 +91,7 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
     mode: "all",
   });
 
-  const onCreateStakeholderGroupSuccess = () =>
+  const onCreateStakeholderGroupSuccess = (_group: StakeholderGroup) =>
     pushNotification({
       title: t("toastr.success.create", {
         type: t("terms.stakeholderGroup"),
@@ -113,10 +113,7 @@ export const StakeholderGroupForm: React.FC<StakeholderGroupFormProps> = ({
     onCreateStakeholderGroupError
   );
 
-  const onUpdateStakeholderGroupSuccess = (
-    _response: unknown,
-    group: StakeholderGroup
-  ) =>
+  const onUpdateStakeholderGroupSuccess = (group: StakeholderGroup) =>
     pushNotification({
       title: t("toastr.success.saveWhat", {
         what: group.name,

--- a/client/src/app/queries/stakeholdergroups.ts
+++ b/client/src/app/queries/stakeholdergroups.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
-import { StakeholderGroup } from "@app/api/models";
+import { New, StakeholderGroup } from "@app/api/models";
 import {
   createStakeholderGroup,
   deleteStakeholderGroup,
@@ -37,7 +37,7 @@ export const useCreateStakeholderGroupMutation = (
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: createStakeholderGroup,
+    mutationFn: (obj: New<StakeholderGroup>) => createStakeholderGroup(obj),
     onSuccess: (res) => {
       onSuccess(res);
       queryClient.invalidateQueries({ queryKey: [StakeholderGroupsQueryKey] });
@@ -47,14 +47,14 @@ export const useCreateStakeholderGroupMutation = (
 };
 
 export const useUpdateStakeholderGroupMutation = (
-  onSuccess: (response: unknown, group: StakeholderGroup) => void,
+  onSuccess: (group: StakeholderGroup) => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateStakeholderGroup,
-    onSuccess: (response, group) => {
-      onSuccess(response, group);
+    onSuccess: (_, group) => {
+      onSuccess(group);
       queryClient.invalidateQueries({ queryKey: [StakeholderGroupsQueryKey] });
     },
     onError: onError,
@@ -62,15 +62,15 @@ export const useUpdateStakeholderGroupMutation = (
 };
 
 export const useDeleteStakeholderGroupMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: deleteStakeholderGroup,
-    onSuccess: (res) => {
-      onSuccess(res);
+    onSuccess: () => {
+      onSuccess();
       queryClient.invalidateQueries({ queryKey: [StakeholderGroupsQueryKey] });
     },
     onError: (err: AxiosError) => {


### PR DESCRIPTION
Closes #3314
Part of #2630

## Summary
Move stakeholder group rest functions to rest/stakeholder-groups.ts. POST returns StakeholderGroup, PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stakeholder-group create, update, and delete operations to handle API responses consistently.
  - Success notifications now receive the correct stakeholder-group information.
  - Delete errors are handled more reliably while keeping displayed stakeholder-group data current.
  - Updated mutation behavior to refresh stakeholder-group data after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->