### PR TITLE
:seedling: Refactor tags and tag categories rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/tags.ts
+++ b/client/src/app/api/rest/tags.ts
@@ -6,32 +6,35 @@ import { hub } from "../rest";
 const TAGS = hub`/tags`;
 const TAG_CATEGORIES = hub`/tagcategories`;
 
-export const getTags = (): Promise<Tag[]> =>
-  axios.get(TAGS).then((response) => response.data);
+export const getTags = () =>
+  axios.get<Tag[]>(TAGS).then((response) => response.data);
 
-export const getTagById = (id: number | string): Promise<Tag> =>
-  axios.get(`${TAGS}/${id}`).then((response) => response.data);
+export const getTagById = (id: number | string) =>
+  axios.get<Tag>(`${TAGS}/${id}`).then((response) => response.data);
 
-export const createTag = (obj: New<Tag>): Promise<Tag> => axios.post(TAGS, obj);
+export const createTag = (obj: New<Tag>) =>
+  axios.post<Tag>(TAGS, obj).then((response) => response.data);
 
-export const deleteTag = (id: number): Promise<Tag> =>
-  axios.delete(`${TAGS}/${id}`);
+export const updateTag = (obj: Tag) =>
+  axios.put<void>(`${TAGS}/${obj.id}`, obj);
 
-export const updateTag = (obj: Tag): Promise<Tag> =>
-  axios.put(`${TAGS}/${obj.id}`, obj);
+export const deleteTag = (id: number) => axios.delete<void>(`${TAGS}/${id}`);
 
-export const getTagCategories = (): Promise<Array<TagCategory>> =>
-  axios.get(TAG_CATEGORIES).then((response) => response.data);
+export const getTagCategories = () =>
+  axios.get<TagCategory[]>(TAG_CATEGORIES).then((response) => response.data);
 
-export const getTagCategoryById = (id: number): Promise<TagCategory> =>
-  axios.get(`${TAG_CATEGORIES}/${id}`).then((response) => response.data);
+export const getTagCategoryById = (id: number) =>
+  axios
+    .get<TagCategory>(`${TAG_CATEGORIES}/${id}`)
+    .then((response) => response.data);
 
-export const deleteTagCategory = (id: number): Promise<TagCategory> =>
-  axios.delete(`${TAG_CATEGORIES}/${id}`);
+export const createTagCategory = (obj: New<TagCategory>) =>
+  axios
+    .post<TagCategory>(TAG_CATEGORIES, obj)
+    .then((response) => response.data);
 
-export const createTagCategory = (
-  obj: New<TagCategory>
-): Promise<TagCategory> => axios.post(TAG_CATEGORIES, obj);
+export const updateTagCategory = (obj: TagCategory) =>
+  axios.put<void>(`${TAG_CATEGORIES}/${obj.id}`, obj);
 
-export const updateTagCategory = (obj: TagCategory): Promise<TagCategory> =>
-  axios.put(`${TAG_CATEGORIES}/${obj.id}`, obj);
+export const deleteTagCategory = (id: number) =>
+  axios.delete<void>(`${TAG_CATEGORIES}/${id}`);

--- a/client/src/app/api/rest/tags.ts
+++ b/client/src/app/api/rest/tags.ts
@@ -16,10 +16,10 @@ export const createTag = (obj: New<Tag>) =>
   axios.post<Tag>(TAGS, obj).then((response) => response.data);
 
 export const updateTag = (obj: Tag) =>
-  axios.put<void>(`${TAGS}/${obj.id}`, obj).then((r) => r.data);
+  axios.put<void>(`${TAGS}/${obj.id}`, obj).then(() => undefined);
 
 export const deleteTag = (id: number) =>
-  axios.delete<void>(`${TAGS}/${id}`).then((r) => r.data);
+  axios.delete<void>(`${TAGS}/${id}`).then(() => undefined);
 
 export const getTagCategories = () =>
   axios.get<TagCategory[]>(TAG_CATEGORIES).then((response) => response.data);
@@ -35,7 +35,7 @@ export const createTagCategory = (obj: New<TagCategory>) =>
     .then((response) => response.data);
 
 export const updateTagCategory = (obj: TagCategory) =>
-  axios.put<void>(`${TAG_CATEGORIES}/${obj.id}`, obj).then((r) => r.data);
+  axios.put<void>(`${TAG_CATEGORIES}/${obj.id}`, obj).then(() => undefined);
 
 export const deleteTagCategory = (id: number) =>
