### PR TITLE
:bug: Fit long titles into masthead logo container

### DIFF
--- a/client/src/app/layout/HeaderApp/HeaderApp.tsx
+++ b/client/src/app/layout/HeaderApp/HeaderApp.tsx
@@ -126,7 +126,7 @@ export const HeaderApp: React.FC = () => {
           />
         </MastheadToggle>
         <MastheadBrand>
-          <MastheadLogo>
+          <MastheadLogo className="logo-container">
             {leftBrand ? (
               <Brand
                 src={leftBrand.src}

--- a/client/src/app/layout/HeaderApp/header.css
+++ b/client/src/app/layout/HeaderApp/header.css
@@ -1,3 +1,12 @@
 .logo-pointer {
   cursor: default !important;
 }
+
+.logo-container {
+  display: flex;
+  align-items: center;
+  /** remove the built-in limit on the width of the logo 
+  * as it breaks for long titles  
+  */
+  width: unset;
+}

--- a/client/src/app/layout/HeaderApp/tests/__snapshots__/HeaderApp.test.tsx.snap
+++ b/client/src/app/layout/HeaderApp/tests/__snapshots__/HeaderApp.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`Test snapshot 1`] = `
             class="pf-v6-c-masthead__brand"
           >
             <span
-              class="pf-v6-c-masthead__logo"
+              class="pf-v6-c-masthead__logo logo-container"
             >
               <img
                 alt="brand"
@@ -231,7 +231,7 @@ exports[`Test snapshot 1`] = `
           class="pf-v6-c-masthead__brand"
         >
           <span
-            class="pf-v6-c-masthead__logo"
+            class="pf-v6-c-masthead__logo logo-container"
           >
             <img
               alt="brand"


### PR DESCRIPTION
Remove the built-in limit on the width of the logo as it breaks long titles used in branding.

Fixes: https://redhat.atlassian.net/browse/MTA-7239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app header logo area to better support longer titles and improve alignment.
  * The logo now sits within a flexible container, keeping it vertically centered and removing the previous width limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->