### PR TITLE
:seedling: Use cooldown period for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   # Track Docker image updates
   - package-ecosystem: docker
     directory: /
+    cooldown:
+      default-days: 5
     schedule:
       interval: weekly
       day: monday
@@ -12,6 +14,8 @@ updates:
   # GitHub Actions workflow dependencies
   - package-ecosystem: github-actions
     directory: /
+    cooldown:
+      default-days: 5
     schedule:
       interval: monthly
       day: monday
@@ -22,6 +26,8 @@ updates:
   # Uses a single root entry so dependabot can update the shared package-lock.json
   - package-ecosystem: "npm"
     directory: "/"
+    cooldown:
+      default-days: 5
     schedule:
       interval: "monthly"
       day: monday


### PR DESCRIPTION
Reference-Url: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to apply a 5-day cooldown period for automated Docker, GitHub Actions, and npm dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->