### PR TITLE
:sparkles: Display scopes for api-key tokens

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -701,8 +701,6 @@
     "tokenKindAccess": "access",
     "tokenKindApi": "api",
     "tokenKindOther": "other",
-    "allUserScopes": "All scopes available for login \"{{login}}\" at the given point in time.",
-    "scopesForLogin": "Scopes for \"{{login}}\"",
     "showExpiredTokens": "Show expired tokens"
   },
   "titles": {

--- a/client/src/app/pages/user-management/components/scope-labels.tsx
+++ b/client/src/app/pages/user-management/components/scope-labels.tsx
@@ -48,22 +48,25 @@ export const groupScopes = (scopes: string[]) =>
 
 export const ScopeLabels: FC<{
   group: { resource: string; verbs: string[] };
-}> = ({ group }) => (
-  <>
-    <LabelGroup
-      isVertical
-      numLabels={group.verbs.length}
-      categoryName={group.resource}
-      isCompact
-    >
-      {group.verbs
-        .filter(Boolean)
-        .toSorted(sortGetLast)
-        .map((verb) => (
+}> = ({ group }) => {
+  const verbs = group.verbs.filter(Boolean);
+  if (verbs.length === 0) {
+    return <Label variant="outline">{group.resource}</Label>;
+  }
+  return (
+    <>
+      <LabelGroup
+        isVertical
+        numLabels={group.verbs.length}
+        categoryName={group.resource}
+        isCompact
+      >
+        {verbs.toSorted(sortGetLast).map((verb) => (
           <Label key={verb} color={verbToColor(verb)} isCompact>
             {verb}
           </Label>
         ))}
-    </LabelGroup>
-  </>
-);
+      </LabelGroup>
+    </>
+  );
+};

--- a/client/src/app/pages/user-management/components/scope-labels.tsx
+++ b/client/src/app/pages/user-management/components/scope-labels.tsx
@@ -57,7 +57,7 @@ export const ScopeLabels: FC<{
     <>
       <LabelGroup
         isVertical
-        numLabels={group.verbs.length}
+        numLabels={verbs.length}
         categoryName={group.resource}
         isCompact
       >

--- a/client/src/app/pages/user-management/tokens/tokens.tsx
+++ b/client/src/app/pages/user-management/tokens/tokens.tsx
@@ -174,22 +174,7 @@ export const TokensPage: FC = () => {
     id,
     kind,
     login: getLogin(user?.id, loginById),
-    scopes:
-      kind === "api-key" ? (
-        <Tooltip
-          content={t("terms.allUserScopes", {
-            login: getLogin(user?.id, loginById) || "????",
-          })}
-        >
-          <span>
-            {t("terms.scopesForLogin", {
-              login: getLogin(user?.id, loginById) || "????",
-            })}
-          </span>
-        </Tooltip>
-      ) : (
-        (scopes?.length ?? 0)
-      ),
+    scopes: scopes?.length ?? 0,
     issued: <DateCell raw={issued} />,
     expiration: <DateCell raw={expiration} />,
     lifespan: lifespan ?? "",
@@ -293,9 +278,7 @@ export const TokensPage: FC = () => {
                               key={`${columnKey}_${token.id}`}
                               {...getTdProps({
                                 columnKey,
-                                isCompoundExpandToggle:
-                                  columnKey === "scopes" &&
-                                  token.kind !== "api-key",
+                                isCompoundExpandToggle: columnKey === "scopes",
                                 item: token,
                                 rowIndex,
                               })}
@@ -326,16 +309,9 @@ export const TokensPage: FC = () => {
                           {...getExpandedContentTdProps({ item: token })}
                         >
                           <ExpandableRowContent>
-                            {token.kind === "api-key"
-                              ? null
-                              : groupScopes(token?.scopes ?? []).map(
-                                  (group) => (
-                                    <ScopeLabels
-                                      key={group.resource}
-                                      group={group}
-                                    />
-                                  )
-                                )}
+                            {groupScopes(token?.scopes ?? []).map((group) => (
+                              <ScopeLabels key={group.resource} group={group} />
+                            ))}
                           </ExpandableRowContent>
                         </Td>
                       </Tr>

--- a/client/src/app/pages/user-management/tokens/tokens.tsx
+++ b/client/src/app/pages/user-management/tokens/tokens.tsx
@@ -10,7 +10,6 @@ import {
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  Tooltip,
 } from "@patternfly/react-core";
 import {
   ActionsColumn,


### PR DESCRIPTION
Related fix - display correctly non-verb scopes.

Fixes: #3359 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scope display in tokens table to consistently show scope information across all token types.

* **Improvements**
  * Enhanced scope label rendering to properly handle cases with no available scopes.
  * Simplified scope visualization in expanded token rows for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->