### PR TITLE
:seedling: Refactor facts rest function to correct return type

### DIFF
--- a/client/src/app/api/rest/facts.ts
+++ b/client/src/app/api/rest/facts.ts
@@ -2,9 +2,7 @@ import axios from "axios";
 
 import { hub } from "../rest";
 
-export const getFacts = (id: number | string | undefined) =>
-  id
-    ? axios
-        .get<Record<string, unknown>>(hub`/applications/${id}/facts`)
-        .then((response) => response.data)
-    : Promise.reject();
+export const getFacts = (id: number | string) =>
+  axios
+    .get<Record<string, unknown>>(hub`/applications/${id}/facts`)
+    .then((response) => response.data);

--- a/client/src/app/api/rest/facts.ts
+++ b/client/src/app/api/rest/facts.ts
@@ -1,12 +1,10 @@
 import axios from "axios";
 
-import { UnstructuredFact } from "../models";
 import { hub } from "../rest";
 
 export const getFacts = (id: number | string | undefined) =>
-  // TODO: Address this when moving to structured facts api
   id
     ? axios
-        .get<UnstructuredFact>(hub`/applications/${id}/facts`)
+        .get<Record<string, unknown>>(hub`/applications/${id}/facts`)
         .then((response) => response.data)
     : Promise.reject();

--- a/client/src/app/queries/facts.ts
+++ b/client/src/app/queries/facts.ts
@@ -13,11 +13,19 @@ export const useFetchFacts = (
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: [FactsQueryKey, applicationID],
-    queryFn: () => getFacts(applicationID),
+    queryFn: () => {
+      if (applicationID === undefined) {
+        return Promise.reject();
+      }
+      return getFacts(applicationID);
+    },
     enabled: !!applicationID,
-    onError: (error: AxiosError) => console.log("error, ", error),
+    onError: (error) => console.log("error, ", error),
     select: (facts): Fact[] =>
-      Object.keys(facts).map((fact) => ({ name: fact, data: facts[fact] })),
+      Object.keys(facts).map((fact) => ({
+        name: fact,
+        data: facts[fact],
+      })),
     refetchInterval,
   });
 

--- a/client/src/app/queries/facts.ts
+++ b/client/src/app/queries/facts.ts
@@ -12,19 +12,19 @@ export const useFetchFacts = (
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: [FactsQueryKey, applicationID],
-    queryFn: () => {
-      if (applicationID === undefined) {
-        return Promise.reject();
-      }
-      return getFacts(applicationID);
-    },
+    queryFn: () =>
+      applicationID === undefined
+        ? Promise.resolve(undefined)
+        : getFacts(applicationID),
     enabled: !!applicationID,
     onError: (error) => console.log("error, ", error),
     select: (facts): Fact[] =>
-      Object.keys(facts).map((fact) => ({
-        name: fact,
-        data: facts[fact],
-      })),
+      facts === undefined
+        ? []
+        : Object.keys(facts).map((fact) => ({
+            name: fact,
+            data: facts[fact],
+          })),
     refetchInterval,
   });
 

--- a/client/src/app/queries/facts.ts
+++ b/client/src/app/queries/facts.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { AxiosError } from "axios";
 
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { Fact } from "@app/api/models";


### PR DESCRIPTION
Closes #3317
Part of #2630

## Summary
Move facts rest function to rest/facts.ts. GET /applications/{id}/facts returns Record<string, unknown> (map of fact key to value).

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved facts retrieval by ensuring requests only occur when an application identifier is available.
  * Kept the displayed facts output consistent after fetching and formatting.
* **Refactor**
  * Simplified the facts API contract to require a valid identifier for fetching, improving reliability and clarity of the data flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->