### PR TITLE
:sparkles: Replace deprecated DualListSelector component

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -357,8 +357,8 @@
     "updateRequestSubmitted": "Update request submitted.",
     "noApplicationsForAssignment": "No applications are available for assignment.",
     "noApplicationsForExport": "No applications are available for export.",
-    "searchAvailableScopes": "Search available scopes",
-    "searchChosenScopes": "Search chosen scopes",
+    "searchAvailableOptions": "Search available options",
+    "searchChosenOptions": "Search chosen options",
     "systemQuestionnaireDisabled": "Disabled because it is a system questionnaire.",
     "selectedOptions": "{{count}} of {{total}} options selected"
   },

--- a/client/src/app/components/dual-list-selector.tsx
+++ b/client/src/app/components/dual-list-selector.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
-  DualListSelector,
+  DualListSelector as PFDualListSelector,
   DualListSelectorControl,
   DualListSelectorControlsWrapper,
   DualListSelectorList,
@@ -30,16 +30,20 @@ const toggleSet = (
   setState(next);
 };
 
-export interface DualScopesListProps {
-  chosenScopes: string[];
-  onChange: (chosenScopes: string[]) => void;
-  allScopes: string[];
+export interface DualListSelectorProps {
+  chosenOptions: string[];
+  onChange: (chosenOptions: string[]) => void;
+  allOptions: string[];
+  allOptionsTitle: string;
+  chosenOptionsTitle: string;
 }
 
-export const DualScopesList: FC<DualScopesListProps> = ({
-  chosenScopes,
+export const DualListSelector: FC<DualListSelectorProps> = ({
+  chosenOptions,
   onChange,
-  allScopes,
+  allOptions,
+  allOptionsTitle,
+  chosenOptionsTitle,
 }) => {
   const { t } = useTranslation();
 
@@ -50,51 +54,52 @@ export const DualScopesList: FC<DualScopesListProps> = ({
   );
   const [chosenSelected, setChosenSelected] = useState<Set<string>>(new Set());
 
-  const matchesFilter = (scope: string, filter: string) =>
-    !filter || scope.toLowerCase().includes(filter.toLowerCase());
+  const matchesFilter = (option: string, filter: string) =>
+    !filter || option.toLowerCase().includes(filter.toLowerCase());
 
-  const availableScopes = allScopes.filter(
-    (scope) => !chosenScopes.includes(scope)
+  const availableOptions = allOptions.filter(
+    (option) => !chosenOptions.includes(option)
   );
 
   // show already selected to avoid silent modifications
-  const visibleAvailable = availableScopes.filter(
-    (scope) =>
-      matchesFilter(scope, availableFilter) || availableSelected.has(scope)
+  const visibleAvailable = availableOptions.filter(
+    (option) =>
+      matchesFilter(option, availableFilter) || availableSelected.has(option)
   );
-  const visibleChosen = chosenScopes.filter(
-    (scope) => matchesFilter(scope, chosenFilter) || chosenSelected.has(scope)
+  const visibleChosen = chosenOptions.filter(
+    (option) =>
+      matchesFilter(option, chosenFilter) || chosenSelected.has(option)
   );
 
   const moveToChosen = (items: string[]) => {
-    onChange([...chosenScopes, ...items]);
+    onChange([...chosenOptions, ...items]);
     setAvailableSelected(new Set());
   };
   const moveToAvailable = (items: string[]) => {
-    const removeScopes = new Set(items);
-    onChange(chosenScopes.filter((scope) => !removeScopes.has(scope)));
+    const removeOptions = new Set(items);
+    onChange(chosenOptions.filter((option) => !removeOptions.has(option)));
     setChosenSelected(new Set());
   };
   const moveAllVisibleToChosen = () => {
-    onChange([...chosenScopes, ...visibleAvailable]);
+    onChange([...chosenOptions, ...visibleAvailable]);
     setAvailableSelected(new Set());
   };
   const moveAllVisibleToAvailable = () => {
-    const removeScopes = new Set(visibleChosen);
-    onChange(chosenScopes.filter((scope) => !removeScopes.has(scope)));
+    const removeOptions = new Set(visibleChosen);
+    onChange(chosenOptions.filter((option) => !removeOptions.has(option)));
     setChosenSelected(new Set());
   };
-  const numAvailSel = visibleAvailable.filter((scope) =>
-    availableSelected.has(scope)
+  const numAvailSel = visibleAvailable.filter((option) =>
+    availableSelected.has(option)
   ).length;
-  const numChosenSel = visibleChosen.filter((scope) =>
-    chosenSelected.has(scope)
+  const numChosenSel = visibleChosen.filter((option) =>
+    chosenSelected.has(option)
   ).length;
 
   return (
-    <DualListSelector>
+    <PFDualListSelector>
       <DualListSelectorPane
-        title={t("terms.availableScopes")}
+        title={allOptionsTitle}
         status={t("message.selectedOptions", {
           count: numAvailSel,
           total: visibleAvailable.length,
@@ -104,7 +109,7 @@ export const DualScopesList: FC<DualScopesListProps> = ({
             value={availableFilter}
             onChange={(_event, value) => setAvailableFilter(value)}
             onClear={() => setAvailableFilter("")}
-            aria-label={t("message.searchAvailableScopes")}
+            aria-label={t("message.searchAvailableOptions")}
           />
         }
         listMinHeight="300px"
@@ -122,15 +127,15 @@ export const DualScopesList: FC<DualScopesListProps> = ({
         )}
 
         <DualListSelectorList>
-          {visibleAvailable.map((scope) => (
+          {visibleAvailable.map((option) => (
             <DualListSelectorListItem
-              key={scope}
-              isSelected={availableSelected.has(scope)}
+              key={option}
+              isSelected={availableSelected.has(option)}
               onOptionSelect={() =>
-                toggleSet(availableSelected, setAvailableSelected, scope)
+                toggleSet(availableSelected, setAvailableSelected, option)
               }
             >
-              {scope}
+              {option}
             </DualListSelectorListItem>
           ))}
         </DualListSelectorList>
@@ -141,7 +146,7 @@ export const DualScopesList: FC<DualScopesListProps> = ({
           isDisabled={numAvailSel === 0}
           onClick={() =>
             moveToChosen(
-              visibleAvailable.filter((scope) => availableSelected.has(scope))
+              visibleAvailable.filter((option) => availableSelected.has(option))
             )
           }
           aria-label={t("actions.addSelected")}
@@ -161,7 +166,7 @@ export const DualScopesList: FC<DualScopesListProps> = ({
           isDisabled={numChosenSel === 0}
           onClick={() =>
             moveToAvailable(
-              visibleChosen.filter((scope) => chosenSelected.has(scope))
+              visibleChosen.filter((option) => chosenSelected.has(option))
             )
           }
           aria-label={t("actions.removeSelected")}
@@ -180,7 +185,7 @@ export const DualScopesList: FC<DualScopesListProps> = ({
       </DualListSelectorControlsWrapper>
 
       <DualListSelectorPane
-        title={t("terms.chosenScopes")}
+        title={chosenOptionsTitle}
         status={t("message.selectedOptions", {
           count: numChosenSel,
           total: visibleChosen.length,
@@ -190,7 +195,7 @@ export const DualScopesList: FC<DualScopesListProps> = ({
             value={chosenFilter}
             onChange={(_event, value) => setChosenFilter(value)}
             onClear={() => setChosenFilter("")}
-            aria-label={t("message.searchChosenScopes")}
+            aria-label={t("message.searchChosenOptions")}
           />
         }
         listMinHeight="300px"
@@ -208,19 +213,19 @@ export const DualScopesList: FC<DualScopesListProps> = ({
           />
         )}
         <DualListSelectorList>
-          {visibleChosen.map((scope) => (
+          {visibleChosen.map((option) => (
             <DualListSelectorListItem
-              key={scope}
-              isSelected={chosenSelected.has(scope)}
+              key={option}
+              isSelected={chosenSelected.has(option)}
               onOptionSelect={() =>
-                toggleSet(chosenSelected, setChosenSelected, scope)
+                toggleSet(chosenSelected, setChosenSelected, option)
               }
             >
-              {scope}
+              {option}
             </DualListSelectorListItem>
           ))}
         </DualListSelectorList>
       </DualListSelectorPane>
-    </DualListSelector>
+    </PFDualListSelector>
   );
 };

--- a/client/src/app/pages/archetypes/components/target-profile-form.tsx
+++ b/client/src/app/pages/archetypes/components/target-profile-form.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useState } from "react";
 import * as React from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";

--- a/client/src/app/pages/archetypes/components/target-profile-form.tsx
+++ b/client/src/app/pages/archetypes/components/target-profile-form.tsx
@@ -13,7 +13,6 @@ import {
   ModalHeader,
   Spinner,
 } from "@patternfly/react-core";
-import { DualListSelector } from "@patternfly/react-core/deprecated";
 
 import type {
   AnalysisProfile,
@@ -31,6 +30,7 @@ import { useFetchGenerators } from "@app/queries/generators";
 import { refsToItems, toRef, toRefs } from "@app/utils/model-utils";
 import { duplicateNameCheck } from "@app/utils/utils";
 
+import { DualListSelector } from "../../../components/dual-list-selector";
 import { useAnalysisProfileOptions } from "../hooks/useAnalysisProfileOptions";
 
 interface TargetProfileFormValues {
@@ -87,22 +87,6 @@ const TargetProfileFormInner: React.FC<TargetProfileFormPropsInner> = ({
 }) => {
   const { t } = useTranslation();
 
-  // Dual list selector state
-  const [availableOptions, setAvailableOptions] = useState<Generator[]>(() => {
-    if (profile) {
-      return generators.filter(
-        (g) => !profile.generators.some((r) => r.id === g.id)
-      );
-    }
-    return generators;
-  });
-  const [chosenOptions, setChosenOptions] = useState<Generator[]>(() => {
-    if (profile) {
-      return refsToItems(generators, profile.generators);
-    }
-    return [];
-  });
-
   const validationSchema = yup.object().shape({
     name: yup
       .string()
@@ -128,7 +112,6 @@ const TargetProfileFormInner: React.FC<TargetProfileFormPropsInner> = ({
   const {
     handleSubmit,
     control,
-    setValue,
     formState: { isValid },
   } = useForm<TargetProfileFormValues>({
     defaultValues: {
@@ -140,38 +123,13 @@ const TargetProfileFormInner: React.FC<TargetProfileFormPropsInner> = ({
     mode: "all",
   });
 
-  const onListChange = useCallback(
-    (
-      _event: React.MouseEvent,
-      newAvailableOptions: React.ReactNode[],
-      newChosenOptions: React.ReactNode[]
-    ) => {
-      const newAvailable = newAvailableOptions
-        .map((node) => node?.toString())
-        .map((name) => generators.find((g) => g.name === name))
-        .filter(Boolean)
-        .sort((a, b) => a.name.localeCompare(b.name));
-
-      const newChosen = newChosenOptions
-        .map((node) => node?.toString())
-        .map((name) => generators.find((g) => g.name === name))
-        .filter(Boolean)
-        .sort((a, b) => a.name.localeCompare(b.name));
-
-      setAvailableOptions(newAvailable);
-      setChosenOptions(newChosen);
-      setValue("generators", newChosen, { shouldValidate: true });
-    },
-    [generators, setValue]
-  );
-
   const submitToOnSave = (values: TargetProfileFormValues) => {
     if (!generators) return;
 
     const newProfile: TargetProfile = {
       id: profile?.id ?? 0,
       name: values.name,
-      generators: toRefs(chosenOptions),
+      generators: toRefs(values.generators),
       analysisProfile: toRef(values.analysisProfile ?? undefined),
     };
 
@@ -207,13 +165,16 @@ const TargetProfileFormInner: React.FC<TargetProfileFormPropsInner> = ({
             name="generators"
             label={t("terms.generators")}
             fieldId="target-profile-generators"
-            renderInput={() => (
+            renderInput={({ field: { value: chosenGenerators, onChange } }) => (
               <DualListSelector
-                availableOptions={availableOptions.map(({ name }) => name)}
-                chosenOptions={chosenOptions.map(({ name }) => name)}
-                onListChange={onListChange}
-                id="target-profile-generators-selector"
-                availableOptionsTitle={t("message.generatorsAvailable")}
+                allOptions={generators.map(({ name }) => name)}
+                chosenOptions={chosenGenerators?.map(({ name }) => name) ?? []}
+                onChange={(newGenerators) =>
+                  onChange(
+                    generators.filter((g) => newGenerators.includes(g.name))
+                  )
+                }
+                allOptionsTitle={t("message.generatorsAvailable")}
                 chosenOptionsTitle={t("message.generatorsChosen")}
               />
             )}

--- a/client/src/app/pages/user-management/roles/role-form.tsx
+++ b/client/src/app/pages/user-management/roles/role-form.tsx
@@ -42,9 +42,9 @@ export const RoleForm: FC<RoleFormProps> = ({ form }) => {
         renderInput={({ field: { value: chosenScopes, onChange } }) => {
           return (
             <DualListSelector
-              chosenOptions={chosenScopes}
+              chosenOptions={chosenScopes ?? []}
               onChange={onChange}
-              allOptions={allScopes.map((scope) => scope.name)}
+              allOptions={(allScopes ?? []).map((scope) => scope.name)}
               allOptionsTitle={t("terms.availableScopes")}
               chosenOptionsTitle={t("terms.chosenScopes")}
             />

--- a/client/src/app/pages/user-management/roles/role-form.tsx
+++ b/client/src/app/pages/user-management/roles/role-form.tsx
@@ -9,9 +9,8 @@ import {
   HookFormPFTextInput,
 } from "@app/components/HookFormPFFields";
 
+import { DualListSelector } from "../../../components/dual-list-selector";
 import { useFetchScopes } from "../../../queries/scopes";
-
-import { DualScopesList } from "./dual-scopes-list";
 
 export type RoleFormValues = Pick<Role, "name" | "scopes">;
 
@@ -42,10 +41,12 @@ export const RoleForm: FC<RoleFormProps> = ({ form }) => {
         fieldId="scopes"
         renderInput={({ field: { value: chosenScopes, onChange } }) => {
           return (
-            <DualScopesList
-              chosenScopes={chosenScopes}
+            <DualListSelector
+              chosenOptions={chosenScopes}
               onChange={onChange}
-              allScopes={allScopes.map((scope) => scope.name)}
+              allOptions={allScopes.map((scope) => scope.name)}
+              allOptionsTitle={t("terms.availableScopes")}
+              chosenOptionsTitle={t("terms.chosenScopes")}
             />
           );
         }}


### PR DESCRIPTION
Create a reusable component from existing
dual-scopes-list.tsx component.

Fixes: #3455 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable options-based dual-list selector for choosing and managing available vs selected items.
  * Updated generator and role forms to use the new selector with explicit available/selected list titles.

* **Bug Fixes**
  * Improved form synchronization so selected generators and scopes are correctly derived from form state on submit.
  * Updated accessibility labeling to reference available and selected options.

* **Documentation**
  * Updated English UI translation keys for search-related “scopes” → “options” naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->