### PR TITLE
:seedling: Refactor proxies rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/proxies.ts
+++ b/client/src/app/api/rest/proxies.ts
@@ -5,8 +5,8 @@ import { hub } from "../rest";
 
 const PROXIES = hub`/proxies`;
 
-export const getProxies = (): Promise<Proxy[]> =>
-  axios.get(PROXIES).then((response) => response.data);
+export const getProxies = () =>
+  axios.get<Proxy[]>(PROXIES).then((response) => response.data);
 
-export const updateProxy = (obj: Proxy): Promise<Proxy> =>
-  axios.put(`${PROXIES}/${obj.id}`, obj);
+export const updateProxy = (obj: Proxy) =>
+  axios.put<void>(`${PROXIES}/${obj.id}`, obj);

--- a/client/src/app/api/rest/proxies.ts
+++ b/client/src/app/api/rest/proxies.ts
@@ -9,4 +9,4 @@ export const getProxies = () =>
   axios.get<Proxy[]>(PROXIES).then((response) => response.data);
 
 export const updateProxy = (obj: Proxy) =>
-  axios.put<void>(`${PROXIES}/${obj.id}`, obj);
+  axios.put<void>(`${PROXIES}/${obj.id}`, obj).then(() => {});


### PR DESCRIPTION
Closes #3318
Part of #2630

## Summary
Move proxy rest functions to rest/proxies.ts. GET returns Proxy[], PUT returns void. 

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured proxy REST API implementation by consolidating proxy endpoints into a dedicated module, improving code organization with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->