### PR TITLE
[release-0.9] :ghost: Update axios dependency to 1.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cypress"
       ],
       "dependencies": {
-        "axios": "^1.16.1",
+        "axios": "^1.19.0",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "http-proxy-middleware": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "wait-on": "^9.0.10"
   },
   "dependencies": {
-    "axios": "^1.16.1",
+    "axios": "^1.19.0",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "http-proxy-middleware": "^3.0.7"


### PR DESCRIPTION
package-lock.json was already updated to axios@1.19.0, so just update package.json to match.

Bug-Url: https://redhat.atlassian.net/browse/MTA-7569
Bug-Url: https://redhat.atlassian.net/browse/MTA-7572
Bug-Url: https://redhat.atlassian.net/browse/MTA-7573
Bug-Url: https://redhat.atlassian.net/browse/MTA-7574

CVEs: CVE-2026-67314, CVE-2026-67320, CVE-2026-67313, CVE-2026-67321