### PR TITLE
:seedling: Add pull-requests permission to nightly CI repo workflows

### DIFF
--- a/.github/workflows/nightly-main-ci-repo.yaml
+++ b/.github/workflows/nightly-main-ci-repo.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   nightly:

--- a/.github/workflows/nightly-release-0.10-ci-repo.yaml
+++ b/.github/workflows/nightly-release-0.10-ci-repo.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   nightly:

--- a/.github/workflows/nightly-release-0.9-ci-repo.yaml
+++ b/.github/workflows/nightly-release-0.9-ci-repo.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   nightly:


### PR DESCRIPTION
The nightly CI repo workflows call to the `ci-repo.yml` workflow in the appropriate branch. If the `ci-repo.yml` workflow in the branch requires both `contents` and `pull-requests` read permissions, then the nightly CI repo workflows also requires these permissions.

In practice, the pull-requests permission is not used, but it is required to call the `ci-repo.yml` workflow.

Fixes: #3489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly CI workflows to support read-only access to pull request information.
  * No changes were made to workflow jobs or execution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->