### PR TITLE
:bug: Take all vertical space for code editor

### DIFF
--- a/client/src/app/components/simple-document-viewer/SimpleDocumentViewer.css
+++ b/client/src/app/components/simple-document-viewer/SimpleDocumentViewer.css
@@ -28,7 +28,7 @@
 .simple-task-viewer-container {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 180px);
+  flex-grow: 1;
 }
 
 .simple-task-viewer-code {


### PR DESCRIPTION
Known problem - the editor can only grow.

Depends on #3416 
Fixes: #3259 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the document viewer layout to remove the fixed viewport-based height and let the main container grow within its parent flex layout.
  * Improves responsiveness and flexibility across varying screen sizes and page structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->