-  axios.delete<void>(`${TAG_CATEGORIES}/${id}`).then((r) => r.data);
+  axios.delete<void>(`${TAG_CATEGORIES}/${id}`).then(() => undefined);

--- a/client/src/app/api/rest/tags.ts
+++ b/client/src/app/api/rest/tags.ts
@@ -16,9 +16,10 @@ export const createTag = (obj: New<Tag>) =>
   axios.post<Tag>(TAGS, obj).then((response) => response.data);
 
 export const updateTag = (obj: Tag) =>
-  axios.put<void>(`${TAGS}/${obj.id}`, obj);
+  axios.put<void>(`${TAGS}/${obj.id}`, obj).then((r) => r.data);
 
-export const deleteTag = (id: number) => axios.delete<void>(`${TAGS}/${id}`);
+export const deleteTag = (id: number) =>
+  axios.delete<void>(`${TAGS}/${id}`).then((r) => r.data);
 
 export const getTagCategories = () =>
   axios.get<TagCategory[]>(TAG_CATEGORIES).then((response) => response.data);
@@ -34,7 +35,7 @@ export const createTagCategory = (obj: New<TagCategory>) =>
     .then((response) => response.data);
 
 export const updateTagCategory = (obj: TagCategory) =>
-  axios.put<void>(`${TAG_CATEGORIES}/${obj.id}`, obj);
+  axios.put<void>(`${TAG_CATEGORIES}/${obj.id}`, obj).then((r) => r.data);
 
 export const deleteTagCategory = (id: number) =>
-  axios.delete<void>(`${TAG_CATEGORIES}/${id}`);
+  axios.delete<void>(`${TAG_CATEGORIES}/${id}`).then((r) => r.data);

--- a/client/src/app/queries/tags.ts
+++ b/client/src/app/queries/tags.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
+import { New, Tag, TagCategory } from "@app/api/models";
 import {
   createTag,
   createTagCategory,
@@ -63,12 +64,9 @@ export interface TagItemType {
 export const useFetchTagsWithTagItems = (
   refetchInterval: number | false = false
 ) => {
-  // fetching tag categories with their tags is to most compact way to get all of
-  // that information in a single call
   const { tagCategories, isFetching, isSuccess, fetchError, refetch } =
     useFetchTagCategories(refetchInterval);
 
-  // transform the tag categories in a list of tags with category refs
   const tags = useMemo(
     () =>
       tagCategories
@@ -83,7 +81,6 @@ export const useFetchTagsWithTagItems = (
     [tagCategories]
   );
 
-  // for each tag, build a `TagItemType` for easy use in the UI
   const tagItems: TagItemType[] = useMemo(() => {
     return tags
       .map<TagItemType>((tag) => ({
@@ -108,17 +105,17 @@ export const useFetchTagsWithTagItems = (
 };
 
 export const useCreateTagMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: createTag,
-    onSuccess: (res) => {
+    mutationFn: (obj: New<Tag>) => createTag(obj),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -129,16 +126,16 @@ export const useCreateTagMutation = (
 };
 
 export const useCreateTagCategoryMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: createTagCategory,
-    onSuccess: (res) => {
+    mutationFn: (obj: New<TagCategory>) => createTagCategory(obj),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -148,17 +145,17 @@ export const useCreateTagCategoryMutation = (
 };
 
 export const useUpdateTagMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: updateTag,
-    onSuccess: (res) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -169,17 +166,17 @@ export const useUpdateTagMutation = (
 };
 
 export const useUpdateTagCategoryMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: updateTagCategory,
-    onSuccess: (res) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -188,18 +185,19 @@ export const useUpdateTagCategoryMutation = (
     },
   });
 };
+
 export const useDeleteTagMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: deleteTag,
-    onSuccess: (res) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -210,17 +208,17 @@ export const useDeleteTagMutation = (
 };
 
 export const useDeleteTagCategoryMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: deleteTagCategory,
-    onSuccess: (res) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });


### PR DESCRIPTION
Closes #3315
Part of #2630

## Summary
Move tag and tag category rest functions to rest/tags.ts. POST returns Tag/TagCategory, PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag and tag category operations to return consistent, usable results.
  * Corrected create, update, and delete behavior for more reliable tag management.
  * Tag and category lists now refresh consistently after changes.

* **Refactor**
  * Standardized success handling across tag and category actions.
  * Improved type consistency for tag-related data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->