### PR TITLE
:seedling: Update Dockerfile labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ LABEL name="konveyor/tackle2-ui" \
 COPY --from=builder /opt/app-root/src/dist /opt/app-root/dist/
 
 ENV DEBUG=1
-ENV NODE_EXTRA_CA_CERTS=/opt/app-root/src/ca.crt
 
 WORKDIR /opt/app-root/dist
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,24 +32,29 @@ RUN microdnf -y install tar procps-ng && microdnf clean all
 USER 1001
 
 LABEL name="konveyor/tackle2-ui" \
-      description="Konveyor for Tackle - User Interface" \
-      help="For more information visit https://konveyor.io" \
-      license="Apache License 2.0" \
-      maintainer="gdubreui@redhat.com,ibolton@redhat.com" \
-      summary="Konveyor for Tackle - User Interface" \
+      description="Konveyor - User Interface" \
+      summary="Konveyor UI provides the web-based frontend for managing application modernization workflows" \
       url="https://quay.io/konveyor/tackle2-ui" \
-      usage="podman run -p 80 -v konveyor/tackle2-ui:latest" \
+      help="For more information visit https://konveyor.io" \
+      license="Apache-2.0" \
+      maintainer="sdickers@redhat.com,rszwajko@redhat.com,ibolton@redhat.com" \
+      usage="podman run -p 8080:8080 konveyor/tackle2-ui:latest" \
       com.redhat.component="konveyor-tackle2-ui-container" \
       io.k8s.display-name="tackle2-ui" \
-      io.k8s.description="Konveyor for Tackle - User Interface" \
-      io.openshift.expose-services="80:http" \
-      io.openshift.tags="operator,konveyor,ui,nodejs18" \
-      io.openshift.min-cpu="100m" \
-      io.openshift.min-memory="350Mi"
+      io.k8s.description="Konveyor - User Interface" \
+      io.openshift.tags="operator,konveyor,ui,nodejs" \
+      org.opencontainers.image.title="tackle2-ui" \
+      org.opencontainers.image.description="Konveyor - User Interface" \
+      org.opencontainers.image.url="https://konveyor.io" \
+      org.opencontainers.image.source="https://github.com/konveyor/tackle2-ui" \
+      org.opencontainers.image.documentation="https://konveyor.io/docs" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Konveyor"
 
 COPY --from=builder /opt/app-root/src/dist /opt/app-root/dist/
 
 ENV DEBUG=1
+ENV NODE_EXTRA_CA_CERTS=/opt/app-root/src/ca.crt
 
 WORKDIR /opt/app-root/dist
 ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,6 @@ if [[ $AUTH_REQUIRED != "false" ]]; then
 fi
 
 # Copy the Kube API and service CA bundle to /opt/app-root/src/ca.crt if they exist
-NODE_EXTRA_CA_CERTS=${NODE_EXTRA_CA_CERTS:-/opt/app-root/src/ca.crt}
 
 # Add Kube API CA
 if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,7 @@ if [[ $AUTH_REQUIRED != "false" ]]; then
 fi
 
 # Copy the Kube API and service CA bundle to /opt/app-root/src/ca.crt if they exist
+NODE_EXTRA_CA_CERTS=${NODE_EXTRA_CA_CERTS:-/opt/app-root/src/ca.crt}
 
 # Add Kube API CA
 if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then


### PR DESCRIPTION
Resolves: #3151

Update Dockerfile labels to:
  - Add new and useful labels (OCI standard)
  - Remove deprecated labels (OpenShift 3 specific)
  - Update values of existing labels to current state of the project

Note, the `image-build.yaml` workflow calls the shared `konveyor/release-tools/.github/workflows/build-push-images.yaml@main` workflow. This workflow will generate OCI labels based on the checked out repository used to build the image. If any labels that overlap between the Dockerfile and input at build time, the build time label values will be used.

Assisted-by: Cursor:claude-opus-4.6-high

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated container metadata with clearer product descriptions, links, licensing, and vendor information.
  * Improved container usage instructions, including port mapping and image tag examples.
  * Simplified and standardized platform labeling for better container cataloging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->