### PR TITLE
[release-0.10] :seedling: Refactor metrics endpoint setup in e2e-run-ui-tests.yaml (#3481)

### DIFF
--- a/.github/workflows/e2e-run-ui-tests.yaml
+++ b/.github/workflows/e2e-run-ui-tests.yaml
@@ -128,89 +128,15 @@ jobs:
           echo "ingress is ready at: ${minikube_ip}"
           echo "UI_URL=https://${minikube_ip}" >>$GITHUB_ENV
 
-      - name: Expose metrics endpoint
-        run: |
-          # Wait for tackle-hub pod to be ready
-          echo "Waiting for tackle-hub pod to be ready..."
-          kubectl wait --for=condition=ready pod \
-            -n konveyor-tackle \
-            -l app.kubernetes.io/name=tackle-hub \
-            --timeout=600s
-
-          # Find the tackle-hub pod
-          HUB_POD=$(kubectl get pods -n konveyor-tackle -l app.kubernetes.io/name=tackle-hub -o jsonpath='{.items[0].metadata.name}')
-          echo "Hub pod: $HUB_POD"
-
-          # Verify metrics endpoint is available inside the pod first
-          echo "Checking if metrics endpoint is available inside the pod..."
-          for i in {1..30}; do
-            if kubectl exec -n konveyor-tackle "$HUB_POD" -- curl -s http://localhost:2112/metrics > /dev/null 2>&1; then
-              echo "Metrics endpoint is available inside the pod"
-              break
-            fi
-            echo "Waiting for metrics endpoint to be available (attempt $i/30)..."
-            sleep 2
-          done
-
-          # Port-forward metrics endpoint in the background (persistent across steps)
-          nohup kubectl port-forward -n konveyor-tackle "$HUB_POD" 2112:2112 > /tmp/port-forward-metrics.log 2>&1 &
-          echo $! > /tmp/port-forward-metrics.pid
-          echo "Port-forward PID: $(cat /tmp/port-forward-metrics.pid)"
-
-          # Wait for port-forward to be ready with retry logic
-          echo "Waiting for port-forward to be ready..."
-          for i in {1..30}; do
-            if curl -s http://localhost:2112/metrics > /dev/null 2>&1; then
-              echo "Port-forward is ready and metrics endpoint is accessible"
-              break
-            fi
-            echo "Waiting for port-forward (attempt $i/30)..."
-            sleep 2
-          done
-
-          # Verify metrics endpoint is accessible
-          echo "Testing metrics endpoint..."
-          if curl -s http://localhost:2112/metrics > /dev/null 2>&1; then
-            echo "Metrics endpoint test successful"
-          else
-            echo "Failed to access metrics endpoint"
-            kubectl logs -n konveyor-tackle "$HUB_POD" --tail=50
-            exit 1
-          fi
-
-          # Set metrics URL for Cypress tests
-          echo "METRICS_URL=http://localhost:2112/metrics" >>$GITHUB_ENV
-
       - name: "Checkout the repo (ref: ${{ inputs.test_ref }})"
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.test_ref }}
           path: tackle2-ui
 
-      - name: Verify metrics endpoint is still accessible
+      - name: Expose metrics endpoint
         run: |
-          echo "Verifying port-forward is still running..."
-          if [[ -f /tmp/port-forward-metrics.pid ]]; then
-            PID=$(cat /tmp/port-forward-metrics.pid)
-            if ps -p $PID > /dev/null 2>&1; then
-              echo "✓ Port-forward process is running (PID: $PID)"
-            else
-              echo "✗ Port-forward process is NOT running!"
-              exit 1
-            fi
-          else
-            echo "✗ Port-forward PID file not found!"
-            exit 1
-          fi
-
-          echo "Testing metrics endpoint accessibility..."
-          if curl -s http://localhost:2112/metrics > /dev/null 2>&1; then
-            echo "✓ Metrics endpoint is accessible"
-          else
-            echo "✗ Metrics endpoint is NOT accessible!"
-            cat /tmp/port-forward-metrics.log
-            exit 1
-          fi
+          tackle2-ui/hack/setup-metrics-endpoint.sh
 
       - name: "Run UI tests"
         uses: ./tackle2-ui/.github/actions/run-ui-tests

--- a/hack/setup-metrics-endpoint.sh
+++ b/hack/setup-metrics-endpoint.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Create a Service + Ingress to expose the tackle-hub metrics endpoint
+# on /hub-metrics (rewritten to /metrics on the backend).
+#
+# Writes METRICS_URL to $GITHUB_ENV when running in GitHub Actions.
+#
+set -euo pipefail
+
+NAMESPACE="konveyor-tackle"
+
+kubectl wait --for=condition=ready pod \
+  -n "$NAMESPACE" \
+  -l app.kubernetes.io/name=tackle-hub \
+  --timeout=600s
+
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: tackle-hub-metrics
+  namespace: konveyor-tackle
+  labels:
+    app.kubernetes.io/name: tackle-hub
+    app.kubernetes.io/component: hub
+    app.kubernetes.io/part-of: tackle
+spec:
+  selector:
+    app.kubernetes.io/name: tackle-hub
+    app.kubernetes.io/component: hub
+    app.kubernetes.io/part-of: tackle
+  ports:
+    - port: 2112
+      targetPort: 2112
+      protocol: TCP
+      name: metrics
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tackle-hub-metrics
+  namespace: konveyor-tackle
+  labels:
+    app.kubernetes.io/name: tackle-hub-metrics
+    app.kubernetes.io/component: ingress
+    app.kubernetes.io/part-of: tackle
+    app: tackle
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /metrics
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /hub-metrics
+            pathType: Exact
+            backend:
+              service:
+                name: tackle-hub-metrics
+                port:
+                  number: 2112
+EOF
+
+kubectl wait \
+  -n "$NAMESPACE" \
+  ingress/tackle-hub-metrics \
+  --timeout=300s \
+  --for=jsonpath='{.status.loadBalancer.ingress[0]}'
+
+MINIKUBE_IP=$(minikube ip)
+METRICS_URL="https://${MINIKUBE_IP}/hub-metrics"
+echo "Metrics ingress ready at: ${METRICS_URL}"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "METRICS_URL=${METRICS_URL}" >>"$GITHUB_ENV"
+fi


### PR DESCRIPTION
Refactor the metrics endpoint setup in the e2e-run-ui-tests.yaml workflow to use a new service and ingress instead of port-forwarding. This allows a stable metrics endpoint to be accessible during the e2e tests.

The new service and ingress are created by the
`hack/setup-metrics-endpoint.sh` and can be used to easily expose the metrics endpoint in any minikube/ingress cluster.

Cherry-pick-of: #3481