### PR TITLE
:seedling: Replace global-ci-bundle with internal e2e runner, support release-* branches

### DIFF
--- a/.github/actions/run-ui-tests/action.yml
+++ b/.github/actions/run-ui-tests/action.yml
@@ -132,6 +132,7 @@ runs:
         cd ui-tests/cypress
         SPEC=$(node scripts/findTierFiles.mjs ${TEST_TAGS})
         echo "test_spec=${SPEC}" >> "$GITHUB_ENV"
+
     - name: Sanitize and generate report artifact name if missing
       if: always()
       env:

--- a/.github/actions/run-ui-tests/action.yml
+++ b/.github/actions/run-ui-tests/action.yml
@@ -88,14 +88,14 @@ runs:
   using: "composite"
   steps:
     - name: "Checkout the tests (ref: ${{ inputs.tests_ref }})"
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: "${{ inputs.tests_ref }}"
         repository: konveyor/tackle2-ui
         path: ui-tests
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version-file: "ui-tests/package.json"
         cache: "npm"
@@ -109,7 +109,7 @@ runs:
         npx cypress install
 
     - name: Run login tests
-      uses: cypress-io/github-action@v6
+      uses: cypress-io/github-action@v7
       env:
         CYPRESS_BASE_URL: "${{ inputs.base_url }}"
         CYPRESS_USER: admin
@@ -150,7 +150,7 @@ runs:
         echo "Using report artifact name: ${SAFE_FINAL}"
 
     - name: "Run UI tests (${{ inputs.test_tags }})"
-      uses: cypress-io/github-action@v6
+      uses: cypress-io/github-action@v7
       env:
         CYPRESS_INCLUDE_TAGS: "${{ inputs.test_tags }}"
         CYPRESS_EXCLUDE_TAGS: "cf,downstream${{ inputs.feature_auth_required != 'true' && ',@authNeeded' || '' }}"
@@ -214,7 +214,7 @@ runs:
         fi
 
     - name: Upload cypress report data as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         overwrite: true

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -44,11 +44,18 @@ jobs:
       - id: container
         name: build the tackle2-ui container
         env:
+          REF: ${{ inputs.checkout_ref }}
           IMG_NAME: ttl.sh/tackle2-ui-${{ github.sha }}:2h
         run: |
           echo "IMG_NAME=${IMG_NAME}" >> "$GITHUB_OUTPUT"
           docker build . -t ${IMG_NAME}
           docker push ${IMG_NAME}
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Test UI Image
+            - checkout ref: \`${REF:-(default branch)}\`
+            - UI image: \`$IMG_NAME\`
+          EOF
 
   determine-branch-params:
     runs-on: ubuntu-latest
@@ -60,12 +67,16 @@ jobs:
     steps:
       - name: Determine branch-specific parameters
         id: params
+        env:
+          CHECKOUT_REF: ${{ inputs.checkout_ref }}
+          BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # Resolve the effective branch from available context
           # Priority: explicit workflow_call input > PR target branch > push branch / schedule default
-          REF="${{ inputs.checkout_ref }}"
-          REF="${REF:-${{ github.base_ref }}}"
-          REF="${REF:-${{ github.ref_name }}}"
+          REF="${CHECKOUT_REF}"
+          REF="${REF:-${BASE_REF}}"
+          REF="${REF:-${REF_NAME}}"
 
           # Normalize: strip any refs/heads/ prefix
           BRANCH="${REF#refs/heads/}"
@@ -87,8 +98,8 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           ## Branch Parameters
             - effective_branch: \`$BRANCH\`
-            - bundle_image: \`$BUNDLE\`
             - install_konveyor_version: \`$BRANCH\`
+            - bundle_image: \`$BUNDLE\`
             - test_ref: \`$REF\`
           EOF
 

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "release-*"
 
   pull_request:
     paths-ignore:
@@ -14,6 +15,7 @@ on:
       - ".coderabbit.yaml"
     branches:
       - "main"
+      - "release-*"
 
   workflow_call:
     inputs:
@@ -22,32 +24,15 @@ on:
         description: Git ref to checkout (defaults to the triggering ref)
         required: false
 
-###
-# The global CI settings need to be adjusted for the `release-*`` branches such that:
-#  1. The operator uses the correct `:release-*` images
-#  2. The `*-tests_ref` use the correct branches
-#
-# on:
-#   push:
-#     branches:
-#       - 'main'
-#       - 'release-*'
-#
-#   pull_request:
-#     branches:
-#       - 'main'
-#       - 'release-*'
-##
-
 permissions:
   contents: read
 
 concurrency:
