### PR TITLE
:seedling: Add nightly workflows for release-0.10

### DIFF
--- a/.github/workflows/nightly-main-e2e.yaml
+++ b/.github/workflows/nightly-main-e2e.yaml
@@ -1,4 +1,10 @@
 name: Nightly e2e (@main)
+#
+# Runs e2e tests using:
+#  - `:latest` images
+#  - use the konveyor-operator install konveyor action from `main`
+#  - use UI e2e tests from `main`
+#
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-main-e2e.yaml
+++ b/.github/workflows/nightly-main-e2e.yaml
@@ -3,6 +3,7 @@ name: Nightly e2e (@main)
 # Runs e2e tests using:
 #  - `:latest` images
 #  - use the konveyor-operator install konveyor action from `main`
+#  - use e2e test runner workflow from `main`
 #  - use UI e2e tests from `main`
 #
 
@@ -34,7 +35,7 @@ jobs:
           - test_tags: "@authNeeded"
             auth_required: false
     name: "Nightly e2e - all tiers"
-    uses: ./.github/workflows/e2e-run-ui-tests.yaml
+    uses: konveyor/tackle2-ui/.github/workflows/e2e-run-ui-tests.yaml@main
     with:
       test_tags: ${{ matrix.test_tags }}
       feature_auth_required: ${{ matrix.auth_required }}

--- a/.github/workflows/nightly-release-0.10-ci-repo.yaml
+++ b/.github/workflows/nightly-release-0.10-ci-repo.yaml
@@ -1,0 +1,14 @@
+name: Nightly CI (repo level @release-0.9)
+
+on:
+  schedule:
+    - cron: "35 5 * * *" # every day @ 5:35am UTC
+
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    uses: konveyor/tackle2-ui/.github/workflows/ci-repo.yml@release-0.10
+    secrets: inherit
+    with:
+      checkout_ref: release-0.10

--- a/.github/workflows/nightly-release-0.10-ci-repo.yaml
+++ b/.github/workflows/nightly-release-0.10-ci-repo.yaml
@@ -1,4 +1,4 @@
-name: Nightly CI (repo level @release-0.9)
+name: Nightly CI (repo level @release-0.10)
 
 on:
   schedule:

--- a/.github/workflows/nightly-release-0.10-ci-repo.yaml
+++ b/.github/workflows/nightly-release-0.10-ci-repo.yaml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   nightly:
     uses: konveyor/tackle2-ui/.github/workflows/ci-repo.yml@release-0.10

--- a/.github/workflows/nightly-release-0.10-e2e.yaml
+++ b/.github/workflows/nightly-release-0.10-e2e.yaml
@@ -1,0 +1,81 @@
+name: Nightly e2e (@release-0.10)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: e2e-nightly-release-0.10-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nightly-e2e:
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        test_tags:
+          - "@tier2_secretsNeeded,@tier3_secretsNeeded"
+          - "@ci,@tier0,@tier2_A,@tier2_B"
+          - "@tier3_A,@tier3_B,@tier3_C"
+          - "@tier3_D,@tier3_E,@tier3_F"
+          - "@authNeeded"
+        auth_required:
+          - true
+          - false
+        exclude:
+          - test_tags: "@authNeeded"
+            auth_required: false
+    name: "Nightly e2e - all tiers"
+    uses: ./.github/workflows/e2e-run-ui-tests.yaml
+    with:
+      test_tags: ${{ matrix.test_tags }}
+      feature_auth_required: ${{ matrix.auth_required }}
+      bundle_image: quay.io/konveyor/tackle2-operator-bundle:release-0.10
+      ui_image: quay.io/konveyor/tackle2-ui:release-0.10
+      install_konveyor_version: release-0.10
+      test_ref: release-0.10
+    secrets: inherit
+
+  slack-notification:
+    name: Send Slack notification
+    runs-on: ubuntu-latest
+    needs: [nightly-e2e]
+    if: always()
+    steps:
+      - name: Determine workflow status
+        id: status
+        run: |
+          if [[ "${{ needs.nightly-e2e.result }}" == "success" ]]; then
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "color=good" >> $GITHUB_OUTPUT
+            echo "emoji=:white_check_mark:" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.nightly-e2e.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "color=danger" >> $GITHUB_OUTPUT
+            echo "emoji=:x:" >> $GITHUB_OUTPUT
+          else
+            echo "status=cancelled" >> $GITHUB_OUTPUT
+            echo "color=warning" >> $GITHUB_OUTPUT
+            echo "emoji=:warning:" >> $GITHUB_OUTPUT
+          fi
+          echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "${{ steps.status.outputs.color }}",
+                  "text": "${{ steps.status.outputs.emoji }} *Nightly E2E Tests (@release-0.10)* - ${{ steps.status.outputs.status }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>",
+                  "footer": "tackle2-ui",
+                  "footer_icon": "https://github.com/konveyor.png",
+                  "ts": ${{ steps.status.outputs.timestamp }}
+                }
+              ]
+            }

