### PR TITLE
:bug:  Hide report charts if no applications

### DIFF
--- a/client/src/app/pages/reports/reports.tsx
+++ b/client/src/app/pages/reports/reports.tsx
@@ -116,65 +116,63 @@ export const Reports: React.FC = () => {
     .map((assessment) => toIdRef(assessment))
     .filter(Boolean);
 
+  const waitingForData =
+    isApplicationsFetching || isAssessmentsFetching || isQuestionnairesFetching;
+
   return (
     <>
       {pageHeaderSection}
       <PageSection hasBodyWrapper={false}>
-        <ConditionalRender
-          when={
-            isApplicationsFetching ||
-            isAssessmentsFetching ||
-            isQuestionnairesFetching
-          }
-          then={<AppPlaceholder />}
-        >
+        <ConditionalRender when={waitingForData} then={<AppPlaceholder />}>
           <ApplicationSelectionContextProvider
             applications={applications || []}
           >
             <Stack hasGutter>
-              <StackItem>
-                <Card isClickable isSelectable>
-                  <CardHeader>
-                    <Content>
-                      <Flex>
-                        <FlexItem>
-                          <Content component="h3">
-                            {t("terms.currentLandscape")}
-                          </Content>
-                        </FlexItem>
-                        <FlexItem>
-                          <SimpleSelect
-                            toggleId="select-questionnaires"
-                            toggleAriaLabel="select questionnaires dropdown toggle"
-                            value={selectedQuestionnaireId.toString()}
-                            onSelect={(value) =>
-                              setSelectedQuestionnaireId(Number(value))
-                            }
-                            options={[
-                              {
-                                value: ALL_QUESTIONNAIRES.toString(),
-                                label: "All questionnaires",
-                              },
-                              ...answeredQuestionnaires.map(
-                                (answeredQuestionnaire) => ({
-                                  value: answeredQuestionnaire.id.toString(),
-                                  label: answeredQuestionnaire.name,
-                                })
-                              ),
-                            ]}
-                          />
-                        </FlexItem>
-                      </Flex>
-                    </Content>
-                  </CardHeader>
-                  <CardBody>
-                    <ApplicationLandscape
-                      questionnaire={questionnaire}
-                      assessmentRefs={assessmentRefs}
-                    />
-                  </CardBody>
-                </Card>
-              </StackItem>
+              {applications?.length > 0 && (
+                <StackItem>
+                  <Card isClickable isSelectable>
+                    <CardHeader>
+                      <Content>
+                        <Flex>
+                          <FlexItem>
+                            <Content component="h3">
+                              {t("terms.currentLandscape")}
+                            </Content>
+                          </FlexItem>
+                          <FlexItem>
+                            <SimpleSelect
+                              toggleId="select-questionnaires"
+                              toggleAriaLabel="select questionnaires dropdown toggle"
+                              value={selectedQuestionnaireId.toString()}
+                              onSelect={(value) =>
+                                setSelectedQuestionnaireId(Number(value))
+                              }
+                              options={[
+                                {
+                                  value: ALL_QUESTIONNAIRES.toString(),
+                                  label: "All questionnaires",
+                                },
+                                ...answeredQuestionnaires.map(
+                                  (answeredQuestionnaire) => ({
+                                    value: answeredQuestionnaire.id.toString(),
+                                    label: answeredQuestionnaire.name,
+                                  })
+                                ),
+                              ]}
+                            />
+                          </FlexItem>
+                        </Flex>
+                      </Content>
+                    </CardHeader>
+                    <CardBody>
+                      <ApplicationLandscape
+                        questionnaire={questionnaire}
+                        assessmentRefs={assessmentRefs}
+                      />
+                    </CardBody>
+                  </Card>
+                </StackItem>
+              )}
               <StackItem>
                 <Card>
                   <CardHeader>

--- a/client/src/app/pages/reports/reports.tsx
+++ b/client/src/app/pages/reports/reports.tsx
@@ -130,7 +130,11 @@ export const Reports: React.FC = () => {
             <Stack hasGutter>
               {applications?.length > 0 && (
                 <StackItem>
-                  <Card isClickable isSelectable>
+                  <Card
+                    ouiaId="current-landscape-card"
+                    isClickable
+                    isSelectable
+                  >
                     <CardHeader>
                       <Content>
                         <Flex>
@@ -174,7 +178,7 @@ export const Reports: React.FC = () => {
                 </StackItem>
               )}
               <StackItem>
-                <Card>
+                <Card ouiaId="identified-risks-card">
                   <CardHeader>
                     <Content>
                       <Content component="h3">

--- a/cypress/e2e/models/migration/reports-tab/reports-tab.ts
+++ b/cypress/e2e/models/migration/reports-tab/reports-tab.ts
@@ -23,7 +23,9 @@ import {
 import { SEC, migration } from "../../../types/constants";
 import { navMenu } from "../../../views/menu.view";
 import {
+  currentLandscapeCard,
   highRiskDonut,
+  identifiedRisksCard,
   lowRiskDonut,
   mediumRiskDonut,
   unknownRiskDonut,
@@ -76,7 +78,21 @@ export class Reports {
     riskDonutSelector: string
   ): Cypress.Chainable<string> {
     Reports.open();
-    return cy.get(riskDonutSelector).eq(0).find("tspan").eq(0).invoke("text");
+    return cy
+      .get(`${currentLandscapeCard},${identifiedRisksCard}`)
+      .then(($elements) => {
+        if ($elements.length > 1) {
+          return cy
+            .get(riskDonutSelector)
+            .eq(0)
+            .find("tspan")
+            .eq(0)
+            .invoke("text");
+        } else {
+          // no charts card, use fallback value
+          return cy.wrap("0");
+        }
+      });
   }
 
   public static getTotalApplicationsValue(

--- a/cypress/e2e/views/reportsTab.view.ts
+++ b/cypress/e2e/views/reportsTab.view.ts
@@ -15,7 +15,10 @@ limitations under the License.
 */
 
 export const switchToggle = ".pf-v6-c-switch__toggle";
-
+export const currentLandscapeCard =
+  "[data-ouia-component-id='current-landscape-card']";
+export const identifiedRisksCard =
+  "[data-ouia-component-id='identified-risks-card']";
 export const highRiskDonut = "#landscape-donut-red";
 export const mediumRiskDonut = "#landscape-donut-yellow";
 export const lowRiskDonut = "#landscape-donut-green";


### PR DESCRIPTION

Fixes: #3404 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reports page loading behavior so placeholders remain visible until all required data is fetched.
  * Prevented the “current landscape” card from rendering when there are no applications, while keeping the rest of the page visible.
* **Tests**
  * Enhanced reports tab test selectors and made donut value extraction more resilient when specific chart cards aren’t present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->