### PR TITLE
:seedling: Update CI workflow to use LTS node versions

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -129,44 +129,7 @@ jobs:
             done
           fi
 
-  unit-test:
-    runs-on: ubuntu-latest
-    needs: unit-test-lookup
-    if: ${{ needs.unit-test-lookup.outputs.should-test == 'true' }}
-
-    # Use the same container as the Dockerfile's "FROM * as builder"
-    container: ${{ needs.unit-test-lookup.outputs.builder-image }}
-
-    name: "unit-test (Container: ${{ needs.unit-test-lookup.outputs.builder-image }})"
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.checkout_ref }}
-          persist-credentials: false
-
-      - name: Verify package-lock.json
-        run: ./scripts/verify_lock.mjs
-
-      - name: Install
-        run: |
-          npm version
-          npm clean-install --ignore-scripts --no-audit
-
-      - name: Lint sources
-        run: |
-          npm run postinstall
-          npm run format:check
-          npm run lint
-
-      - name: Build
-        if: ${{ needs.unit-test-lookup.outputs.should-build == 'true' }}
-        run: npm run build
-
-      - name: Test
-        if: ${{ needs.unit-test-lookup.outputs.should-build == 'true' }}
-        run: npm run test -- --coverage --watchAll=false
-
-  unit-test-lts:
+  unit-test-matrix:
     runs-on: ubuntu-latest
     needs: unit-test-lookup
     if: ${{ needs.unit-test-lookup.outputs.should-test == 'true' }}
@@ -174,25 +137,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # lts/* = active LTS, lts/-1 = previous (maintenance) LTS
-        # setup-node resolves these against the Node.js release schedule at
-        # runtime, so the job always targets the two current LTS lines.
-        node-version:
-          - "lts/-1"
-          - "lts/*"
+        # "container" uses the Dockerfile builder image; the lts/* entries use
+        # setup-node on bare ubuntu. setup-node resolves lts aliases against
+        # the Node.js release schedule at runtime.
+        include:
+          - runtime: container
+          - runtime: "lts/-1"
+          - runtime: "lts/*"
 
-    name: "unit-test (Node ${{ matrix.node-version }})"
+    container: ${{ matrix.runtime == 'container' && needs.unit-test-lookup.outputs.builder-image || '' }}
+
+    name: >-
+      unit-test (${{
+        matrix.runtime == 'container'
+          && format('Container: {0}', needs.unit-test-lookup.outputs.builder-image)
+          || format('Node {0}', matrix.runtime)
+      }})
+
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout_ref }}
           persist-credentials: false
 
-      - name: Set up Node.js ${{ matrix.node-version }}
+      - name: Set up Node.js ${{ matrix.runtime }}
+        if: matrix.runtime != 'container'
         uses: actions/setup-node@v7
         with:
           check-latest: true
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.runtime }}
           cache: "npm"
 
       - name: Verify package-lock.json
@@ -216,3 +189,19 @@ jobs:
       - name: Test
         if: ${{ needs.unit-test-lookup.outputs.should-build == 'true' }}
         run: npm run test -- --coverage --watchAll=false
+
+  unit-test:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [unit-test-lookup, unit-test-matrix]
+    steps:
+      - name: Check matrix results
+        run: |
+          if [[ "${{ needs.unit-test-lookup.outputs.should-test }}" != "true" ]]; then
+            echo "Unit tests were skipped (docs/hacks-only change)"
+            exit 0
+          fi
+          if [[ "${{ needs.unit-test-matrix.result }}" != "success" ]]; then
+            echo "One or more matrix jobs failed: ${{ needs.unit-test-matrix.result }}"
+            exit 1
+          fi

--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -135,13 +135,60 @@ jobs:
     # Use the same container as the Dockerfile's "FROM * as builder"
     container: ${{ needs.unit-test-lookup.outputs.builder-image }}
 
+    name: "unit-test (Container: ${{ needs.unit-test-lookup.outputs.builder-image }})"
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout_ref }}
 
-      # TODO: Setup a cache for npm so it could install faster
-      #       follow actions/setup-node@v4 techniques
+      - name: Verify package-lock.json
+        run: ./scripts/verify_lock.mjs
+
+      - name: Install
+        run: |
+          npm version
+          npm clean-install --ignore-scripts --no-audit
+
+      - name: Lint sources
+        run: |
+          npm run postinstall
+          npm run format:check
+          npm run lint
+
+      - name: Build
+        if: ${{ needs.unit-test-lookup.outputs.should-build == 'true' }}
+        run: npm run build
+
+      - name: Test
+        if: ${{ needs.unit-test-lookup.outputs.should-build == 'true' }}
+        run: npm run test -- --coverage --watchAll=false
+
+  unit-test-lts:
+    runs-on: ubuntu-latest
+    needs: unit-test-lookup
+    if: ${{ needs.unit-test-lookup.outputs.should-test == 'true' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # lts/* = active LTS, lts/-1 = previous (maintenance) LTS
+        # setup-node resolves these against the Node.js release schedule at
+        # runtime, so the job always targets the two current LTS lines.
+        node-version:
+          - "lts/-1"
+          - "lts/*"
+
+    name: "unit-test (Node ${{ matrix.node-version }})"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
 
       - name: Verify package-lock.json
         run: ./scripts/verify_lock.mjs

--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -197,6 +197,10 @@ jobs:
     steps:
       - name: Check matrix results
         run: |
+          if [[ "${{ needs.unit-test-lookup.result }}" != "success" ]]; then
+            echo "Unit-test lookup failed: ${{ needs.unit-test-lookup.result }}"
+            exit 1
+          fi
           if [[ "${{ needs.unit-test-lookup.outputs.should-test }}" != "true" ]]; then
             echo "Unit tests were skipped (docs/hacks-only change)"
             exit 0

--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -23,6 +23,7 @@ on:
 permissions:
   contents: read
   pull-requests: read # required for tj-actions/changed-files
+
 concurrency:
   group: ci-repo-${{ github.event_name }}-${{ github.ref }}-${{ inputs.checkout_ref || 'main'}}
   cancel-in-progress: true
@@ -40,6 +41,7 @@ jobs:
         with:
           ref: ${{ inputs.checkout_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lookup builder image from the project's Dockerfile
         id: grepBuilder
@@ -140,6 +142,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Verify package-lock.json
         run: ./scripts/verify_lock.mjs
@@ -183,10 +186,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
         with:
+          check-latest: true
           node-version: ${{ matrix.node-version }}
           cache: "npm"
 


### PR DESCRIPTION
In addition to using the Dockerfile's "FROM * as builder" container to run unit tests, this change uses setup-node@v7 to run unit test against both the current and previous LTS node versions.  This helps ensure that the codebase is compatible with the two most recent LTS node versions even if the builder container is outdated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated unit-test checks into a single matrix covering the builder container and current LTS Node.js runtimes.
  * Clarified CI job names to identify the runtime or container environment.
  * Added a final test-status check to reliably report skipped or failed matrix runs.
  * Improved CI security by preventing checkout steps from persisting credentials.
  * Updated test setup to run only for applicable runtime environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->