### PR TITLE
:bug: Set padding-top for custom rules toolbar

### DIFF
--- a/client/src/app/components/analysis/components/custom-rules-table.tsx
+++ b/client/src/app/components/analysis/components/custom-rules-table.tsx
@@ -18,6 +18,7 @@ import {
   TrProps,
 } from "@patternfly/react-table";
 
+import "./custom-rules.css";
 import { UploadFile } from "@app/api/models";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { NoDataEmptyState } from "@app/components/NoDataEmptyState";
@@ -95,6 +96,7 @@ const CustomRulesTable: React.FC<{
       <Toolbar
         {...toolbarProps}
         clearAllFilters={() => filterToolbarProps.setFilterValues({})}
+        className="custom-rules-toolbar-padding-start"
       >
         <ToolbarContent>
           <FilterToolbar {...filterToolbarProps} />

--- a/client/src/app/components/analysis/components/custom-rules.css
+++ b/client/src/app/components/analysis/components/custom-rules.css
@@ -1,0 +1,4 @@
+.custom-rules-toolbar-padding-start {
+  /** --pf-v6-c-toolbar--PaddingBlockStart is zero  */
+  padding-top: var(--pf-v6-c-toolbar--PaddingBlockEnd);
+}


### PR DESCRIPTION
Fixes: #3365 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the custom rules toolbar spacing for a cleaner layout.
  * Adjusted toolbar padding to better match the surrounding interface styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->