### PR TITLE
:test_tube: Increase Node.js max HTTP header size for OIDC cookie support (#v7)

### DIFF
--- a/.github/actions/run-ui-tests/action.yml
+++ b/.github/actions/run-ui-tests/action.yml
@@ -111,6 +111,7 @@ runs:
     - name: Run login tests
       uses: cypress-io/github-action@v7
       env:
+        NODE_OPTIONS: "--max-http-header-size=65536"
         CYPRESS_BASE_URL: "${{ inputs.base_url }}"
         CYPRESS_USER: admin
         CYPRESS_PASSWORD: admin
@@ -153,6 +154,7 @@ runs:
     - name: "Run UI tests (${{ inputs.test_tags }})"
       uses: cypress-io/github-action@v7
       env:
+        NODE_OPTIONS: "--max-http-header-size=65536"
         CYPRESS_INCLUDE_TAGS: "${{ inputs.test_tags }}"
         CYPRESS_EXCLUDE_TAGS: "cf,downstream${{ inputs.feature_auth_required != 'true' && ',@authNeeded' || '' }}"
         # These should match what is listed in `cypress/.env.example`


### PR DESCRIPTION
cypress-io/github-action@v7 runs on Node.js 20, which enforces a
  stricter default maxHeaderSize (16KB). OIDC/Keycloak session cookies
  exceed this limit, causing 400 Request Header Or Cookie Too Large
  errors in auth-enabled nightly runs.
