### PR TITLE
:seedling: Refactor tag categories rest functions to correct return types (consolidated with tags)

### DIFF
--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -23,8 +23,6 @@ import {
   SettingTypes,
   Stakeholder,
   StakeholderGroup,
-  Tag,
-  TagCategory,
   Target,
   Taskgroup,
   Ticket,
@@ -59,8 +57,6 @@ const REVIEWS = hub`/reviews`;
 const SETTINGS = hub`/settings`;
 const STAKEHOLDER_GROUPS = hub`/stakeholdergroups`;
 const STAKEHOLDERS = hub`/stakeholders`;
-const TAG_CATEGORIES = hub`/tagcategories`;
-const TAGS = hub`/tags`;
 const TARGETS = hub`/targets`;
 const TASKGROUPS = hub`/taskgroups`;
 const TICKETS = hub`/tickets`;
@@ -101,6 +97,7 @@ export * from "./rest/migration-waves";
 export * from "./rest/platforms";
 export * from "./rest/schemas";
 export * from "./rest/tasks";
+export * from "./rest/tags";
 export * from "./rest/tokens";
 export * from "./rest/roles";
 export * from "./rest/scopes";
@@ -405,42 +402,6 @@ export const updateStakeholderGroup = (
   obj: StakeholderGroup
 ): Promise<StakeholderGroup> =>
   axios.put(`${STAKEHOLDER_GROUPS}/${obj.id}`, obj);
-
-// ---------------------------------------
-// Tags
-//
-export const getTags = (): Promise<Tag[]> =>
-  axios.get(TAGS).then((response) => response.data);
-
-export const getTagById = (id: number | string): Promise<Tag> =>
-  axios.get(`${TAGS}/${id}`).then((response) => response.data);
-
-export const createTag = (obj: New<Tag>): Promise<Tag> => axios.post(TAGS, obj);
-
-export const deleteTag = (id: number): Promise<Tag> =>
-  axios.delete(`${TAGS}/${id}`);
-
-export const updateTag = (obj: Tag): Promise<Tag> =>
-  axios.put(`${TAGS}/${obj.id}`, obj);
-
-// ---------------------------------------
-// Tag categories
-//
-export const getTagCategories = (): Promise<Array<TagCategory>> =>
-  axios.get(TAG_CATEGORIES).then((response) => response.data);
-
-export const getTagCategoryById = (id: number): Promise<TagCategory> =>
-  axios.get(`${TAG_CATEGORIES}/${id}`).then((response) => response.data);
-
-export const deleteTagCategory = (id: number): Promise<TagCategory> =>
-  axios.delete(`${TAG_CATEGORIES}/${id}`);
-
-export const createTagCategory = (
-  obj: New<TagCategory>
-): Promise<TagCategory> => axios.post(TAG_CATEGORIES, obj);
-
-export const updateTagCategory = (obj: TagCategory): Promise<TagCategory> =>
-  axios.put(`${TAG_CATEGORIES}/${obj.id}`, obj);
 
 // ---------------------------------------
 // Facts

--- a/client/src/app/api/rest/tags.ts
+++ b/client/src/app/api/rest/tags.ts
@@ -1,0 +1,40 @@
+import axios from "axios";
+
+import { New, Tag, TagCategory } from "../models";
+import { hub } from "../rest";
+
+const TAGS = hub`/tags`;
+const TAG_CATEGORIES = hub`/tagcategories`;
+
+export const getTags = () =>
+  axios.get<Tag[]>(TAGS).then((response) => response.data);
+
+export const getTagById = (id: number | string) =>
+  axios.get<Tag>(`${TAGS}/${id}`).then((response) => response.data);
+
+export const createTag = (obj: New<Tag>) =>
+  axios.post<Tag>(TAGS, obj).then((response) => response.data);
+
+export const updateTag = (obj: Tag) =>
+  axios.put<void>(`${TAGS}/${obj.id}`, obj);
+
+export const deleteTag = (id: number) => axios.delete<void>(`${TAGS}/${id}`);
+
+export const getTagCategories = () =>
+  axios.get<TagCategory[]>(TAG_CATEGORIES).then((response) => response.data);
+
+export const getTagCategoryById = (id: number) =>
+  axios
+    .get<TagCategory>(`${TAG_CATEGORIES}/${id}`)
+    .then((response) => response.data);
+
+export const createTagCategory = (obj: New<TagCategory>) =>
+  axios
+    .post<TagCategory>(TAG_CATEGORIES, obj)
+    .then((response) => response.data);
+
+export const updateTagCategory = (obj: TagCategory) =>
+  axios.put<void>(`${TAG_CATEGORIES}/${obj.id}`, obj);
+
+export const deleteTagCategory = (id: number) =>
+  axios.delete<void>(`${TAG_CATEGORIES}/${id}`);

--- a/client/src/app/queries/tags.ts
+++ b/client/src/app/queries/tags.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
+import { New, Tag, TagCategory } from "@app/api/models";
 import {
   createTag,
   createTagCategory,
@@ -63,12 +64,9 @@ export interface TagItemType {
 export const useFetchTagsWithTagItems = (
   refetchInterval: number | false = false
 ) => {
-  // fetching tag categories with their tags is to most compact way to get all of
-  // that information in a single call
   const { tagCategories, isFetching, isSuccess, fetchError, refetch } =
     useFetchTagCategories(refetchInterval);
 
-  // transform the tag categories in a list of tags with category refs
   const tags = useMemo(
     () =>
       tagCategories
@@ -83,7 +81,6 @@ export const useFetchTagsWithTagItems = (
     [tagCategories]
   );
 
-  // for each tag, build a `TagItemType` for easy use in the UI
   const tagItems: TagItemType[] = useMemo(() => {
     return tags
       .map<TagItemType>((tag) => ({
@@ -108,17 +105,17 @@ export const useFetchTagsWithTagItems = (
 };
 
 export const useCreateTagMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: createTag,
-    onSuccess: (res) => {
+    mutationFn: (obj: New<Tag>) => createTag(obj),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -129,16 +126,16 @@ export const useCreateTagMutation = (
 };
 
 export const useCreateTagCategoryMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: createTagCategory,
-    onSuccess: (res) => {
+    mutationFn: (obj: New<TagCategory>) => createTagCategory(obj),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -148,17 +145,17 @@ export const useCreateTagCategoryMutation = (
 };
 
 export const useUpdateTagMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: updateTag,
-    onSuccess: (res) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -169,17 +166,17 @@ export const useUpdateTagMutation = (
 };
 
 export const useUpdateTagCategoryMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: updateTagCategory,
-    onSuccess: (res) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -188,18 +185,19 @@ export const useUpdateTagCategoryMutation = (
     },
   });
 };
+
 export const useDeleteTagMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: deleteTag,
-    onSuccess: (res) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
@@ -210,17 +208,17 @@ export const useDeleteTagMutation = (
 };
 
 export const useDeleteTagCategoryMutation = (
-  onSuccess: (res: unknown) => void,
+  onSuccess: () => void,
   onError: (err: AxiosError) => void
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: deleteTagCategory,
-    onSuccess: (res) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey] });
-      onSuccess(res);
+      onSuccess();
     },
     onError: (err: AxiosError) => {
       queryClient.invalidateQueries({ queryKey: [TagCategoriesQueryKey] });


### PR DESCRIPTION
Closes #3316
Part of #2630

## Summary
Tag categories are consolidated in rest/tags.ts alongside tag functions. POST returns TagCategory, PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`