--- a/.github/workflows/nightly-release-0.10-e2e.yaml
+++ b/.github/workflows/nightly-release-0.10-e2e.yaml
@@ -3,6 +3,7 @@ name: Nightly e2e (@release-0.10)
 # Runs e2e tests using:
 #  - `:release-0.10` images
 #  - use the konveyor-operator install konveyor action from `release-0.10`
+#  - use e2e test runner workflow from `release-0.10`
 #  - use UI e2e tests from `release-0.10`
 #
 
@@ -34,7 +35,7 @@ jobs:
           - test_tags: "@authNeeded"
             auth_required: false
     name: "Nightly e2e - all tiers"
-    uses: ./.github/workflows/e2e-run-ui-tests.yaml
+    uses: konveyor/tackle2-ui/.github/workflows/e2e-run-ui-tests.yaml@release-0.10
     with:
       test_tags: ${{ matrix.test_tags }}
       feature_auth_required: ${{ matrix.auth_required }}

--- a/.github/workflows/nightly-release-0.10-e2e.yaml
+++ b/.github/workflows/nightly-release-0.10-e2e.yaml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-nightly-release-0.10-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/nightly-release-0.10-e2e.yaml
+++ b/.github/workflows/nightly-release-0.10-e2e.yaml
@@ -1,4 +1,10 @@
 name: Nightly e2e (@release-0.10)
+#
+# Runs e2e tests using:
+#  - `:release-0.10` images
+#  - use the konveyor-operator install konveyor action from `release-0.10`
+#  - use UI e2e tests from `release-0.10`
+#
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-release-0.9-e2e.yaml
+++ b/.github/workflows/nightly-release-0.9-e2e.yaml
@@ -1,4 +1,10 @@
 name: Nightly e2e - run all non-analysis tests (@release-0.9)
+#
+# Runs e2e tests using:
+#  - `:release-0.9` images
+#  - use the konveyor-operator install konveyor action from `release-0.9`
+#  - use UI e2e tests from `release-0.9`
+#
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-release-0.9-e2e.yaml
+++ b/.github/workflows/nightly-release-0.9-e2e.yaml
@@ -3,6 +3,7 @@ name: Nightly e2e - run all non-analysis tests (@release-0.9)
 # Runs e2e tests using:
 #  - `:release-0.9` images
 #  - use the konveyor-operator install konveyor action from `release-0.9`
+#  - use e2e test runner workflow from `release-0.9`
 #  - use UI e2e tests from `release-0.9`
 #
 


### PR DESCRIPTION
Part of #3469 

Adds nightly workflows for the release-0.10 branch to:
  - Run repo level CI tests on the release-0.10 branch nightly
  - Run e2e tests using:
    - `:release-0.10` published image
    - use the konveyor-operator install konveyor action from `release-0.10`
    - use UI e2e tests from `release-0.10`

Add comments to the main and release-0.9 nightly e2e workflows about what set of inputs are used to run the e2e tests.

There is no `nightly-release-0.10-ci-global.yaml` workflow since the e2e workflow runs the same tests without needing an extra redundant container image build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added nightly CI workflow for the release 0.10 branch, running repo-level checks on a daily schedule and via manual trigger.
  - Added scheduled nightly end-to-end testing for release 0.10, including authentication-required coverage and automated Slack status notifications.
- **Documentation**
  - Improved workflow header documentation describing how nightly end-to-end tests are executed for the main branch and for release 0.9.
  - Updated nightly main workflow wiring to use the upstream UI e2e workflow for a consistent release flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->