### PR TITLE
:bug: Align right side logo to the header center

### DIFF
--- a/client/src/app/layout/HeaderApp/HeaderApp.tsx
+++ b/client/src/app/layout/HeaderApp/HeaderApp.tsx
@@ -102,7 +102,7 @@ export const HeaderApp: React.FC = () => {
 
         {rightBrand ? (
           <ToolbarGroup>
-            <ToolbarItem>
+            <ToolbarItem id="logo-container-right">
               <Brand
                 src={rightBrand.src}
                 alt={rightBrand.alt}

--- a/client/src/app/layout/HeaderApp/header.css
+++ b/client/src/app/layout/HeaderApp/header.css
@@ -10,3 +10,12 @@
   */
   width: unset;
 }
+
+#logo-container-right {
+  /** existing PF6 rule connected with isFullHeight flag
+  * has specificity (0,3,0) and overrides the styling
+  * applied on the ToolbarItem with alignItems="center"
+  * which results in rule with specificity (0,2,0).
+  */
+  align-items: center;
+}


### PR DESCRIPTION
Fixes: https://redhat.atlassian.net/browse/MTA-7238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment of the right-side brand logo in the application header.
  * Ensured the logo remains vertically centered despite existing toolbar styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->