### PR TITLE
:seedling: Refactor questionnaires rest functions to correct return types

### DIFF
--- a/client/src/app/api/rest/questionnaires.ts
+++ b/client/src/app/api/rest/questionnaires.ts
@@ -19,7 +19,7 @@ export const createQuestionnaire = (obj: Questionnaire) =>
     .then((response) => response.data);
 
 export const updateQuestionnaire = (obj: Questionnaire) =>
-  axios.put<void>(`${QUESTIONNAIRES}/${obj.id}`, obj);
+  axios.put<void>(`${QUESTIONNAIRES}/${obj.id}`, obj).then(() => {});
 
 export const deleteQuestionnaire = (id: number) =>
-  axios.delete<void>(`${QUESTIONNAIRES}/${id}`);
+  axios.delete<void>(`${QUESTIONNAIRES}/${id}`).then(() => {});

--- a/client/src/app/api/rest/questionnaires.ts
+++ b/client/src/app/api/rest/questionnaires.ts
@@ -5,20 +5,21 @@ import { hub } from "../rest";
 
 export const QUESTIONNAIRES = hub`/questionnaires`;
 
-export const getQuestionnaires = (): Promise<Questionnaire[]> =>
-  axios.get(QUESTIONNAIRES).then((response) => response.data);
+export const getQuestionnaires = () =>
+  axios.get<Questionnaire[]>(QUESTIONNAIRES).then((response) => response.data);
 
-export const getQuestionnaireById = <T>(id: number | string): Promise<T> =>
-  axios.get(`${QUESTIONNAIRES}/${id}`).then((response) => response.data);
+export const getQuestionnaireById = (id: number | string) =>
+  axios
+    .get<Questionnaire>(`${QUESTIONNAIRES}/${id}`)
+    .then((response) => response.data);
 
-export const createQuestionnaire = (
-  obj: Questionnaire
-): Promise<Questionnaire> =>
-  axios.post(`${QUESTIONNAIRES}`, obj).then((response) => response.data);
+export const createQuestionnaire = (obj: Questionnaire) =>
+  axios
+    .post<Questionnaire>(QUESTIONNAIRES, obj)
+    .then((response) => response.data);
 
-export const updateQuestionnaire = (
-  obj: Questionnaire
-): Promise<Questionnaire> => axios.put(`${QUESTIONNAIRES}/${obj.id}`, obj);
+export const updateQuestionnaire = (obj: Questionnaire) =>
+  axios.put<void>(`${QUESTIONNAIRES}/${obj.id}`, obj);
 
-export const deleteQuestionnaire = (id: number): Promise<Questionnaire> =>
-  axios.delete(`${QUESTIONNAIRES}/${id}`);
+export const deleteQuestionnaire = (id: number) =>
+  axios.delete<void>(`${QUESTIONNAIRES}/${id}`);

--- a/client/src/app/queries/questionnaires.ts
+++ b/client/src/app/queries/questionnaires.ts
@@ -16,23 +16,6 @@ import {
 export const QuestionnairesQueryKey = "questionnaires";
 const QuestionnaireByIdQueryKey = "questionnaireById";
 
-/**
- * For a Questionnaire, walk the structure and sort lists by order if the items
- * in that list have an order.  Hub stores things in the document order not logical
- * order.  UI needs to have things in logical order.
- */
-//TODO: this is not working, need to figure out why https://issues.redhat.com/browse/MTA-1907
-// function inPlaceSortByOrder(q: Questionnaire) {
-//   q.sections.sort((a, b) => a.order - b.order);
-//   q.sections.forEach((s) => {
-//     s.questions.sort((a, b) => a.order - b.order);
-//     s.questions.forEach((q) => {
-//       q.answers.sort((a, b) => a.order - b.order);
-//     });
-//   });
-//   return q;
-// }
-
 export const useFetchQuestionnaires = (
   refetchInterval: number | false = false
 ) => {
@@ -40,10 +23,6 @@ export const useFetchQuestionnaires = (
     queryKey: [QuestionnairesQueryKey],
     queryFn: getQuestionnaires,
     onError: (error: AxiosError) => console.log("error, ", error),
-    // select: (questionnaires) => {
-    //   questionnaires.forEach((q) => inPlaceSortByOrder(q));
-    //   return questionnaires;
-    // },
     refetchInterval,
   });
   return {
@@ -61,7 +40,6 @@ export const useUpdateQuestionnaireMutation = (
 
   return useMutation({
     mutationFn: updateQuestionnaire,
-
     onSuccess: () => {
       onSuccess();
       queryClient.invalidateQueries({ queryKey: [QuestionnairesQueryKey] });
@@ -79,7 +57,6 @@ export const useDeleteQuestionnaireMutation = (
   return useMutation({
     mutationFn: ({ questionnaire }: { questionnaire: Questionnaire }) =>
       deleteQuestionnaire(questionnaire.id),
-
     onSuccess: (_, { questionnaire }) => {
       onSuccess(questionnaire.name);
       queryClient.invalidateQueries({ queryKey: [QuestionnairesQueryKey] });
@@ -97,9 +74,8 @@ export const useFetchQuestionnaireById = (
 ) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [QuestionnaireByIdQueryKey, id],
-    queryFn: () => getQuestionnaireById<Questionnaire>(id),
+    queryFn: () => getQuestionnaireById(id),
     onError: (error: AxiosError) => console.log("error, ", error),
-    // select: (q) => inPlaceSortByOrder(q),
     refetchInterval,
   });
 


### PR DESCRIPTION
Closes #3319
Part of #2630

## Summary
Move questionnaire rest functions to rest/questionnaires.ts. GET by id returns Questionnaire (was generic T), PUT/DELETE return void.

## Pattern Applied
- `GET` returns `Entity` or `Entity[]`
- `POST` takes `New<Entity>` and returns the created `Entity`
- `PUT` takes an `Entity` and returns `void`
- `DELETE` takes an id and returns `void`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved questionnaire REST API response handling with consistent typed responses.
  * Updated questionnaire fetch-by-id to return a concrete questionnaire type.
  * Adjusted update and delete operations to correctly reflect they return no questionnaire data.
  * Simplified questionnaire query behavior by removing unused/commented-out selection logic while preserving existing query keys and error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->