-  group: ci-global-${{ github.ref }}-${{ inputs.checkout_ref || 'main'}}
+  group: ci-e2e-tests-${{ github.ref }}-${{ inputs.checkout_ref || 'main' }}
   cancel-in-progress: true
 
 jobs:
-  build-and-upload-for-global-ci:
+  build-and-upload-test-ui-image:
     runs-on: ubuntu-latest
     outputs:
       IMG_NAME: ${{ steps.container.outputs.IMG_NAME }}
@@ -65,20 +50,54 @@ jobs:
           docker build . -t ${IMG_NAME}
           docker push ${IMG_NAME}
 
-  determine-ui-tests-ref:
+  determine-branch-params:
     runs-on: ubuntu-latest
     outputs:
-      ui_tests_ref: ${{ steps.determine-ref.outputs.ui_tests_ref }}
+      effective_branch: ${{ steps.params.outputs.effective_branch }}
+      bundle_image: ${{ steps.params.outputs.bundle_image }}
+      install_konveyor_version: ${{ steps.params.outputs.install_konveyor_version }}
+      test_ref: ${{ steps.params.outputs.test_ref }}
     steps:
-      - name: Determine what git ref to use for the UI tests
-        id: determine-ref
+      - name: Determine branch-specific parameters
+        id: params
         run: |
