### PR TITLE
:seedling: Bump react-error-boundary to 6.1.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,7 +49,7 @@
     "radash": "^12.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-error-boundary": "^6.0.0",
+    "react-error-boundary": "^6.1.2",
     "react-hook-form": "^7.71.2",
     "react-i18next": "^16.5.4",
     "react-markdown": "^10.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -14,8 +14,8 @@
     "test": "NODE_ENV=test TZ=UTC jest --rootDir=. --config=./config/jest.config.ts",
     "format": "prettier --ignore-path ../.gitignore --ignore-path ../.prettierignore --ignore-unknown --write .",
     "format:check": "prettier --ignore-path ../.gitignore --ignore-path ../.prettierignore --ignore-unknown --check .",
-    "lint": "eslint --max-warnings=21 .",
-    "lint:fix": "eslint --max-warnings=21 --fix .",
+    "lint": "eslint --max-warnings=20 .",
+    "lint:fix": "eslint --max-warnings=20 --fix .",
     "tsc": "tsc -p ./tsconfig.json"
   },
   "dependencies": {

--- a/client/src/app/components/ErrorFallback.tsx
+++ b/client/src/app/components/ErrorFallback.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef } from "react";
+import { useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {
@@ -13,35 +13,29 @@ import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
 import { NotificationsContext } from "@app/components/NotificationsContext";
 
-const usePrevious = <T,>(value: T) => {
-  const ref = useRef<T>();
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
-  return ref.current;
-};
-
 export const ErrorFallback = ({
   error,
   resetErrorBoundary,
 }: {
-  error: Error;
+  error: unknown;
   resetErrorBoundary: (...args: Array<unknown>) => void;
 }) => {
   const { t } = useTranslation();
 
   const history = useHistory();
   const { pushNotification } = useContext(NotificationsContext);
-  const prevError = usePrevious(error);
 
-  if (error.message !== prevError?.message) {
+  const errorMessage =
+    error instanceof Error ? error.message : String(error ?? "Unknown error");
+
+  useEffect(() => {
     pushNotification({
       title: "Failed",
-      message: error.message,
+      message: errorMessage,
       variant: "danger",
       timeout: 30000,
     });
-  }
+  }, [errorMessage, pushNotification]);
 
   return (
     <Bullseye>

--- a/client/src/app/components/NotificationsContext.tsx
+++ b/client/src/app/components/NotificationsContext.tsx
@@ -48,19 +48,22 @@ export const NotificationsProvider: React.FunctionComponent<
   const [notifications, setNotifications] = React.useState<INotification[]>([]);
 
   const pushNotification = React.useCallback(
-    (notification: INotification, clearNotificationDelay?: number) => {
+    (notification: INotification, clearNotificationDelay: number = 8000) => {
       setNotifications((prevNotifications) => [
         ...prevNotifications,
         { ...notificationDefault, ...notification },
       ]);
 
-      setTimeout(() => {
-        setNotifications((prevNotifications) =>
-          prevNotifications.filter(
-            (notif) => notif.title !== notification.title
-          )
-        );
-      }, clearNotificationDelay || 8000);
+      setTimeout(
+        () => {
+          setNotifications((prevNotifications) =>
+            prevNotifications.filter(
+              (notif) => notif.title !== notification.title
+            )
+          );
+        },
+        clearNotificationDelay < 0 ? 0 : clearNotificationDelay
+      );
     },
     []
   );

--- a/client/src/app/components/NotificationsContext.tsx
+++ b/client/src/app/components/NotificationsContext.tsx
@@ -47,39 +47,41 @@ export const NotificationsProvider: React.FunctionComponent<
 > = ({ children }: INotificationsProvider) => {
   const [notifications, setNotifications] = React.useState<INotification[]>([]);
 
-  const pushNotification = (
-    notification: INotification,
-    clearNotificationDelay?: number
-  ) => {
-    setNotifications((prevNotifications) => [
-      ...prevNotifications,
-      { ...notificationDefault, ...notification },
-    ]);
+  const pushNotification = React.useCallback(
+    (notification: INotification, clearNotificationDelay?: number) => {
+      setNotifications((prevNotifications) => [
+        ...prevNotifications,
+        { ...notificationDefault, ...notification },
+      ]);
 
-    setTimeout(() => {
-      setNotifications((prevNotifications) => {
-        return prevNotifications.filter(
-          (notif) => notif.title !== notification.title
+      setTimeout(() => {
+        setNotifications((prevNotifications) =>
+          prevNotifications.filter(
+            (notif) => notif.title !== notification.title
+          )
         );
-      });
-    }, clearNotificationDelay || 8000);
-  };
+      }, clearNotificationDelay || 8000);
+    },
+    []
+  );
 
-  const dismissNotification = (title: string) => {
-    const remainingNotifications = notifications.filter(
-      (n) => n.title !== title
+  const dismissNotification = React.useCallback((title: string) => {
+    setNotifications((prevNotifications) =>
+      prevNotifications.filter((n) => n.title !== title)
     );
-    setNotifications(remainingNotifications);
-  };
+  }, []);
+
+  const contextValue = React.useMemo(
+    () => ({
+      pushNotification,
+      dismissNotification,
+      notifications,
+    }),
+    [pushNotification, dismissNotification, notifications]
+  );
 
   return (
-    <NotificationsContext.Provider
-      value={{
-        pushNotification,
-        dismissNotification,
-        notifications,
-      }}
-    >
+    <NotificationsContext.Provider value={contextValue}>
       {children}
     </NotificationsContext.Provider>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "radash": "^12.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-error-boundary": "^6.0.0",
+        "react-error-boundary": "^6.1.2",
         "react-hook-form": "^7.71.2",
         "react-i18next": "^16.5.4",
         "react-markdown": "^10.1.0",
@@ -168,6 +168,15 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "client/node_modules/react-error-boundary": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.2.tgz",
+      "integrity": "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "client/node_modules/react-refresh": {
@@ -22155,18 +22164,6 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
-      }
-    },
-    "node_modules/react-error-boundary": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
-      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
       }
     },
     "node_modules/react-fast-compare": {


### PR DESCRIPTION
- react-error-boundary to 6.1.2
- update ErrorFallback component to use new API types
- ErrorFallback useEffect instead of useRef to handle notification

Follow up to: #3357


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error display and notification behavior so users receive clearer, more reliable feedback when errors occur.
* **Chores**
  * Updated the error-handling library to a newer compatible minor version to keep error boundary handling current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->