### PR TITLE
:bug: Request offline_access so the builtin OP issues a refresh token

### DIFF
--- a/client/src/app/auth/oidc/userManager.ts
+++ b/client/src/app/auth/oidc/userManager.ts
@@ -11,7 +11,7 @@ export const userManager = new UserManager({
   redirect_uri: window.location.origin,
   post_logout_redirect_uri: window.location.origin,
   response_type: "code", // Authorization Code + PKCE (oidc-client-ts default for SPAs)
-  scope: "openid profile email",
+  scope: "openid profile email offline_access",
   userStore: new WebStorageStateStore({ store: window.sessionStorage }), // sessionStorage == new login for each tab
 
   // Automatically try a silent renew before expiry.


### PR DESCRIPTION
UI sessions against a hub with auth required die ~5 minutes after login: every hub call starts returning 401 and the app eventually bounces to the login form. The chain, verified live:

- Hub access tokens live 300 s (`Settings.Token.Lifespan` default).
- The UI requests `scope: "openid profile email"`. The builtin OP (zitadel/oidc) issues a refresh token only when `offline_access` is requested — so none is issued.
- `automaticSilentRenew` then falls back to hidden-iframe renew, which cannot work here: the OP answers `prompt=none` with a login redirect (not `error=login_required`), and the SPA registers no silent-callback route. Every renew times out, and the expired bearer keeps being sent.

The fix is one line: also request `offline_access`, so renewal rides the refresh grant.

This is the ask from #3302, which was closed as unnecessary because the hub can issue refresh tokens without the explicit scope — with Keycloak that's true, but the builtin OP enforces the OIDC-spec requirement (live-verified: the token response carries no `refresh_token` without the scope). The hub's own Go binding has always requested `openid profile email offline_access` (`shared/binding/auth/oidc.go`), so any hub that works with addons already accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