-          REF="${{ inputs.checkout_ref || github.ref }}"
-          echo "ui_tests_ref=$REF"
-          echo "ui_tests_ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "Using \`ui_tests_ref=$REF\`" >> "$GITHUB_STEP_SUMMARY"
+          # Resolve the effective branch from available context
+          # Priority: explicit workflow_call input > PR target branch > push branch / schedule default
+          REF="${{ inputs.checkout_ref }}"
+          REF="${REF:-${{ github.base_ref }}}"
+          REF="${REF:-${{ github.ref_name }}}"
 
-  run-global-ci:
+          # Normalize: strip any refs/heads/ prefix
+          BRANCH="${REF#refs/heads/}"
+
+          # Map branch to image tag (main -> latest, release-X.Y -> release-X.Y)
+          if [[ "$BRANCH" == "main" ]]; then
+            IMAGE_TAG="latest"
+          else
+            IMAGE_TAG="$BRANCH"
+          fi
+
+          BUNDLE="quay.io/konveyor/tackle2-operator-bundle:${IMAGE_TAG}"
+
+          echo "effective_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "bundle_image=$BUNDLE" >> "$GITHUB_OUTPUT"
+          echo "install_konveyor_version=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "test_ref=$REF" >> "$GITHUB_OUTPUT"
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Branch Parameters
+            - effective_branch: \`$BRANCH\`
+            - bundle_image: \`$BUNDLE\`
+            - install_konveyor_version: \`$BRANCH\`
+            - test_ref: \`$REF\`
+          EOF
+
+  run-e2e-tests:
+    needs:
+      - build-and-upload-test-ui-image
+      - determine-branch-params
+    secrets: inherit
+
     strategy:
       fail-fast: false
       matrix:
@@ -92,11 +111,11 @@ jobs:
           - "@tier3_D"
           - "@tier3_E"
           - "@tier3_F"
-    needs: [build-and-upload-for-global-ci, determine-ui-tests-ref]
-    uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main
+    uses: ./.github/workflows/e2e-run-ui-tests.yaml
     with:
-      tackle_ui: ${{ needs.build-and-upload-for-global-ci.outputs.IMG_NAME }}
-      run_api_tests: false
-      run_ui_tests: true
-      ui_test_tags: ${{ matrix.test_tags }}
-      ui_tests_ref: ${{ needs.determine-ui-tests-ref.outputs.ui_tests_ref }}
+      test_tags: ${{ matrix.test_tags }}
+      feature_auth_required: false
+      install_konveyor_version: ${{ needs.determine-branch-params.outputs.install_konveyor_version }}
+      bundle_image: ${{ needs.determine-branch-params.outputs.bundle_image }}
+      ui_image: ${{ needs.build-and-upload-test-ui-image.outputs.IMG_NAME }}
+      test_ref: ${{ needs.determine-branch-params.outputs.test_ref }}

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -28,23 +28,79 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-e2e-tests-${{ github.ref }}-${{ inputs.checkout_ref || 'main' }}
+  group: ci-e2e-tests-${{ inputs.checkout_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  determine-branch-params:
+    runs-on: ubuntu-latest
+    outputs:
+      target_branch: ${{ steps.params.outputs.target_branch }}
+      bundle_image: ${{ steps.params.outputs.bundle_image }}
+      install_konveyor_version: ${{ steps.params.outputs.install_konveyor_version }}
+      build_checkout_ref: ${{ steps.params.outputs.build_checkout_ref }}
+      test_from_checkout_ref: ${{ steps.params.outputs.test_from_checkout_ref }}
+    steps:
+      - name: Determine branch-specific parameters
+        id: params
+        env:
+          CHECKOUT_REF: ${{ inputs.checkout_ref }}
+          BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          # Resolve the target branch (deployment context)
+          # Priority: explicit workflow_call input > PR base branch > push branch
+          TARGET="${CHECKOUT_REF:-${BASE_REF:-${REF_NAME}}}"
+          TARGET="${TARGET#refs/heads/}"
+
+          # Resolve the checkout ref (code to build)
+          # workflow_call with explicit ref: use that ref
+          # pull_request / push: use github.ref (PR merge ref or branch ref)
+          CHECKOUT="${CHECKOUT_REF:-${GITHUB_REF}}"
+
+          # Resolve the test from checkout ref (code to test)
+          # TODO: This implies build and test from the same ref. If we need to build and test
+          #       from different refs, this var will need to be updated.
+          TEST_FROM_CHECKOUT_REF="${CHECKOUT}"
+
+          # Map target branch to image tag (main -> latest, release-X.Y -> release-X.Y)
+          if [[ "$TARGET" == "main" ]]; then
+            IMAGE_TAG="latest"
+          else
+            IMAGE_TAG="$TARGET"
+          fi
+
+          BUNDLE="quay.io/konveyor/tackle2-operator-bundle:${IMAGE_TAG}"
+
+          echo "target_branch=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "bundle_image=$BUNDLE" >> "$GITHUB_OUTPUT"
+          echo "install_konveyor_version=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "build_checkout_ref=$CHECKOUT" >> "$GITHUB_OUTPUT"
+          echo "test_from_checkout_ref=$TEST_FROM_CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Branch Parameters
+            - target_branch: \`$TARGET\`
+            - build_checkout_ref: \`$CHECKOUT\`
+            - test_from_checkout_ref: \`$TEST_FROM_CHECKOUT_REF\`
+            - install_konveyor_version: \`$TARGET\`
+            - bundle_image: \`$BUNDLE\`
+          EOF
+
   build-and-upload-test-ui-image:
+    needs: determine-branch-params
     runs-on: ubuntu-latest
     outputs:
       IMG_NAME: ${{ steps.container.outputs.IMG_NAME }}
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.checkout_ref }}
+          ref: ${{ needs.determine-branch-params.outputs.build_checkout_ref }}
 
       - id: container
         name: build the tackle2-ui container
         env:
-          REF: ${{ inputs.checkout_ref }}
           IMG_NAME: ttl.sh/tackle2-ui-${{ github.sha }}:2h
         run: |
           echo "IMG_NAME=${IMG_NAME}" >> "$GITHUB_OUTPUT"
@@ -53,60 +109,13 @@ jobs:
 
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           ## Test UI Image
-            - checkout ref: \`${REF:-(default branch)}\`
             - UI image: \`$IMG_NAME\`
-          EOF
-
-  determine-branch-params:
-    runs-on: ubuntu-latest
-    outputs:
-      effective_branch: ${{ steps.params.outputs.effective_branch }}
-      bundle_image: ${{ steps.params.outputs.bundle_image }}
-      install_konveyor_version: ${{ steps.params.outputs.install_konveyor_version }}
-      test_ref: ${{ steps.params.outputs.test_ref }}
-    steps:
-      - name: Determine branch-specific parameters
-        id: params
-        env:
-          CHECKOUT_REF: ${{ inputs.checkout_ref }}
-          BASE_REF: ${{ github.base_ref }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          # Resolve the effective branch from available context
-          # Priority: explicit workflow_call input > PR target branch > push branch / schedule default
-          REF="${CHECKOUT_REF}"
-          REF="${REF:-${BASE_REF}}"
-          REF="${REF:-${REF_NAME}}"
-
-          # Normalize: strip any refs/heads/ prefix
-          BRANCH="${REF#refs/heads/}"
-
-          # Map branch to image tag (main -> latest, release-X.Y -> release-X.Y)
-          if [[ "$BRANCH" == "main" ]]; then
-            IMAGE_TAG="latest"
-          else
-            IMAGE_TAG="$BRANCH"
-          fi
-
-          BUNDLE="quay.io/konveyor/tackle2-operator-bundle:${IMAGE_TAG}"
-
-          echo "effective_branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "bundle_image=$BUNDLE" >> "$GITHUB_OUTPUT"
-          echo "install_konveyor_version=$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "test_ref=$REF" >> "$GITHUB_OUTPUT"
-
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          ## Branch Parameters
-            - effective_branch: \`$BRANCH\`
-            - install_konveyor_version: \`$BRANCH\`
-            - bundle_image: \`$BUNDLE\`
-            - test_ref: \`$REF\`
           EOF
 
   run-e2e-tests:
     needs:
-      - build-and-upload-test-ui-image
       - determine-branch-params
+      - build-and-upload-test-ui-image
     secrets: inherit
 
     strategy:
@@ -129,4 +138,4 @@ jobs:
       install_konveyor_version: ${{ needs.determine-branch-params.outputs.install_konveyor_version }}
       bundle_image: ${{ needs.determine-branch-params.outputs.bundle_image }}
       ui_image: ${{ needs.build-and-upload-test-ui-image.outputs.IMG_NAME }}
-      test_ref: ${{ needs.determine-branch-params.outputs.test_ref }}
+      test_ref: ${{ needs.determine-branch-params.outputs.test_from_checkout_ref }}


### PR DESCRIPTION
Resolves: #3469
Resolves: #3284

Switch `ci-e2e-tests.yml` from the external konveyor/ci `global-ci-bundle.yml` workflow to the internal `e2e-run-ui-tests.yaml` reusable workflow. Make all branch-specific values derived dynamically so the same workflow file works on main, release-0.10, release-0.9, and any future release branch without modification.

Update the run-ui-tests action to use the latest versions of its actions.

Changes:
- Expand push/pull_request triggers to include "release-*" branches
- Remove the stale manual-adjustment comment block
- Replace determine-ui-tests-ref with determine-branch-params, which resolves the effective branch (inputs.checkout_ref > github.base_ref > github.ref_name) and derives bundle_image, install_konveyor_version, and test_ref from it (main -> :latest, release-X.Y -> :release-X.Y)
- Replace run-global-ci (uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main) with run-e2e-tests (uses: ./.github/workflows/e2e-run-ui-tests.yaml) The relative path resolves to whichever branch the workflow runs on, so no @ref pin is needed when a new release branch is created
- Update the run-ui-tests action to use node24 based versions of its actions as the previous node versions are no longer supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI and Testing**
  * Upgraded automated UI test workflow steps to newer major versions of common GitHub Actions.
  * Extended end-to-end UI test runs to `release-*` branches (in addition to `main`).
  * Reworked end-to-end workflow orchestration to select the correct build/test references and image tags based on the target branch.
  * Added clearer step summaries for the UI image build and ensured Cypress test selection and artifact publishing remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->