### PR TITLE
:test_tube: Update run-ui-tests action admin credentials

### DIFF
--- a/.github/actions/run-ui-tests/action.yml
+++ b/.github/actions/run-ui-tests/action.yml
@@ -113,8 +113,9 @@ runs:
       env:
         CYPRESS_BASE_URL: "${{ inputs.base_url }}"
         CYPRESS_USER: admin
-        CYPRESS_PASSWORD: Dog8code
-        CYPRESS_INITIAL_PASSWORD: Passw0rd!
+        CYPRESS_PASSWORD: admin
+        HUB_USER: admin
+        HUB_PASSWORD: admin
       with:
         install: false
         working-directory: ./ui-tests

--- a/.github/actions/run-ui-tests/action.yml
+++ b/.github/actions/run-ui-tests/action.yml
@@ -165,7 +165,9 @@ runs:
         # These should match what is listed in `cypress/.env.example`
         CYPRESS_BASE_URL: "${{ inputs.base_url }}"
         CYPRESS_USER: admin
-        CYPRESS_PASSWORD: Dog8code
+        CYPRESS_PASSWORD: admin
+        HUB_USER: admin
+        HUB_PASSWORD: admin
         CYPRESS_GIT_USER: ${{ inputs.git_user }}
         CYPRESS_GIT_PASSWORD: ${{ inputs.git_password }}
         CYPRESS_SVN_USER: ${{ inputs.svn_user }}


### PR DESCRIPTION
Update the run-ui-tests action to use the updated default admin credentials for the Cypress tests based on the HUB OIDC provider changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure authentication configuration to support hub credentials alongside existing test framework credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->