### PR TITLE
:bug: Fix OIDC loop issue by setting forward header for all hub proxies

### DIFF
--- a/client/src/app/auth/oidc/OidcAuthStrategy.tsx
+++ b/client/src/app/auth/oidc/OidcAuthStrategy.tsx
@@ -6,7 +6,7 @@
  *                       the error / loading / authenticated sub-states.
  */
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useMemo } from "react";
 import * as React from "react";
 import {
   AuthProvider as OidcAuthProvider,
@@ -15,7 +15,6 @@ import {
   useAutoSignin,
 } from "react-oidc-context";
 
-import { initAuthInterceptors } from "@app/axios-config";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 
 import { AuthProviderProps, AuthStateContext } from "../AuthProvider";
@@ -28,54 +27,45 @@ import { accountManagementUrl, userManager } from "./userManager";
  * This gate is used to determine if the user is authenticated and to redirect
  * to the OIDC provider if not authenticated and no auth params are present in
  * the URL (i.e. we are not returning from a redirect).
- *
- * It also starts the auth interceptors only after a real authenticated session
- * is available.
  */
 const AuthReadyGate: React.FC<AuthProviderProps> = ({ children }) => {
-  useAutoSignin();
+  const { isAuthenticated, isLoading, error } = useAutoSignin();
 
-  const auth = useOidcAuth();
-  useEffect(() => {
-    if (auth.isAuthenticated) {
-      initAuthInterceptors();
-    }
-  }, [auth.isAuthenticated]);
+  const { user, signinRedirect, signoutRedirect } = useOidcAuth();
 
-  const user = auth.user ?? null;
-  const profile = user?.profile ?? null;
-  const scopes = new Set<string>(user?.scope?.split(" ").filter(Boolean) ?? []);
+  const authState: AuthState = useMemo(() => {
+    const profile = user?.profile ?? null;
+    const scopes = new Set<string>(
+      user?.scope?.split(" ").filter(Boolean) ?? []
+    );
 
-  const authState: AuthState = {
-    isLoaded: !auth.isLoading,
-    isAuthenticated: auth.isAuthenticated,
-    username:
-      (profile?.preferred_username as string | undefined) ??
-      profile?.sub ??
-      "unknown",
-    scopes,
-    allScopesGranted: false,
-    signIn: () => auth.signinRedirect(),
-    signOut: () =>
-      auth.signoutRedirect({
-        post_logout_redirect_uri: window.location.origin,
-      }),
-    manageAccount: accountManagementUrl
-      ? () => window.open(accountManagementUrl, "_blank", "noopener")
-      : undefined,
-    ToolbarContent: OidcToolbarItem,
-  };
+    return {
+      isLoaded: !isLoading,
+      isAuthenticated,
+      username: profile?.preferred_username ?? profile?.sub ?? "unknown",
+      scopes,
+      allScopesGranted: false,
+
+      signIn: () => signinRedirect(),
+      signOut: () => signoutRedirect(),
+      manageAccount: accountManagementUrl
+        ? () => window.open(accountManagementUrl, "_blank", "noopener")
+        : undefined,
+
+      ToolbarContent: OidcToolbarItem,
+    };
+  }, [isLoading, isAuthenticated, user, signinRedirect, signoutRedirect]);
 
   // Surface OIDC errors (e.g. failed signinCallback) immediately.
   // This check must precede the hasAuthParams() gate: if the callback
   // failed, the code/state params are never stripped from the URL, so
   // hasAuthParams() stays true and the user would be stuck on the
   // loading spinner forever.
-  if (auth.error) {
+  if (error) {
     return (
       <AuthStateContext.Provider value={authState}>
         <div role="alert" style={{ padding: "2rem" }}>
-          <strong>Authentication error:</strong> {auth.error.message}
+          <strong>Authentication error:</strong> {error.message}
         </div>
       </AuthStateContext.Provider>
     );
@@ -85,7 +75,7 @@ const AuthReadyGate: React.FC<AuthProviderProps> = ({ children }) => {
   //  - the OIDC library is still initializing
   //  - we are processing the callback (code/state params in the URL)
   //  - we are not yet authenticated (about to redirect, or mid-redirect)
-  if (auth.isLoading || hasAuthParams() || !auth.isAuthenticated) {
+  if (isLoading || hasAuthParams() || !isAuthenticated) {
     return (
       <AuthStateContext.Provider value={authState}>
         <AppPlaceholder />

--- a/client/src/app/axios-auth.ts
+++ b/client/src/app/axios-auth.ts
@@ -1,5 +1,5 @@
 /**
- * Centralized Axios interceptors for the Tackle UI.
+ * Axios auth interceptors.
  *
  * Request interceptor: attaches the current OIDC access token as a Bearer header.
  *
@@ -13,14 +13,7 @@ import axios from "axios";
 import { isAuthRequired } from "@app/Constants";
 import { userManager } from "@app/auth/oidc/userManager";
 
-// Guard against duplicate interceptor registration (e.g. React StrictMode double-invoke).
-let _initialized = false;
-
-export const initAuthInterceptors = () => {
-  if (!isAuthRequired) return;
-  if (_initialized) return;
-  _initialized = true;
-
+const initAuthInterceptors = () => {
   // ── Request: attach Bearer token ──────────────────────────────────────────
   axios.interceptors.request.use(
     async (config) => {
@@ -77,3 +70,7 @@ export const initAuthInterceptors = () => {
     }
   );
 };
+
+if (isAuthRequired) {
+  initAuthInterceptors();
+}

--- a/client/src/app/axios-config/index.ts
+++ b/client/src/app/axios-config/index.ts
@@ -1,1 +1,0 @@
-export { initAuthInterceptors } from "./apiInit";

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -6,12 +6,12 @@ import { createRoot } from "react-dom/client";
 
 import App from "@app/App";
 import { AuthProvider } from "@app/auth";
-import { ENV } from "@app/env";
 
 import "@app/dayjs";
 import "@app/i18n";
 import "@app/yup";
 import "@app/code-editor";
+import "@app/axios-auth";
 
 const queryClient = new QueryClient();
 
@@ -28,7 +28,7 @@ const renderApp = () => {
   );
 };
 
-if (ENV.NODE_ENV === "development") {
+if (process.env.NODE_ENV === "development") {
   import("./mocks/browser").then((browserMocks) => {
     if (browserMocks.config.enabled) {
       browserMocks.worker.start();

--- a/server/src/proxies.js
+++ b/server/src/proxies.js
@@ -118,6 +118,7 @@ export default {
     },
 
     on: {
+      proxyReq: setForwardedHeader,
       proxyRes: redirectIfUnauthorized,
     },
   },
@@ -133,6 +134,7 @@ export default {
     },
 
     on: {
+      proxyReq: setForwardedHeader,
       proxyRes: redirectIfUnauthorized,
     },
   },


### PR DESCRIPTION
Resolves: #3339
Requires: #3345

Changes:
- Update `OidcAuthStrategy` to properly use the `useAutoSignin()` hook.
- `UserManager` is using sessionStorage for the user store, so there is a new login for each tab.
- Initialize the axios auth interceptors in the index.tsx file.
- Add the Forwarded header to all proxies targeting HUB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication state handling and sign-out behavior
  * Enhanced proxy header forwarding for better request routing

* **Refactor**
  * Simplified authentication interceptor initialization for improved reliability
  * Streamlined environment detection for development and production modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->