### PR TITLE
:bug: Surface Hub errors on the agentic pages instead of spinning

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -1583,6 +1583,13 @@
       "unverifiableAlertTitle_one": "{{names}} cannot pass the controller's verification",
       "unverifiableAlertTitle_other": "{{count}} gateways cannot pass the controller's verification: {{names}}",
       "unverifiableAlertBody": "The controller verifies a gateway by probing GET /v1/models on its endpoint, which the native aws-bedrock and gcp-vertex-ai APIs do not serve, so these gateways never become Ready and every Agent that references them stays Not Ready — runs are blocked behind that hold even with valid credentials. Tracked as <issue>agentic-controller#167</issue>."
+    },
+    "fetchError": {
+      "title": "Unable to load agentic resources",
+      "rbacTitle": "The Hub cannot read agentic resources",
+      "rbacHint": "The Hub's ServiceAccount was denied by Kubernetes RBAC. The Hub reads Agents, Gateways, AgentRuns and their credential Secrets from its own namespace only, so they must be created there, and the tackle-hub ServiceAccount needs a Role granting access to konveyor.io resources in that namespace.",
+      "serverSaid": "Server response:",
+      "retry": "Retry"
     }
   }
 }

--- a/client/src/app/components/AgenticFetchError.tsx
+++ b/client/src/app/components/AgenticFetchError.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { AxiosError } from "axios";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateVariant,
+} from "@patternfly/react-core";
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
+
+import { isAgenticRbacError } from "@app/utils/agentic";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
+export interface AgenticFetchErrorProps {
+  /** The error returned by a `useFetch*` agentic query hook. */
+  error: unknown;
+  /** Re-run the query. Polling pauses while a query is errored, so this is how the page recovers without a reload. */
+  onRetry?: () => void;
+}
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof AxiosError) return getAxiosErrorMessage(error);
+  if (error instanceof Error) return error.message;
+  return String(error);
+};
+
+/**
+ * Error state for the agentic pages. Unlike the generic `StateError`, this
+ * surfaces the Hub's actual response so a misconfigured cluster is diagnosable
+ * from the browser, and names the fix when the failure is the Hub's own
+ * ServiceAccount being denied by RBAC.
+ */
+export const AgenticFetchError: React.FC<AgenticFetchErrorProps> = ({
+  error,
+  onRetry,
+}) => {
+  const { t } = useTranslation();
+  const rbac = isAgenticRbacError(error);
+  const message = errorMessage(error);
+
+  return (
+    <EmptyState
+      headingLevel="h2"
+      icon={ExclamationCircleIcon}
+      titleText={
+        rbac ? t("agentic.fetchError.rbacTitle") : t("agentic.fetchError.title")
+      }
+      variant={EmptyStateVariant.sm}
+      status="danger"
+    >
+      <EmptyStateBody>
+        {rbac && <p>{t("agentic.fetchError.rbacHint")}</p>}
+        <p>
+          <strong>{t("agentic.fetchError.serverSaid")}</strong>{" "}
+          <code>{message}</code>
+        </p>
+      </EmptyStateBody>
+      {onRetry && (
+        <EmptyStateFooter>
+          <Button variant="link" onClick={onRetry}>
+            {t("agentic.fetchError.retry")}
+          </Button>
+        </EmptyStateFooter>
+      )}
+    </EmptyState>
+  );
+};

--- a/client/src/app/pages/agent-runs/agent-run-detail-page.tsx
+++ b/client/src/app/pages/agent-runs/agent-run-detail-page.tsx
@@ -21,8 +21,8 @@ import type { AgentRunDetailsRoute } from "@app/Paths";
 import { DevPaths } from "@app/Paths";
 import { isTerminalPhase, runHubCoordinates } from "@app/api/agentic/contract";
 import { useHasSomeScopes } from "@app/auth";
+import { AgenticFetchError } from "@app/components/AgenticFetchError";
 import { PageHeader } from "@app/components/PageHeader";
