### PR TITLE
:seedling: Update entrypoint.sh ca-certs handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,13 @@ FROM registry.access.redhat.com/ubi10/nodejs-22-minimal:1784704585
 
 # Add ps package to allow liveness probe for k8s cluster
 # Add tar package to allow copying files with kubectl scp
+# Setup a directory to store the CA certificates to be given to nodejs in entrypoint.sh
 USER 0
-RUN microdnf -y install tar procps-ng && microdnf clean all
+RUN microdnf -y install tar procps-ng && \
+    microdnf clean all && \
+    mkdir -p /opt/app-root/ca-certs.d && \
+    chown 1001:0 /opt/app-root/ca-certs.d && \
+    chmod 775 /opt/app-root/ca-certs.d
 
 USER 1001
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,64 @@ Please read the [Pull Request (PR) Process](https://github.com/konveyor/release-
 section of the [Konveyor versioning and branching doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md)
 for more information.
 
+# Container Runtime
+
+When running the built container image (outside of local development), the
+[entrypoint.sh](entrypoint.sh) script starts the Node.js server and assembles a
+CA certificate bundle nodejs uses for TLS connections.
+
+## CA Certificate Handling
+
+Node.js does not use the operating system trust store. The entrypoint builds a
+combined PEM bundle at `/tmp/node-ca-bundle.pem` and sets `NODE_EXTRA_CA_CERTS`
+to point at it. This adds the bundled CAs on top of Node's compiled-in Mozilla
+root CAs.
+
+The following sources are checked automatically:
+
+| Source                       | Path                                                           | When present                                     |
+| ---------------------------- | -------------------------------------------------------------- | ------------------------------------------------ |
+| Kubernetes API server CA     | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`         | Always on K8s/OpenShift                          |
+| OpenShift service-serving CA | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` | When the operator mounts it                      |
+| Cluster-injected / proxy CAs | `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`            | When `trusted_ca_enabled` is set in the operator |
+| Drop-in directory            | `/opt/app-root/ca-certs.d/*.crt`, `*.pem`                      | User-provided (see below)                        |
+
+If none of the sources exist, `NODE_EXTRA_CA_CERTS` is left unset and Node uses
+its built-in Mozilla roots only.
+
+## Adding Custom CA Certificates
+
+To inject a custom CA (e.g. an internal corporate root CA) without rebuilding
+the image, mount a ConfigMap or Secret containing PEM files into the drop-in
+directory `/opt/app-root/ca-certs.d/`. Any file ending in `.crt` or `.pem` will
+be included in the bundle automatically.
+
+**ConfigMap example (Deployment snippet):**
+
+```yaml
+containers:
+  - name: tackle-ui
+    volumeMounts:
+      - name: custom-ca
+        mountPath: /opt/app-root/ca-certs.d
+        readOnly: true
+volumes:
+  - name: custom-ca
+    configMap:
+      name: my-custom-ca
+      items:
+        - key: corporate-root.crt
+          path: corporate-root.crt
+```
+
+On OpenShift, the cluster-wide trusted CA injection mechanism
+(`config.openshift.io/inject-trusted-cabundle: "true"`) can also be used. The
+operator mounts the injected ConfigMap to
+`/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`, which the entrypoint
+already reads from `ca_sources`. See
+[docs/operator-ca-certs-followup.md](docs/operator-ca-certs-followup.md) for
+operator-side details.
+
 # Testing
 
 ## Unit Tests

--- a/docs/operator-ca-certs-followup.md
+++ b/docs/operator-ca-certs-followup.md
@@ -7,39 +7,31 @@ This document tracks the changes needed in the [konveyor/operator](https://githu
 `entrypoint.sh` was refactored to:
 
 1. Use `/tmp/node-ca-bundle.pem` as the **output** path (rather than `/opt/app-root/src/ca.crt`)
-2. Treat any pre-set `NODE_EXTRA_CA_CERTS` as an **input source** (safe to point at read-only mounts)
-3. Automatically pick up `*.crt` and `*.pem` files from the drop-in directory `/opt/app-root/ca-certs.d/`
+2. Automatically pick up `*.crt` and `*.pem` files from the drop-in directory `/opt/app-root/ca-certs.d/`
+3. Fully own the `NODE_EXTRA_CA_CERTS` variable -- any externally set value is ignored
 
-## Required Operator Changes (roles/tackle/defaults/main.yml)
+## Required Operator Changes
 
-The `ui_node_extra_ca_certs` default currently points at the old output path:
+### Remove the NODE_EXTRA_CA_CERTS env var (roles/tackle/templates/deployment-ui.yml.j2)
 
-```yaml
-# Before
-ui_node_extra_ca_certs: "/opt/app-root/src/ca.crt"
-```
-
-It should either be removed (the entrypoint no longer needs it set externally) or updated to the new output path. Removing it is preferred — the entrypoint manages everything internally now:
+The entrypoint now manages `NODE_EXTRA_CA_CERTS` internally. The operator should stop setting it:
 
 ```yaml
-# After: remove the line entirely, OR update to new output path if other
-# tooling depends on a predictable env var value at runtime:
-ui_node_extra_ca_certs: "/tmp/node-ca-bundle.pem"
-```
-
-And in `roles/tackle/templates/deployment-ui.yml.j2`, the env var block:
-
-```yaml
-# Before
+# Remove this block from deployment-ui.yml.j2:
 - name: NODE_EXTRA_CA_CERTS
   value: { { ui_node_extra_ca_certs } }
 ```
 
-Can be removed entirely, or kept pointing at `/tmp/node-ca-bundle.pem` if downstream tooling needs the env var present regardless.
+And remove the default from `roles/tackle/defaults/main.yml`:
 
-## Optional: Drop-in Directory Mount (deployment-ui.yml.j2)
+```yaml
+# Remove this line:
+ui_node_extra_ca_certs: "/opt/app-root/src/ca.crt"
+```
 
-For deployments that need to inject a custom CA without using the OpenShift cluster-wide trust bundle mechanism, operators can mount a Secret or ConfigMap into `/opt/app-root/ca-certs.d/`. The entrypoint will automatically include any `*.crt` or `*.pem` files found there.
+### Mount custom CAs to the drop-in directory (deployment-ui.yml.j2)
+
+For deployments that need to inject a custom CA without using the OpenShift cluster-wide trust bundle mechanism, mount a Secret or ConfigMap into `/opt/app-root/ca-certs.d/`. The entrypoint will automatically include any `*.crt` or `*.pem` files found there.
 
 Example volume + mount:
 
@@ -53,7 +45,6 @@ Example volume + mount:
 - name: custom-ca
   secret:
     secretName: my-custom-ca-secret
-    # Each key in the Secret that ends in .crt or .pem will be picked up.
 ```
 
 Or with a ConfigMap:
@@ -82,4 +73,4 @@ The existing conditional volume mount in `deployment-ui.yml.j2`:
 {% endif %}
 ```
 
-continues to work unchanged — `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` remains a hardcoded source in `ca_sources` in the entrypoint.
+continues to work unchanged -- `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` remains a hardcoded source in `ca_sources` in the entrypoint.

--- a/docs/operator-ca-certs-followup.md
+++ b/docs/operator-ca-certs-followup.md
@@ -1,0 +1,85 @@
+# Operator Follow-up: CA Certificate Handling for tackle2-ui
+
+This document tracks the changes needed in the [konveyor/operator](https://github.com/konveyor/operator) repository to align with the updated CA cert handling in `entrypoint.sh`.
+
+## Background
+
+`entrypoint.sh` was refactored to:
+
+1. Use `/tmp/node-ca-bundle.pem` as the **output** path (rather than `/opt/app-root/src/ca.crt`)
+2. Treat any pre-set `NODE_EXTRA_CA_CERTS` as an **input source** (safe to point at read-only mounts)
+3. Automatically pick up `*.crt` and `*.pem` files from the drop-in directory `/opt/app-root/ca-certs.d/`
+
+## Required Operator Changes (roles/tackle/defaults/main.yml)
+
+The `ui_node_extra_ca_certs` default currently points at the old output path:
+
+```yaml
+# Before
+ui_node_extra_ca_certs: "/opt/app-root/src/ca.crt"
+```
+
+It should either be removed (the entrypoint no longer needs it set externally) or updated to the new output path. Removing it is preferred — the entrypoint manages everything internally now:
+
+```yaml
+# After: remove the line entirely, OR update to new output path if other
+# tooling depends on a predictable env var value at runtime:
+ui_node_extra_ca_certs: "/tmp/node-ca-bundle.pem"
+```
+
+And in `roles/tackle/templates/deployment-ui.yml.j2`, the env var block:
+
+```yaml
+# Before
+- name: NODE_EXTRA_CA_CERTS
+  value: { { ui_node_extra_ca_certs } }
+```
+
+Can be removed entirely, or kept pointing at `/tmp/node-ca-bundle.pem` if downstream tooling needs the env var present regardless.
+
+## Optional: Drop-in Directory Mount (deployment-ui.yml.j2)
+
+For deployments that need to inject a custom CA without using the OpenShift cluster-wide trust bundle mechanism, operators can mount a Secret or ConfigMap into `/opt/app-root/ca-certs.d/`. The entrypoint will automatically include any `*.crt` or `*.pem` files found there.
+
+Example volume + mount:
+
+```yaml
+# In the container's volumeMounts:
+- name: custom-ca
+  mountPath: /opt/app-root/ca-certs.d
+  readOnly: true
+
+# In the pod's volumes:
+- name: custom-ca
+  secret:
+    secretName: my-custom-ca-secret
+    # Each key in the Secret that ends in .crt or .pem will be picked up.
+```
+
+Or with a ConfigMap:
+
+```yaml
+volumes:
+  - name: custom-ca
+    configMap:
+      name: my-custom-ca-configmap
+      items:
+        - key: ca.crt
+          path: ca.crt
+```
+
+This is an alternative to (or complement of) the existing `trusted_ca_enabled` mechanism that mounts the OpenShift cluster CA bundle to `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`.
+
+## Existing trusted_ca_enabled Mechanism: No Change Needed
+
+The existing conditional volume mount in `deployment-ui.yml.j2`:
+
+```yaml
+{% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
+- name: trusted-ca
+  mountPath: /etc/pki/ca-trust/extracted/pem
+  readOnly: true
+{% endif %}
+```
+
+continues to work unchanged — `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` remains a hardcoded source in `ca_sources` in the entrypoint.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,11 +23,9 @@ if [[ $AUTH_REQUIRED != "false" ]]; then
   fi
 fi
 
-# Build a combined CA bundle for Node.js, which does not use the system trust store.
-# NODE_EXTRA_CA_CERTS adds CAs on top of Node's compiled-in Mozilla root CAs.
-# If NODE_EXTRA_CA_CERTS is already set to an existing file, it is treated as
-# an additional input source rather than the output path, so read-only mounts
-# (Secrets, ConfigMaps) are safe to use.
+# Nodejs does not use the system trust store by default. We build a combined CA
+# bundle from known sources and set NODE_EXTRA_CA_CERTS to point at it. This adds
+# CAs on top of Node's compiled-in Mozilla root CAs.
 ca_bundle="/tmp/node-ca-bundle.pem"
 
 ca_sources=(
@@ -39,12 +37,6 @@ ca_sources=(
   /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 )
 
-# If the caller pre-set NODE_EXTRA_CA_CERTS to an existing file, include it.
-if [ -n "${NODE_EXTRA_CA_CERTS:-}" ] && [ -f "${NODE_EXTRA_CA_CERTS}" ]; then
-  ca_sources+=("${NODE_EXTRA_CA_CERTS}")
-fi
-
-# Pick up any certs dropped into the well-known drop-in directory.
 # Mount a ConfigMap or Secret to /opt/app-root/ca-certs.d/ with *.crt or *.pem
 # files and they will be included automatically without rebuilding the image.
 for f in /opt/app-root/ca-certs.d/*.crt /opt/app-root/ca-certs.d/*.pem; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,10 @@ fi
 
 # Build a combined CA bundle for Node.js, which does not use the system trust store.
 # NODE_EXTRA_CA_CERTS adds CAs on top of Node's compiled-in Mozilla root CAs.
-export NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-/opt/app-root/src/ca.crt}"
+# If NODE_EXTRA_CA_CERTS is already set to an existing file, it is treated as
+# an additional input source rather than the output path, so read-only mounts
+# (Secrets, ConfigMaps) are safe to use.
+ca_bundle="/tmp/node-ca-bundle.pem"
 
 ca_sources=(
   # Kubernetes API server CA (standard SA volume mount)
@@ -36,17 +39,31 @@ ca_sources=(
   /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 )
 
+# If the caller pre-set NODE_EXTRA_CA_CERTS to an existing file, include it.
+if [ -n "${NODE_EXTRA_CA_CERTS:-}" ] && [ -f "${NODE_EXTRA_CA_CERTS}" ]; then
+  ca_sources+=("${NODE_EXTRA_CA_CERTS}")
+fi
+
+# Pick up any certs dropped into the well-known drop-in directory.
+# Mount a ConfigMap or Secret to /opt/app-root/ca-certs.d/ with *.crt or *.pem
+# files and they will be included automatically without rebuilding the image.
+for f in /opt/app-root/ca-certs.d/*.crt /opt/app-root/ca-certs.d/*.pem; do
+  [ -f "$f" ] && ca_sources+=("$f")
+done
+
 found=false
-touch "${NODE_EXTRA_CA_CERTS}"
+: > "${ca_bundle}"
 for src in "${ca_sources[@]}"; do
   if [ -f "$src" ]; then
-    cat "$src" >> "${NODE_EXTRA_CA_CERTS}"
+    cat "$src" >> "${ca_bundle}"
     found=true
   fi
 done
 
-if [ "$found" = false ]; then
-  rm -f "${NODE_EXTRA_CA_CERTS}"
+if [ "$found" = true ]; then
+  export NODE_EXTRA_CA_CERTS="${ca_bundle}"
+else
+  rm -f "${ca_bundle}"
   unset NODE_EXTRA_CA_CERTS
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,21 +23,31 @@ if [[ $AUTH_REQUIRED != "false" ]]; then
   fi
 fi
 
-# Copy the Kube API and service CA bundle to /opt/app-root/src/ca.crt if they exist
+# Build a combined CA bundle for Node.js, which does not use the system trust store.
+# NODE_EXTRA_CA_CERTS adds CAs on top of Node's compiled-in Mozilla root CAs.
+export NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-/opt/app-root/src/ca.crt}"
 
-# Add Kube API CA
-if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then
-   cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt ${NODE_EXTRA_CA_CERTS}
-fi
+ca_sources=(
+  # Kubernetes API server CA (standard SA volume mount)
+  /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  # OpenShift service-serving CA (requires operator-managed ConfigMap mount)
+  /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+  # Cluster-injected custom/proxy CAs via RHEL trust store
+  /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+)
 
-# Add service serving CA
-if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" ]; then
-    cat /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt >> ${NODE_EXTRA_CA_CERTS}
-fi
+found=false
+touch "${NODE_EXTRA_CA_CERTS}"
+for src in "${ca_sources[@]}"; do
+  if [ -f "$src" ]; then
+    cat "$src" >> "${NODE_EXTRA_CA_CERTS}"
+    found=true
+  fi
+done
 
-# Add custom ingress CA if it exists
-if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ]; then
-    cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem >> ${NODE_EXTRA_CA_CERTS}
+if [ "$found" = false ]; then
+  rm -f "${NODE_EXTRA_CA_CERTS}"
+  unset NODE_EXTRA_CA_CERTS
 fi
 
 exec node --enable-source-maps server/dist/index.js


### PR DESCRIPTION
Update the entrypoint script to build up a ca-certs file to contain certs potentially available in the running container and make it available to the nodejs process.

This is a workaround for the nodejs process not using the system trust store by default. It will use the certs in the NODE_EXTRA_CA_CERTS pointed file for the extra certs.

The NODE_EXTRA_CA_CERTS environment variable is not required to be set, but if the file needs to be stored in a different location in the running container, the environment variable should be set to the desired location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Node.js TLS certificate handling in container deployments by combining available trusted CA certificates automatically.
  * Added support for custom `.crt` and `.pem` certificates mounted into the container.
  * Added support for common Kubernetes and OpenShift certificate sources.

* **Documentation**
  * Added configuration guidance and deployment examples for custom CA certificates.
  * Documented operator follow-up steps for the updated certificate injection workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->