### PR TITLE
:ghost: Fix serialize-javascript vulnerabilities

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -81,7 +81,7 @@
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "copy-webpack-plugin": "^14.0.0",
     "css-loader": "^7.1.2",
-    "css-minimizer-webpack-plugin": "^7.0.2",
+    "css-minimizer-webpack-plugin": "^8.0.0",
     "fork-ts-checker-webpack-plugin": "^9.1.0",
     "html-webpack-plugin": "^5.6.5",
     "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,7 @@
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "copy-webpack-plugin": "^14.0.0",
         "css-loader": "^7.1.2",
-        "css-minimizer-webpack-plugin": "^7.0.2",
+        "css-minimizer-webpack-plugin": "^8.0.0",
         "fork-ts-checker-webpack-plugin": "^9.1.0",
         "html-webpack-plugin": "^5.6.5",
         "jest": "^29.7.0",
@@ -10032,16 +10032,6 @@
         "webpack": "^5.1.0"
       }
     },
-    "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
-      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/copyfiles": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
@@ -10375,9 +10365,9 @@
       }
     },
     "node_modules/css-minimizer-webpack-plugin": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-7.0.4.tgz",
-      "integrity": "sha512-2iACis+P8qdLj1tHcShtztkGhCNIRUajJj7iX0IM9a5FA0wXGwjV8Nf6+HsBjBfb4LO8TTAVoetBbM54V6f3+Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-8.0.0.tgz",
+      "integrity": "sha512-9bEpzHs8gEq6/cbEj418jXL/YWjBUD2YTLLk905Npt2JODqnRITin0+So5Vx4Dp5vyi2Lpt9pp2QHzQ7fdxNrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10386,10 +10376,10 @@
         "jest-worker": "^30.0.5",
         "postcss": "^8.4.40",
         "schema-utils": "^4.2.0",
-        "serialize-javascript": "^6.0.2"
+        "serialize-javascript": "^7.0.3"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 20.9.0"
       },
       "funding": {
         "type": "opencollective",
@@ -23603,13 +23593,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/package.json
+++ b/package.json
@@ -80,8 +80,9 @@
     "http-proxy-middleware": "~4.1.1"
   },
   "overrides": {
-    "follow-redirects": "^1.16.0",
-    "qs": "^6.14.1",
+    "mocha": {
+      "serialize-javascript": "^7.0.6"
+    },
     "webpack-dev-server": {
       "express": "$express"
     }


### PR DESCRIPTION
Force serialize-javascript v7 for mocha. 
The only breaking change between v6 and v7 is node v20+ support.

Cleanup override section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated a build/minification dependency to a newer major version to improve tooling compatibility.
  * Adjusted package dependency overrides to align transitive versions more consistently, including forcing a compatible `serialize-javascript` version for the test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->