-import { StateError } from "@app/components/StateError";
 import { useFetchAgentRun } from "@app/queries/agent-runs";
 import { useFetchAgents } from "@app/queries/agents";
 import { useFetchApplications } from "@app/queries/applications";
@@ -115,7 +115,7 @@ const AgentRunDetailPage: React.FC = () => {
               />
             </Alert>
           ) : (
-            <StateError />
+            <AgenticFetchError error={fetchError} />
           )}
         </PageSection>
       </>

--- a/client/src/app/pages/agent-runs/agent-runs-page.tsx
+++ b/client/src/app/pages/agent-runs/agent-runs-page.tsx
@@ -19,6 +19,7 @@ import { TablePersistenceKeyPrefix } from "@app/Constants";
 import { DevPaths } from "@app/Paths";
 import type { AgentRun, AgentRunPhase } from "@app/api/agentic/contract";
 import { useHasSomeScopes } from "@app/auth";
+import { AgenticFetchError } from "@app/components/AgenticFetchError";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
@@ -68,7 +69,7 @@ const RUN_PHASES: AgentRunPhase[] = [
 const AgentRunsPage: React.FC = () => {
   const { t } = useTranslation();
   const history = useHistory();
-  const { agentRuns, isLoading, fetchError } = useFetchAgentRuns();
+  const { agentRuns, isLoading, fetchError, refetch } = useFetchAgentRuns();
   const { data: applications } = useFetchApplications();
   // Every hub role can list runs; creating one is admin/architect/migrator
   // (tackle2-hub#1119).
@@ -236,8 +237,10 @@ const AgentRunsPage: React.FC = () => {
               </Tr>
             </Thead>
             <ConditionalTableBody
-              isLoading={isLoading}
               isError={!!fetchError}
+              errorEmptyState={
+                <AgenticFetchError error={fetchError} onRetry={refetch} />
+              }
               isNoData={currentPageItems.length === 0}
               noDataEmptyState={
                 <EmptyState

--- a/client/src/app/pages/agents/agents-page.tsx
+++ b/client/src/app/pages/agents/agents-page.tsx
@@ -25,11 +25,11 @@ import {
 
 import type { AgentResource } from "@app/api/agentic/contract";
 import { useHasSomeScopes } from "@app/auth";
+import { AgenticFetchError } from "@app/components/AgenticFetchError";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { useNotifications } from "@app/components/NotificationsContext";
-import { StateError } from "@app/components/StateError";
 import {
   ReadyLabel,
   skillCount,
@@ -104,7 +104,7 @@ const AgentsPage: React.FC = () => {
           )}
 
           {fetchError ? (
-            <StateError />
+            <AgenticFetchError error={fetchError} onRetry={refetch} />
           ) : sortedAgents.length === 0 ? (
             <EmptyState
               headingLevel="h2"

--- a/client/src/app/pages/gateways/gateways-page.tsx
+++ b/client/src/app/pages/gateways/gateways-page.tsx
@@ -13,9 +13,9 @@ import { CubesIcon, ExclamationTriangleIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import type { Gateway } from "@app/api/agentic/contract";
+import { AgenticFetchError } from "@app/components/AgenticFetchError";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
-import { StateError } from "@app/components/StateError";
 import {
   ReadyLabel,
   readyCondition,
@@ -53,7 +53,7 @@ export function isHeldByVerification(gateway: Gateway): boolean {
 
 const GatewaysPage: React.FC = () => {
   const { t } = useTranslation();
-  const { gateways, isLoading, fetchError } = useFetchGateways();
+  const { gateways, isLoading, fetchError, refetch } = useFetchGateways();
 
   const sorted = [...gateways].sort((a, b) =>
     (a.metadata.name ?? "").localeCompare(b.metadata.name ?? "")
@@ -99,7 +99,7 @@ const GatewaysPage: React.FC = () => {
           )}
 
           {fetchError ? (
-            <StateError />
+            <AgenticFetchError error={fetchError} onRetry={refetch} />
           ) : sorted.length === 0 ? (
             <EmptyState
               headingLevel="h2"

--- a/client/src/app/pages/skills/skills-page.tsx
+++ b/client/src/app/pages/skills/skills-page.tsx
@@ -26,11 +26,11 @@ import {
 
 import type { SkillCard, SkillCollection } from "@app/api/agentic/contract";
 import { useHasSomeScopes } from "@app/auth";
+import { AgenticFetchError } from "@app/components/AgenticFetchError";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { useNotifications } from "@app/components/NotificationsContext";
-import { StateError } from "@app/components/StateError";
 import { ReadyLabel } from "@app/pages/agent-runs/components/ReadyLabel";
 import { useFetchAgents } from "@app/queries/agents";
 import {
@@ -112,11 +112,13 @@ const SkillsPage: React.FC = () => {
     skillCards,
     isLoading: cardsLoading,
     fetchError: cardsError,
+    refetch: refetchCards,
   } = useFetchSkillCards();
   const {
     skillCollections,
     isLoading: collectionsLoading,
     fetchError: collectionsError,
+    refetch: refetchCollections,
   } = useFetchSkillCollections();
   // Only for the drawers' "Referenced by" section.
   const { agents } = useFetchAgents();
@@ -260,7 +262,7 @@ const SkillsPage: React.FC = () => {
           )}
 
           {cardsError ? (
-            <StateError />
+            <AgenticFetchError error={cardsError} onRetry={refetchCards} />
           ) : sortedCards.length === 0 ? (
             <EmptyState
               headingLevel="h3"
@@ -419,7 +421,10 @@ const SkillsPage: React.FC = () => {
           )}
 
           {collectionsError ? (
-            <StateError />
+            <AgenticFetchError
+              error={collectionsError}
+              onRetry={refetchCollections}
+            />
           ) : sortedCollections.length === 0 ? (
             <EmptyState
               headingLevel="h3"

--- a/client/src/app/pages/workflow-runs/workflow-run-detail-page.tsx
+++ b/client/src/app/pages/workflow-runs/workflow-run-detail-page.tsx
@@ -23,8 +23,8 @@ import { DevPaths } from "@app/Paths";
 import type { AgentRunPhase } from "@app/api/agentic/contract";
 import { isTerminalPhase, runHubCoordinates } from "@app/api/agentic/contract";
 import { useHasSomeScopes } from "@app/auth";
+import { AgenticFetchError } from "@app/components/AgenticFetchError";
 import { PageHeader } from "@app/components/PageHeader";
-import { StateError } from "@app/components/StateError";
 import { BranchPanel } from "@app/pages/agent-runs/components/BranchPanel";
 import { PhaseLabel } from "@app/pages/agent-runs/components/PhaseLabel";
 import { RunConditionSummary } from "@app/pages/agent-runs/components/RunConditionSummary";
@@ -110,7 +110,7 @@ const WorkflowRunDetailPage: React.FC = () => {
               />
             </Alert>
           ) : (
-            <StateError />
+            <AgenticFetchError error={fetchError} />
           )}
         </PageSection>
       </>

--- a/client/src/app/pages/workflow-runs/workflow-runs-page.tsx
+++ b/client/src/app/pages/workflow-runs/workflow-runs-page.tsx
@@ -22,6 +22,7 @@ import type {
   AgentWorkflowRunPhase,
 } from "@app/api/agentic/contract";
 import { useHasSomeScopes } from "@app/auth";
+import { AgenticFetchError } from "@app/components/AgenticFetchError";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
@@ -79,7 +80,8 @@ const RUN_PHASES: AgentWorkflowRunPhase[] = [
 const WorkflowRunsPage: React.FC = () => {
   const { t } = useTranslation();
   const history = useHistory();
-  const { workflowRuns, isLoading, fetchError } = useFetchWorkflowRuns();
+  const { workflowRuns, isLoading, fetchError, refetch } =
+    useFetchWorkflowRuns();
   const { data: applications } = useFetchApplications();
   // Every hub role can list runs; creating one is admin/architect/migrator
   // (tackle2-hub#1119).
@@ -267,8 +269,10 @@ const WorkflowRunsPage: React.FC = () => {
               </Tr>
             </Thead>
             <ConditionalTableBody
-              isLoading={isLoading}
               isError={!!fetchError}
+              errorEmptyState={
+                <AgenticFetchError error={fetchError} onRetry={refetch} />
+              }
               isNoData={currentPageItems.length === 0}
               noDataEmptyState={
                 <EmptyState

--- a/client/src/app/pages/workflows/workflows-page.tsx
+++ b/client/src/app/pages/workflows/workflows-page.tsx
@@ -27,11 +27,11 @@ import {
 import { DevPaths } from "@app/Paths";
 import type { AgentWorkflow } from "@app/api/agentic/contract";
 import { useHasSomeScopes } from "@app/auth";
+import { AgenticFetchError } from "@app/components/AgenticFetchError";
 import { AppPlaceholder } from "@app/components/AppPlaceholder";
 import { ConditionalRender } from "@app/components/ConditionalRender";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { useNotifications } from "@app/components/NotificationsContext";
-import { StateError } from "@app/components/StateError";
 import { ReadyLabel } from "@app/pages/agent-runs/components/ReadyLabel";
 import { CreateWorkflowRunModal } from "@app/pages/workflow-runs/components/CreateWorkflowRunModal";
 import {
@@ -58,7 +58,7 @@ const WorkflowsPage: React.FC = () => {
   const { t } = useTranslation();
   const history = useHistory();
   const { pushNotification } = useNotifications();
-  const { workflows, isLoading, fetchError } = useFetchWorkflows();
+  const { workflows, isLoading, fetchError, refetch } = useFetchWorkflows();
   // Authoring is admin/architect; running one is also a migrator's
   // (tackle2-hub#1119). Hide what would 403.
   const canWrite = useHasSomeScopes(agenticWorkflowsWriteScopes);
@@ -121,7 +121,7 @@ const WorkflowsPage: React.FC = () => {
           )}
 
           {fetchError ? (
-            <StateError />
+            <AgenticFetchError error={fetchError} onRetry={refetch} />
           ) : sortedWorkflows.length === 0 ? (
             <EmptyState
               headingLevel="h2"

--- a/client/src/app/queries/agent-runs.ts
+++ b/client/src/app/queries/agent-runs.ts
@@ -4,6 +4,10 @@ import { AxiosError } from "axios";
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import type { AgentRun } from "@app/api/agentic/contract";
 import { createAgentRun, getAgentRun, getAgentRuns } from "@app/api/rest";
+import {
+  AGENTIC_QUERY_RETRY,
+  pollUnlessErrored,
+} from "@app/queries/agentic-polling";
 
 export const AGENT_RUNS_QUERY_KEY = "agentRuns";
 export const AGENT_RUN_QUERY_KEY = "agentRun";
@@ -15,7 +19,9 @@ export const useFetchAgentRuns = (
     queryKey: [AGENT_RUNS_QUERY_KEY],
     queryFn: getAgentRuns,
     onError: (error: AxiosError) => console.log(error),
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
     // Runs mutate server-side while the user is elsewhere — keep polling
     // even when the tab is hidden so the page is current on return.
     refetchIntervalInBackground: true,
@@ -37,7 +43,9 @@ export const useFetchAgentRun = (
     queryKey: [AGENT_RUN_QUERY_KEY, name],
     queryFn: () => getAgentRun(name),
     onError: (error: AxiosError) => console.log(error),
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
     refetchIntervalInBackground: true,
     enabled: !!name,
   });

--- a/client/src/app/queries/agentic-catalog.ts
+++ b/client/src/app/queries/agentic-catalog.ts
@@ -3,6 +3,10 @@ import { AxiosError } from "axios";
 
 import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { getGateways } from "@app/api/rest";
+import {
+  AGENTIC_QUERY_RETRY,
+  pollUnlessErrored,
+} from "@app/queries/agentic-polling";
 
 export const GATEWAYS_QUERY_KEY = "gateways";
 
@@ -16,7 +20,9 @@ export const useFetchGateways = (
     queryFn: getGateways,
     onError: (error: AxiosError) => console.log(error),
     // Verification flips Ready on its own schedule — keep the page live.
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
   });
   return { gateways: data || [], isLoading, fetchError: error, refetch };
 };

--- a/client/src/app/queries/agentic-polling.ts
+++ b/client/src/app/queries/agentic-polling.ts
@@ -1,0 +1,23 @@
+import type { QueryStatus } from "@tanstack/react-query";
+
+/**
+ * Polling policy shared by the agentic `useFetch*` hooks.
+ *
+ * The agentic pages poll the Hub every few seconds. When the Hub is
+ * misconfigured (typically its ServiceAccount is denied by RBAC), the default
+ * react-query behaviour — three exponential-backoff retries per fetch, then
+ * poll again — keeps the query "fetching" almost continuously, so the tables
+ * render a spinner instead of the error. Bound the retries and pause polling
+ * while the query is errored; `refetchOnWindowFocus` and the error state's
+ * Retry button bring it back.
+ *
+ * Used inline rather than spread into the options object: a pre-typed
+ * `refetchInterval` callback would feed `unknown` into react-query's `TData`
+ * inference and erase the hook's return type.
+ */
+export const AGENTIC_QUERY_RETRY = 1;
+
+export const pollUnlessErrored = (
+  query: { state: { status: QueryStatus } },
+  refetchInterval: number | false
+): number | false => (query.state.status === "error" ? false : refetchInterval);

--- a/client/src/app/queries/agents.ts
+++ b/client/src/app/queries/agents.ts
@@ -12,6 +12,10 @@ import {
   getAgents,
   updateAgent,
 } from "@app/api/rest";
+import {
+  AGENTIC_QUERY_RETRY,
+  pollUnlessErrored,
+} from "@app/queries/agentic-polling";
 
 export const AGENTS_QUERY_KEY = "agents";
 
@@ -22,7 +26,9 @@ export const useFetchAgents = (
     queryKey: [AGENTS_QUERY_KEY],
     queryFn: getAgents,
     onError: (error: AxiosError) => console.log(error),
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
   });
 
   return {

--- a/client/src/app/queries/skills.ts
+++ b/client/src/app/queries/skills.ts
@@ -18,6 +18,10 @@ import {
   updateSkillCard,
   updateSkillCollection,
 } from "@app/api/rest";
+import {
+  AGENTIC_QUERY_RETRY,
+  pollUnlessErrored,
+} from "@app/queries/agentic-polling";
 
 export const SKILL_CARDS_QUERY_KEY = "skillCards";
 export const SKILL_COLLECTIONS_QUERY_KEY = "skillCollections";
@@ -31,7 +35,9 @@ export const useFetchSkillCards = (
     queryKey: [SKILL_CARDS_QUERY_KEY],
     queryFn: getSkillCards,
     onError: (error: AxiosError) => console.log(error),
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
   });
   return { skillCards: data || [], isLoading, fetchError: error, refetch };
 };
@@ -92,7 +98,9 @@ export const useFetchSkillCollections = (
     queryKey: [SKILL_COLLECTIONS_QUERY_KEY],
     queryFn: getSkillCollections,
     onError: (error: AxiosError) => console.log(error),
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
   });
   return {
     skillCollections: data || [],

--- a/client/src/app/queries/workflow-runs.ts
+++ b/client/src/app/queries/workflow-runs.ts
@@ -8,6 +8,10 @@ import {
   getWorkflowRun,
   getWorkflowRuns,
 } from "@app/api/rest";
+import {
+  AGENTIC_QUERY_RETRY,
+  pollUnlessErrored,
+} from "@app/queries/agentic-polling";
 
 export const WORKFLOW_RUNS_QUERY_KEY = "workflowRuns";
 export const WORKFLOW_RUN_QUERY_KEY = "workflowRun";
@@ -19,7 +23,9 @@ export const useFetchWorkflowRuns = (
     queryKey: [WORKFLOW_RUNS_QUERY_KEY],
     queryFn: getWorkflowRuns,
     onError: (error: AxiosError) => console.log(error),
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
     // Runs mutate server-side while the user is elsewhere — keep polling
     // even when the tab is hidden so the page is current on return.
     refetchIntervalInBackground: true,
@@ -41,7 +47,9 @@ export const useFetchWorkflowRun = (
     queryKey: [WORKFLOW_RUN_QUERY_KEY, name],
     queryFn: () => getWorkflowRun(name),
     onError: (error: AxiosError) => console.log(error),
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
     refetchIntervalInBackground: true,
     enabled: !!name,
   });

--- a/client/src/app/queries/workflows.ts
+++ b/client/src/app/queries/workflows.ts
@@ -12,6 +12,10 @@ import {
   getWorkflows,
   updateWorkflow,
 } from "@app/api/rest";
+import {
+  AGENTIC_QUERY_RETRY,
+  pollUnlessErrored,
+} from "@app/queries/agentic-polling";
 
 export const WORKFLOWS_QUERY_KEY = "workflows";
 
@@ -22,7 +26,9 @@ export const useFetchWorkflows = (
     queryKey: [WORKFLOWS_QUERY_KEY],
     queryFn: getWorkflows,
     onError: (error: AxiosError) => console.log(error),
-    refetchInterval,
+    retry: AGENTIC_QUERY_RETRY,
+    refetchInterval: (_data, query) =>
+      pollUnlessErrored(query, refetchInterval),
   });
   return { workflows: data || [], isLoading, fetchError: error, refetch };
 };

--- a/client/src/app/utils/agentic-fetch-error.test.ts
+++ b/client/src/app/utils/agentic-fetch-error.test.ts
@@ -1,0 +1,42 @@
+import { AxiosError, AxiosHeaders } from "axios";
+
+import { isAgenticRbacError } from "./agentic";
+
+const axiosError = (status: number, data: unknown) =>
+  new AxiosError("Request failed", String(status), undefined, undefined, {
+    status,
+    statusText: "",
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+    data,
+  });
+
+const FORBIDDEN =
+  'agents.konveyor.io is forbidden: User "system:serviceaccount:konveyor-tackle:tackle-hub" cannot list resource "agents" in API group "konveyor.io" in the namespace "konveyor-tackle"';
+
+describe("isAgenticRbacError", () => {
+  it("recognises the Hub's RBAC denial on a 500", () => {
+    expect(isAgenticRbacError(axiosError(500, { error: FORBIDDEN }))).toBe(
+      true
+    );
+  });
+
+  it("recognises the denial on a 403 with a plain-text body", () => {
+    expect(isAgenticRbacError(axiosError(403, FORBIDDEN))).toBe(true);
+  });
+
+  it("ignores other 500s", () => {
+    expect(
+      isAgenticRbacError(axiosError(500, { error: "storage is initializing" }))
+    ).toBe(false);
+  });
+
+  it("ignores forbidden responses that are not about konveyor.io", () => {
+    expect(isAgenticRbacError(axiosError(403, "forbidden"))).toBe(false);
+  });
+
+  it("ignores non-axios errors", () => {
+    expect(isAgenticRbacError(new Error(FORBIDDEN))).toBe(false);
+    expect(isAgenticRbacError(undefined)).toBe(false);
+  });
+});

--- a/client/src/app/utils/agentic.ts
+++ b/client/src/app/utils/agentic.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from "axios";
+
 import type {
   AgentResource,
   AgentWorkflow,
@@ -8,6 +10,7 @@ import {
   invalidTargetBranchReason,
 } from "@app/api/agentic/contract";
 import type { Application } from "@app/api/models";
+import { getAxiosErrorMessage } from "@app/utils/utils";
 
 /** kubectl-style compact age: 45s, 12m, 3h, 2d. */
 export function formatAge(creationTimestamp?: string): string {
@@ -216,4 +219,22 @@ export function partitionByRunEligibility<T extends RunnableApplication>(
     else eligible.push(application);
   }
   return { eligible, excluded };
+}
+
+// ------------------------------------------------------------ fetch errors
+
+/**
+ * True when a Hub `/hub/agentic/*` request failed because the Hub's own
+ * ServiceAccount was denied by Kubernetes RBAC. The Hub reads agentic CRs from
+ * its own namespace only, so this fires when the resources (or the Role that
+ * grants `konveyor.io` access) were created somewhere else — the message looks
+ * like `agents.konveyor.io is forbidden: User "system:serviceaccount:...:tackle-hub"
+ * cannot list resource "agents" in API group "konveyor.io" in the namespace "..."`.
+ */
+export function isAgenticRbacError(error: unknown): boolean {
+  if (!(error instanceof AxiosError)) return false;
+  const status = error.response?.status;
+  if (status !== 500 && status !== 403) return false;
+  const message = getAxiosErrorMessage(error);
+  return /forbidden/i.test(message) && /konveyor\.io/.test(message);
 }


### PR DESCRIPTION
## Summary

When Hub's `/hub/agentic/*` endpoints fail, the agentic pages showed either an endless spinner or the generic "Unable to connect" state, so a misconfigured cluster could not be diagnosed from the browser.

**Motivating incident.** Hub returned 500 on `GET /hub/agentic/agents` with:

```
agents.konveyor.io is forbidden: User "system:serviceaccount:konveyor-tackle:tackle-hub"
cannot list resource "agents" in API group "konveyor.io" in the namespace "konveyor-tackle"
```

The agentic CRs and the Hub's Role had been created in a different namespace than the one Hub reads from. The message named the fix; the UI rendered a spinner. Two people hit this independently.

Three things stacked up:

- The agentic query hooks handled errors with `console.log` only and kept react-query's default three exponential-backoff retries plus a 5s `refetchInterval`, so the query was "fetching" almost continuously.
- `agent-runs-page` and `workflow-runs-page` passed `isLoading` to `ConditionalTableBody`, which checks loading before error, so the spinner won while a retry was in flight. `applications-table` deliberately omits `isLoading` for this reason.
- The fallback `StateError` has a fixed body pointing at the network.

## Changes

- **New `AgenticFetchError` component** (`client/src/app/components/AgenticFetchError.tsx`). Renders the server's actual message via `getAxiosErrorMessage`, plus an optional Retry button. When the failure is the Hub ServiceAccount being denied on `konveyor.io` resources (`isAgenticRbacError` in `utils/agentic.ts`), the title and body explain that Agents, Gateways, runs and credential Secrets must live in Hub's namespace with a Role granting access there.
- **Used on every agentic page**: agent-runs, workflow-runs (as `errorEmptyState`, with `isLoading` dropped from `ConditionalTableBody`), agents, gateways, workflows, skills (both lists), and the agent-run / workflow-run detail pages' non-404 branch.
- **Polling policy** (`client/src/app/queries/agentic-polling.ts`): agentic `useFetch*` hooks now use `retry: 1` and pause `refetchInterval` while the query is in error state. `refetchOnWindowFocus` and the Retry button recover the page once the cluster is fixed. Applied to agents, agent-runs, agentic-catalog, workflows, workflow-runs, skills.
- **i18n**: new `agentic.fetchError.*` keys in `translation.json`.
- **Test**: `utils/agentic-fetch-error.test.ts` covers the RBAC-signature detection (500 with JSON body, 403 with text body, unrelated 500/403, non-axios errors).

## Test plan

- [x] `tsc -p client/tsconfig.json` clean
- [x] `eslint .` in `client/`: 3 errors / 20 warnings, identical to `main` (the errors are pre-existing `exhaustive-deps` in `queries/analysis.ts`)
- [x] `prettier --check` on changed files
- [x] `jest src/app/utils src/app/components`: 387 passed, 1 skipped
- [ ] Manual: point the UI at a Hub whose ServiceAccount lacks the `konveyor.io` Role. Agent runs page should show the RBAC explanation with the quoted server message within ~2s and stop polling; fixing RBAC and clicking Retry (or refocusing the tab) should load the table.
- [ ] Manual: with a healthy Hub, confirm the list pages still poll every 5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zbD1ctadmTyEpVBa2TMEd