### PR TITLE
[release-0.9] :bug: CVE update for `js-yaml`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,7 @@
     "i18next": "^25.3.0",
     "i18next-http-backend": "^3.0.5",
     "immer": "^10.2.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.2",
     "keycloak-js": "^26.1.0",
     "lodash-es": "^4.18.1",
     "monaco-editor": "^0.52.2",

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -39,7 +39,7 @@
     "esbuild": "^0.27.2",
     "faker": "^5.5.3",
     "glob": "^10.3.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.2.3",
     "license-check-and-add": "^4.0.5",
     "mocha": "^11.7.5",
     "mocha-junit-reporter": "^2.2.1",

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -39,7 +39,7 @@
     "esbuild": "^0.27.2",
     "faker": "^5.5.3",
     "glob": "^10.3.0",
-    "js-yaml": "^4.2.3",
+    "js-yaml": "^4.3.2",
     "license-check-and-add": "^4.0.5",
     "mocha": "^11.7.5",
     "mocha-junit-reporter": "^2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "i18next": "^25.3.0",
         "i18next-http-backend": "^3.0.5",
         "immer": "^10.2.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.2",
         "keycloak-js": "^26.1.0",
         "lodash-es": "^4.18.1",
         "monaco-editor": "^0.52.2",
@@ -209,7 +209,7 @@
         "esbuild": "^0.27.2",
         "faker": "^5.5.3",
         "glob": "^10.3.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.2.3",
         "junit-report-merger": "^9.0.4",
         "license-check-and-add": "^4.0.5",
         "mocha": "^11.7.5",
@@ -3541,9 +3541,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16888,9 +16888,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Update js-yaml to 4.3.2 to fix CVE-2026-59869 and CVE-2026-84375.

Bug-Url: https://redhat.atlassian.net/browse/MTA-7640
Bug-Url: https://redhat.atlassian.net/browse/MTA-7655